### PR TITLE
Add copy-mode APIs and packaging fixes for cmux

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -58,6 +58,7 @@ pub fn build(b: *std.Build) !void {
 
     // All our steps which we'll hook up later. The steps are shown
     // up here just so that they are more self-documenting.
+    const libvt_step = b.step("lib-vt", "Build libghostty-vt");
     const cli_helper_step = b.step("cli-helper", "Build the Ghostty CLI helper");
     const run_step = b.step("run", "Run the app");
     const run_valgrind_step = b.step(
@@ -129,6 +130,7 @@ pub fn build(b: *std.Build) !void {
             &mod,
         );
     };
+    libghostty_vt_shared.install(libvt_step);
     libghostty_vt_shared.install(b.getInstallStep());
 
     // libghostty-vt static lib

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1155,6 +1155,15 @@ GHOSTTY_API void ghostty_surface_complete_clipboard_request(ghostty_surface_t,
                                                                bool);
 GHOSTTY_API bool ghostty_surface_has_selection(ghostty_surface_t);
 GHOSTTY_API bool ghostty_surface_select_cursor_cell(ghostty_surface_t);
+GHOSTTY_API bool ghostty_surface_select_viewport_cell(ghostty_surface_t, uint16_t, uint16_t);
+GHOSTTY_API bool ghostty_surface_select_viewport_line_range(ghostty_surface_t, uint16_t, uint16_t, uint16_t);
+GHOSTTY_API bool ghostty_surface_extend_viewport_line_selection(ghostty_surface_t, uint16_t);
+GHOSTTY_API bool ghostty_surface_extend_viewport_selection(ghostty_surface_t, uint16_t, uint16_t);
+GHOSTTY_API bool ghostty_surface_convert_selection_to_viewport_line_mode(ghostty_surface_t);
+GHOSTTY_API bool ghostty_surface_selection_endpoint_cell(ghostty_surface_t, uint16_t*, uint16_t*);
+GHOSTTY_API bool ghostty_surface_viewport_is_top(ghostty_surface_t);
+GHOSTTY_API bool ghostty_surface_viewport_is_bottom(ghostty_surface_t);
+GHOSTTY_API bool ghostty_surface_jump_to_prompt_cell(ghostty_surface_t, int16_t, uint16_t*, uint16_t*);
 GHOSTTY_API bool ghostty_surface_clear_selection(ghostty_surface_t);
 GHOSTTY_API bool ghostty_surface_read_selection(ghostty_surface_t, ghostty_text_s*);
 GHOSTTY_API bool ghostty_surface_read_text(ghostty_surface_t,

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -2069,6 +2069,211 @@ pub fn selectCursorCell(self: *Surface) !bool {
     return true;
 }
 
+/// Start a 1-cell selection at a specific viewport cell.
+pub fn selectViewportCell(self: *Surface, x: u16, y: u16) !bool {
+    self.renderer_state.mutex.lock();
+    defer self.renderer_state.mutex.unlock();
+
+    const screen: *terminal.Screen = self.io.terminal.screens.active;
+    if (x >= screen.pages.cols or y >= screen.pages.rows) return false;
+
+    const pin = screen.pages.pin(.{ .viewport = .{ .x = x, .y = y } }) orelse return false;
+    try screen.select(terminal.Selection.init(pin, pin, false));
+    screen.dirty.selection = true;
+    try self.queueRender();
+    return true;
+}
+
+/// Start a full-line selection spanning the given viewport rows.
+pub fn selectViewportLineRange(self: *Surface, x: u16, start_y: u16, end_y: u16) !bool {
+    self.renderer_state.mutex.lock();
+    defer self.renderer_state.mutex.unlock();
+
+    const screen: *terminal.Screen = self.io.terminal.screens.active;
+    if (screen.pages.cols == 0 or screen.pages.rows == 0) return false;
+    if (x >= screen.pages.cols or start_y >= screen.pages.rows or end_y >= screen.pages.rows) return false;
+
+    const cols: u16 = @intCast(screen.pages.cols);
+    const left_x: u16 = 0;
+    const right_x: u16 = cols - 1;
+    const top_y = @min(start_y, end_y);
+    const bottom_y = @max(start_y, end_y);
+
+    const start_pin = screen.pages.pin(.{ .viewport = .{ .x = left_x, .y = top_y } }) orelse return false;
+    const end_pin = screen.pages.pin(.{ .viewport = .{ .x = right_x, .y = bottom_y } }) orelse return false;
+    const sel = terminal.Selection.init(start_pin, end_pin, false);
+
+    try screen.select(sel);
+    screen.dirty.selection = true;
+    try self.queueRender();
+    return true;
+}
+
+/// Extend an existing full-line selection while preserving its tracked anchor.
+pub fn extendViewportLineSelection(self: *Surface, end_y: u16) !bool {
+    self.renderer_state.mutex.lock();
+    defer self.renderer_state.mutex.unlock();
+
+    const screen: *terminal.Screen = self.io.terminal.screens.active;
+    if (screen.pages.cols == 0 or screen.pages.rows == 0) return false;
+    if (end_y >= screen.pages.rows) return false;
+
+    const existing = screen.selection orelse return false;
+    var anchor_pin = existing.start();
+    var current_pin = screen.pages.pin(.{
+        .viewport = .{
+            .x = 0,
+            .y = end_y,
+        },
+    }) orelse return false;
+
+    const anchor_pt = screen.pages.pointFromPin(.screen, anchor_pin) orelse return false;
+    const current_pt = screen.pages.pointFromPin(.screen, current_pin) orelse return false;
+    const right_x = screen.pages.cols - 1;
+
+    if (current_pt.screen.y < anchor_pt.screen.y) {
+        anchor_pin.x = right_x;
+    } else {
+        anchor_pin.x = 0;
+        current_pin.x = right_x;
+    }
+
+    try screen.select(terminal.Selection.init(anchor_pin, current_pin, false));
+    screen.dirty.selection = true;
+    try self.queueRender();
+    return true;
+}
+
+/// Extend an existing selection to a specific viewport cell while preserving
+/// the tracked anchor.
+pub fn extendViewportSelection(self: *Surface, x: u16, y: u16) !bool {
+    self.renderer_state.mutex.lock();
+    defer self.renderer_state.mutex.unlock();
+
+    const screen: *terminal.Screen = self.io.terminal.screens.active;
+    if (x >= screen.pages.cols or y >= screen.pages.rows) return false;
+
+    const existing = screen.selection orelse return false;
+    const current_pin = screen.pages.pin(.{ .viewport = .{ .x = x, .y = y } }) orelse return false;
+
+    try screen.select(terminal.Selection.init(existing.start(), current_pin, false));
+    screen.dirty.selection = true;
+    try self.queueRender();
+    return true;
+}
+
+/// Convert the current selection into a full-line selection while preserving
+/// the existing active end.
+pub fn convertSelectionToViewportLineMode(self: *Surface) !bool {
+    self.renderer_state.mutex.lock();
+    defer self.renderer_state.mutex.unlock();
+
+    const screen: *terminal.Screen = self.io.terminal.screens.active;
+    if (screen.pages.cols == 0 or screen.pages.rows == 0) return false;
+
+    var existing = screen.selection orelse return false;
+    var anchor_pin = existing.start();
+    var current_pin = existing.end();
+
+    const anchor_pt = screen.pages.pointFromPin(.screen, anchor_pin) orelse return false;
+    const current_pt = screen.pages.pointFromPin(.screen, current_pin) orelse return false;
+    const right_x = screen.pages.cols - 1;
+
+    if (current_pt.screen.y < anchor_pt.screen.y) {
+        anchor_pin.x = right_x;
+        current_pin.x = 0;
+    } else {
+        anchor_pin.x = 0;
+        current_pin.x = right_x;
+    }
+
+    try screen.select(terminal.Selection.init(anchor_pin, current_pin, false));
+    screen.dirty.selection = true;
+    try self.queueRender();
+    return true;
+}
+
+/// Return the active selection endpoint if it is visible in the viewport.
+pub fn selectionEndpointViewportCell(self: *Surface) ?struct { x: u16, y: u16 } {
+    self.renderer_state.mutex.lock();
+    defer self.renderer_state.mutex.unlock();
+
+    const screen: *terminal.Screen = self.io.terminal.screens.active;
+    const sel = screen.selection orelse return null;
+    const point = screen.pages.pointFromPin(.viewport, sel.end()) orelse return null;
+    if (point.viewport.y >= screen.pages.rows or point.viewport.x >= screen.pages.cols) return null;
+
+    return .{
+        .x = @intCast(point.viewport.x),
+        .y = @intCast(point.viewport.y),
+    };
+}
+
+/// Return whether the viewport is already pinned to the top of scrollback.
+pub fn viewportIsTop(self: *Surface) bool {
+    self.renderer_state.mutex.lock();
+    defer self.renderer_state.mutex.unlock();
+
+    const screen: *terminal.Screen = self.io.terminal.screens.active;
+    return screen.pages.getTopLeft(.viewport).eql(screen.pages.getTopLeft(.screen));
+}
+
+/// Return whether the viewport is already pinned to the active area.
+pub fn viewportIsBottom(self: *Surface) bool {
+    self.renderer_state.mutex.lock();
+    defer self.renderer_state.mutex.unlock();
+
+    return self.io.terminal.screens.active.viewportIsBottom();
+}
+
+/// Jump to a semantic prompt and return its viewport cell if visible.
+pub fn jumpToPromptViewportCell(
+    self: *Surface,
+    delta: i16,
+) !?struct { x: u16, y: u16 } {
+    self.renderer_state.mutex.lock();
+    defer self.renderer_state.mutex.unlock();
+
+    if (delta == 0) return null;
+
+    const screen: *terminal.Screen = self.io.terminal.screens.active;
+    const delta_abs: usize = @intCast(if (delta > 0) delta else -delta);
+
+    const start_pin = start: {
+        const tl = screen.pages.getTopLeft(.viewport);
+        const adjusted: ?terminal.Pin = if (delta > 0)
+            tl.down(1)
+        else
+            tl.up(1);
+        break :start adjusted orelse return null;
+    };
+
+    var remaining = delta_abs;
+    var prompt_pin: ?terminal.Pin = null;
+    var it = start_pin.promptIterator(
+        if (delta > 0) .right_down else .left_up,
+        null,
+    );
+    while (it.next()) |next| {
+        prompt_pin = next;
+        remaining -= 1;
+        if (remaining == 0) break;
+    }
+
+    const target = prompt_pin orelse return null;
+    screen.scroll(.{ .delta_prompt = delta });
+    screen.dirty.selection = true;
+    try self.queueRender();
+
+    const point = screen.pages.pointFromPin(.viewport, target) orelse return null;
+    if (point.viewport.y >= screen.pages.rows or point.viewport.x >= screen.pages.cols) return null;
+
+    return .{
+        .x = @intCast(point.viewport.x),
+        .y = @intCast(point.viewport.y),
+    };
+}
+
 /// Clear the active selection (cmux-specific).
 pub fn clearSelection(self: *Surface) !bool {
     self.renderer_state.mutex.lock();

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1611,6 +1611,108 @@ pub const CAPI = struct {
         };
     }
 
+    /// Start a selection at a specific viewport cell.
+    export fn ghostty_surface_select_viewport_cell(surface: *Surface, x: u16, y: u16) bool {
+        return surface.core_surface.selectViewportCell(x, y) catch |err| {
+            log.warn("error selecting viewport cell err={} x={} y={}", .{ err, x, y });
+            return false;
+        };
+    }
+
+    /// Start a full-line selection spanning the given viewport rows.
+    export fn ghostty_surface_select_viewport_line_range(
+        surface: *Surface,
+        x: u16,
+        start_y: u16,
+        end_y: u16,
+    ) bool {
+        return surface.core_surface.selectViewportLineRange(x, start_y, end_y) catch |err| {
+            log.warn(
+                "error selecting viewport line range err={} x={} start_y={} end_y={}",
+                .{ err, x, start_y, end_y },
+            );
+            return false;
+        };
+    }
+
+    /// Extend a full-line selection using the existing tracked anchor.
+    export fn ghostty_surface_extend_viewport_line_selection(
+        surface: *Surface,
+        end_y: u16,
+    ) bool {
+        return surface.core_surface.extendViewportLineSelection(end_y) catch |err| {
+            log.warn(
+                "error extending viewport line selection err={} end_y={}",
+                .{ err, end_y },
+            );
+            return false;
+        };
+    }
+
+    /// Extend an existing selection to a viewport cell while preserving its tracked anchor.
+    export fn ghostty_surface_extend_viewport_selection(
+        surface: *Surface,
+        x: u16,
+        y: u16,
+    ) bool {
+        return surface.core_surface.extendViewportSelection(x, y) catch |err| {
+            log.warn(
+                "error extending viewport selection err={} x={} y={}",
+                .{ err, x, y },
+            );
+            return false;
+        };
+    }
+
+    /// Convert the current selection to linewise mode while preserving the active end.
+    export fn ghostty_surface_convert_selection_to_viewport_line_mode(surface: *Surface) bool {
+        return surface.core_surface.convertSelectionToViewportLineMode() catch |err| {
+            log.warn(
+                "error converting selection to viewport line mode err={}",
+                .{err},
+            );
+            return false;
+        };
+    }
+
+    /// Return the active selection endpoint if it is visible in the viewport.
+    export fn ghostty_surface_selection_endpoint_cell(
+        surface: *Surface,
+        x: *u16,
+        y: *u16,
+    ) bool {
+        const cell = surface.core_surface.selectionEndpointViewportCell() orelse return false;
+        x.* = cell.x;
+        y.* = cell.y;
+        return true;
+    }
+
+    /// Return whether the viewport is already at the top of scrollback.
+    export fn ghostty_surface_viewport_is_top(surface: *Surface) bool {
+        return surface.core_surface.viewportIsTop();
+    }
+
+    /// Return whether the viewport is already at the bottom active area.
+    export fn ghostty_surface_viewport_is_bottom(surface: *Surface) bool {
+        return surface.core_surface.viewportIsBottom();
+    }
+
+    /// Jump to a prompt and return its viewport cell if visible.
+    export fn ghostty_surface_jump_to_prompt_cell(
+        surface: *Surface,
+        delta: i16,
+        x: *u16,
+        y: *u16,
+    ) bool {
+        const cell = surface.core_surface.jumpToPromptViewportCell(delta) catch |err| {
+            log.warn("error jumping to prompt cell err={} delta={}", .{ err, delta });
+            return false;
+        } orelse return false;
+        x.* = cell.x;
+        y.* = cell.y;
+        return true;
+    }
+
     /// Clear the active selection (cmux-specific).
     export fn ghostty_surface_clear_selection(surface: *Surface) bool {
         return surface.core_surface.clearSelection() catch |err| {

--- a/src/build/GhosttyXCFramework.zig
+++ b/src/build/GhosttyXCFramework.zig
@@ -10,6 +10,19 @@ const Target = @import("xcframework.zig").Target;
 xcframework: *XCFrameworkStep,
 target: Target,
 
+fn headersDir(b: *std.Build) std.Build.LazyPath {
+    const wf = b.addWriteFiles();
+    _ = wf.addCopyFile(b.path("include/ghostty.h"), "ghostty.h");
+    _ = wf.add("module.modulemap",
+        \\module GhosttyKit {
+        \\    header "ghostty.h"
+        \\    export *
+        \\}
+        \\
+    );
+    return wf.getDirectory();
+}
+
 pub fn init(
     b: *std.Build,
     deps: *const SharedDeps,
@@ -54,7 +67,10 @@ pub fn init(
     ));
 
     // The xcframework wraps our ghostty library so that we can link
-    // it to the final app built with Swift.
+    // it to the final app built with Swift. Keep this headers payload
+    // limited to the embedding API; the libghostty-vt headers ship via
+    // ghostty-vt.xcframework and otherwise trigger umbrella warnings.
+    const headers = headersDir(b);
     const xcframework = XCFrameworkStep.create(b, .{
         .name = "GhosttyKit",
         .out_path = "macos/GhosttyKit.xcframework",
@@ -62,24 +78,24 @@ pub fn init(
             .universal => &.{
                 .{
                     .library = macos_universal.output,
-                    .headers = b.path("include"),
+                    .headers = headers,
                     .dsym = macos_universal.dsym,
                 },
                 .{
                     .library = ios.output,
-                    .headers = b.path("include"),
+                    .headers = headers,
                     .dsym = ios.dsym,
                 },
                 .{
                     .library = ios_sim.output,
-                    .headers = b.path("include"),
+                    .headers = headers,
                     .dsym = ios_sim.dsym,
                 },
             },
 
             .native => &.{.{
                 .library = macos_native.output,
-                .headers = b.path("include"),
+                .headers = headers,
                 .dsym = macos_native.dsym,
             }},
         },


### PR DESCRIPTION
Summary
- add the viewport-aware selection and prompt-jump C APIs needed by cmux copy mode
- keep the GhosttyKit xcframework headers payload limited to the embedding API
- restore the dedicated lib-vt build step used by cmux integration

Verification
- git log --oneline origin/main..HEAD shows the branch as exactly 2 commits
- git diff --stat origin/main..HEAD is limited to build.zig, include/ghostty.h, src/Surface.zig, src/apprt/embedded.zig, and src/build/GhosttyXCFramework.zig
- local zig build -Demit-xcframework=true -Dxcframework-target=universal -Doptimize=ReleaseFast is blocked in this environment by a missing Metal Toolchain (xcodebuild -downloadComponent MetalToolchain), so the packaging change itself was validated earlier through the equivalent cmux tagged reload build

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add viewport-aware copy-mode C APIs for cmux and fix `GhosttyKit` packaging. Enables vim-style selection and prompt jumps, and restores the `lib-vt` build step while limiting headers to the embedding API.

- New Features
  - Viewport selection APIs: start at cell or line range, extend by cell/line, convert to linewise, and read active endpoint.
  - Viewport state helpers: check if at top/bottom of scrollback.
  - Prompt navigation: jump to next/previous prompt and return the viewport cell.

- Refactors
  - `GhosttyKit.xcframework` now ships only the embedding header (`ghostty.h`) to avoid umbrella-header warnings.
  - Restored dedicated `lib-vt` build step for cmux integration.

<sup>Written for commit b167579f3980ce96dc8fdaee123949151eb730ad. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive viewport-based selection APIs enabling intuitive cell and line selection across viewport coordinates
  * Introduced selection extension and mode conversion capabilities to support flexible text selection workflows
  * Added viewport navigation utilities including semantic prompt jumping and viewport boundary state detection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->