### PR TITLE
Reset to clean v1.3.1 + cmux patches

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -36,6 +36,7 @@ pub fn build(b: *std.Build) !void {
     // All our steps which we'll hook up later. The steps are shown
     // up here just so that they are more self-documenting.
     const libvt_step = b.step("lib-vt", "Build libghostty-vt");
+    const cli_helper_step = b.step("cli-helper", "Build the Ghostty CLI helper");
     const run_step = b.step("run", "Run the app");
     const run_valgrind_step = b.step(
         "run-valgrind",
@@ -61,6 +62,7 @@ pub fn build(b: *std.Build) !void {
 
     // Ghostty executable, the actual runnable Ghostty program.
     const exe = try buildpkg.GhosttyExe.init(b, &config, &deps);
+    cli_helper_step.dependOn(&exe.install_step.step);
 
     // Ghostty docs
     const docs = try buildpkg.GhosttyDocs.init(b, &deps);

--- a/src/build/Config.zig
+++ b/src/build/Config.zig
@@ -244,8 +244,11 @@ pub fn init(b: *std.Build, appVersion: []const u8) !Config {
             else => return err,
         };
         if (vsn.tag) |tag| {
-            // Tip releases behave just like any other pre-release so we skip.
-            if (!std.mem.eql(u8, tag, "tip")) {
+            // Tip releases and xcframework tags behave just like any other
+            // pre-release so we skip.
+            if (!std.mem.eql(u8, tag, "tip") and
+                !std.mem.startsWith(u8, tag, "xcframework-"))
+            {
                 const expected = b.fmt("v{d}.{d}.{d}", .{
                     app_version.major,
                     app_version.minor,

--- a/src/main_ghostty.zig
+++ b/src/main_ghostty.zig
@@ -72,7 +72,8 @@ pub fn main() !MainReturn {
     }
 
     if (comptime build_config.app_runtime == .none) {
-        const stdout = std.io.getStdOut().writer();
+        const stdout_file: std.fs.File = .{ .handle = std.posix.STDOUT_FILENO };
+        const stdout = stdout_file.deprecatedWriter();
         try stdout.print("Usage: ghostty +<action> [flags]\n\n", .{});
         try stdout.print(
             \\This is the Ghostty helper CLI that accompanies the graphical Ghostty app.


### PR DESCRIPTION
Replaces the broken upstream merge with clean v1.3.1 + 3 cmux patches (xcframework tag fix, cli-helper step, zig 0.15.2 compat).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resets to clean v1.3.1 and applies cmux patches to stabilize version detection, CI builds, and Zig 0.15.2 compatibility.

- **Bug Fixes**
  - Skip `xcframework-*` tags in version checks to prevent false mismatches.
  - Add a `cli-helper` build step and hook it to the executable install step for CI.
  - Use `deprecatedWriter` for helper CLI stdout to work with Zig 0.15.2.

<sup>Written for commit fc59b46ba67787e4fd6ad0de63e5e469592d3eae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized build process for CLI tool artifact generation and installation workflow.
  * Enhanced version tag validation to properly handle pre-release identifiers and framework-specific build configurations.
  * Refined output handling in non-graphical build environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->