### PR TITLE
Add C APIs for keyboard copy-mode selection control

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -2010,6 +2010,46 @@ pub fn hasSelection(self: *const Surface) bool {
     return self.io.terminal.screens.active.selection != null;
 }
 
+/// Start a selection anchored at the active cursor position.
+pub fn selectCursorCell(self: *Surface) !bool {
+    self.renderer_state.mutex.lock();
+    defer self.renderer_state.mutex.unlock();
+
+    const screen: *terminal.Screen = self.io.terminal.screens.active;
+    const pin = pin: {
+        // pointFromPin(.viewport, ...) can return points beyond the visible rows
+        // when the viewport includes additional written history; only anchor to
+        // the live cursor if it is truly visible in the viewport.
+        if (screen.pages.pointFromPin(.viewport, screen.cursor.page_pin.*)) |pt| {
+            if (pt.viewport.y < @as(u32, screen.pages.rows)) {
+                break :pin screen.cursor.page_pin.*;
+            }
+        }
+
+        // If we've scrolled away from the live cursor, start at the viewport origin
+        // so copy mode can select from the currently visible history.
+        break :pin screen.pages.pin(.{ .viewport = .{} }) orelse return false;
+    };
+    // Entering keyboard copy mode should not clobber clipboard contents.
+    try screen.select(terminal.Selection.init(pin, pin, false));
+    screen.dirty.selection = true;
+    try self.queueRender();
+    return true;
+}
+
+/// Clear the active selection, if any.
+pub fn clearSelection(self: *Surface) !bool {
+    self.renderer_state.mutex.lock();
+    defer self.renderer_state.mutex.unlock();
+
+    const screen: *terminal.Screen = self.io.terminal.screens.active;
+    if (screen.selection == null) return false;
+    try self.setSelection(null);
+    screen.dirty.selection = true;
+    try self.queueRender();
+    return true;
+}
+
 /// Returns the selected text. This is allocated.
 pub fn selectionString(self: *Surface, alloc: Allocator) !?[:0]const u8 {
     self.renderer_state.mutex.lock();

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1584,6 +1584,22 @@ pub const CAPI = struct {
         return surface.core_surface.hasSelection();
     }
 
+    /// Start a selection at the active cursor cell.
+    export fn ghostty_surface_select_cursor_cell(surface: *Surface) bool {
+        return surface.core_surface.selectCursorCell() catch |err| {
+            log.warn("error selecting cursor cell err={}", .{err});
+            return false;
+        };
+    }
+
+    /// Clear the active selection.
+    export fn ghostty_surface_clear_selection(surface: *Surface) bool {
+        return surface.core_surface.clearSelection() catch |err| {
+            log.warn("error clearing selection err={}", .{err});
+            return false;
+        };
+    }
+
     /// Same as ghostty_surface_read_text but reads from the user selection,
     /// if any.
     export fn ghostty_surface_read_selection(


### PR DESCRIPTION
## Summary
- expose ghostty_surface_select_cursor_cell and ghostty_surface_clear_selection from embedded C API
- add Surface.selectCursorCell()/Surface.clearSelection() helpers for selection lifecycle
- anchor cursor-cell selection to viewport origin when the live cursor is off-screen, so keyboard copy mode starts on visible content

Related: https://github.com/manaflow-ai/cmux/issues/788


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add embedded C APIs to start and clear keyboard copy-mode selections, and make copy mode start on visible content. Supports terminal vi copy mode work (cmux#788).

- **New Features**
  - Export ghostty_surface_select_cursor_cell and ghostty_surface_clear_selection.
  - Add Surface.selectCursorCell() and Surface.clearSelection() helpers that update selection and trigger render.

- **Bug Fixes**
  - When the live cursor is off-screen, start selection at the viewport origin so keyboard copy mode anchors to visible text.

<sup>Written for commit 7dd589824d4c9bda8265355718800cccaf7189a0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Select text starting from the cell at your cursor position
  * Clear your current selection with a dedicated command

<!-- end of auto-generated comment: release notes by coderabbit.ai -->