### PR TITLE
Cherry-pick: respect cursor-click-to-move for OSC133 prompt click

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -4277,6 +4277,9 @@ fn maybePromptClick(self: *Surface) !bool {
     // do anything.
     if (screen.semantic_prompt.click == .none) return false;
 
+    // If cursor-click-to-move is disabled, we don't do any prompt clicking.
+    if (!self.config.cursor_click_to_move) return false;
+
     // If our cursor isn't currently at a prompt then we don't handle
     // prompt clicks because we can't move if we're not in a prompt!
     if (!t.cursorIsAtPrompt()) return false;

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -874,19 +874,18 @@ palette: Palette = .{},
 /// background color.
 @"cursor-text": ?TerminalColor = null,
 
-/// Enables the ability to move the cursor at prompts by using `alt+click` on
-/// Linux and `option+click` on macOS.
+/// Enables the ability to move the cursor at prompts by clicking on a
+/// location in the prompt text.
 ///
-/// This feature requires shell integration (specifically prompt marking
-/// via `OSC 133`) and only works in primary screen mode. Alternate screen
-/// applications like vim usually have their own version of this feature but
-/// this configuration doesn't control that.
+/// This feature requires shell integration, specifically prompt marking
+/// via `OSC 133`. Some shells like Fish (v4) and Nu (0.111+) natively
+/// support this while others may require additional configuration or
+/// Ghostty's shell integration features to be enabled.
 ///
-/// It should be noted that this feature works by translating your desired
-/// position into a series of synthetic arrow key movements, so some weird
-/// behavior around edge cases are to be expected. This is unfortunately how
-/// this feature is implemented across terminals because there isn't any other
-/// way to implement it.
+/// Depending on the shell, this works either by translating your click
+/// position into a series of synthetic arrow key movements or by sending
+/// a click event directly to the shell. In either case, some unexpected
+/// behavior around edge cases is possible.
 @"cursor-click-to-move": bool = true,
 
 /// Hide the mouse immediately when typing. The mouse becomes visible again


### PR DESCRIPTION
## Summary

Cherry-pick of upstream [bb646926f8c4](https://github.com/ghostty-org/ghostty/commit/bb646926f8c4c242365cd2e915140760f95c1c75) (upstream [#11138](https://github.com/ghostty-org/ghostty/issues/11138)).

When `cursor-click-to-move` is false, `maybePromptClick()` now returns early, preventing raw mouse escape fragments (`0;34;24M...`) from leaking into the shell on prompt click.

Fixes https://github.com/manaflow-ai/cmux/issues/805

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Respect the "cursor-click-to-move" setting for OSC 133 prompt clicks. When disabled, prompt clicks are ignored to prevent raw mouse escape sequences from reaching the shell; config docs updated to reflect this behavior.

- **Bug Fixes**
  - Covers both paths: synthetic arrow-key movement and shell click events.

<sup>Written for commit cd99c4dcd173deecf3a56b3d48b43a4387972f05. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

