### PR TITLE
v1.3.1 base + cmux patches (cli-helper, xcframework tag, zig 0.15.2 compat)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -36,6 +36,7 @@ pub fn build(b: *std.Build) !void {
     // All our steps which we'll hook up later. The steps are shown
     // up here just so that they are more self-documenting.
     const libvt_step = b.step("lib-vt", "Build libghostty-vt");
+    const cli_helper_step = b.step("cli-helper", "Build the Ghostty CLI helper");
     const run_step = b.step("run", "Run the app");
     const run_valgrind_step = b.step(
         "run-valgrind",
@@ -61,6 +62,7 @@ pub fn build(b: *std.Build) !void {
 
     // Ghostty executable, the actual runnable Ghostty program.
     const exe = try buildpkg.GhosttyExe.init(b, &config, &deps);
+    cli_helper_step.dependOn(&exe.install_step.step);
 
     // Ghostty docs
     const docs = try buildpkg.GhosttyDocs.init(b, &deps);

--- a/src/build/Config.zig
+++ b/src/build/Config.zig
@@ -244,8 +244,11 @@ pub fn init(b: *std.Build, appVersion: []const u8) !Config {
             else => return err,
         };
         if (vsn.tag) |tag| {
-            // Tip releases behave just like any other pre-release so we skip.
-            if (!std.mem.eql(u8, tag, "tip")) {
+            // Tip releases and xcframework tags behave just like any other
+            // pre-release so we skip.
+            if (!std.mem.eql(u8, tag, "tip") and
+                !std.mem.startsWith(u8, tag, "xcframework-"))
+            {
                 const expected = b.fmt("v{d}.{d}.{d}", .{
                     app_version.major,
                     app_version.minor,

--- a/src/main_ghostty.zig
+++ b/src/main_ghostty.zig
@@ -72,7 +72,8 @@ pub fn main() !MainReturn {
     }
 
     if (comptime build_config.app_runtime == .none) {
-        const stdout = std.io.getStdOut().writer();
+        const stdout_file: std.fs.File = .{ .handle = std.posix.STDOUT_FILENO };
+        const stdout = stdout_file.deprecatedWriter();
         try stdout.print("Usage: ghostty +<action> [flags]\n\n", .{});
         try stdout.print(
             \\This is the Ghostty helper CLI that accompanies the graphical Ghostty app.


### PR DESCRIPTION
Clean v1.3.1 base with 3 cmux patches. Fixes zig 0.15.2 std.io.getStdOut removal.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates Ghostty to the v1.3.1 base with three cmux patches. Adds a `cli-helper` build step, skips `xcframework-*` tags in version checks, and restores Zig 0.15.2 compatibility.

- **Bug Fixes**
  - Zig 0.15.2: replace `std.io.getStdOut()` with `deprecatedWriter()` on `STDOUT_FILENO` for CLI usage output.
  - Version detection: treat `xcframework-*` tags like pre-releases and skip strict version checks.

- **Refactors**
  - Build: add `cli-helper` step that depends on the exe install step (for cmux CI).

<sup>Written for commit fc59b46ba67787e4fd6ad0de63e5e469592d3eae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build system infrastructure with improved step integration
  * Updated version tag validation for framework-specific builds

<!-- end of auto-generated comment: release notes by coderabbit.ai -->