### PR TITLE
fix: zig 0.15.2 compat for std.io.getStdOut

### DIFF
--- a/src/main_ghostty.zig
+++ b/src/main_ghostty.zig
@@ -72,7 +72,7 @@ pub fn main() !MainReturn {
     }
 
     if (comptime build_config.app_runtime == .none) {
-        const stdout = std.io.getStdOut().writer();
+        const stdout = (std.fs.File{ .handle = std.posix.STDOUT_FILENO }).deprecatedWriter();
         try stdout.print("Usage: ghostty +<action> [flags]\n\n", .{});
         try stdout.print(
             \\This is the Ghostty helper CLI that accompanies the graphical Ghostty app.


### PR DESCRIPTION
std.io.getStdOut() was removed in zig 0.15.2. Use deprecatedWriter() instead.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Zig 0.15.2 compatibility by replacing `std.io.getStdOut().writer()` with `(std.fs.File{ .handle = std.posix.STDOUT_FILENO }).deprecatedWriter()` for stdout in the Ghostty helper CLI. This ensures the usage message prints correctly after the API removal.

<sup>Written for commit 97b8b8faa2ed017b93a26f6353599eb3cb6ad749. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

