### PR TITLE
macos: restart display link after display ID change

### DIFF
--- a/pkg/macos/animation.zig
+++ b/pkg/macos/animation.zig
@@ -4,6 +4,7 @@ pub const c = @import("animation/c.zig").c;
 pub extern "c" const kCAGravityTopLeft: *anyopaque;
 pub extern "c" const kCAGravityBottomLeft: *anyopaque;
 pub extern "c" const kCAGravityCenter: *anyopaque;
+pub extern "c" const kCAGravityResize: *anyopaque;
 
 test {
     @import("std").testing.refAllDecls(@This());

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -2437,6 +2437,12 @@ pub fn sizeCallback(self: *Surface, size: apprt.SurfaceSize) !void {
 }
 
 fn resize(self: *Surface, size: rendererpkg.ScreenSize) !void {
+    // Resizes can arrive during UI/layout transitions where the surface is momentarily
+    // too small to fit even a single terminal cell. Rendering at a 0xN or Nx0 grid
+    // produces a transient "blank" frame. Keep the last valid size until we have
+    // a usable grid again.
+    const prev_size = self.size;
+
     // Save our screen size
     self.size.screen = size;
     self.balancePaddingIfNeeded();
@@ -2446,6 +2452,10 @@ fn resize(self: *Surface, size: rendererpkg.ScreenSize) !void {
     // We have to update the IO thread no matter what because we send
     // pixel-level sizing to the subprocess.
     const grid_size = self.size.grid();
+    if (grid_size.columns == 0 or grid_size.rows == 0) {
+        self.size = prev_size;
+        return;
+    }
     if (grid_size.columns < 5 and (self.size.padding.left > 0 or self.size.padding.right > 0)) {
         log.warn("WARNING: very small terminal grid detected with padding " ++
             "set. Is your padding reasonable?", .{});

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -781,6 +781,11 @@ pub const Surface = struct {
     }
 
     pub fn updateSize(self: *Surface, width: u32, height: u32) void {
+        // A 0-sized surface can't be rendered and is commonly produced transiently
+        // by UI/layout systems during split/resize operations. Treat it as a no-op
+        // so we keep the last valid size/content until a real size arrives.
+        if (width == 0 or height == 0) return;
+
         // Runtimes sometimes generate superfluous resize events even
         // if the size did not actually change (SwiftUI). We check
         // that the size actually changed from what we last recorded

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -17,6 +17,7 @@ const shadertoy = @import("shadertoy.zig");
 
 const mtl = @import("metal/api.zig");
 const IOSurfaceLayer = @import("metal/IOSurfaceLayer.zig");
+const IOSurface = macos.iosurface.IOSurface;
 
 pub const GraphicsAPI = Metal;
 pub const Target = @import("metal/Target.zig");
@@ -60,6 +61,13 @@ max_texture_size: u32,
 
 /// We start an AutoreleasePool before `drawFrame` and end it afterwards.
 autorelease_pool: ?*objc.AutoreleasePool = null,
+
+/// Keep a retained reference to the last presented IOSurface so we can
+/// re-present it during resize/display callbacks without drawing a new frame.
+///
+/// This prevents transient blank frames when CA requests a synchronous display
+/// before the terminal has rebuilt its cell buffers for the new size.
+last_surface: ?*IOSurface = null,
 
 pub fn init(alloc: Allocator, opts: rendererpkg.Options) !Metal {
     comptime switch (builtin.os.tag) {
@@ -152,10 +160,12 @@ pub fn init(alloc: Allocator, opts: rendererpkg.Options) !Metal {
         .blending = opts.config.blending,
         .default_storage_mode = default_storage_mode,
         .max_texture_size = max_texture_size,
+        .last_surface = null,
     };
 }
 
 pub fn deinit(self: *Metal) void {
+    if (self.last_surface) |s| s.release();
     self.queue.release();
     self.device.release();
     self.layer.release();
@@ -251,6 +261,14 @@ pub fn initTarget(self: *const Metal, width: usize, height: usize) !Target {
 
 /// Present the provided target.
 pub inline fn present(self: *Metal, target: Target, sync: bool) !void {
+    // Most of the time we want top-left gravity to avoid stretching/jank.
+    self.layer.layer.setProperty("contentsGravity", macos.animation.kCAGravityTopLeft);
+
+    // Track the last presented surface so `presentLastTarget` can re-present it.
+    if (self.last_surface) |s| s.release();
+    target.surface.retain();
+    self.last_surface = target.surface;
+
     if (sync) {
         self.layer.setSurfaceSync(target.surface);
     } else {
@@ -258,9 +276,25 @@ pub inline fn present(self: *Metal, target: Target, sync: bool) !void {
     }
 }
 
-/// Present the last presented target again. (noop for Metal)
+/// Present the last presented target again.
 pub inline fn presentLastTarget(self: *Metal) !void {
-    _ = self;
+    const surface = self.last_surface orelse return;
+
+    // During a resize, re-presenting the last surface at top-left can leave newly
+    // exposed regions blank. Temporarily allow CA to scale it to fill the new bounds.
+    self.layer.layer.setProperty("contentsGravity", macos.animation.kCAGravityResize);
+
+    // Prefer synchronous set on the main thread (matches the CA display callback
+    // path). If we're off-main-thread, use the async helper which marshals to the
+    // main queue to avoid visual artifacts.
+    const NSThread = objc.getClass("NSThread").?;
+    if (NSThread.msgSend(bool, "isMainThread", .{})) {
+        self.layer.setSurfaceSync(surface);
+    } else {
+        // During resize, we intentionally want to show the last good frame even if it
+        // doesn't match the current layer bounds; CA will scale it (kCAGravityResize).
+        try self.layer.setSurfaceUnchecked(surface);
+    }
 }
 
 /// Returns the options to use when constructing buffers.

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -365,11 +365,6 @@ fn drainMailbox(self: *Thread) !void {
                 // Visibility affects our QoS class
                 self.setQosClass();
 
-                // If we became visible then we immediately trigger a draw.
-                // We don't need to update frame data because that should
-                // still be happening.
-                if (v) self.drawFrame(false);
-
                 // Notify the renderer so it can update any state.
                 self.renderer.setVisible(v);
 

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -147,6 +147,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
         /// cells for the draw call.
         cells_rebuilt: bool = false,
 
+
         /// The current GPU uniform values.
         uniforms: shaderpkg.Uniforms,
 
@@ -200,6 +201,11 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
 
         /// Health of the most recently completed frame.
         health: std.atomic.Value(Health) = .{ .raw = .healthy },
+
+        /// True once we've successfully presented at least one frame. Used to
+        /// safely re-present the last target during synchronous resize callbacks
+        /// without risking an initial blank window.
+        has_presented: std.atomic.Value(bool) = .{ .raw = false },
 
         /// Our swap chain (multiple buffering)
         swap_chain: SwapChain,
@@ -1303,6 +1309,9 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 self.draw_mutex.lock();
                 defer self.draw_mutex.unlock();
 
+                _ = self.terminal_state.rows;
+                _ = self.terminal_state.cols;
+
                 // Build our GPU cells
                 self.rebuildCells(
                     critical.preedit,
@@ -1394,6 +1403,40 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             const size_changed =
                 self.size.screen.width != surface_size.width or
                 self.size.screen.height != surface_size.height;
+
+            // On macOS, CoreAnimation can synchronously request a display during bounds changes.
+            // If we resize our render target and present a freshly cleared surface before the IO
+            // thread delivers the new terminal state/cell buffers, we can show a single-frame
+            // blank flash. To avoid this, satisfy the synchronous display by re-presenting the
+            // last completed frame and let the normal render loop catch up on the next tick.
+            if (sync and size_changed and self.has_presented.load(.monotonic)) {
+                try self.api.presentLastTarget();
+                return;
+            }
+
+            // During resize/layout transitions, the platform can trigger draws before the IO
+            // thread has delivered the corresponding terminal resize (and thus before updateFrame
+            // has rebuilt GPU cell buffers for the new grid). If we draw in that window we can
+            // render nothing but background (visually blank) because the projection/padding math
+            // uses a stale `cells.size` that doesn't match the new screen size.
+            //
+            // Detect this by computing the expected grid for the current surface size and
+            // comparing it to the currently rebuilt cell buffer grid. If they don't match, keep
+            // the last presented frame on-screen until the new cells arrive.
+            if (size_changed) {
+                const expected_grid = (renderer.Size{
+                    .screen = .{ .width = surface_size.width, .height = surface_size.height },
+                    .cell = self.size.cell,
+                    .padding = self.size.padding,
+                }).grid();
+
+                if (expected_grid.columns != self.cells.size.columns or
+                    expected_grid.rows != self.cells.size.rows)
+                {
+                    try self.api.presentLastTarget();
+                    return;
+                }
+            }
 
             // Conditions under which we need to draw the frame, otherwise we
             // don't need to since the previous frame should be identical.
@@ -1647,6 +1690,11 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
 
             // Always release our semaphore
             self.swap_chain.releaseFrame();
+
+            if (health == .healthy) {
+                // Track that we have a last good frame to re-present during sync resize callbacks.
+                self.has_presented.store(true, .monotonic);
+            }
         }
 
         fn drawImagePlacements(

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -996,9 +996,19 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             if (comptime DisplayLink == void) return;
             const display_link = self.display_link orelse return;
             log.info("updating display link display id={}", .{id});
+            const was_running = display_link.isRunning();
             display_link.setCurrentCGDisplay(id) catch |err| {
                 log.warn("error setting display link display id err={}", .{err});
+                return;
             };
+
+            // CVDisplayLink can silently "run" without ever delivering callbacks if it
+            // was started before a valid current display was set. Restarting it after
+            // we successfully set the display fixes the stuck-vsync-no-frames state.
+            if (was_running and self.focused) {
+                display_link.stop() catch {};
+                display_link.start() catch {};
+            }
         }
 
         /// True if our renderer has animations so that a higher frequency

--- a/src/renderer/metal/IOSurfaceLayer.zig
+++ b/src/renderer/metal/IOSurfaceLayer.zig
@@ -77,6 +77,30 @@ pub inline fn setSurface(self: *IOSurfaceLayer, surface: *IOSurface) !void {
     }
 }
 
+/// Sets the layer's `contents` to the provided IOSurface without checking size.
+///
+/// This is intended for "re-present last frame" paths during resize where we want
+/// CoreAnimation to scale the last good surface to cover new bounds (i.e. avoid
+/// a transient blank flash) even if the surface dimensions don't match the layer.
+pub inline fn setSurfaceUnchecked(self: *IOSurfaceLayer, surface: *IOSurface) !void {
+    surface.retain();
+
+    var block = SetSurfaceUncheckedBlock.init(.{
+        .layer = self.layer.value,
+        .surface = surface,
+    }, &setSurfaceUncheckedCallback);
+
+    const NSThread = objc.getClass("NSThread").?;
+    if (NSThread.msgSend(bool, "isMainThread", .{})) {
+        setSurfaceUncheckedCallback(&block);
+    } else {
+        macos.dispatch.dispatch_async(
+            @ptrCast(macos.dispatch.queue.getMain()),
+            @ptrCast(&block),
+        );
+    }
+}
+
 /// Sets the layer's `contents` to the provided IOSurface.
 ///
 /// Does not ensure this happens on the main thread.
@@ -85,6 +109,11 @@ pub inline fn setSurfaceSync(self: *IOSurfaceLayer, surface: *IOSurface) void {
 }
 
 const SetSurfaceBlock = objc.Block(struct {
+    layer: objc.c.id,
+    surface: *IOSurface,
+}, .{}, void);
+
+const SetSurfaceUncheckedBlock = objc.Block(struct {
     layer: objc.c.id,
     surface: *IOSurface,
 }, .{}, void);
@@ -114,6 +143,16 @@ fn setSurfaceCallback(
         );
         return;
     }
+
+    layer.setProperty("contents", surface);
+}
+
+fn setSurfaceUncheckedCallback(
+    block: *const SetSurfaceUncheckedBlock.Context,
+) callconv(.c) void {
+    const layer = objc.Object.fromId(block.layer);
+    const surface: *IOSurface = block.surface;
+    defer surface.release();
 
     layer.setProperty("contents", surface);
 }


### PR DESCRIPTION
Restart the macOS CVDisplayLink after updating the current CGDisplay in `setMacOSDisplayID`.

This avoids a rare state where vsync is "running" but the display link never delivers callbacks (surfaces appear frozen until focus/occlusion changes force a draw).
