### PR TITLE
termio: add PTY output tap for real-time terminal streaming

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1087,6 +1087,12 @@ void ghostty_surface_draw(ghostty_surface_t);
 void ghostty_surface_set_content_scale(ghostty_surface_t, double, double);
 void ghostty_surface_set_focus(ghostty_surface_t, bool);
 void ghostty_surface_set_occlusion(ghostty_surface_t, bool);
+/* PTY tap: real-time raw byte streaming */
+bool ghostty_surface_pty_tap_open(ghostty_surface_t, uint32_t buffer_size);
+uint32_t ghostty_surface_pty_tap_read(ghostty_surface_t, void* buf, uint32_t max_len);
+void ghostty_surface_pty_tap_close(ghostty_surface_t);
+int32_t ghostty_surface_pty_write(ghostty_surface_t, const void* buf, uint32_t len);
+
 void ghostty_surface_set_size(ghostty_surface_t, uint32_t, uint32_t);
 ghostty_surface_size_s ghostty_surface_size(ghostty_surface_t);
 void ghostty_surface_set_color_scheme(ghostty_surface_t,

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -15,6 +15,7 @@ const input = @import("../input.zig");
 const internal_os = @import("../os/main.zig");
 const renderer = @import("../renderer.zig");
 const terminal = @import("../terminal/main.zig");
+const termio = @import("../termio.zig");
 const CoreApp = @import("../App.zig");
 const CoreInspector = @import("../inspector/main.zig").Inspector;
 const CoreSurface = @import("../Surface.zig");
@@ -1735,6 +1736,40 @@ pub const CAPI = struct {
     /// call as soon as possible (NOW if possible).
     export fn ghostty_surface_draw(surface: *Surface) void {
         surface.draw();
+    }
+
+    // -- PTY tap: real-time raw byte streaming --
+
+    /// Enable the PTY tap for this surface, allocating a ring buffer.
+    export fn ghostty_surface_pty_tap_open(surface: *Surface, buffer_size: u32) bool {
+        const termio_ptr = &surface.core_surface.io;
+        const tap = termio.PtyTap.init(surface.core_surface.alloc, buffer_size) catch return false;
+        tap.active.store(true, .release);
+        termio_ptr.pty_tap = tap;
+        return true;
+    }
+
+    /// Read available bytes from the PTY tap buffer (non-blocking).
+    export fn ghostty_surface_pty_tap_read(surface: *Surface, buf: [*]u8, max_len: u32) u32 {
+        const tap = surface.core_surface.io.pty_tap orelse return 0;
+        return @intCast(tap.read(buf[0..max_len]));
+    }
+
+    /// Close the PTY tap and free the ring buffer.
+    export fn ghostty_surface_pty_tap_close(surface: *Surface) void {
+        const termio_ptr = &surface.core_surface.io;
+        if (termio_ptr.pty_tap) |tap| {
+            tap.active.store(false, .release);
+            tap.deinit();
+            termio_ptr.pty_tap = null;
+        }
+    }
+
+    /// Write raw bytes to the PTY master fd (for input from remote client).
+    export fn ghostty_surface_pty_write(surface: *Surface, buf: [*]const u8, len: u32) i32 {
+        const fd = surface.core_surface.io.getPtyMasterFd() orelse return -1;
+        const result = std.posix.write(fd, buf[0..len]) catch return -1;
+        return @intCast(result);
     }
 
     /// Update the size of a surface. This will trigger resize notifications

--- a/src/termio.zig
+++ b/src/termio.zig
@@ -34,6 +34,7 @@ pub const Backend = backend.Backend;
 pub const DerivedConfig = Termio.DerivedConfig;
 pub const Mailbox = mailbox.Mailbox;
 pub const Message = message.Message;
+pub const PtyTap = @import("termio/pty_tap.zig").PtyTap;
 pub const StreamHandler = stream_handler.StreamHandler;
 
 test {

--- a/src/termio/Termio.zig
+++ b/src/termio/Termio.zig
@@ -62,6 +62,9 @@ mailbox: termio.Mailbox,
 /// from the child process and calls callbacks in the stream handler.
 terminal_stream: StreamHandler.Stream,
 
+/// Optional PTY tap for real-time output streaming to external consumers.
+pty_tap: ?*termio.PtyTap = null,
+
 /// Last time the cursor was reset. This is used to prevent message
 /// flooding with cursor resets.
 last_cursor_reset: ?std.time.Instant = null,
@@ -327,6 +330,12 @@ pub fn deinit(self: *Termio) void {
 
     // Clear any StreamHandler state
     self.terminal_stream.deinit();
+
+    // Clean up PTY tap if allocated
+    if (self.pty_tap) |tap| {
+        tap.deinit();
+        self.pty_tap = null;
+    }
 
     // Clear any initial state if we have it
     if (self.thread_enter_state) |v| v.destroy();
@@ -676,11 +685,28 @@ pub fn focusGained(self: *Termio, td: *ThreadData, focused: bool) !void {
 /// call with pty data but it is also called by the read thread when using
 /// an exec subprocess.
 pub fn processOutput(self: *Termio, buf: []const u8) void {
+    // Copy raw PTY data to tap buffer before any processing.
+    // This must be done before the renderer lock to avoid contention.
+    if (self.pty_tap) |tap| {
+        tap.write(buf);
+    }
+
     // We are modifying terminal state from here on out and we need
     // the lock to grab our read data.
     self.renderer_state.mutex.lock();
     defer self.renderer_state.mutex.unlock();
     self.processOutputLocked(buf);
+}
+
+/// Returns the PTY master file descriptor if available (exec backend only).
+pub fn getPtyMasterFd(self: *Termio) ?std.posix.fd_t {
+    switch (self.backend) {
+        .exec => |*exec| {
+            if (exec.subprocess.pty) |*pty| return pty.master;
+            return null;
+        },
+        else => return null,
+    }
 }
 
 /// Process output from readdata but the lock is already held.

--- a/src/termio/pty_tap.zig
+++ b/src/termio/pty_tap.zig
@@ -1,0 +1,87 @@
+//! A lock-free SPSC (single-producer, single-consumer) ring buffer for
+//! tapping raw PTY output. The producer is the PTY read path and the
+//! consumer is an external reader (e.g. a bridge server streaming terminal
+//! data to a mobile client).
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+
+pub const PtyTap = struct {
+    buf: []u8,
+    capacity: usize,
+    head: std.atomic.Value(usize),
+    tail: std.atomic.Value(usize),
+    active: std.atomic.Value(bool),
+    alloc: Allocator,
+
+    pub fn init(alloc: Allocator, capacity: usize) !*PtyTap {
+        const self = try alloc.create(PtyTap);
+        self.* = .{
+            .buf = try alloc.alloc(u8, capacity),
+            .capacity = capacity,
+            .head = std.atomic.Value(usize).init(0),
+            .tail = std.atomic.Value(usize).init(0),
+            .active = std.atomic.Value(bool).init(false),
+            .alloc = alloc,
+        };
+        return self;
+    }
+
+    pub fn deinit(self: *PtyTap) void {
+        const alloc = self.alloc;
+        alloc.free(self.buf);
+        alloc.destroy(self);
+    }
+
+    /// Producer: write data to the ring buffer. Drops oldest data on overflow.
+    /// Only called from the PTY read thread (single producer).
+    pub fn write(self: *PtyTap, data: []const u8) void {
+        if (!self.active.load(.acquire)) return;
+        if (data.len == 0) return;
+
+        var head = self.head.load(.monotonic);
+        const tail = self.tail.load(.acquire);
+        const cap = self.capacity;
+
+        for (data) |byte| {
+            self.buf[head % cap] = byte;
+            head +%= 1;
+        }
+
+        // If we wrote more than capacity, advance tail to drop oldest.
+        // Safe because we are the only producer — no CAS needed.
+        const written_ahead = head -% tail;
+        if (written_ahead > cap) {
+            self.tail.store(head -% cap, .release);
+        }
+
+        self.head.store(head, .release);
+    }
+
+    /// Consumer: read available data from the ring buffer. Returns bytes read.
+    /// Only called from the socket handler thread (single consumer).
+    pub fn read(self: *PtyTap, out: []u8) usize {
+        const tail = self.tail.load(.acquire);
+        const head = self.head.load(.acquire);
+
+        if (head == tail) return 0;
+
+        const avail = head -% tail;
+        const to_read = @min(avail, out.len);
+        const cap = self.capacity;
+
+        var i: usize = 0;
+        while (i < to_read) : (i += 1) {
+            out[i] = self.buf[(tail +% i) % cap];
+        }
+
+        self.tail.store(tail +% to_read, .release);
+        return to_read;
+    }
+
+    /// Returns number of bytes available to read.
+    pub fn available(self: *PtyTap) usize {
+        const tail = self.tail.load(.acquire);
+        const head = self.head.load(.acquire);
+        return head -% tail;
+    }
+};


### PR DESCRIPTION
## Summary

**What changed?**

Added a PTY output tap mechanism that allows external consumers to read raw terminal output in real time. This is implemented as a lock-free SPSC ring buffer that copies PTY data before it reaches the terminal parser, with zero overhead when no tap is active.

New C API functions:
- `ghostty_surface_pty_tap_open(surface, buffer_size)` — allocate ring buffer and start tapping
- `ghostty_surface_pty_tap_read(surface, buf, max_len)` — read available bytes (non-blocking)
- `ghostty_surface_pty_tap_close(surface)` — stop tapping and free buffer
- `ghostty_surface_pty_write(surface, buf, len)` — write raw bytes to PTY master fd

**Why?**

Enables real-time terminal access for external tools — remote viewers, session recording, accessibility clients, testing harnesses, etc. This is the foundation for addressing cmux feature requests for remote/mobile terminal access (manaflow-ai/cmux#2587, manaflow-ai/cmux#1037, manaflow-ai/cmux#870).

The tap inserts a single null-pointer check in `processOutput()` before the renderer mutex lock. When no tap is active, this is branch-predicted away with zero measurable cost.

## Files changed

| File | Change |
|------|--------|
| `src/termio/pty_tap.zig` | **New.** Lock-free SPSC ring buffer (~85 lines) |
| `src/termio/Termio.zig` | Added `pty_tap` field, tap write in `processOutput()`, cleanup in `deinit()`, and `getPtyMasterFd()` method |
| `src/termio.zig` | Module re-export for `PtyTap` |
| `src/apprt/embedded.zig` | 4 exported C API functions |
| `include/ghostty.h` | C declarations for the 4 new functions |

## Testing

- Built xcframework with `zig build -Demit-xcframework=true -Doptimize=ReleaseFast` — compiles cleanly
- Linked against cmux tagged dev build — `surface.stream` command uses all 4 API functions successfully
- Verified zero overhead: ran terminal with no tap active, confirmed no performance regression
- Verified tap correctness: raw PTY bytes captured match terminal output (ANSI sequences preserved)
- Verified cleanup: tap close frees buffer, `Termio.deinit()` cleans up orphaned taps

## Design notes

- **Ring buffer overflow:** oldest data silently dropped when buffer fills — correct for real-time streaming where consumers that fall behind should see latest data
- **Thread safety:** SPSC with atomic head/tail. Producer = Ghostty IO thread, consumer = external thread. No mutex needed.
- **PTY write:** Direct `write()` to master fd. Thread-safe per POSIX guarantees (atomic up to PIPE_BUF)
- **Memory safety:** `Termio.deinit()` cleans up any allocated tap to prevent leaks

## Checklist

- [x] Tested locally with tagged cmux dev build
- [x] No existing tests broken
- [x] Zero overhead when tap is inactive
- [x] All new API functions documented in header
- [x] Memory leak prevention in Termio.deinit()

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a PTY output tap for real-time terminal streaming. External tools can read raw PTY bytes and write input with zero overhead when the tap is inactive.

- New Features
  - Lock-free SPSC ring buffer `PtyTap` mirrors PTY output; oldest data drops on overflow.
  - Tap write happens in `Termio.processOutput()` before the renderer lock; does nothing when no tap is set.
  - New C API: `ghostty_surface_pty_tap_open(surface, buffer_size)`, `ghostty_surface_pty_tap_read(surface, buf, max_len)`, `ghostty_surface_pty_tap_close(surface)`, `ghostty_surface_pty_write(surface, buf, len)`.
  - Cleanup in `Termio.deinit()`, `termio.PtyTap` re-export, and `getPtyMasterFd()` added for safe direct writes.

<sup>Written for commit f936eb1e4050c6ce34b918443c2c00c491a8cbd7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PTY tap streaming interface to the embedding API for real-time access to terminal I/O.
  * Enables opening a configurable buffer tap on output and reading available bytes non-blockingly.
  * Added capability to write raw bytes directly to PTY input.
  * Includes tap lifecycle management through open, read, and close operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->