### PR TITLE
renderer: disable stale-frame resize guard for embedded

### DIFF
--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -1496,7 +1496,19 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             // thread delivers the new terminal state/cell buffers, we can show a single-frame
             // blank flash. To avoid this, satisfy the synchronous display by re-presenting the
             // last completed frame and let the normal render loop catch up on the next tick.
-            if (sync and size_changed and self.has_presented.load(.monotonic)) {
+            // The embedded host already drives resize and redraw tightly from
+            // the UI thread, so re-presenting the last frame here turns a
+            // transient resize mismatch into a visibly stale terminal.
+            const use_stale_frame_guard = switch (apprt.runtime) {
+                apprt.embedded => false,
+                else => true,
+            };
+
+            if (use_stale_frame_guard and
+                sync and
+                size_changed and
+                self.has_presented.load(.monotonic))
+            {
                 try self.api.presentLastTarget();
                 return;
             }
@@ -1510,7 +1522,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             // Detect this by computing the expected grid for the current surface size and
             // comparing it to the currently rebuilt cell buffer grid. If they don't match, keep
             // the last presented frame on-screen until the new cells arrive.
-            if (size_changed) {
+            if (size_changed and use_stale_frame_guard) {
                 const expected_grid = (renderer.Size{
                     .screen = .{ .width = surface_size.width, .height = surface_size.height },
                     .cell = self.size.cell,

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -1496,15 +1496,15 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             // thread delivers the new terminal state/cell buffers, we can show a single-frame
             // blank flash. To avoid this, satisfy the synchronous display by re-presenting the
             // last completed frame and let the normal render loop catch up on the next tick.
-            // The embedded host already drives resize and redraw tightly from
-            // the UI thread, so re-presenting the last frame here turns a
-            // transient resize mismatch into a visibly stale terminal.
-            const use_stale_frame_guard = switch (apprt.runtime) {
+            // Embedded hosts can synchronously trigger redraws during interactive
+            // resize. Re-presenting the last frame on those sync callbacks can
+            // leave the terminal visually stale even though the UI is repainting.
+            const use_sync_stale_frame_guard = switch (apprt.runtime) {
                 apprt.embedded => false,
                 else => true,
             };
 
-            if (use_stale_frame_guard and
+            if (use_sync_stale_frame_guard and
                 sync and
                 size_changed and
                 self.has_presented.load(.monotonic))
@@ -1522,7 +1522,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             // Detect this by computing the expected grid for the current surface size and
             // comparing it to the currently rebuilt cell buffer grid. If they don't match, keep
             // the last presented frame on-screen until the new cells arrive.
-            if (size_changed and use_stale_frame_guard) {
+            if (size_changed) {
                 const expected_grid = (renderer.Size{
                     .screen = .{ .width = surface_size.width, .height = surface_size.height },
                     .cell = self.size.cell,


### PR DESCRIPTION
## Summary

Disable the stale-frame resize guard for the embedded runtime in `renderer/generic.zig`.

## Problem

The generic renderer keeps the last presented frame on-screen during some resize transitions to avoid a transient blank flash while the resized cell buffers catch up.

That policy is reasonable for native hosts that may synchronously request display during resize.
For the embedded runtime, it can produce the opposite failure mode: the UI keeps repainting, but the terminal body visibly stays on a stale frame during resize.

## Change

- introduce `use_stale_frame_guard`
- keep the existing guard for non-embedded runtimes
- disable it for `apprt.embedded`

## Why this layer

This is renderer presentation policy, not host event wiring.
The embedded host was already delivering:

- resize events
- redraw requests
- input
- PTY I/O

The remaining failure was that the renderer intentionally preferred the previous frame for a size-mismatch window that is acceptable in native hosts but wrong for the embedded host.

## Validation

Validated from the cmux embedded host against the failure mode this branch was hitting:

- before: terminal body stayed visually stale during resize even though GTK continued repainting
- after: terminal body follows resize correctly and input remains usable

## Notes

- This is being opened first as a draft because it is part of the Ubuntu MVP integration path for cmux.
- If this direction is accepted in the manaflow fork, I plan to come back and propose the same renderer-policy change upstream after going through Ghostty's vouch process.


## Related draft PRs

This PR is one part of the Ghostty-side dependency chain for the Ubuntu/cmux MVP.

- Paired host-support PR: https://github.com/manaflow-ai/ghostty/pull/9
- App-side PR that depends on both: https://github.com/manaflow-ai/cmux/pull/828

Scope split:

- `#8`: renderer policy for `apprt.embedded` resize presentation
- `#9`: Linux embedded host support for `GtkGLArea` / OpenGL bring-up


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unintended frame presentation during synchronous callbacks in embedded runtimes, reducing redundant redraws.
  * Improved stability and consistency of redraws during window resize across runtime environments by gating presentation to appropriate conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->