### PR TITLE
Add ghostty_config_set_color_scheme C API

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1073,6 +1073,8 @@ GHOSTTY_API void ghostty_config_load_file(ghostty_config_t, const char*);
 GHOSTTY_API void ghostty_config_load_default_files(ghostty_config_t);
 GHOSTTY_API void ghostty_config_load_recursive_files(ghostty_config_t);
 GHOSTTY_API void ghostty_config_finalize(ghostty_config_t);
+GHOSTTY_API void ghostty_config_set_color_scheme(ghostty_config_t,
+                                                    ghostty_color_scheme_e);
 GHOSTTY_API bool ghostty_config_get(ghostty_config_t, void*, const char*, uintptr_t);
 GHOSTTY_API ghostty_input_trigger_s ghostty_config_trigger(ghostty_config_t,
                                                               const char*,

--- a/src/config/CApi.zig
+++ b/src/config/CApi.zig
@@ -3,6 +3,7 @@ const inputpkg = @import("../input.zig");
 const state = &@import("../global.zig").state;
 const c = @import("../main_c.zig");
 
+const conditional = @import("conditional.zig");
 const Config = @import("Config.zig");
 const c_get = @import("c_get.zig");
 const edit = @import("edit.zig");
@@ -86,6 +87,24 @@ export fn ghostty_config_load_recursive_files(self: *Config) void {
 export fn ghostty_config_finalize(self: *Config) void {
     self.finalize() catch |err| {
         log.err("error finalizing config err={}", .{err});
+    };
+}
+
+/// Set the color scheme on a configuration's conditional state before
+/// finalization. This ensures that conditional theme resolution (e.g.
+/// `theme = light:Foo,dark:Bar`) uses the correct scheme during
+/// `ghostty_config_finalize`. Must be called before finalize.
+export fn ghostty_config_set_color_scheme(self: *Config, scheme_raw: c_int) void {
+    self._conditional_state.theme = switch (scheme_raw) {
+        0 => .light,
+        1 => .dark,
+        else => {
+            log.warn(
+                "invalid color scheme to ghostty_config_set_color_scheme value={}",
+                .{scheme_raw},
+            );
+            return;
+        },
     };
 }
 


### PR DESCRIPTION
## Summary

Adds a new C API function `ghostty_config_set_color_scheme` that allows setting the config's conditional theme state before finalization.

## Why

Without this, `ghostty_config_finalize` always uses `ConditionalState.theme = .light` (the Zig struct default) to resolve conditional theme configs like `theme = light:Foo,dark:Bar`. Apps end up loading the light theme colors even when the system is in dark mode, and the background/foreground state can only be corrected after a surface color scheme change triggers a cascade re-derivation — which has race conditions and doesn't fully update the app-level default background color used by embedding apprts.

With this API, embedders can set the scheme before finalization so the config resolves the correct theme from the start.

## Test plan

- [ ] Verify `ghostty_config_set_color_scheme(config, GHOSTTY_COLOR_SCHEME_DARK)` before `ghostty_config_finalize(config)` results in the config loading dark theme conditional values
- [ ] Verify `ghostty_config_set_color_scheme(config, GHOSTTY_COLOR_SCHEME_LIGHT)` loads light theme conditional values
- [ ] Invalid scheme values emit a warning and don't modify state

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a C API to set the config’s color scheme before finalization so conditional themes resolve correctly from the start. This prevents apps from defaulting to light colors when the system is in dark mode.

- **New Features**
  - Added ghostty_config_set_color_scheme(ghostty_config_t, ghostty_color_scheme_e) to set the conditional theme used during ghostty_config_finalize.
  - Invalid scheme values log a warning and do not change state.

- **Migration**
  - Call ghostty_config_set_color_scheme(config, GHOSTTY_COLOR_SCHEME_DARK or GHOSTTY_COLOR_SCHEME_LIGHT) before ghostty_config_finalize(config).

<sup>Written for commit e0f6eba3d0d00bb6d312d1e65e5b868de4e9c89c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a public API function to set color schemes on application configurations, allowing users to directly specify light or dark color scheme preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->