### PR TITLE
Revert no-reflow resize override, use upstream defaults

### DIFF
--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -2831,13 +2831,8 @@ pub fn resize(
     try primary.resize(.{
         .cols = cols,
         .rows = rows,
-        // cmux: preserve terminal content stability across aggressive pane
-        // resize churn (especially for SSH-driven shells). Prefer tmux-style
-        // no-reflow semantics over potential history loss.
-        .reflow = false,
-        // cmux: prompt redraw on resize can blank substantial history under
-        // repeated split-resize churn. Preserve scrollback over prompt cleanup.
-        .prompt_redraw = .false,
+        .reflow = self.modes.get(.wraparound),
+        .prompt_redraw = self.flags.shell_redraws_prompt,
     });
 
     // Alternate screen, if it exists, doesn't reflow


### PR DESCRIPTION
## Summary

Removes the cmux-specific `reflow=false` / `prompt_redraw=.false` overrides in `Terminal.resize()`, restoring upstream behavior.

The no-reflow patch was a workaround for old reflow bugs that have since been fixed in 5+ upstream commits. With reflow disabled, `PageList.resizeWithoutReflow` permanently destroys cell content beyond the new column boundary on every shrink. Growing back doesn't recover it.

This drops the cmux patch count from 7 to 6.

## Related

- https://github.com/manaflow-ai/cmux/issues/805
- https://github.com/manaflow-ai/cmux/issues/824

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores upstream resize defaults by removing the cmux-specific reflow=false and prompt_redraw=.false overrides. Prevents content loss on column shrink, with reflow now following wraparound mode and prompt redraw using shell settings; also drops our patch count from 7 to 6.

<sup>Written for commit a8fe0cd69c3ecfebbe5b7dd48fd27c152781e0a6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

