### PR TITLE
Apply cmux theme from picker search

### DIFF
--- a/src/cli/list_themes.zig
+++ b/src/cli/list_themes.zig
@@ -902,8 +902,18 @@ const Preview = struct {
                             self.mode = .normal;
                     },
                     .search => search: {
-                        if (key.matchesAny(&.{ vaxis.Key.escape, vaxis.Key.enter }, .{})) {
+                        if (key.matches(vaxis.Key.escape, .{})) {
                             self.mode = .normal;
+                            break :search;
+                        }
+                        if (key.matchesAny(&.{ vaxis.Key.enter, vaxis.Key.kp_enter }, .{})) {
+                            if (self.cmux != null) {
+                                try self.applyCmuxSelectionForCurrentTheme();
+                                self.outcome = .apply;
+                                self.should_quit = true;
+                            } else {
+                                self.mode = .normal;
+                            }
                             break :search;
                         }
                         if (key.matchesAny(&.{ 'x', '/' }, .{ .ctrl = true })) {


### PR DESCRIPTION
## Summary
- Apply the current filtered cmux theme when Enter is pressed from picker search mode.
- Preserve Escape as search cancel and keep non-cmux Ghostty search Enter behavior unchanged.

## Testing
- Built through cmux tagged reload: `./scripts/reload.sh --tag thmenter`
- Published and verified GhosttyKit artifact: https://github.com/manaflow-ai/ghostty/releases/tag/xcframework-4265d34282ce2023c27da851c454dabe6cdc76ce


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced search mode keyboard navigation: ESC key now clearly exits search mode; Enter key behavior refined to properly apply theme selection or exit search mode based on your configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->