### PR TITLE
fix: flush stdout in CLI help output

### DIFF
--- a/src/main_ghostty.zig
+++ b/src/main_ghostty.zig
@@ -89,6 +89,7 @@ pub fn main() !MainReturn {
         ,
             .{},
         );
+        try stdout.flush();
 
         posix.exit(0);
     }


### PR DESCRIPTION
## Summary
- Added explicit `stdout.flush()` call before `posix.exit(0)` in CLI help output path
- Without this, help text can be silently truncated when using `deprecatedWriter`

## Test plan
- [ ] Run `ghostty +help` (or any invalid action) and verify full help text is printed
- [ ] Verify no truncation when piping output: `ghostty +help | cat`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure CLI help text prints fully by flushing stdout before exit. Prevents truncated output when output is buffered or piped.

- **Bug Fixes**
  - Call stdout.flush() before posix.exit(0) in the help path to avoid losing buffered output.

<sup>Written for commit 9c5b401b7e6c5f02891472882e8de62a782eaf2c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where help and usage information may not display properly during startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->