### PR TITLE
macos: fall back to RTF/HTML when pasted plain text is encoding-lossy

### DIFF
--- a/macos/Sources/Helpers/Extensions/NSPasteboard+Extension.swift
+++ b/macos/Sources/Helpers/Extensions/NSPasteboard+Extension.swift
@@ -36,6 +36,8 @@ extension NSPasteboard {
     /// Does these things in order:
     /// - Tries to get the absolute filesystem path of the file in the pasteboard if there is one and ensures the file path is properly escaped.
     /// - Tries to get any string from the pasteboard.
+    /// - If the plain-text variant looks encoding-lossy, falls back to
+    ///   extracting plain text from the RTF or HTML variant.
     /// If all of the above fail, returns None.
     func getOpinionatedStringContents() -> String? {
         if let urls = readObjects(forClasses: [NSURL.self]) as? [URL],
@@ -45,7 +47,74 @@ extension NSPasteboard {
                 .joined(separator: " ")
         }
 
-        return self.string(forType: .string)
+        let plainText = self.string(forType: .string)
+
+        // Some apps (certain IMs, Electron ports, legacy native apps) write a
+        // mangled plain-text variant alongside a correctly-encoded rich-text
+        // variant — e.g. non-ASCII chars arrive as U+FFFD or literal '?' runs
+        // because the app's plain-text writer fell back to an ASCII encoding.
+        // Prefer the rich-text variant only when it demonstrably carries more
+        // non-ASCII content than the plain variant, so that legitimate user
+        // text containing '?' runs is not replaced by a stripped RTF/HTML
+        // rendering.
+        if let s = plainText, Self.looksEncodingLossy(s),
+           let recovered = self.richTextFallback(),
+           Self.nonASCIIScalarCount(recovered) > Self.nonASCIIScalarCount(s) {
+            return recovered
+        }
+
+        if let s = plainText { return s }
+        return self.richTextFallback()
+    }
+
+    private static func looksEncodingLossy(_ s: String) -> Bool {
+        if s.contains("\u{FFFD}") { return true }
+        var run = 0
+        for scalar in s.unicodeScalars {
+            if scalar == "?" {
+                run += 1
+                if run >= 3 { return true }
+            } else {
+                run = 0
+            }
+        }
+        return false
+    }
+
+    private static func nonASCIIScalarCount(_ s: String) -> Int {
+        s.unicodeScalars.reduce(0) { $1.value > 127 ? $0 + 1 : $0 }
+    }
+
+    private func richTextFallback() -> String? {
+        // Try RTF first: Apple's RTF parser is local and never fetches
+        // external resources. Fall back to HTML only when RTF is absent,
+        // since HTML parsing via NSAttributedString goes through WebKit
+        // and is heavier even when the attributed string is only used to
+        // extract `.string`.
+        if let data = self.data(forType: .rtf),
+           let attr = try? NSAttributedString(
+               data: data,
+               options: [.documentType: NSAttributedString.DocumentType.rtf],
+               documentAttributes: nil
+           ),
+           !attr.string.isEmpty {
+            return attr.string
+        }
+
+        if let data = self.data(forType: .html),
+           let attr = try? NSAttributedString(
+               data: data,
+               options: [
+                   .documentType: NSAttributedString.DocumentType.html,
+                   .characterEncoding: String.Encoding.utf8.rawValue,
+               ],
+               documentAttributes: nil
+           ),
+           !attr.string.isEmpty {
+            return attr.string
+        }
+
+        return nil
     }
 
     /// The pasteboard for the Ghostty enum type.


### PR DESCRIPTION
## Summary
- Some macOS apps (certain Chinese IMs, Electron ports, legacy native apps) write a mangled plain-text pasteboard variant alongside a correctly-encoded RTF/HTML variant — non-ASCII chars arrive as `U+FFFD` or literal `?` runs because the app's plain-text writer fell back to an ASCII encoding. Pasting into a terminal surface produced `?????`.
- Pasting the same clipboard into another app (e.g. TextEdit) and re-copying normalizes it to clean UTF-8, which is why the bug only reproduces for certain source apps.
- `getOpinionatedStringContents()` now recovers from the rich-text variant when the plain-text variant is encoding-lossy, preserving existing behavior for clean pastes.

## How
1. Reads plain text first (unchanged fast path).
2. If plain text looks encoding-lossy (contains `U+FFFD` or a run of 3+ `?`) **and** the rich-text variant carries strictly more non-ASCII scalars, returns the rich-text-derived plain string.
3. Rich-text extraction prefers RTF (local parser, no network calls); HTML is a fallback so WebKit is only touched when an app writes HTML but no RTF.
4. Falls back to rich-text extraction when plain text is absent entirely (previously returned `nil`).

The "more non-ASCII scalars" swap condition prevents regressing legitimate user text like `"really???"` — both variants have the same non-ASCII count, so the rich-text version is not preferred.

## Test plan
- [x] Copy Chinese from a source app that previously reproduced `?????` → now shows the correct characters.
- [x] Copy ASCII text from Chrome (plain + HTML both present) → plain-text path used; HTML never parsed.
- [x] Text containing `"really???"` style runs is preserved untouched.
- [ ] Copy Chinese from Slack / Discord / other Electron apps that write only HTML → recovered via HTML fallback.

No new unit tests — this path depends on live `NSPasteboard` + `NSAttributedString` runtime behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes garbled pastes like “?????” from some macOS apps by falling back to RTF/HTML when the plain-text pasteboard data is encoding-lossy. Keeps the fast plain-text path for clean pastes and prefers RTF to avoid WebKit.

- **Bug Fixes**
  - In `getOpinionatedStringContents()`, detect lossy plain text (contains U+FFFD or runs of 3+ '?').
  - Prefer rich-text only if it has more non-ASCII scalars than the plain variant to avoid replacing valid text like “really???”.
  - Parse RTF first; use HTML only if RTF is absent.
  - Recover from rich-text when plain text is missing entirely.

<sup>Written for commit 50904e2320d9986ade2dc2f93b5e37c0c0d2c541. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved clipboard text retrieval to better handle text copied from rich-text sources (such as word processors). The system now detects corrupted or incorrectly encoded text and attempts to recover the original content from formatting data, providing more reliable paste functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->