### PR TITLE
build: add cli-helper step for cmux CI

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -58,6 +58,7 @@ pub fn build(b: *std.Build) !void {
 
     // All our steps which we'll hook up later. The steps are shown
     // up here just so that they are more self-documenting.
+    const cli_helper_step = b.step("cli-helper", "Build the Ghostty CLI helper");
     const run_step = b.step("run", "Run the app");
     const run_valgrind_step = b.step(
         "run-valgrind",
@@ -83,6 +84,7 @@ pub fn build(b: *std.Build) !void {
 
     // Ghostty executable, the actual runnable Ghostty program.
     const exe = try buildpkg.GhosttyExe.init(b, &config, &deps);
+    cli_helper_step.dependOn(&exe.install_step.step);
 
     // Ghostty docs
     const docs = try buildpkg.GhosttyDocs.init(b, &deps);


### PR DESCRIPTION
cmux CI builds the Ghostty CLI helper via 'zig build cli-helper'. Add the step.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a `cli-helper` build step to support cmux CI. It builds the Ghostty CLI helper via `zig build cli-helper` and depends on the executable install step.

<sup>Written for commit 7be05f894d5dba504d6e64f7fecfc412fe5a94ed. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated CLI helper into the build and installation workflow, making it available alongside the main executable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->