### PR TITLE
Add ghostty_surface_foreground_pid C API for cmux

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1156,6 +1156,7 @@ GHOSTTY_API void ghostty_surface_complete_clipboard_request(ghostty_surface_t,
 GHOSTTY_API bool ghostty_surface_has_selection(ghostty_surface_t);
 GHOSTTY_API bool ghostty_surface_select_cursor_cell(ghostty_surface_t);
 GHOSTTY_API bool ghostty_surface_clear_selection(ghostty_surface_t);
+GHOSTTY_API int32_t ghostty_surface_foreground_pid(ghostty_surface_t);
 GHOSTTY_API bool ghostty_surface_read_selection(ghostty_surface_t, ghostty_text_s*);
 GHOSTTY_API bool ghostty_surface_read_text(ghostty_surface_t,
                                               ghostty_selection_s,

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1619,6 +1619,14 @@ pub const CAPI = struct {
         };
     }
 
+    /// Returns the foreground process group PID (pid_t) of the surface's
+    /// pty master, or -1 if unavailable (cmux-specific).
+    export fn ghostty_surface_foreground_pid(surface: *Surface) i32 {
+        const raw = surface.core_surface.getProcessInfo(.foreground_pid) orelse return -1;
+        if (raw > @as(u64, @intCast(std.math.maxInt(i32)))) return -1;
+        return @intCast(raw);
+    }
+
     /// Same as ghostty_surface_read_text but reads from the user selection,
     /// if any.
     export fn ghostty_surface_read_selection(


### PR DESCRIPTION
## Summary
- Adds `ghostty_surface_foreground_pid()` C API that exposes the foreground process group PID (as `int32_t`) of a surface's pty master.
- Returns `-1` when unavailable (no pty / `tcgetpgrp` failure / PID > `INT32_MAX`).
- Backed by the existing `Surface.getProcessInfo(.foreground_pid)` path, which uses `tcgetpgrp(master_fd)` on macOS.

## Motivation
cmux uses this to detect when a CLI tool (Claude Code / Codex / Gemini) is the foreground process of a pty so it can switch Enter-key semantics on a per-process basis (Enter=newline for CLI, Enter=submit otherwise).

## Files
- `include/ghostty.h`
- `src/apprt/embedded.zig`

Follows the pattern of the existing cmux-specific exports (`ghostty_surface_select_cursor_cell`, `ghostty_surface_clear_selection`).

## Test plan
- [x] `zig build -Demit-xcframework=true -Dxcframework-target=universal -Doptimize=ReleaseFast` succeeds
- [x] `nm` on the resulting `libghostty.a` shows `T _ghostty_surface_foreground_pid`
- [x] cmux Debug build links against the rebuilt xcframework and resolves the new symbol

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a C API `ghostty_surface_foreground_pid()` to fetch the foreground process group PID for a surface’s pty master. This enables `cmux` to switch Enter-key behavior when a CLI tool is in the foreground.

- **New Features**
  - Returns `int32_t` PID; `-1` if no pty, `tcgetpgrp` fails, or PID > `INT32_MAX`.
  - Uses `Surface.getProcessInfo(.foreground_pid)` under the hood (`tcgetpgrp` on macOS).

<sup>Written for commit 22ad48b6aa43c56ff8b6b2710b4c03e8a20cc6a6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Exposed a new API function to retrieve the process identifier of the foreground process running in a surface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->