### PR TITLE
embedded: add Linux host support

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -38,6 +38,7 @@ typedef enum {
   GHOSTTY_PLATFORM_INVALID,
   GHOSTTY_PLATFORM_MACOS,
   GHOSTTY_PLATFORM_IOS,
+  GHOSTTY_PLATFORM_LINUX,
 } ghostty_platform_e;
 
 typedef enum {
@@ -426,9 +427,14 @@ typedef struct {
   void* uiview;
 } ghostty_platform_ios_s;
 
+typedef struct {
+  void* gl_area;
+} ghostty_platform_linux_s;
+
 typedef union {
   ghostty_platform_macos_s macos;
   ghostty_platform_ios_s ios;
+  ghostty_platform_linux_s linux;
 } ghostty_platform_u;
 
 typedef enum {

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -26,6 +26,10 @@ const log = std.log.scoped(.embedded_window);
 pub const resourcesDir = internal_os.resourcesDir;
 
 pub const App = struct {
+    /// On Linux, the host (GtkGLArea) owns the GL context on the main thread.
+    /// The renderer thread must dispatch redraws back to the app thread.
+    pub const must_draw_from_app_thread = (builtin.target.os.tag == .linux);
+
     /// Because we only expect the embedding API to be used in embedded
     /// environments, the options are extern so that we can expose it
     /// directly to a C callconv and not pay for any translation costs.
@@ -342,6 +346,7 @@ pub const App = struct {
 pub const Platform = union(PlatformTag) {
     macos: MacOS,
     ios: IOS,
+    linux: Linux,
 
     // If our build target for libghostty is not darwin then we do
     // not include macos support at all.
@@ -355,6 +360,11 @@ pub const Platform = union(PlatformTag) {
         uiview: objc.Object,
     } else void;
 
+    pub const Linux = if (builtin.target.os.tag == .linux) struct {
+        /// The GtkGLArea pointer — host owns the GL widget and context.
+        gl_area: *anyopaque,
+    } else void;
+
     // The C ABI compatible version of this union. The tag is expected
     // to be stored elsewhere.
     pub const C = extern union {
@@ -364,6 +374,10 @@ pub const Platform = union(PlatformTag) {
 
         ios: extern struct {
             uiview: ?*anyopaque,
+        },
+
+        linux: extern struct {
+            gl_area: ?*anyopaque,
         },
     };
 
@@ -384,6 +398,13 @@ pub const Platform = union(PlatformTag) {
                     break :ios error.UIViewMustBeSet);
                 break :ios .{ .ios = .{ .uiview = uiview } };
             } else error.UnsupportedPlatform,
+
+            .linux => if (Linux != void) linux: {
+                const config = c_platform.linux;
+                const gl_area = config.gl_area orelse
+                    break :linux error.UnsupportedPlatform;
+                break :linux .{ .linux = .{ .gl_area = gl_area } };
+            } else error.UnsupportedPlatform,
         };
     }
 };
@@ -394,6 +415,7 @@ pub const PlatformTag = enum(c_int) {
 
     macos = 1,
     ios = 2,
+    linux = 3,
 };
 
 pub const EnvVar = extern struct {

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -170,9 +170,10 @@ pub fn surfaceInit(surface: *apprt.Surface) !void {
         => try prepareContext(null),
 
         apprt.embedded => {
-            // TODO(mitchellh): this does nothing today to allow libghostty
-            // to compile for OpenGL targets but libghostty is strictly
-            // broken for rendering on this platforms.
+            // The host (e.g. GtkGLArea) has already made the GL context
+            // current before calling into libghostty, so we can load
+            // GL function pointers from the current context.
+            try prepareContext(null);
         },
     }
 
@@ -209,9 +210,8 @@ pub fn threadEnter(self: *const OpenGL, surface: *apprt.Surface) !void {
         },
 
         apprt.embedded => {
-            // TODO(mitchellh): this does nothing today to allow libghostty
-            // to compile for OpenGL targets but libghostty is strictly
-            // broken for rendering on this platforms.
+            // Like GTK, the embedded host manages the GL context on the
+            // main thread. Nothing to do here for thread setup.
         },
     }
 }
@@ -238,14 +238,14 @@ pub fn displayRealized(self: *const OpenGL) void {
     _ = self;
 
     switch (apprt.runtime) {
-        apprt.gtk => prepareContext(null) catch |err| {
+        apprt.gtk, apprt.embedded => prepareContext(null) catch |err| {
             log.warn(
                 "Error preparing GL context in displayRealized, err={}",
                 .{err},
             );
         },
 
-        else => @compileError("only GTK should be calling displayRealized"),
+        else => @compileError("only GTK/embedded should be calling displayRealized"),
     }
 }
 

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -1496,7 +1496,19 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             // thread delivers the new terminal state/cell buffers, we can show a single-frame
             // blank flash. To avoid this, satisfy the synchronous display by re-presenting the
             // last completed frame and let the normal render loop catch up on the next tick.
-            if (sync and size_changed and self.has_presented.load(.monotonic)) {
+            // The embedded host already drives resize and redraw tightly from
+            // the UI thread, so re-presenting the last frame here turns a
+            // transient resize mismatch into a visibly stale terminal.
+            const use_stale_frame_guard = switch (apprt.runtime) {
+                apprt.embedded => false,
+                else => true,
+            };
+
+            if (use_stale_frame_guard and
+                sync and
+                size_changed and
+                self.has_presented.load(.monotonic))
+            {
                 try self.api.presentLastTarget();
                 return;
             }
@@ -1510,7 +1522,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             // Detect this by computing the expected grid for the current surface size and
             // comparing it to the currently rebuilt cell buffer grid. If they don't match, keep
             // the last presented frame on-screen until the new cells arrive.
-            if (size_changed) {
+            if (size_changed and use_stale_frame_guard) {
                 const expected_grid = (renderer.Size{
                     .screen = .{ .width = surface_size.width, .height = surface_size.height },
                     .cell = self.size.cell,

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -152,7 +152,6 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
         /// cells for the draw call.
         cells_rebuilt: bool = false,
 
-
         /// The current GPU uniform values.
         uniforms: shaderpkg.Uniforms,
 
@@ -1496,11 +1495,13 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             // thread delivers the new terminal state/cell buffers, we can show a single-frame
             // blank flash. To avoid this, satisfy the synchronous display by re-presenting the
             // last completed frame and let the normal render loop catch up on the next tick.
-            // Embedded hosts can synchronously trigger redraws during interactive
-            // resize. Re-presenting the last frame on those sync callbacks can
-            // leave the terminal visually stale even though the UI is repainting.
+            // Linux embedded hosts can synchronously trigger redraws during
+            // interactive resize. Re-presenting the last frame on those sync
+            // callbacks can leave the terminal visually stale even though the
+            // UI is repainting. Keep the stale-frame guard for other embedded
+            // hosts such as GhosttyKit on Darwin.
             const use_sync_stale_frame_guard = switch (apprt.runtime) {
-                apprt.embedded => false,
+                apprt.embedded => builtin.target.os.tag != .linux,
                 else => true,
             };
 

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -1496,15 +1496,15 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             // thread delivers the new terminal state/cell buffers, we can show a single-frame
             // blank flash. To avoid this, satisfy the synchronous display by re-presenting the
             // last completed frame and let the normal render loop catch up on the next tick.
-            // The embedded host already drives resize and redraw tightly from
-            // the UI thread, so re-presenting the last frame here turns a
-            // transient resize mismatch into a visibly stale terminal.
-            const use_stale_frame_guard = switch (apprt.runtime) {
+            // Embedded hosts can synchronously trigger redraws during interactive
+            // resize. Re-presenting the last frame on those sync callbacks can
+            // leave the terminal visually stale even though the UI is repainting.
+            const use_sync_stale_frame_guard = switch (apprt.runtime) {
                 apprt.embedded => false,
                 else => true,
             };
 
-            if (use_stale_frame_guard and
+            if (use_sync_stale_frame_guard and
                 sync and
                 size_changed and
                 self.has_presented.load(.monotonic))
@@ -1522,7 +1522,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             // Detect this by computing the expected grid for the current surface size and
             // comparing it to the currently rebuilt cell buffer grid. If they don't match, keep
             // the last presented frame on-screen until the new cells arrive.
-            if (size_changed and use_stale_frame_guard) {
+            if (size_changed) {
                 const expected_grid = (renderer.Size{
                     .screen = .{ .width = surface_size.width, .height = surface_size.height },
                     .cell = self.size.cell,


### PR DESCRIPTION
## Summary

Add the Linux-specific embedded host support needed for a `GtkGLArea`-based libghostty host.

## Problem

The embedded runtime already works for the macOS host, and `#8` addresses the renderer-side stale-frame behavior during resize.

That still leaves a separate gap for the Ubuntu/cmux host:

- the public C ABI does not expose a Linux embedded platform payload
- `apprt.embedded` does not recognize a Linux host surface
- the OpenGL backend still treats embedded rendering as effectively unimplemented

Without this, the Ubuntu host is relying on local-only Ghostty changes for basic surface creation and draw-thread behavior.

## Change

- add `GHOSTTY_PLATFORM_LINUX` and `ghostty_platform_linux_s` to `ghostty.h`
- teach `src/apprt/embedded.zig` to accept a Linux `gl_area` platform payload
- mark Linux embedded as `must_draw_from_app_thread`
- make `src/renderer/OpenGL.zig` initialize from the current embedded GL context and treat `displayRealized` like GTK

## Why this layer

This is platform bring-up for the embedded runtime, not renderer resize policy.

- `#8` keeps resize presentation policy correct for `apprt.embedded`
- this PR makes the Linux embedded host itself a first-class runtime path

Keeping them separate makes review clearer:

- `#8`: renderer policy
- this PR: Linux embedded platform support

## Validation

Validated through the cmux Ubuntu host integration path:

- the host passes a Linux `GtkGLArea` payload into libghostty
- resize/draw behavior depends on the embedded runtime treating Linux like an app-thread-owned GL host
- `zig build -Dapp-runtime=none` passes in this branch

Note: full `zig build` in this environment still stops earlier on missing local build tools (`msgfmt`, `blueprint-compiler`), which is unrelated to this diff.

## Notes

- This is a draft because it is part of the Ubuntu MVP dependency chain for cmux.
- The full usable Ubuntu MVP currently depends on both this PR and `#8`.


## Related draft PRs

This PR is one part of the Ghostty-side dependency chain for the Ubuntu/cmux MVP.

- Paired renderer-policy PR: https://github.com/manaflow-ai/ghostty/pull/8
- App-side PR that depends on both: https://github.com/manaflow-ai/cmux/pull/828

Scope split:

- `#8`: renderer policy for `apprt.embedded` resize presentation
- `#9`: Linux embedded host support for `GtkGLArea` / OpenGL bring-up

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Linux embedded host support for `GtkGLArea` so Linux hosts can create a surface and render via the embedded runtime. OpenGL now initializes from the host-owned context, draws on the app thread, and the resize stale-frame guard override is limited to Linux to avoid stale visuals during interactive resize.

- **New Features**
  - C ABI: adds `GHOSTTY_PLATFORM_LINUX` and `ghostty_platform_linux_s { gl_area }` to `ghostty.h`.
  - Embedded runtime: accepts a Linux `gl_area` payload; sets `must_draw_from_app_thread` on Linux.
  - OpenGL: initializes from the current embedded GL context; treats `displayRealized` like GTK; no thread setup for embedded.

- **Bug Fixes**
  - Renderer: disable the sync stale-frame guard only for Linux embedded; keep it for other embedded hosts (e.g., Darwin) to prevent stale frames during interactive resize.

<sup>Written for commit 9b0febb591623d801b51f77566c138ce631ad940. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Linux platform support to the embedding API so apps can run embedded GUIs on Linux.
  * Exposed Linux-specific platform configuration to allow proper graphics/GL area handling on Linux.
  * Improved embedded runtime initialization to correctly prepare OpenGL contexts across Linux, macOS, and iOS.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->