### PR TITLE
Add ghostty_config_set_color_scheme C API

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1073,6 +1073,8 @@ GHOSTTY_API void ghostty_config_load_file(ghostty_config_t, const char*);
 GHOSTTY_API void ghostty_config_load_default_files(ghostty_config_t);
 GHOSTTY_API void ghostty_config_load_recursive_files(ghostty_config_t);
 GHOSTTY_API void ghostty_config_finalize(ghostty_config_t);
+GHOSTTY_API void ghostty_config_set_color_scheme(ghostty_config_t,
+                                                    ghostty_color_scheme_e);
 GHOSTTY_API bool ghostty_config_get(ghostty_config_t, void*, const char*, uintptr_t);
 GHOSTTY_API ghostty_input_trigger_s ghostty_config_trigger(ghostty_config_t,
                                                               const char*,

--- a/src/config/CApi.zig
+++ b/src/config/CApi.zig
@@ -3,6 +3,7 @@ const inputpkg = @import("../input.zig");
 const state = &@import("../global.zig").state;
 const c = @import("../main_c.zig");
 
+const conditional = @import("conditional.zig");
 const Config = @import("Config.zig");
 const c_get = @import("c_get.zig");
 const edit = @import("edit.zig");
@@ -86,6 +87,24 @@ export fn ghostty_config_load_recursive_files(self: *Config) void {
 export fn ghostty_config_finalize(self: *Config) void {
     self.finalize() catch |err| {
         log.err("error finalizing config err={}", .{err});
+    };
+}
+
+/// Set the color scheme on a configuration's conditional state before
+/// finalization. This ensures that conditional theme resolution (e.g.
+/// `theme = light:Foo,dark:Bar`) uses the correct scheme during
+/// `ghostty_config_finalize`. Must be called before finalize.
+export fn ghostty_config_set_color_scheme(self: *Config, scheme_raw: c_int) void {
+    self._conditional_state.theme = switch (scheme_raw) {
+        0 => .light,
+        1 => .dark,
+        else => {
+            log.warn(
+                "invalid color scheme to ghostty_config_set_color_scheme value={}",
+                .{scheme_raw},
+            );
+            return;
+        },
     };
 }
 


### PR DESCRIPTION
Companion to [cmux #2710](https://github.com/manaflow-ai/cmux/pull/2710) — terminal surfaces losing theme after config reload.

## Summary
Adds a new C API, `ghostty_config_set_color_scheme`, that lets embedders set the config's conditional theme state before finalization so conditional theme resolution (e.g. `theme = light:Foo,dark:Bar`) uses the correct scheme during `ghostty_config_finalize`.

## Why
Without this, finalization always uses the ConditionalState default (`.light`), causing embedded apps (cmux) to load the wrong theme colors until a surface color-scheme change triggers re-derivation. The cmux PR that depends on this API is #2710; merging this first lets the cmux side repoint its ghostty submodule back to manaflow-ai/ghostty#main instead of rod's fork.

## Test plan
- [ ] `zig build` clean
- [ ] Call `ghostty_config_set_color_scheme` from embedder before `ghostty_config_finalize`, confirm conditional `theme = light:X,dark:Y` resolves to the expected scheme
- [ ] cmux PR #2710 green once pointer bumps to this merged SHA

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `ghostty_config_set_color_scheme` C API to set the config’s color scheme before finalization so conditional themes resolve to the correct light/dark variant. Prevents wrong theme after config reload in embedders like `cmux`.

- New Features
  - New API: `ghostty_config_set_color_scheme(ghostty_config_t, ghostty_color_scheme_e)`; call before `ghostty_config_finalize` to set `.light` or `.dark` for conditional theme resolution. Invalid values are ignored with a warning; default remains `.light` if not set.

<sup>Written for commit e0f6eba3d0d00bb6d312d1e65e5b868de4e9c89c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new public API function to set color scheme preferences (light or dark) on configuration objects with input validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->