### PR TITLE
fix(macos): auto-scroll when dragging selection beyond viewport

### DIFF
--- a/macos/Sources/Ghostty/Surface View/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/Surface View/SurfaceView_AppKit.swift
@@ -216,6 +216,11 @@ extension Ghostty {
         private var markedText: NSMutableAttributedString
         private(set) var focused: Bool = true
         private var prevPressureStage: Int = 0
+
+        // Auto-scroll state for drag selection beyond viewport
+        private var autoScrollTimer: Timer?
+        private var autoScrollUp: Bool = false
+        private var lastDragEvent: NSEvent?
         private var appearanceObserver: NSKeyValueObservation?
 
         // This is set to non-null during keyDown to accumulate insertText contents
@@ -854,6 +859,8 @@ extension Ghostty {
         }
 
         override func mouseUp(with event: NSEvent) {
+            stopAutoScroll()
+
             // Always reset our pressure when the mouse goes up
             prevPressureStage = 0
 
@@ -980,6 +987,16 @@ extension Ghostty {
 
         override func mouseDragged(with event: NSEvent) {
             self.mouseMoved(with: event)
+            lastDragEvent = event
+
+            let pos = self.convert(event.locationInWindow, from: nil)
+            let viewY = frame.height - pos.y
+
+            if viewY < 0 || viewY > frame.height {
+                startAutoScroll(scrollUp: viewY < 0)
+            } else {
+                stopAutoScroll()
+            }
         }
 
         override func rightMouseDragged(with event: NSEvent) {
@@ -988,6 +1005,44 @@ extension Ghostty {
 
         override func otherMouseDragged(with event: NSEvent) {
             self.mouseMoved(with: event)
+        }
+
+        // MARK: - Auto-scroll during drag selection
+
+        private func startAutoScroll(scrollUp: Bool) {
+            // Already running in the same direction
+            if autoScrollTimer != nil && autoScrollUp == scrollUp { return }
+            stopAutoScroll()
+            autoScrollUp = scrollUp
+
+            autoScrollTimer = Timer.scheduledTimer(withTimeInterval: 0.05, repeats: true) { [weak self] _ in
+                guard let self, let surfaceModel = self.surfaceModel else { return }
+
+                let scrollY: Double = scrollUp ? 1.0 : -1.0
+                let scrollEvent = Ghostty.Input.MouseScrollEvent(
+                    x: 0,
+                    y: scrollY,
+                    mods: .init(precision: false, momentum: .none)
+                )
+                surfaceModel.sendMouseScroll(scrollEvent)
+
+                // Re-send mouse position so selection extends while scrolling
+                if let lastEvent = self.lastDragEvent {
+                    let pos = self.convert(lastEvent.locationInWindow, from: nil)
+                    let mouseEvent = Ghostty.Input.MousePosEvent(
+                        x: pos.x,
+                        y: self.frame.height - pos.y,
+                        mods: .init(nsFlags: lastEvent.modifierFlags)
+                    )
+                    surfaceModel.sendMousePos(mouseEvent)
+                }
+            }
+        }
+
+        private func stopAutoScroll() {
+            autoScrollTimer?.invalidate()
+            autoScrollTimer = nil
+            lastDragEvent = nil
         }
 
         override func scrollWheel(with event: NSEvent) {

--- a/macos/Sources/Ghostty/Surface View/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/Surface View/SurfaceView_AppKit.swift
@@ -433,6 +433,9 @@ extension Ghostty {
 
             // Cancel progress report timer
             progressReportTimer?.invalidate()
+
+            // Cancel auto-scroll timer
+            stopAutoScroll()
         }
 
         func focusDidChange(_ focused: Bool) {
@@ -987,13 +990,13 @@ extension Ghostty {
 
         override func mouseDragged(with event: NSEvent) {
             self.mouseMoved(with: event)
-            lastDragEvent = event
 
             let pos = self.convert(event.locationInWindow, from: nil)
             let viewY = frame.height - pos.y
 
             if viewY < 0 || viewY > frame.height {
                 startAutoScroll(scrollUp: viewY < 0)
+                lastDragEvent = event
             } else {
                 stopAutoScroll()
             }
@@ -1015,7 +1018,7 @@ extension Ghostty {
             stopAutoScroll()
             autoScrollUp = scrollUp
 
-            autoScrollTimer = Timer.scheduledTimer(withTimeInterval: 0.05, repeats: true) { [weak self] _ in
+            let timer = Timer(timeInterval: 0.05, repeats: true) { [weak self] _ in
                 guard let self, let surfaceModel = self.surfaceModel else { return }
 
                 let scrollY: Double = scrollUp ? 1.0 : -1.0
@@ -1037,6 +1040,8 @@ extension Ghostty {
                     surfaceModel.sendMousePos(mouseEvent)
                 }
             }
+            RunLoop.main.add(timer, forMode: .common)
+            autoScrollTimer = timer
         }
 
         private func stopAutoScroll() {

--- a/macos/Sources/Ghostty/Surface View/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/Surface View/SurfaceView_AppKit.swift
@@ -1012,6 +1012,8 @@ extension Ghostty {
 
         // MARK: - Auto-scroll during drag selection
 
+        /// Starts a repeating timer that sends synthetic scroll and mouse position
+        /// events so the selection extends while the cursor is held outside the viewport.
         private func startAutoScroll(scrollUp: Bool) {
             // Already running in the same direction
             if autoScrollTimer != nil && autoScrollUp == scrollUp { return }
@@ -1044,6 +1046,7 @@ extension Ghostty {
             autoScrollTimer = timer
         }
 
+        /// Invalidates the auto-scroll timer and clears associated drag state.
         private func stopAutoScroll() {
             autoScrollTimer?.invalidate()
             autoScrollTimer = nil


### PR DESCRIPTION
## Summary

- When selecting text by dragging, moving the cursor above or below the terminal viewport now auto-scrolls so users can select text beyond the visible area
- Previously `mouseDragged` only forwarded the position to Ghostty core with no scroll behavior — selecting was limited to the currently visible content

## Implementation

- Added a repeating timer (50ms) in `mouseDragged` that sends scroll events + updates selection position while the cursor is outside the view bounds
- Timer direction changes correctly when dragging switches from up to down (or vice versa)
- Timer stops on `mouseUp` or when cursor returns to the viewport

## Test plan

- [ ] Select text by clicking and dragging down past the bottom edge — terminal should scroll down while extending selection
- [ ] Same for dragging up past the top edge — should scroll up
- [ ] Drag down past edge, then move cursor back up past top edge without releasing — scroll direction should reverse
- [ ] Release mouse button — scrolling should stop immediately
- [ ] Normal drag selection within viewport should work as before

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables auto-scroll when dragging a text selection past the top or bottom of the terminal on macOS, letting you select beyond the visible area. Fixes the previous limit to on-screen content.

- **Bug Fixes**
  - Start auto-scroll during drag when the cursor exits the viewport; extend selection as it scrolls.
  - Reverse direction when crossing edges; stop on mouse up, re-entering the view, or lifecycle cleanup.
  - Use a 50ms timer to send scroll and position updates; don't restart if direction is unchanged; in-viewport drags are unchanged.

- **Refactors**
  - Added docstrings to auto-scroll helpers for clarity and future maintenance.

<sup>Written for commit f0a063aa2c1578041cbae70a02dcb9fc6208ee6d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced macOS text selection with auto-scrolling when dragging beyond the visible top or bottom, allowing seamless selection across the document. Auto-scroll smoothly continues selection while scrolling and adapts when scrolling direction changes.
* **Bug Fixes**
  * Auto-scroll reliably stops when the drag ends or the view is closed, preventing unintended scrolling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->