### PR TITLE
Fix fork CI runner fallback

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,7 +80,10 @@ jobs:
   required:
     name: "Required Checks: Test"
     if: always()
-    runs-on: namespace-profile-ghostty-xsm
+    # Forks skip the upstream-only matrix jobs, but this aggregate job still
+    # needs to complete so fork pushes do not wait on Ghostty's Namespace
+    # runner labels.
+    runs-on: ${{ github.repository == 'ghostty-org/ghostty' && 'namespace-profile-ghostty-xsm' || 'ubuntu-latest' }}
     needs:
       - skip
       - build-bench

--- a/.github/workflows/vouch-check-issue.yml
+++ b/.github/workflows/vouch-check-issue.yml
@@ -6,6 +6,7 @@ name: "Vouch - Check Issue"
 
 jobs:
   check:
+    if: github.repository == 'ghostty-org/ghostty'
     runs-on: namespace-profile-ghostty-xsm
     steps:
       - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1

--- a/.github/workflows/vouch-check-pr.yml
+++ b/.github/workflows/vouch-check-pr.yml
@@ -6,6 +6,7 @@ name: "Vouch - Check PR"
 
 jobs:
   check:
+    if: github.repository == 'ghostty-org/ghostty'
     runs-on: namespace-profile-ghostty-xsm
     steps:
       - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1

--- a/.github/workflows/vouch-manage-by-discussion.yml
+++ b/.github/workflows/vouch-manage-by-discussion.yml
@@ -10,6 +10,7 @@ concurrency:
 
 jobs:
   manage:
+    if: github.repository == 'ghostty-org/ghostty'
     runs-on: namespace-profile-ghostty-xsm
     steps:
       - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1

--- a/.github/workflows/vouch-manage-by-issue.yml
+++ b/.github/workflows/vouch-manage-by-issue.yml
@@ -10,6 +10,7 @@ concurrency:
 
 jobs:
   manage:
+    if: github.repository == 'ghostty-org/ghostty'
     runs-on: namespace-profile-ghostty-xsm
     steps:
       - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1

--- a/.github/workflows/vouch-sync-codeowners.yml
+++ b/.github/workflows/vouch-sync-codeowners.yml
@@ -11,6 +11,7 @@ concurrency:
 
 jobs:
   sync:
+    if: github.repository == 'ghostty-org/ghostty'
     runs-on: namespace-profile-ghostty-xsm
     steps:
       - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1


### PR DESCRIPTION
Fixes CI/CD on the manaflow-ai/ghostty fork by letting the aggregate Test required-check job run on ubuntu-latest outside ghostty-org/ghostty, while preserving upstream Namespace runners for the upstream repo. Also skips Vouch workflows outside upstream so fork issue/PR events do not wait on unavailable Namespace runner labels or missing Vouch secrets.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CI on forks by using `ubuntu-latest` for the aggregate “Required Checks: Test” job and limiting Vouch workflows to the upstream repo. This unblocks fork pushes and PRs without changing upstream behavior.

- **Bug Fixes**
  - Dynamic runner for required test job: upstream uses `namespace-profile-ghostty-xsm`, forks use `ubuntu-latest`.
  - Gate all Vouch workflows with `if: github.repository == 'ghostty-org/ghostty'` to skip on forks.

<sup>Written for commit ae0ad5936b5c3114eecfd0b514bd82571fda7981. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/51?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

