### PR TITLE
Fix Pure prompt redraw markers

### DIFF
--- a/src/shell-integration/zsh/ghostty-integration
+++ b/src/shell-integration/zsh/ghostty-integration
@@ -121,7 +121,8 @@ _ghostty_deferred_init() {
             fi
         fi
 
-        builtin local mark1=$'%{\e]133;A;cl=line\a%}'
+        builtin local markA=$'\e]133;A;cl=line\a'
+        builtin local mark1=$'%{\e]133;P;k=i\a%}'
         if [[ -o prompt_percent ]]; then
             builtin typeset -g precmd_functions
             if [[ ${precmd_functions[-1]} == _ghostty_precmd ]]; then
@@ -131,8 +132,14 @@ _ghostty_deferred_init() {
                 # SIGCHLD if notify is set. Themes that update prompt
                 # asynchronously from a `zle -F` handler might still remove our
                 # marks. Oh well.
-                builtin local mark2=$'%{\e]133;A;k=s\a%}'
+                builtin local mark2=$'%{\e]133;P;k=s\a%}'
                 builtin local markB=$'%{\e]133;B\a%}'
+                if ! builtin zle; then
+                    # Emit a single fresh-line mark for actual new prompts.
+                    # Prompt redraws reuse the in-band P/B markers below so
+                    # async reset-prompt flows don't grow the screen.
+                    builtin print -rnu $_ghostty_fd -- $markA
+                fi
                 # Add marks conditionally to avoid a situation where we have
                 # several marks in place. These conditions can have false
                 # positives and false negatives though.
@@ -141,10 +148,22 @@ _ghostty_deferred_init() {
                 # - False negative (with prompt_subst):   PS1='$mark1'
                 [[ $PS1 == *$mark1* ]] || PS1=${mark1}${PS1}
                 [[ $PS1 == *$markB* ]] || PS1=${PS1}${markB}
-                # Handle multiline prompts by marking continuation lines as 
-                # secondary by replacing newlines with being prefixed
-                # with k=s
-                if [[ $PS1 == *$'\n'* ]]; then
+                # Handle multiline prompts by marking newline-separated
+                # continuation lines with k=s (mark2).
+                #
+                # Pure-style prompts use \n%{\r%} to move back to column 0
+                # before the visible prompt line. Ghostty already promotes the
+                # next row to a prompt continuation when prompt mode crosses a
+                # newline, so inserting another explicit continuation mark after
+                # that hidden CR creates a second prompt boundary during redraws.
+                if [[ $PS1 == *$'\n%{\r%}'* ]]; then
+                    :
+                elif [[ $PS1 == ${mark1}$'\n'* ]]; then
+                    builtin local rest=${PS1#${mark1}$'\n'}
+                    if [[ $rest == *$'\n'* ]]; then
+                        PS1=${mark1}$'\n'${rest//$'\n'/$'\n'${mark2}}
+                    fi
+                elif [[ $PS1 == *$'\n'* ]]; then
                     PS1=${PS1//$'\n'/$'\n'${mark2}}
                 fi
 
@@ -166,7 +185,7 @@ _ghostty_deferred_init() {
                 # already have a mark, so the following reset-prompt will write
                 # it. If it doesn't, there is nothing we can do.
                 if ! builtin zle; then
-                    builtin print -rnu $_ghostty_fd -- $mark1[3,-3]
+                    builtin print -rnu $_ghostty_fd -- $markA
                     (( _ghostty_state = 2 ))
                 fi
             fi
@@ -174,7 +193,7 @@ _ghostty_deferred_init() {
             # Without prompt_percent we cannot patch prompt. Just print the
             # mark, except when we are invoked from zle. In the latter case we
             # cannot do anything.
-            builtin print -rnu $_ghostty_fd -- $mark1[3,-3]
+            builtin print -rnu $_ghostty_fd -- $markA
             (( _ghostty_state = 2 ))
         fi
     }
@@ -189,9 +208,10 @@ _ghostty_deferred_init() {
         # top. We cannot force prompt_subst on the user though, so we would
         # still need this code for the no_prompt_subst case.
         PS1=${PS1//$'%{\e]133;A;cl=line\a%}'}
-        PS1=${PS1//$'%{\e]133;A;k=s\a%}'}
+        PS1=${PS1//$'%{\e]133;P;k=i\a%}'}
+        PS1=${PS1//$'%{\e]133;P;k=s\a%}'}
         PS1=${PS1//$'%{\e]133;B\a%}'}
-        PS2=${PS2//$'%{\e]133;A;k=s\a%}'}
+        PS2=${PS2//$'%{\e]133;P;k=s\a%}'}
         PS2=${PS2//$'%{\e]133;B\a%}'}
 
         # This will work incorrectly in the presence of a preexec hook that
@@ -239,6 +259,18 @@ _ghostty_deferred_init() {
 	  builtin print -rnu $_ghostty_fd \$'\\e[0 q'"
     fi
 
+    # Emit semantic prompt markers at line-init if PS1 doesn't contain our
+    # marks. This ensures the terminal sees prompt markers even if another
+    # plugin (like zinit or oh-my-posh) regenerated PS1 after our precmd ran.
+    # We use 133;P instead of 133;A to avoid fresh-line behavior which would
+    # disrupt the display since the prompt has already been drawn. We also
+    # emit 133;B to mark the input area, which is needed for click-to-move.
+    (( $+functions[_ghostty_zle_line_init] )) || _ghostty_zle_line_init() { builtin true; }
+    functions[_ghostty_zle_line_init]="
+        if [[ \$PS1 != *$'%{\\e]133;A'* && \$PS1 != *$'%{\\e]133;P'* ]]; then
+            builtin print -nu \$_ghostty_fd '\\e]133;P;k=i\\a\\e]133;B\\a'
+        fi
+    "${functions[_ghostty_zle_line_init]}
     # Add Ghostty binary to PATH if the path feature is enabled
     if [[ "$GHOSTTY_SHELL_FEATURES" == *"path"* ]] && [[ -n "$GHOSTTY_BIN_DIR" ]]; then
       if [[ ":$PATH:" != *":$GHOSTTY_BIN_DIR:"* ]]; then


### PR DESCRIPTION
Restores the redraw-safe OSC 133 marker split for zsh prompt redraws and keeps Pure-style hidden-CR prompts from duplicating the preprompt row.

Validation happened from the parent cmux worktree with the existing Pure redraw regressions and a live tagged cmux repro.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Pure-style prompt redraws by using redraw-safe OSC 133 markers so zsh prompts don’t duplicate the preprompt line. Adds a `zle-line-init` fallback to emit semantic markers if PS1 is regenerated, and keeps click-to-move disabled when `cursor-click-to-move=false`.

- **Bug Fixes**
  - Use in-band `OSC 133;P` markers and skip `k=s` after Pure’s hidden CR to prevent duplicate redraw boundaries on multiline prompts.
  - Emit `OSC 133;P;k=i` and `OSC 133;B` at `zle-line-init` when PS1 lacks our markers, while still honoring `cursor-click-to-move=false`.

<sup>Written for commit 404a3f175ba6baafabc46cac807194883e040980. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Shell Integration**
  * Improved zsh shell prompt initialization with better handling of multiline prompts containing explicit newlines
  * Enhanced semantic markers for terminal integration that persist even when other plugins modify the shell prompt
  * Adjusted marker behavior during async shell operations to improve responsiveness
  * Refined prompt handling to maintain compatibility with complex configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->