### PR TITLE
Do not send unsolicited DSR 997 when DECSET 2031 is enabled

### DIFF
--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -797,6 +797,16 @@ pub const StreamHandler = struct {
             .mouse_format_urxvt => self.terminal.flags.mouse_format = if (enabled) .urxvt else .x10,
             .mouse_format_sgr_pixels => self.terminal.flags.mouse_format = if (enabled) .sgr_pixels else .x10,
 
+            // Mode 2031 (ColorPaletteUpdates) notifies applications when the
+            // color scheme *changes*. Do not synthesize an immediate DSR 997
+            // report when the mode is enabled, otherwise applications that
+            // enable DECSET 2031 during startup without arranging to consume
+            // a response (for example, Claude Code) receive a spurious CSI
+            // sequence that leaks into the shell input buffer as literal
+            // text. Applications that want the current scheme can query it
+            // explicitly via DSR 996.
+            .report_color_scheme => {},
+
             else => {},
         }
     }
@@ -1554,3 +1564,51 @@ pub const StreamHandler = struct {
         self.surfaceMessageWriter(.{ .progress_report = report });
     }
 };
+
+test "enabling mode 2031 does not emit an immediate color scheme report" {
+    const testing = std.testing;
+
+    var term = try terminal.Terminal.init(testing.allocator, .{
+        .cols = 10,
+        .rows = 5,
+    });
+    defer term.deinit(testing.allocator);
+
+    var mailbox = try termio.Mailbox.initSPSC(testing.allocator);
+    defer mailbox.deinit(testing.allocator);
+
+    var mutex: std.Thread.Mutex = .{};
+    var renderer_state: renderer.State = .{
+        .mutex = &mutex,
+        .terminal = &term,
+    };
+    var size: renderer.Size = .{
+        .screen = .{ .width = 800, .height = 600 },
+        .cell = .{ .width = 8, .height = 16 },
+        .padding = .{},
+    };
+    var handler = StreamHandler{
+        .alloc = testing.allocator,
+        .size = &size,
+        .terminal = &term,
+        .termio_mailbox = &mailbox,
+        .surface_mailbox = undefined,
+        .renderer_state = &renderer_state,
+        .renderer_mailbox = undefined,
+        .renderer_wakeup = undefined,
+        .default_cursor_style = .block,
+        .default_cursor_blink = null,
+        .enquiry_response = "",
+        .osc_color_report_format = .none,
+        .clipboard_write = .deny,
+    };
+    defer handler.deinit();
+
+    mutex.lock();
+    defer mutex.unlock();
+    try handler.setMode(.report_color_scheme, true);
+
+    try testing.expect(term.modes.get(.report_color_scheme));
+    try testing.expect(!handler.termio_messaged);
+    try testing.expect(mailbox.spsc.queue.pop() == null);
+}


### PR DESCRIPTION
## Summary

Mode 2031 (ColorPaletteUpdates) is defined to **notify** applications when the color scheme changes — it is not a query. PR #21 made DECSET 2031 synthesize an immediate `DSR 997` report on enable. Applications that enable 2031 during startup without arranging to consume a response (e.g. Claude Code) have that CSI sequence leak into the shell input buffer as literal text like `?997;1n`.

This matches the shape of the bug already fixed by #40 for DECSET 1004 (focus reporting): spontaneous reports on mode-enable are wrong, applications can query explicitly via DSR 996 if they want the current scheme.

## Repro

In an affected cmux build on fish:

```
printf '\e[?2031h'; sleep 0.1; printf '\n'
```

Prints `?997;1n` into the prompt. With this patch, nothing leaks.

Originally reported against cmux: manaflow-ai/cmux#2636.

## Change

`src/termio/stream_handler.zig`: `.report_color_scheme` branch in `setMode` no longer emits a color scheme report on enable. The mode bit is still toggled so future palette changes notify normally.

## Test

Adds `test "enabling mode 2031 does not emit an immediate color scheme report"` in the same file, mirroring the structure of the focus-report regression test from #40. Verifies:

- The mode bit is set after `setMode(.report_color_scheme, true)`.
- `termio_messaged` stays false.
- The termio mailbox is empty.

## Verification

Built `GhosttyKit.xcframework` locally with and without this patch. Confirmed `printf '\e[?2031h'` leaks `?997;1n` on the control build and is silent on the patched build.

Refs: #40, manaflow-ai/cmux#2636.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop sending unsolicited DSR 997 when enabling DECSET 2031. The mode now only reports on color scheme changes, preventing `?997;1n` from leaking into shell input.

- **Bug Fixes**
  - `setMode(.report_color_scheme, ...)` no longer sends an immediate report; only toggles the mode bit.
  - Added a test to ensure the mode is set, no termio message is sent, and the mailbox stays empty.
  - Apps that need the current scheme can query via DSR 996.

<sup>Written for commit 5292e8c187b826ff145a9a73af227d77c94b5427. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/44?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected behavior when enabling mode 2031 so it no longer emits an immediate color scheme report.

* **Tests**
  * Added a unit test ensuring enabling mode 2031 enables the mode without producing any immediate terminal messages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/ghostty/pull/44?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->