### PR TITLE
Add viewport VT export action

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -5656,6 +5656,11 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
             v,
         ),
 
+        .write_viewport_file => |v| try self.writeScreenFile(
+            .viewport,
+            v,
+        ),
+
         .write_scrollback_file => |v| try self.writeScreenFile(
             .history,
             v,
@@ -6048,6 +6053,7 @@ fn closingAction(action: input.Binding.Action) bool {
 /// The portion of the screen to write for writeScreenFile.
 const WriteScreenLoc = enum {
     screen, // Full screen
+    viewport, // Visible viewport
     history, // History (scrollback)
     selection, // Selected text
 };
@@ -6099,6 +6105,15 @@ fn writeScreenFile(
         // command always works on the primary screen.
         const pages = &self.io.terminal.screens.active.pages;
         const sel_: ?terminal.Selection = switch (loc) {
+            .viewport => viewport: {
+                break :viewport terminal.Selection.init(
+                    pages.getTopLeft(.viewport),
+                    pages.getBottomRight(.viewport) orelse
+                        break :viewport null,
+                    false,
+                );
+            },
+
             .history => history: {
                 // We do not support this for alternate screens
                 // because they don't have scrollback anyways.

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -517,6 +517,12 @@ pub const Action = union(enum) {
     /// See `write_scrollback_file` for possible actions.
     write_screen_file: WriteScreen,
 
+    /// Write the visible viewport into a temporary file with the
+    /// specified action.
+    ///
+    /// See `write_scrollback_file` for possible actions.
+    write_viewport_file: WriteScreen,
+
     /// Write the currently selected text into a temporary file with the
     /// specified action.
     ///
@@ -1338,6 +1344,7 @@ pub const Action = union(enum) {
             .jump_to_prompt,
             .write_scrollback_file,
             .write_screen_file,
+            .write_viewport_file,
             .write_selection_file,
             .close_surface,
             .close_tab,

--- a/src/input/command.zig
+++ b/src/input/command.zig
@@ -339,6 +339,74 @@ fn actionCommands(action: Action.Key) []const Command {
             },
         },
 
+        .write_viewport_file => comptime &.{
+            .{
+                .action = .{ .write_viewport_file = .copy },
+                .title = "Copy Viewport to Temporary File and Copy Path",
+                .description = "Copy the visible viewport contents to a temporary file and copy the path to the clipboard.",
+            },
+            .{
+                .action = .{ .write_viewport_file = .paste },
+                .title = "Copy Viewport to Temporary File and Paste Path",
+                .description = "Copy the visible viewport contents to a temporary file and paste the path to the file.",
+            },
+            .{
+                .action = .{ .write_viewport_file = .open },
+                .title = "Copy Viewport to Temporary File and Open",
+                .description = "Copy the visible viewport contents to a temporary file and open it.",
+            },
+
+            .{
+                .action = .{ .write_viewport_file = .{
+                    .action = .copy,
+                    .emit = .html,
+                } },
+                .title = "Copy Viewport as HTML to Temporary File and Copy Path",
+                .description = "Copy the visible viewport contents as HTML to a temporary file and copy the path to the clipboard.",
+            },
+            .{
+                .action = .{ .write_viewport_file = .{
+                    .action = .paste,
+                    .emit = .html,
+                } },
+                .title = "Copy Viewport as HTML to Temporary File and Paste Path",
+                .description = "Copy the visible viewport contents as HTML to a temporary file and paste the path to the file.",
+            },
+            .{
+                .action = .{ .write_viewport_file = .{
+                    .action = .open,
+                    .emit = .html,
+                } },
+                .title = "Copy Viewport as HTML to Temporary File and Open",
+                .description = "Copy the visible viewport contents as HTML to a temporary file and open it.",
+            },
+
+            .{
+                .action = .{ .write_viewport_file = .{
+                    .action = .copy,
+                    .emit = .vt,
+                } },
+                .title = "Copy Viewport as ANSI Sequences to Temporary File and Copy Path",
+                .description = "Copy the visible viewport contents as ANSI escape sequences to a temporary file and copy the path to the clipboard.",
+            },
+            .{
+                .action = .{ .write_viewport_file = .{
+                    .action = .paste,
+                    .emit = .vt,
+                } },
+                .title = "Copy Viewport as ANSI Sequences to Temporary File and Paste Path",
+                .description = "Copy the visible viewport contents as ANSI escape sequences to a temporary file and paste the path to the file.",
+            },
+            .{
+                .action = .{ .write_viewport_file = .{
+                    .action = .open,
+                    .emit = .vt,
+                } },
+                .title = "Copy Viewport as ANSI Sequences to Temporary File and Open",
+                .description = "Copy the visible viewport contents as ANSI escape sequences to a temporary file and open it.",
+            },
+        },
+
         .write_selection_file => comptime &.{
             .{
                 .action = .{ .write_selection_file = .copy },


### PR DESCRIPTION
## Summary
- add a viewport-specific write-screen binding action that can emit VT/ANSI text
- keep the existing full-screen and scrollback export paths unchanged
- unblock cmux read-screen/capture-pane ANSI preservation for viewport-only reads

## Testing
- built GhosttyKit.xcframework locally with `zig build -Demit-xcframework=true -Dxcframework-target=universal -Doptimize=ReleaseFast -Dversion-string=1.3.0-dev`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a viewport-only export action that can emit plain text, HTML, or VT/ANSI to a temp file, enabling ANSI preservation for visible-viewport reads. Addresses Linear issue #1073.

- **New Features**
  - Added `write_viewport_file` binding and command entries to export only the visible viewport; supports `.copy`, `.paste`, and `.open`.
  - Supports emit formats: plain text, HTML, and VT/ANSI.
  - Extended `writeScreenFile` with a `.viewport` selection using visible bounds; full-screen and scrollback exports are unchanged.

<sup>Written for commit 3058878eb76745b14cbd504dab8937fc5b96df4f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to export the currently visible viewport to a file, separate from full screen history dumps
  * Viewport export supports multiple formats (HTML, ANSI) with copy, paste, and open actions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->