### PR TITLE
build: skip xcframework-* tags in version detection

### DIFF
--- a/src/build/Config.zig
+++ b/src/build/Config.zig
@@ -266,8 +266,11 @@ pub fn init(b: *std.Build, appVersion: []const u8, libVersion: []const u8) !Conf
             else => return err,
         };
         if (vsn.tag) |tag| {
-            // Tip releases behave just like any other pre-release so we skip.
-            if (!std.mem.eql(u8, tag, "tip")) {
+            // Tip releases and xcframework tags behave just like any other
+            // pre-release so we skip.
+            if (!std.mem.eql(u8, tag, "tip") and
+                !std.mem.startsWith(u8, tag, "xcframework-"))
+            {
                 const expected = b.fmt("v{d}.{d}.{d}", .{
                     app_version.major,
                     app_version.minor,


### PR DESCRIPTION
Fixes CI panic: upstream Config.zig panics on non-vX.Y.Z tags, but our build-ghosttykit creates xcframework-* tags.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip `xcframework-*` git tags in version detection to prevent CI panics on non-`vX.Y.Z` tags. These tags are now treated like `tip`, so only semver tags trigger the version check.

<sup>Written for commit a30bfbd07b13ed8b234f393e665006dbcf7c5d80. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed version-tag validation to properly recognize framework-specific tags, preventing potential errors during configuration initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->