### PR TITLE
Expose manual embedded IO for iOS

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -464,6 +464,15 @@ typedef enum {
   GHOSTTY_SURFACE_CONTEXT_SPLIT = 2,
 } ghostty_surface_context_e;
 
+// cmux fork: delete this once upstream libghostty exposes an embedder-owned
+// terminal IO backend for surfaces.
+typedef enum {
+  GHOSTTY_SURFACE_IO_EXEC = 0,
+  GHOSTTY_SURFACE_IO_MANUAL = 1,
+} ghostty_surface_io_mode_e;
+
+typedef void (*ghostty_io_write_cb)(void*, const char*, uintptr_t);
+
 typedef struct {
   ghostty_platform_e platform_tag;
   ghostty_platform_u platform;
@@ -477,6 +486,9 @@ typedef struct {
   const char* initial_input;
   bool wait_after_command;
   ghostty_surface_context_e context;
+  ghostty_surface_io_mode_e io_mode;
+  ghostty_io_write_cb io_write_cb;
+  void* io_write_userdata;
 } ghostty_surface_config_s;
 
 typedef struct {
@@ -1110,6 +1122,9 @@ GHOSTTY_API bool ghostty_surface_needs_confirm_quit(ghostty_surface_t);
 GHOSTTY_API bool ghostty_surface_process_exited(ghostty_surface_t);
 GHOSTTY_API void ghostty_surface_refresh(ghostty_surface_t);
 GHOSTTY_API void ghostty_surface_draw(ghostty_surface_t);
+// cmux fork: delete when upstream exposes a synchronous render tick for
+// embedders that drive rendering from a platform display callback.
+GHOSTTY_API void ghostty_surface_render_now(ghostty_surface_t);
 GHOSTTY_API void ghostty_surface_set_content_scale(ghostty_surface_t, double, double);
 GHOSTTY_API void ghostty_surface_set_focus(ghostty_surface_t, bool);
 GHOSTTY_API void ghostty_surface_set_occlusion(ghostty_surface_t, bool);
@@ -1126,7 +1141,13 @@ GHOSTTY_API bool ghostty_surface_key_is_binding(ghostty_surface_t,
                                                    ghostty_input_key_s,
                                                    ghostty_binding_flags_e*);
 GHOSTTY_API void ghostty_surface_text(ghostty_surface_t, const char*, uintptr_t);
+// cmux fork: delete when upstream separates committed typed text from paste
+// delivery for libghostty embedders.
+GHOSTTY_API void ghostty_surface_text_input(ghostty_surface_t, const char*, uintptr_t);
 GHOSTTY_API void ghostty_surface_preedit(ghostty_surface_t, const char*, uintptr_t);
+// cmux fork: upstream already has internal Termio.processOutput. Delete this
+// C bridge when upstream exports an equivalent surface output API.
+GHOSTTY_API void ghostty_surface_process_output(ghostty_surface_t, const char*, uintptr_t);
 GHOSTTY_API bool ghostty_surface_mouse_captured(ghostty_surface_t);
 GHOSTTY_API bool ghostty_surface_mouse_button(ghostty_surface_t,
                                                  ghostty_input_mouse_state_e,

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -637,38 +637,64 @@ pub fn init(
     // This separate block ({}) is important because our errdefers must
     // be scoped here to be valid.
     {
-        var env = rt_surface.defaultTermioEnv() catch |err| env: {
-            // If an error occurs, we don't want to block surface startup.
-            log.warn("error getting env map for surface err={}", .{err});
-            break :env internal_os.getEnvMap(alloc) catch
-                std.process.EnvMap.init(alloc);
+        // cmux fork: embedded surfaces can opt into manual IO so a host
+        // application owns the PTY/session and Ghostty only renders bytes and
+        // encodes input. Delete this branch when upstream exposes an
+        // embedder-owned IO backend.
+        const use_manual_io = if (comptime @hasDecl(apprt.runtime.Surface, "ioMode"))
+            rt_surface.ioMode() == .manual
+        else
+            false;
+        var io_backend: termio.Backend = if (use_manual_io) manual: {
+            const write_cb = if (comptime @hasDecl(apprt.runtime.Surface, "ioWriteCallback"))
+                rt_surface.ioWriteCallback()
+            else
+                null;
+            const write_userdata = if (comptime @hasDecl(apprt.runtime.Surface, "ioWriteUserdata"))
+                rt_surface.ioWriteUserdata()
+            else
+                null;
+            var manual_backend = try termio.Manual.init(alloc, .{
+                .write_cb = write_cb,
+                .write_userdata = write_userdata,
+            });
+            errdefer manual_backend.deinit();
+            break :manual .{ .manual = manual_backend };
+        } else exec: {
+            var env = rt_surface.defaultTermioEnv() catch |err| env: {
+                // If an error occurs, we don't want to block surface startup.
+                log.warn("error getting env map for surface err={}", .{err});
+                break :env internal_os.getEnvMap(alloc) catch
+                    std.process.EnvMap.init(alloc);
+            };
+            errdefer env.deinit();
+
+            // don't leak GHOSTTY_LOG to any subprocesses
+            env.remove("GHOSTTY_LOG");
+
+            var buf: [18]u8 = undefined;
+            try env.put(
+                "GHOSTTY_SURFACE_ID",
+                std.fmt.bufPrint(&buf, "0x{x:0>16}", .{self.id}) catch unreachable,
+            );
+
+            var io_exec = try termio.Exec.init(alloc, .{
+                .command = command,
+                .env = env,
+                .env_override = config.env,
+                .shell_integration = config.@"shell-integration",
+                .shell_integration_features = config.@"shell-integration-features",
+                .cursor_blink = config.@"cursor-style-blink",
+                .working_directory = if (config.@"working-directory") |wd| wd.value() else null,
+                .resources_dir = global_state.resources_dir.host(),
+                .term = config.term,
+                .rt_pre_exec_info = .init(config),
+                .rt_post_fork_info = .init(config),
+            });
+            errdefer io_exec.deinit();
+            break :exec .{ .exec = io_exec };
         };
-        errdefer env.deinit();
-
-        // don't leak GHOSTTY_LOG to any subprocesses
-        env.remove("GHOSTTY_LOG");
-
-        var buf: [18]u8 = undefined;
-        try env.put(
-            "GHOSTTY_SURFACE_ID",
-            std.fmt.bufPrint(&buf, "0x{x:0>16}", .{self.id}) catch unreachable,
-        );
-
-        // Initialize our IO backend
-        var io_exec = try termio.Exec.init(alloc, .{
-            .command = command,
-            .env = env,
-            .env_override = config.env,
-            .shell_integration = config.@"shell-integration",
-            .shell_integration_features = config.@"shell-integration-features",
-            .cursor_blink = config.@"cursor-style-blink",
-            .working_directory = if (config.@"working-directory") |wd| wd.value() else null,
-            .resources_dir = global_state.resources_dir.host(),
-            .term = config.term,
-            .rt_pre_exec_info = .init(config),
-            .rt_post_fork_info = .init(config),
-        });
-        errdefer io_exec.deinit();
+        errdefer io_backend.deinit();
 
         // Initialize our IO mailbox
         var io_mailbox = try termio.Mailbox.initSPSC(alloc);
@@ -678,7 +704,7 @@ pub fn init(
             .size = size,
             .full_config = config,
             .config = try termio.Termio.DerivedConfig.init(alloc, config),
-            .backend = .{ .exec = io_exec },
+            .backend = io_backend,
             .mailbox = io_mailbox,
             .renderer_state = &self.renderer_state,
             .renderer_wakeup = render_thread.wakeup,
@@ -1312,9 +1338,10 @@ fn childExitedAbnormally(
     const alloc = arena.allocator();
 
     // Build up our command for the error message
-    const command = try std.mem.join(alloc, " ", switch (self.io.backend) {
-        .exec => |*exec| exec.subprocess.args,
-    });
+    const command = switch (self.io.backend) {
+        .exec => |*exec| try std.mem.join(alloc, " ", exec.subprocess.args),
+        .manual => "manual backend",
+    };
     const runtime_str = try std.fmt.allocPrint(alloc, "{d} ms", .{info.runtime_ms});
 
     self.renderer_state.mutex.lock();
@@ -2517,6 +2544,33 @@ fn resize(self: *Surface, size: rendererpkg.ScreenSize) !void {
     self.queueIo(.{ .resize = self.size }, .unlocked);
 }
 
+/// Apply pending terminal resize directly from the calling thread.
+/// cmux fork: iOS drives rendering from the platform display callback, so
+/// pending size changes must be visible before the synchronous render tick.
+/// Delete when upstream provides an embedder render path with resize sync.
+pub fn applyPendingResizeIfNeeded(self: *Surface) void {
+    const grid_size = self.size.grid();
+    if (grid_size.columns == 0 or grid_size.rows == 0) return;
+
+    self.renderer_state.mutex.lock();
+    defer self.renderer_state.mutex.unlock();
+    const t = self.renderer_state.terminal;
+
+    if (t.cols == grid_size.columns and t.rows == grid_size.rows) return;
+
+    t.resize(
+        self.alloc,
+        grid_size.columns,
+        grid_size.rows,
+    ) catch |err| {
+        log.warn("applyPendingResizeIfNeeded: resize error={}", .{err});
+        return;
+    };
+
+    t.width_px = grid_size.columns * self.size.cell.width;
+    t.height_px = grid_size.rows * self.size.cell.height;
+}
+
 /// Recalculate the balanced padding if needed.
 fn balancePaddingIfNeeded(self: *Surface) void {
     if (self.config.window_padding_balance == .false) return;
@@ -3297,6 +3351,17 @@ pub fn textCallback(self: *Surface, text: []const u8) !void {
     defer crash.sentry.thread_state = null;
 
     try self.completeClipboardPaste(text, true);
+}
+
+/// Sends committed text input to the terminal without keyboard protocol
+/// encoding. cmux fork: unlike textCallback, this is not treated like a paste.
+/// Delete when upstream provides committed typed-text input for embedders.
+pub fn textInputCallback(self: *Surface, text: []const u8) !void {
+    // Crash metadata in case we crash in here
+    crash.sentry.thread_state = self.crashThreadState();
+    defer crash.sentry.thread_state = null;
+
+    try self.completeTextInput(text);
 }
 
 /// Callback for when the surface is fully visible or not, regardless
@@ -6169,6 +6234,47 @@ fn completeClipboardPaste(
             vec,
         ), .unlocked);
     };
+}
+
+fn completeTextInput(
+    self: *Surface,
+    data: []const u8,
+) !void {
+    if (data.len == 0) return;
+
+    var data_duped: ?[]u8 = null;
+    const encoded = input.text.encode(data) catch |err| switch (err) {
+        error.MutableRequired => encoded: {
+            const buf: []u8 = try self.alloc.dupe(u8, data);
+            errdefer self.alloc.free(buf);
+            data_duped = buf;
+            break :encoded input.text.encode(buf);
+        },
+    };
+    defer if (data_duped) |v| self.alloc.free(v);
+
+    if (self.child_exited) {
+        self.close();
+        return;
+    }
+
+    self.queueIo(try termio.Message.writeReq(
+        self.alloc,
+        encoded,
+    ), .unlocked);
+
+    self.renderer_state.mutex.lock();
+    defer self.renderer_state.mutex.unlock();
+
+    if (self.config.selection_clear_on_typing) {
+        try self.setSelection(null);
+    }
+
+    if (self.config.scroll_to_bottom.keystroke) {
+        self.io.terminal.scrollViewport(.bottom);
+    }
+
+    try self.queueRender();
 }
 
 fn completeClipboardReadOSC52(

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -406,6 +406,15 @@ pub const EnvVar = extern struct {
     value: [*:0]const u8,
 };
 
+// cmux fork: delete when upstream libghostty exposes equivalent surface IO
+// ownership. iOS uses this so Rust owns the session while Ghostty renders it.
+pub const IoMode = enum(c_int) {
+    exec = 0,
+    manual = 1,
+};
+
+pub const IoWriteCallback = *const fn (?*anyopaque, [*]const u8, usize) callconv(.c) void;
+
 pub const Surface = struct {
     app: *App,
     platform: Platform,
@@ -415,6 +424,9 @@ pub const Surface = struct {
     size: apprt.SurfaceSize,
     cursor_pos: apprt.CursorPos,
     inspector: ?*Inspector = null,
+    io_mode: IoMode = .exec,
+    io_write_cb: ?IoWriteCallback = null,
+    io_write_userdata: ?*anyopaque = null,
 
     /// The current title of the surface. The embedded apprt saves this so
     /// that getTitle works without the implementer needing to save it.
@@ -461,6 +473,15 @@ pub const Surface = struct {
 
         /// Context for the new surface
         context: apprt.surface.NewSurfaceContext = .window,
+
+        /// IO mode for the surface.
+        io_mode: IoMode = .exec,
+
+        /// Callback invoked when Ghostty wants to write to the backend.
+        io_write_cb: ?IoWriteCallback = null,
+
+        /// Userdata passed to io_write_cb.
+        io_write_userdata: ?*anyopaque = null,
     };
 
     pub fn init(self: *Surface, app: *App, opts: Options) !void {
@@ -475,6 +496,9 @@ pub const Surface = struct {
             },
             .size = .{ .width = 800, .height = 600 },
             .cursor_pos = .{ .x = -1, .y = -1 },
+            .io_mode = opts.io_mode,
+            .io_write_cb = opts.io_write_cb,
+            .io_write_userdata = opts.io_write_userdata,
         };
 
         // Add ourselves to the list of surfaces on the app.
@@ -654,6 +678,18 @@ pub const Surface = struct {
         return self.size;
     }
 
+    pub fn ioMode(self: *const Surface) IoMode {
+        return self.io_mode;
+    }
+
+    pub fn ioWriteCallback(self: *const Surface) ?IoWriteCallback {
+        return self.io_write_cb;
+    }
+
+    pub fn ioWriteUserdata(self: *const Surface) ?*anyopaque {
+        return self.io_write_userdata;
+    }
+
     pub fn getTitle(self: *Surface) ?[:0]const u8 {
         return self.title;
     }
@@ -772,6 +808,11 @@ pub const Surface = struct {
             log.err("error in draw err={}", .{err});
             return;
         };
+    }
+
+    pub fn renderNow(self: *Surface) void {
+        self.core_surface.applyPendingResizeIfNeeded();
+        self.core_surface.renderer_thread.renderNow();
     }
 
     pub fn updateContentScale(self: *Surface, x: f64, y: f64) void {
@@ -904,6 +945,13 @@ pub const Surface = struct {
         };
     }
 
+    pub fn textInputCallback(self: *Surface, text: []const u8) void {
+        _ = self.core_surface.textInputCallback(text) catch |err| {
+            log.err("error in text input callback err={}", .{err});
+            return;
+        };
+    }
+
     pub fn focusCallback(self: *Surface, focused: bool) void {
         self.core_surface.focusCallback(focused) catch |err| {
             log.err("error in focus callback err={}", .{err});
@@ -946,6 +994,9 @@ pub const Surface = struct {
             .font_size = font_size,
             .working_directory = working_directory,
             .context = context,
+            .io_mode = self.io_mode,
+            .io_write_cb = self.io_write_cb,
+            .io_write_userdata = self.io_write_userdata,
         };
     }
 
@@ -1707,6 +1758,11 @@ pub const CAPI = struct {
         surface.draw();
     }
 
+    /// Perform a full render cycle synchronously from the calling thread.
+    export fn ghostty_surface_render_now(surface: *Surface) void {
+        surface.renderNow();
+    }
+
     /// Update the size of a surface. This will trigger resize notifications
     /// to the pty and the renderer.
     export fn ghostty_surface_set_size(surface: *Surface, w: u32, h: u32) void {
@@ -1838,6 +1894,17 @@ pub const CAPI = struct {
         surface.textCallback(ptr[0..len]);
     }
 
+    /// Send committed text input to the terminal. This is treated like
+    /// typed text, not a paste. Newlines are normalized to carriage
+    /// returns and bracketed paste mode is not used.
+    export fn ghostty_surface_text_input(
+        surface: *Surface,
+        ptr: [*]const u8,
+        len: usize,
+    ) void {
+        surface.textInputCallback(ptr[0..len]);
+    }
+
     /// Set the preedit text for the surface. This is used for IME
     /// composition. If the length is 0, then the preedit text is cleared.
     export fn ghostty_surface_preedit(
@@ -1846,6 +1913,16 @@ pub const CAPI = struct {
         len: usize,
     ) void {
         surface.preeditCallback(if (len == 0) null else ptr[0..len]);
+    }
+
+    /// Process output bytes as if they were read from the PTY.
+    export fn ghostty_surface_process_output(
+        surface: *Surface,
+        ptr: [*]const u8,
+        len: usize,
+    ) void {
+        if (len == 0) return;
+        surface.core_surface.io.processOutput(ptr[0..len]);
     }
 
     /// Returns true if the surface currently has mouse capturing

--- a/src/input.zig
+++ b/src/input.zig
@@ -14,6 +14,7 @@ pub const key_encode = @import("input/key_encode.zig");
 pub const kitty = @import("input/kitty.zig");
 pub const mouse_encode = @import("input/mouse_encode.zig");
 pub const paste = @import("input/paste.zig");
+pub const text = @import("input/text.zig");
 
 pub const ctrlOrSuper = key.ctrlOrSuper;
 pub const Action = key.Action;

--- a/src/input/text.zig
+++ b/src/input/text.zig
@@ -1,0 +1,55 @@
+const std = @import("std");
+
+/// Encode committed text input for terminal delivery.
+/// cmux fork: delete when upstream has a committed text input encoder for
+/// libghostty embedders.
+///
+/// This differs from paste encoding:
+/// - no bracketed paste wrappers
+/// - no control-byte stripping
+/// - `\n` is normalized to `\r` to match Enter key semantics
+pub fn encode(
+    data: anytype,
+) switch (@TypeOf(data)) {
+    []u8 => []const u8,
+    []const u8 => Error![]const u8,
+    else => unreachable,
+} {
+    const mutable = @TypeOf(data) == []u8;
+
+    if (comptime mutable) {
+        std.mem.replaceScalar(u8, data, '\n', '\r');
+        return data;
+    }
+
+    if (std.mem.indexOfScalar(u8, data, '\n') != null) {
+        return Error.MutableRequired;
+    }
+
+    return data;
+}
+
+pub const Error = error{
+    MutableRequired,
+};
+
+test "encode committed text without newlines" {
+    const testing = std.testing;
+    const result = try encode(@as([]const u8, "hello"));
+    try testing.expectEqualStrings("hello", result);
+}
+
+test "encode committed text with newline const" {
+    const testing = std.testing;
+    try testing.expectError(Error.MutableRequired, encode(
+        @as([]const u8, "hello\nworld"),
+    ));
+}
+
+test "encode committed text with newline mutable" {
+    const testing = std.testing;
+    const data: []u8 = try testing.allocator.dupe(u8, "hello\nworld");
+    defer testing.allocator.free(data);
+    const result = encode(data);
+    try testing.expectEqualStrings("hello\rworld", result);
+}

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -195,6 +195,24 @@ pub fn deinit(self: *Thread) void {
     self.mailbox.destroy(self.alloc);
 }
 
+/// Perform a full render cycle synchronously from the calling thread.
+/// cmux fork: iOS drives frames from a platform display callback. Delete this
+/// when upstream exposes a synchronous embedder render tick.
+pub fn renderNow(self: *Thread) void {
+    self.drainMailbox() catch |err|
+        log.err("renderNow: error draining mailbox err={}", .{err});
+
+    self.renderer.updateFrame(
+        self.state,
+        self.flags.cursor_blink_visible,
+    ) catch |err| {
+        log.warn("renderNow: error updating frame err={}", .{err});
+        return;
+    };
+
+    self.drawFrame(true);
+}
+
 /// The main entrypoint for the thread.
 pub fn threadMain(self: *Thread) void {
     // Call child function so we can use errors...

--- a/src/termio.zig
+++ b/src/termio.zig
@@ -18,11 +18,17 @@
 //! specific backend/mailbox capabilities, and sets up the necessary threads.
 
 const stream_handler = @import("termio/stream_handler.zig");
+// cmux fork: manual IO lets an embedder own terminal transport while reusing
+// Ghostty's renderer/parser. Delete when upstream has an equivalent backend.
+const manual = @import("termio/Manual.zig");
 
 const message = @import("termio/message.zig");
 pub const backend = @import("termio/backend.zig");
 pub const mailbox = @import("termio/mailbox.zig");
 pub const Exec = @import("termio/Exec.zig");
+pub const Manual = manual.Manual;
+pub const ManualConfig = manual.Config;
+pub const ManualThreadData = manual.ThreadData;
 pub const Options = @import("termio/Options.zig");
 pub const Termio = @import("termio/Termio.zig");
 pub const Thread = @import("termio/Thread.zig");

--- a/src/termio/Manual.zig
+++ b/src/termio/Manual.zig
@@ -3,6 +3,8 @@ const termio = @import("../termio.zig");
 const renderer = @import("../renderer.zig");
 const terminal = @import("../terminal/main.zig");
 
+// cmux fork: a minimal backend for libghostty embedders that own the PTY or
+// remote session. Delete when upstream exposes equivalent manual surface IO.
 pub const WriteCallback = *const fn (?*anyopaque, [*]const u8, usize) callconv(.c) void;
 
 pub const Config = struct {
@@ -94,13 +96,13 @@ pub const ThreadData = struct {
 
 test "manual queueWrite linefeed conversion" {
     const testing = std.testing;
-    var out = std.ArrayList(u8).init(testing.allocator);
-    defer out.deinit();
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(testing.allocator);
 
     const cb = struct {
         fn write(ud: ?*anyopaque, ptr: [*]const u8, len: usize) callconv(.c) void {
             const list: *std.ArrayList(u8) = @ptrCast(@alignCast(ud.?));
-            _ = list.appendSlice(ptr[0..len]) catch {};
+            _ = list.appendSlice(testing.allocator, ptr[0..len]) catch {};
         }
     }.write;
 

--- a/src/termio/Termio.zig
+++ b/src/termio/Termio.zig
@@ -59,6 +59,11 @@ size: renderer.Size,
 /// The mailbox implementation to use.
 mailbox: termio.Mailbox,
 
+/// cmux fork: manual IO currently needs an inline write path on iOS because
+/// the writer-thread async wakeup is not reliably firing in that environment.
+/// Delete when upstream supports manual backend writes without this path.
+manual_linefeed_mode: std.atomic.Value(bool) = .{ .raw = false },
+
 /// The stream parser. This parses the stream of escape codes and so on
 /// from the child process and calls callbacks in the stream handler.
 terminal_stream: StreamHandler.Stream,
@@ -394,11 +399,94 @@ pub fn queueMessage(
     msg: termio.Message,
     mutex: MutexState,
 ) void {
+    switch (self.backend) {
+        .manual => {
+            self.queueMessageManual(msg);
+            return;
+        },
+        .exec => {},
+    }
+
     self.mailbox.send(msg, switch (mutex) {
         .locked => self.renderer_state.mutex,
         .unlocked => null,
     });
     self.mailbox.notify();
+}
+
+fn queueMessageManual(self: *Termio, msg: termio.Message) void {
+    var td: ThreadData = .{
+        .alloc = self.alloc,
+        .loop = undefined,
+        .renderer_state = self.renderer_state,
+        .surface_mailbox = self.surface_mailbox,
+        .backend = .{ .manual = .{} },
+        .mailbox = &self.mailbox,
+    };
+
+    switch (msg) {
+        .color_scheme_report => |v| self.colorSchemeReport(&td, v.force) catch |err| {
+            log.warn("manual inline color_scheme_report failed err={}", .{err});
+        },
+        .crash => @panic("crash request, crashing intentionally"),
+        .change_config => |config| {
+            defer config.alloc.destroy(config.ptr);
+            self.changeConfig(&td, config.ptr) catch |err| {
+                log.warn("manual inline change_config failed err={}", .{err});
+            };
+        },
+        .inspector => {},
+        .resize => |v| self.resize(&td, v) catch |err| {
+            log.warn("manual inline resize failed err={}", .{err});
+        },
+        .size_report => |v| self.sizeReport(&td, v) catch |err| {
+            log.warn("manual inline size_report failed err={}", .{err});
+        },
+        .clear_screen => |v| self.clearScreen(&td, v.history) catch |err| {
+            log.warn("manual inline clear_screen failed err={}", .{err});
+        },
+        .scroll_viewport => |v| self.scrollViewport(v),
+        .selection_scroll => {},
+        .jump_to_prompt => |v| self.jumpToPrompt(v) catch |err| {
+            log.warn("manual inline jump_to_prompt failed err={}", .{err});
+        },
+        .start_synchronized_output => {},
+        .linefeed_mode => |v| self.manual_linefeed_mode.store(v, .monotonic),
+        .focused => |v| self.focusGained(&td, v) catch |err| {
+            log.warn("manual inline focused failed err={}", .{err});
+        },
+        .write_small => |v| self.queueWriteManual(
+            &td,
+            v.data[0..v.len],
+        ) catch |err| {
+            log.warn("manual inline write_small failed err={}", .{err});
+        },
+        .write_stable => |v| self.queueWriteManual(&td, v) catch |err| {
+            log.warn("manual inline write_stable failed err={}", .{err});
+        },
+        .write_alloc => |v| {
+            defer v.alloc.free(v.data);
+            self.queueWriteManual(&td, v.data) catch |err| {
+                log.warn("manual inline write_alloc failed err={}", .{err});
+            };
+        },
+    }
+
+    self.renderer_wakeup.notify() catch |err| {
+        log.warn("manual inline renderer wakeup failed err={}", .{err});
+    };
+}
+
+fn queueWriteManual(
+    self: *Termio,
+    td: *ThreadData,
+    data: []const u8,
+) !void {
+    const linefeed = self.manual_linefeed_mode.load(.monotonic);
+    switch (self.backend) {
+        .manual => |*manual| try manual.queueWrite(self.alloc, td, data, linefeed),
+        .exec => unreachable,
+    }
 }
 
 /// Queue a write directly to the pty.

--- a/src/termio/backend.zig
+++ b/src/termio/backend.zig
@@ -11,28 +11,34 @@ const ProcessInfo = @import("../pty.zig").ProcessInfo;
 const WRITE_REQ_PREALLOC = std.math.pow(usize, 2, 5);
 
 /// The kinds of backends.
-pub const Kind = enum { exec };
+pub const Kind = enum { exec, manual };
 
 /// Configuration for the various backend types.
 pub const Config = union(Kind) {
     /// Exec uses posix exec to run a command with a pty.
     exec: termio.Exec.Config,
+    /// cmux fork: manual uses callbacks for writing and accepts output via
+    /// processOutput. Delete when upstream provides equivalent backend IO.
+    manual: termio.ManualConfig,
 };
 
 /// Backend implementations. A backend is responsible for owning the pty
 /// behavior and providing read/write capabilities.
 pub const Backend = union(Kind) {
     exec: termio.Exec,
+    manual: termio.Manual,
 
     pub fn deinit(self: *Backend) void {
         switch (self.*) {
             .exec => |*exec| exec.deinit(),
+            .manual => |*manual| manual.deinit(),
         }
     }
 
     pub fn initTerminal(self: *Backend, t: *terminal.Terminal) void {
         switch (self.*) {
             .exec => |*exec| exec.initTerminal(t),
+            .manual => |*manual| manual.initTerminal(t),
         }
     }
 
@@ -44,12 +50,14 @@ pub const Backend = union(Kind) {
     ) !void {
         switch (self.*) {
             .exec => |*exec| try exec.threadEnter(alloc, io, td),
+            .manual => |*manual| try manual.threadEnter(alloc, io, td),
         }
     }
 
     pub fn threadExit(self: *Backend, td: *termio.Termio.ThreadData) void {
         switch (self.*) {
             .exec => |*exec| exec.threadExit(td),
+            .manual => |*manual| manual.threadExit(td),
         }
     }
 
@@ -60,6 +68,7 @@ pub const Backend = union(Kind) {
     ) !void {
         switch (self.*) {
             .exec => |*exec| try exec.focusGained(td, focused),
+            .manual => |*manual| try manual.focusGained(td, focused),
         }
     }
 
@@ -70,6 +79,7 @@ pub const Backend = union(Kind) {
     ) !void {
         switch (self.*) {
             .exec => |*exec| try exec.resize(grid_size, screen_size),
+            .manual => |*manual| try manual.resize(grid_size, screen_size),
         }
     }
 
@@ -82,6 +92,7 @@ pub const Backend = union(Kind) {
     ) !void {
         switch (self.*) {
             .exec => |*exec| try exec.queueWrite(alloc, td, data, linefeed),
+            .manual => |*manual| try manual.queueWrite(alloc, td, data, linefeed),
         }
     }
 
@@ -99,6 +110,12 @@ pub const Backend = union(Kind) {
                 exit_code,
                 runtime_ms,
             ),
+            .manual => |*manual| try manual.childExitedAbnormally(
+                gpa,
+                t,
+                exit_code,
+                runtime_ms,
+            ),
         }
     }
 
@@ -108,6 +125,7 @@ pub const Backend = union(Kind) {
     pub fn getProcessInfo(self: *Backend, comptime info: ProcessInfo) ?ProcessInfo.Type(info) {
         return switch (self.*) {
             .exec => |*exec| exec.getProcessInfo(info),
+            .manual => null,
         };
     }
 };
@@ -115,10 +133,12 @@ pub const Backend = union(Kind) {
 /// Termio thread data. See termio.ThreadData for docs.
 pub const ThreadData = union(Kind) {
     exec: termio.Exec.ThreadData,
+    manual: termio.ManualThreadData,
 
     pub fn deinit(self: *ThreadData, alloc: Allocator) void {
         switch (self.*) {
             .exec => |*exec| exec.deinit(alloc),
+            .manual => |*manual| manual.deinit(alloc),
         }
     }
 


### PR DESCRIPTION
## Summary
- expose manual embedded surface IO through the C API
- wire the existing manual termio backend into embedded surfaces
- add synchronous render and committed text input entrypoints for libghostty iOS clients

## Verification
- `zig build test`
- `CMUX_GHOSTTYKIT_NO_PREBUILT=1 ./scripts/ensure-ghosttykit.sh` from cmux parent worktree

## cmux iOS requirement
This keeps the old iOS app API surface available without taking stale xcframework/build-system changes from the old branch.