### PR TITLE
feat(termio): add ghostty_surface_set_pty_tap for cmux remote mirroring

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1162,6 +1162,21 @@ GHOSTTY_API bool ghostty_surface_read_text(ghostty_surface_t,
                                               ghostty_text_s*);
 GHOSTTY_API void ghostty_surface_free_text(ghostty_surface_t, ghostty_text_s*);
 
+// cmux fork: raw-PTY tap callback. Fires on Ghostty's IO thread immediately
+// before the terminal stream parser consumes each chunk of bytes. Used by
+// cmux to fan out the byte stream to remote (mobile) mirror clients.
+//
+// The callback MUST be cheap, non-blocking, and allocation-free in the steady
+// state. It may be invoked from any thread; specifically, it runs on the IO
+// thread that owns the PTY read loop.
+//
+// Pass `fn = NULL` to clear the tap. Pass non-NULL to install. Only one tap
+// per surface; setting overwrites any previous tap.
+typedef void (*ghostty_pty_tap_fn)(void* user_data, const uint8_t* bytes, size_t len);
+GHOSTTY_API void ghostty_surface_set_pty_tap(ghostty_surface_t,
+                                             ghostty_pty_tap_fn,
+                                             void* user_data);
+
 #ifdef __APPLE__
 GHOSTTY_API void ghostty_surface_set_display_id(ghostty_surface_t, uint32_t);
 GHOSTTY_API void* ghostty_surface_quicklook_font(ghostty_surface_t);

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1836,7 +1836,7 @@ pub const CAPI = struct {
     /// to remote (mobile) mirror clients. Pass `fn_ptr = null` to clear.
     export fn ghostty_surface_set_pty_tap(
         surface: *Surface,
-        fn_ptr: ?*const fn (?*anyopaque, [*]const u8, usize) callconv(.C) void,
+        fn_ptr: ?*const fn (?*anyopaque, [*]const u8, usize) callconv(.c) void,
         ud: ?*anyopaque,
     ) void {
         surface.core_surface.io.pty_tap = fn_ptr;

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1830,6 +1830,19 @@ pub const CAPI = struct {
         surface.preeditCallback(if (len == 0) null else ptr[0..len]);
     }
 
+    /// cmux fork: install a raw-PTY tap callback on the surface. The callback
+    /// fires on Ghostty's IO thread immediately before the terminal stream
+    /// parser consumes each chunk. cmux uses this to fan out the byte stream
+    /// to remote (mobile) mirror clients. Pass `fn_ptr = null` to clear.
+    export fn ghostty_surface_set_pty_tap(
+        surface: *Surface,
+        fn_ptr: ?*const fn (?*anyopaque, [*]const u8, usize) callconv(.C) void,
+        ud: ?*anyopaque,
+    ) void {
+        surface.core_surface.io.pty_tap = fn_ptr;
+        surface.core_surface.io.pty_tap_userdata = ud;
+    }
+
     /// Returns true if the surface currently has mouse capturing
     /// enabled.
     export fn ghostty_surface_mouse_captured(surface: *Surface) bool {

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -1332,6 +1332,9 @@ pub const ReadThread = struct {
                 if (n == 0) break;
 
                 // log.info("DATA: {d}", .{n});
+                // cmux fork: tap raw PTY bytes for remote mirroring before the
+                // terminal stream parser consumes them. See Termio.pty_tap docs.
+                if (io.pty_tap) |fn_ptr| fn_ptr(io.pty_tap_userdata, buf[0..n].ptr, n);
                 @call(.always_inline, termio.Termio.processOutput, .{ io, buf[0..n] });
             }
 
@@ -1384,6 +1387,8 @@ pub const ReadThread = struct {
                     }
                 }
 
+                // cmux fork: same tap as POSIX path. See Termio.pty_tap docs.
+                if (io.pty_tap) |fn_ptr| fn_ptr(io.pty_tap_userdata, buf[0..n].ptr, n);
                 @call(.always_inline, termio.Termio.processOutput, .{ io, buf[0..n] });
             }
 

--- a/src/termio/Termio.zig
+++ b/src/termio/Termio.zig
@@ -71,6 +71,18 @@ last_cursor_reset: ?std.time.Instant = null,
 /// to keep track of any state or if its already been freed.
 thread_enter_state: ?*ThreadEnterState = null,
 
+/// cmux fork: optional raw-PTY tap callback. Fired on Ghostty's IO thread
+/// immediately before each chunk of bytes is handed to the terminal stream
+/// parser. Set via the C API `ghostty_surface_set_pty_tap` and used by cmux
+/// to fan out the byte stream to remote (mobile) mirror clients.
+///
+/// The callback runs on the IO thread and MUST be cheap, non-blocking, and
+/// allocation-free in the steady state. It receives the same bytes that the
+/// parser is about to consume — multi-byte UTF-8 sequences may split across
+/// invocations.
+pty_tap: ?*const fn (?*anyopaque, [*]const u8, usize) callconv(.C) void = null,
+pty_tap_userdata: ?*anyopaque = null,
+
 /// The state we need to keep around only until we enter the IO
 /// thread. Then we can throw it all away.
 const ThreadEnterState = struct {

--- a/src/termio/Termio.zig
+++ b/src/termio/Termio.zig
@@ -80,7 +80,7 @@ thread_enter_state: ?*ThreadEnterState = null,
 /// allocation-free in the steady state. It receives the same bytes that the
 /// parser is about to consume — multi-byte UTF-8 sequences may split across
 /// invocations.
-pty_tap: ?*const fn (?*anyopaque, [*]const u8, usize) callconv(.C) void = null,
+pty_tap: ?*const fn (?*anyopaque, [*]const u8, usize) callconv(.c) void = null,
 pty_tap_userdata: ?*anyopaque = null,
 
 /// The state we need to keep around only until we enter the IO


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PTY byte stream observation capability enabling applications to monitor raw pseudoterminal data in real-time before terminal stream processing occurs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->