### PR TITLE
build: normalize input archives before Darwin libtool merge

### DIFF
--- a/src/build/LibtoolStep.zig
+++ b/src/build/LibtoolStep.zig
@@ -33,7 +33,15 @@ pub fn create(b: *std.Build, opts: Options) *LibtoolStep {
     const run_step = RunStep.create(b, b.fmt("libtool {s}", .{opts.name}));
     run_step.addArgs(&.{ "libtool", "-static", "-o" });
     const output = run_step.addOutputFileArg(opts.out_name);
-    for (opts.sources) |source| run_step.addFileArg(source);
+    for (opts.sources, 0..) |source, i| {
+        run_step.addFileArg(normalizeArchive(
+            b,
+            opts.name,
+            opts.out_name,
+            i,
+            source,
+        ));
+    }
 
     self.* = .{
         .step = &run_step.step,
@@ -41,4 +49,30 @@ pub fn create(b: *std.Build, opts: Options) *LibtoolStep {
     };
 
     return self;
+}
+
+fn normalizeArchive(
+    b: *std.Build,
+    step_name: []const u8,
+    out_name: []const u8,
+    index: usize,
+    source: LazyPath,
+) LazyPath {
+    // Newer Xcode libtool can drop 64-bit archive members if the input
+    // archive layout doesn't match what it expects. ranlib rewrites the
+    // archive without flattening members through the filesystem, so we
+    // normalize each source archive first. This is a Zig/toolchain
+    // interoperability workaround, not a Ghostty archive format change.
+    const run_step = RunStep.create(
+        b,
+        b.fmt("ranlib {s} #{d}", .{ step_name, index }),
+    );
+    run_step.addArgs(&.{
+        "/bin/sh",
+        "-c",
+        "/bin/cp \"$1\" \"$2\" && /usr/bin/ranlib \"$2\"",
+        "_",
+    });
+    run_step.addFileArg(source);
+    return run_step.addOutputFileArg(b.fmt("{d}-{s}", .{ index, out_name }));
 }


### PR DESCRIPTION
This is the same change as ghostty-org/ghostty#11999 and is required for the build.

## Background

Zig 0.15.2 can produce macOS `.a` archives where some 64-bit Mach-O members are only 4-byte aligned inside the archive. Recent Apple `libtool -static` does not handle that layout correctly: it emits "not 8-byte aligned" warnings and, in the failing case, silently drops those members when creating the combined static library.

In Ghostty, this happened in the Darwin libtool merge step that builds `libghostty-fat.a`. The x86_64 input `libghostty.a` still contained the expected `libghostty_zcu.o` and about 97 exported `_ghostty_` symbols, but after `libtool -static` the output archive contained only 4 SIMD symbols because `libghostty_zcu.o` had been discarded.

## Fix

Normalize each input archive by copying it and running `ranlib -D` on the copy before passing it to `libtool`. This rewrites the archive into a layout Apple's linker tools accept without flattening members through the filesystem or changing the archive's semantic contents.

## Why This Approach

- `ar x` → `ar rcs` can fix the warnings but is a broader, riskier transformation (duplicate member basenames can collide, non-`.o` members can be lost, member order can change).
- `ranlib -D` rewrites the archive in place, preserves all archive members, and is deterministic (`-D` strips timestamps).

## Validation

After applying the normalization step, a clean `zig build` succeeded and the final macOS xcframework archive contained all expected `_ghostty_` symbols in both the x86_64 and arm64 slices.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize input `.a` archives before the Darwin `libtool -static` merge to prevent dropped 64‑bit Mach‑O objects and preserve expected `_ghostty_` symbols in `libghostty-fat.a`.
This fixes build failures seen with recent Xcode `libtool` when using Zig 0.15.2 archives.

- **Bug Fixes**
  - Work around `libtool` misalignment handling by copying each input archive and running `/usr/bin/ranlib` on the copy before merging.
  - Added `normalizeArchive` in `src/build/LibtoolStep.zig`; clean `zig build` now preserves expected symbols for both x86_64 and arm64.

<sup>Written for commit bd759078fb2144da927cb7175a5f7a70d8e81226. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized archive processing in the build system with improved normalization handling to ensure consistency when processing source archives during compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->