### PR TITLE
Disable terminal reflow during resize for cmux stability

### DIFF
--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -2726,8 +2726,13 @@ pub fn resize(
     try primary.resize(.{
         .cols = cols,
         .rows = rows,
-        .reflow = self.modes.get(.wraparound),
-        .prompt_redraw = self.flags.shell_redraws_prompt,
+        // cmux: preserve terminal content stability across aggressive pane
+        // resize churn (especially for SSH-driven shells). Prefer tmux-style
+        // no-reflow semantics over potential history loss.
+        .reflow = false,
+        // cmux: prompt redraw on resize can blank substantial history under
+        // repeated split-resize churn. Preserve scrollback over prompt cleanup.
+        .prompt_redraw = .false,
     });
 
     // Alternate screen, if it exists, doesn't reflow


### PR DESCRIPTION
## Summary
Disable primary-screen reflow on resize in Ghostty's terminal core for cmux builds.

## Why
In SSH sessions under aggressive split resize churn, reflow can corrupt or erase previously drawn content from scrollback. Disabling reflow preserves command output and keeps resize behavior stable (tmux-style).

## Change
- Set `Screen.resize` call in `Terminal.resize` to `reflow = false`
- Keep prompt redraw disabled on resize (`prompt_redraw = .false`) to avoid prompt-region wipes under churn

## Validation
Validated from cmux integration side with:
- `tests_v2/test_ssh_remote_resize_scrollback_regression.py` (PASS)
- `tests_v2/test_pane_resize_preserves_ls_scrollback.py` (PASS)
- `tests_v2/test_pane_resize_preserves_visible_content.py` (PASS)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal stability during pane resizing operations, with better preservation of scrollback content during aggressive resizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->