### PR TITLE
Fix use-after-free in copy-on-select mouse release path

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -2363,7 +2363,13 @@ fn copySelectionToClipboards(
 ///
 /// This must be called with the renderer mutex held.
 fn setSelection(self: *Surface, sel_: ?terminal.Selection) !void {
+    // Evaluate equality BEFORE Screen.select() frees the old tracked
+    // pins. Screen.select() calls old.deinit() which returns tracked
+    // pin memory to the pool; reading prev after that is a
+    // use-after-free that usually (but not always) compares equal,
+    // silently skipping the clipboard copy.
     const prev_ = self.io.terminal.screens.active.selection;
+    const same = if (prev_) |prev| if (sel_) |sel| sel.eql(prev) else false else false;
     try self.io.terminal.screens.active.select(sel_);
 
     // If copy on select is false then exit early.
@@ -2374,7 +2380,7 @@ fn setSelection(self: *Surface, sel_: ?terminal.Selection) !void {
     // again if it changed, since setting the clipboard can be an expensive
     // operation.
     const sel = sel_ orelse return;
-    if (prev_) |prev| if (sel.eql(prev)) return;
+    if (same) return;
 
     switch (self.config.copy_on_select) {
         .false => unreachable, // handled above with an early exit
@@ -3834,19 +3840,35 @@ pub fn mouseButtonCallback(
             );
         }
 
-        // The selection clipboard is only updated for left-click drag when
-        // the left button is released. This is to avoid the clipboard
-        // being updated on every mouse move which would be noisy.
+        // Copy the final selection to the clipboard on mouse-up.
+        // During a drag, mouseDrag → setSelection is called on every
+        // move, but the eql() optimisation skips redundant clipboard
+        // writes while the selection end-point matches the previous
+        // one.  On release we do a direct copy of the tracked
+        // selection to guarantee the clipboard is up-to-date.
         if (self.config.copy_on_select != .false) {
             self.renderer_state.mutex.lock();
             defer self.renderer_state.mutex.unlock();
-            const prev_ = self.io.terminal.screens.active.selection;
-            if (prev_) |prev| {
-                try self.setSelection(terminal.Selection.init(
-                    prev.start(),
-                    prev.end(),
-                    prev.rectangle,
-                ));
+            if (self.io.terminal.screens.active.selection) |sel| {
+                switch (self.config.copy_on_select) {
+                    .false => unreachable,
+                    .clipboard => try self.copySelectionToClipboards(
+                        sel,
+                        &.{ .standard, .selection },
+                        .mixed,
+                    ),
+                    .true => {
+                        const clipboard: apprt.Clipboard = if (self.rt_surface.supportsClipboard(.selection))
+                            .selection
+                        else
+                            .standard;
+                        try self.copySelectionToClipboards(
+                            sel,
+                            &.{clipboard},
+                            .mixed,
+                        );
+                    },
+                }
             }
         }
 


### PR DESCRIPTION
## Summary

- Fix a use-after-free bug in `mouseButtonCallback` that silently skips `copySelectionToClipboards` on mouse release after a drag selection
- Bypass the `setSelection()` eql optimization by reading the existing tracked selection and copying to clipboard directly

## Problem

When the left mouse button is released after a drag selection, the mouse release handler calls `setSelection()` with a new untracked `Selection` built from the existing tracked selection's `start()`/`end()`.

Inside `setSelection()`:
1. `Screen.select()` **frees the old tracked pins** via `old.deinit(self)`
2. The optimization `if (prev_) |prev| if (sel.eql(prev)) return;` then **dereferences the freed `prev` pointer** (use-after-free)
3. Since freed memory pool slots usually retain their old values, `eql()` returns `true`
4. `copySelectionToClipboards` is never called

The bug is intermittent: when the pool happens to reuse the freed slots before the `eql` check, the comparison fails and the copy succeeds.

## Fix

The mouse release path doesn't need to change the selection — it only needs to copy it to the clipboard. Read the existing tracked selection directly and call `copySelectionToClipboards`, bypassing `setSelection()` entirely.

Fixes manaflow-ai/cmux#2664

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a use-after-free in selection handling and ensures copy-on-select always updates the clipboard on mouse release.

- **Bug Fixes**
  - In `setSelection()`, evaluate `eql` before `Screen.select()` frees the old pins to avoid dereferencing a freed `prev`.
  - On left-button release after a drag, copy the tracked selection via `copySelectionToClipboards`, honoring `copy_on_select` (`.clipboard` copies to both `.standard` and `.selection`; `.true` prefers `.selection` with fallback to `.standard`).

<sup>Written for commit 8eaee4d950d7dee24003e44b454060679e1b521a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a race that could skip clipboard updates after selection changes, ensuring selection equality is checked safely before proceeding.
  * Improved mouse-release behavior so the active selection is consistently copied to the correct clipboards according to user settings and system support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->