### PR TITLE
Refresh embedded mouse state when modifiers change

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1178,6 +1178,7 @@ GHOSTTY_API void ghostty_surface_complete_clipboard_request(ghostty_surface_t,
                                                                bool);
 GHOSTTY_API bool ghostty_surface_has_selection(ghostty_surface_t);
 GHOSTTY_API bool ghostty_surface_select_cursor_cell(ghostty_surface_t);
+GHOSTTY_API bool ghostty_surface_select_cursor_line(ghostty_surface_t);
 GHOSTTY_API bool ghostty_surface_clear_selection(ghostty_surface_t);
 GHOSTTY_API bool ghostty_surface_read_selection(ghostty_surface_t, ghostty_text_s*);
 GHOSTTY_API bool ghostty_surface_read_text(ghostty_surface_t,

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -2098,6 +2098,26 @@ pub fn selectCursorCell(self: *Surface) !bool {
     return true;
 }
 
+/// Select the semantic line under the cursor (cmux-specific).
+pub fn selectCursorLine(self: *Surface) !bool {
+    self.renderer_state.mutex.lock();
+    defer self.renderer_state.mutex.unlock();
+
+    const screen: *terminal.Screen = self.io.terminal.screens.active;
+    const pin = screen.cursor.page_pin.*;
+    if (screen.pages.pointFromPin(.viewport, pin)) |pt| {
+        if (pt.viewport.y >= @as(u32, screen.pages.rows)) return false;
+    } else {
+        return false;
+    }
+
+    const sel = screen.selectLine(.{ .pin = pin }) orelse return false;
+    try self.setSelection(sel);
+    screen.dirty.selection = true;
+    try self.queueRender();
+    return true;
+}
+
 /// Clear the active selection (cmux-specific).
 pub fn clearSelection(self: *Surface) !bool {
     self.renderer_state.mutex.lock();

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -423,6 +423,7 @@ pub const Surface = struct {
     content_scale: apprt.ContentScale,
     size: apprt.SurfaceSize,
     cursor_pos: apprt.CursorPos,
+    cursor_pos_mods: input.Mods,
     inspector: ?*Inspector = null,
     io_mode: IoMode = .exec,
     io_write_cb: ?IoWriteCallback = null,
@@ -496,6 +497,7 @@ pub const Surface = struct {
             },
             .size = .{ .width = 800, .height = 600 },
             .cursor_pos = .{ .x = -1, .y = -1 },
+            .cursor_pos_mods = .{},
             .io_mode = opts.io_mode,
             .io_write_cb = opts.io_write_cb,
             .io_write_userdata = opts.io_write_userdata,
@@ -921,9 +923,11 @@ pub const Surface = struct {
         // behavior, we only continue with callback logic if the cursor has
         // actually moved.
         if (@abs(self.cursor_pos.x - pos.x) < 1 and
-            @abs(self.cursor_pos.y - pos.y) < 1) return;
+            @abs(self.cursor_pos.y - pos.y) < 1 and
+            self.cursor_pos_mods.equal(mods)) return;
 
         self.cursor_pos = pos;
+        self.cursor_pos_mods = mods;
 
         self.core_surface.cursorPosCallback(self.cursor_pos, mods) catch |err| {
             log.err("error in cursor pos callback err={}", .{err});

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1663,6 +1663,14 @@ pub const CAPI = struct {
         };
     }
 
+    /// Select the semantic line under the cursor (cmux-specific).
+    export fn ghostty_surface_select_cursor_line(surface: *Surface) bool {
+        return surface.core_surface.selectCursorLine() catch |err| {
+            log.warn("error selecting cursor line err={}", .{err});
+            return false;
+        };
+    }
+
     /// Clear the active selection (cmux-specific).
     export fn ghostty_surface_clear_selection(surface: *Surface) bool {
         return surface.core_surface.clearSelection() catch |err| {

--- a/src/build/Config.zig
+++ b/src/build/Config.zig
@@ -39,6 +39,7 @@ wasm_shared: bool = true,
 exe_entrypoint: ExeEntrypoint = .ghostty,
 version: std.SemanticVersion = .{ .major = 0, .minor = 0, .patch = 0 },
 lib_version: std.SemanticVersion = .{ .major = 0, .minor = 0, .patch = 0 },
+crash_report_subdir: []const u8 = "ghostty/crash",
 
 /// Binary properties
 pie: bool = false,
@@ -312,6 +313,17 @@ pub fn init(b: *std.Build, appVersion: []const u8, libVersion: []const u8) !Conf
     else
         try std.SemanticVersion.parse(libVersion);
 
+    config.crash_report_subdir = b.option(
+        []const u8,
+        "crash-report-subdir",
+        "XDG state subdirectory where crash reports are stored.",
+    ) orelse "ghostty/crash";
+    if (config.crash_report_subdir.len == 0 or
+        std.fs.path.isAbsolute(config.crash_report_subdir))
+    {
+        @panic("crash-report-subdir must be a non-empty relative path");
+    }
+
     //---------------------------------------------------------------
     // Binary Properties
 
@@ -560,6 +572,12 @@ pub fn addOptions(self: *const Config, step: *std.Build.Step.Options) !void {
         "{f}",
         .{self.lib_version},
     ));
+    var crash_report_subdir_buf: [1024]u8 = undefined;
+    step.addOption([:0]const u8, "crash_report_subdir", try std.fmt.bufPrintZ(
+        &crash_report_subdir_buf,
+        "{s}",
+        .{self.crash_report_subdir},
+    ));
     step.addOption(
         ReleaseChannel,
         "release_channel",
@@ -630,6 +648,7 @@ pub fn fromOptions() Config {
         .wasm_target = std.meta.stringToEnum(WasmTarget, @tagName(options.wasm_target)).?,
         .wasm_shared = options.wasm_shared,
         .i18n = options.i18n,
+        .crash_report_subdir = options.crash_report_subdir,
     };
 }
 

--- a/src/build_config.zig
+++ b/src/build_config.zig
@@ -36,6 +36,7 @@ pub const artifact = Artifact.detect();
 /// comments in BuildConfig for details on each.
 const config = BuildConfig.fromOptions();
 pub const exe_entrypoint = config.exe_entrypoint;
+pub const crash_report_subdir = config.crash_report_subdir;
 pub const flatpak = options.flatpak;
 pub const snap = options.snap;
 pub const app_runtime: apprt.Runtime = config.app_runtime;

--- a/src/config/url.zig
+++ b/src/config/url.zig
@@ -98,6 +98,10 @@ const path_body_with_undotted_leaf =
     "(?:" ++ path_segment_chars ++ "+/)*" ++ path_segment_chars_no_dot ++ "+"
 ;
 
+const path_body_with_dotted_leaf =
+    "(?:" ++ path_segment_chars ++ "+/)*" ++ path_segment_chars ++ "*\\." ++ path_segment_chars ++ "+"
+;
+
 const malformed_spaced_path_lookahead =
     "(?=(?:" ++ single_spaced_path_no_dot_segment ++ ")*  )"
 ;
@@ -138,6 +142,19 @@ const dotted_path_space_file_segment =
     "*)"
 ;
 
+const dotted_path_space_single_file_segment =
+    \\(?:(?<!:) (?! )(?!\w+:\/\/)(?!\.{0,2}\/)(?!~\/)
+    ++ path_chars_no_dot ++
+    "+\\." ++
+    path_chars ++
+    "*)"
+;
+
+const dotted_path_space_dir_suffix =
+    dotted_path_space_dir_prefix_segments ++
+    dotted_path_space_dir_segment_dotted_tail
+;
+
 const dotted_path_space_suffix =
     dotted_path_space_dir_prefix_segments ++
     "(?:" ++ dotted_path_space_dir_segment_dotted_tail ++ "|" ++ dotted_path_space_file_segment ++ ")"
@@ -173,6 +190,13 @@ const rooted_or_relative_path_branch =
     dotted_spaced_path_lookahead ++
     path_body_with_undotted_leaf ++
     malformed_spaced_path_lookahead ++
+    no_trailing_colon ++
+    no_trailing_path_punctuation ++
+    trailing_spaces_at_eol ++
+    "|" ++
+    dotted_spaced_path_lookahead ++
+    path_body_with_dotted_leaf ++
+    "(?:" ++ dotted_path_space_dir_suffix ++ "|" ++ dotted_path_space_single_file_segment ++ ")" ++
     no_trailing_colon ++
     no_trailing_path_punctuation ++
     trailing_spaces_at_eol ++
@@ -470,6 +494,14 @@ test "url regex" {
         .{
             .input = "/tmp/foo bar.txt version is 1.2",
             .expect = "/tmp/foo bar.txt",
+        },
+        .{
+            .input = "/tmp/foo.bar baz.txt version is 1.2",
+            .expect = "/tmp/foo.bar baz.txt",
+        },
+        .{
+            .input = "/tmp/v1.2 captures/video.mp4. It is ok",
+            .expect = "/tmp/v1.2 captures/video.mp4",
         },
         .{
             .input = "/tmp/test folder/file.txt version is 1.2",

--- a/src/config/url.zig
+++ b/src/config/url.zig
@@ -359,6 +359,10 @@ test "url regex" {
             .expect = "/tmp/test folder/file.txt",
         },
         .{
+            .input = "Start with /Users/tester/Recovered Screen Recordings/2026-05-18/screen-recording-2026-05-15-raw.mp4. It is a 75 MB Screen Studio recording, 46s long.",
+            .expect = "/Users/tester/Recovered Screen Recordings/2026-05-18/screen-recording-2026-05-15-raw.mp4",
+        },
+        .{
             .input = "/tmp/test  folder/file.txt",
             .expect = "/tmp/test",
         },

--- a/src/config/url.zig
+++ b/src/config/url.zig
@@ -40,6 +40,18 @@ const path_chars =
     \\[\w\-.~:\/?#@!$&*+;=%]
 ;
 
+const path_chars_no_dot =
+    \\[\w\-~:\/?#@!$&*+;=%]
+;
+
+const path_segment_chars =
+    \\[\w\-.~:?#@!$&*+;=%]
+;
+
+const path_segment_chars_no_dot =
+    \\[\w\-~:?#@!$&*+;=%]
+;
+
 const optional_bracketed_word_suffix =
     \\(?:[\(\[]\w*[\)\]])?
 ;
@@ -52,8 +64,16 @@ const no_trailing_colon =
     \\(?<!:)
 ;
 
+const no_trailing_path_punctuation =
+    \\(?:(?<![,.])|(?= *$))
+;
+
 const trailing_spaces_at_eol =
     \\(?: +(?= *$))?
+;
+
+const dotted_spaced_path_lookahead =
+    \\(?=[\w\-.~:\/?#@!$&*+;=% ]*\.)
 ;
 
 const dotted_path_lookahead =
@@ -64,8 +84,63 @@ const non_dotted_path_lookahead =
     \\(?![\w\-.~:\/?#@!$&*+;=%]*\.)
 ;
 
-const dotted_path_space_segments =
-    \\(?:(?<!:) (?!\w+:\/\/)(?!\.{0,2}\/)(?!~\/)[\w\-.~:\/?#@!$&*+;=%]*[\/.])*
+const single_spaced_path_no_dot_segment =
+    \\ (?! )(?!\w+:\/\/)(?!\.{0,2}\/)(?!~\/)
+    ++ path_chars_no_dot ++
+    "+"
+;
+
+const single_spaced_path_no_dot_segments =
+    "(?:" ++ single_spaced_path_no_dot_segment ++ ")*"
+;
+
+const path_body_with_undotted_leaf =
+    "(?:" ++ path_segment_chars ++ "+/)*" ++ path_segment_chars_no_dot ++ "+"
+;
+
+const malformed_spaced_path_lookahead =
+    "(?=(?:" ++ single_spaced_path_no_dot_segment ++ ")*  )"
+;
+
+const dotted_path_space_dir_segment_no_dot_tail =
+    \\(?:(?<!:) (?! )(?!\w+:\/\/)(?!\.{0,2}\/)(?!~\/)
+    ++ path_chars_no_dot ++
+    "+" ++
+    single_spaced_path_no_dot_segments ++
+    "/" ++
+    path_chars_no_dot ++
+    "*)"
+;
+
+const dotted_path_space_dir_segment_dotted_tail =
+    \\(?:(?<!:) (?! )(?!\w+:\/\/)(?!\.{0,2}\/)(?!~\/)
+    ++ path_chars_no_dot ++
+    "+" ++
+    single_spaced_path_no_dot_segments ++
+    "/" ++
+    path_chars_no_dot ++
+    "*\\." ++
+    path_chars ++
+    "*)"
+;
+
+const dotted_path_space_dir_prefix_segments =
+    "(?:" ++ dotted_path_space_dir_segment_no_dot_tail ++ ")*"
+;
+
+const dotted_path_space_file_segment =
+    \\(?:(?<!:) (?! )(?!\w+:\/\/)(?!\.{0,2}\/)(?!~\/)
+    ++ path_chars_no_dot ++
+    "+" ++
+    single_spaced_path_no_dot_segments ++
+    "\\." ++
+    path_chars ++
+    "*)"
+;
+
+const dotted_path_space_suffix =
+    dotted_path_space_dir_prefix_segments ++
+    "(?:" ++ dotted_path_space_dir_segment_dotted_tail ++ "|" ++ dotted_path_space_file_segment ++ ")"
 ;
 
 const any_path_space_segments =
@@ -88,10 +163,24 @@ const rooted_or_relative_path_prefix =
 const rooted_or_relative_path_branch =
     rooted_or_relative_path_prefix ++
     "(?:" ++
+    dotted_spaced_path_lookahead ++
+    path_body_with_undotted_leaf ++
+    dotted_path_space_suffix ++
+    no_trailing_colon ++
+    no_trailing_path_punctuation ++
+    trailing_spaces_at_eol ++
+    "|" ++
+    dotted_spaced_path_lookahead ++
+    path_body_with_undotted_leaf ++
+    malformed_spaced_path_lookahead ++
+    no_trailing_colon ++
+    no_trailing_path_punctuation ++
+    trailing_spaces_at_eol ++
+    "|" ++
     dotted_path_lookahead ++
     path_chars ++ "+" ++
-    dotted_path_space_segments ++
     no_trailing_colon ++
+    no_trailing_path_punctuation ++
     trailing_spaces_at_eol ++
     "|" ++
     non_dotted_path_lookahead ++
@@ -363,8 +452,32 @@ test "url regex" {
             .expect = "/Users/tester/Recovered Screen Recordings/2026-05-18/screen-recording-2026-05-15-raw.mp4",
         },
         .{
+            .input = "/Users/ghostty.user/Recovered Screen Recordings/file.mp4",
+            .expect = "/Users/ghostty.user/Recovered Screen Recordings/file.mp4",
+        },
+        .{
             .input = "/tmp/test  folder/file.txt",
             .expect = "/tmp/test",
+        },
+        .{
+            .input = "/tmp/foo bar  baz.txt",
+            .expect = "/tmp/foo",
+        },
+        .{
+            .input = "/tmp/foo.txt version is 1.2",
+            .expect = "/tmp/foo.txt",
+        },
+        .{
+            .input = "/tmp/foo bar.txt version is 1.2",
+            .expect = "/tmp/foo bar.txt",
+        },
+        .{
+            .input = "/tmp/test folder/file.txt version is 1.2",
+            .expect = "/tmp/test folder/file.txt",
+        },
+        .{
+            .input = "/tmp/test folder/file.txt /tmp/other.txt",
+            .expect = "/tmp/test folder/file.txt",
         },
         // unified diff lines
         .{
@@ -379,6 +492,14 @@ test "url regex" {
         .{
             .input = "/tmp/foo.txt /tmp/bar.txt",
             .expect = "/tmp/foo.txt",
+        },
+        .{
+            .input = "/tmp/foo bar /tmp/baz.txt",
+            .expect = "/tmp/foo bar",
+        },
+        .{
+            .input = "/tmp/foo bar http://example.com/a.txt",
+            .expect = "/tmp/foo bar",
         },
         // Bare relative file paths (no ./ or ../ prefix)
         .{
@@ -509,6 +630,9 @@ test "url regex" {
         "$10/bar.txt",
         // comma should not let dot detection look past it
         "foo/bar,baz.txt",
+        // spaces in prose should not make an undotted bare path look dotted
+        "read/write is complete.",
+        "input/output config.json",
         // $VAR should not match mid-word
         "foo$BAR/baz.txt",
         // ~ should not match mid-word

--- a/src/crash/dir.zig
+++ b/src/crash/dir.zig
@@ -1,12 +1,13 @@
 const std = @import("std");
 const assert = std.debug.assert;
 const Allocator = std.mem.Allocator;
+const build_config = @import("../build_config.zig");
 const internal_os = @import("../os/main.zig");
 
 /// Returns a Dir for the default directory. The Dir.path field must be
 /// freed with the given allocator.
 pub fn defaultDir(alloc: Allocator) !Dir {
-    const crash_dir = try internal_os.xdg.state(alloc, .{ .subdir = "ghostty/crash" });
+    const crash_dir = try internal_os.xdg.state(alloc, .{ .subdir = build_config.crash_report_subdir });
     errdefer alloc.free(crash_dir);
     return .{ .path = crash_dir };
 }

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -49,7 +49,11 @@ fn advanceShaperCellIndexToX(
     shaper_cells_i: *usize,
     x: usize,
 ) void {
-    while (run_offset + shaped_cells[shaper_cells_i.*].x < x) {
+    // A text run can contain terminal cells that produce no shaped glyphs
+    // (for example, an empty tail after IME preedit covered the only glyph).
+    while (shaper_cells_i.* < shaped_cells.len and
+        run_offset + shaped_cells[shaper_cells_i.*].x < x)
+    {
         shaper_cells_i.* += 1;
     }
 }

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -43,6 +43,17 @@ const DisplayLink = switch (builtin.os.tag) {
 
 const log = std.log.scoped(.generic_renderer);
 
+fn advanceShaperCellIndexToX(
+    run_offset: usize,
+    shaped_cells: []const font.shape.Cell,
+    shaper_cells_i: *usize,
+    x: usize,
+) void {
+    while (run_offset + shaped_cells[shaper_cells_i.*].x < x) {
+        shaper_cells_i.* += 1;
+    }
+}
+
 /// Create a renderer type with the provided graphics API wrapper.
 ///
 /// The graphics API wrapper must provide the interface outlined below.
@@ -2758,10 +2769,12 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
 
                     // Advance our index until we reach or pass
                     // our current x position in the shaper cells.
-                    const shaper_cells_unwrapped = shaper_cells.?;
-                    while (run.offset + shaper_cells_unwrapped[shaper_cells_i].x < x) {
-                        shaper_cells_i += 1;
-                    }
+                    advanceShaperCellIndexToX(
+                        run.offset,
+                        shaper_cells.?,
+                        &shaper_cells_i,
+                        x,
+                    );
                 }
 
                 const wide = cell.wide;
@@ -3393,4 +3406,22 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             try texture.replaceRegion(0, 0, atlas.size, atlas.size, atlas.data);
         }
     };
+}
+
+test "renderer rebuild row preedit catch-up tolerates empty tail after covered glyph" {
+    const testing = std.testing;
+
+    const shaped_cells = [_]font.shape.Cell{
+        .{ .x = 0, .glyph_index = 1 },
+    };
+    var shaper_cells_i: usize = 0;
+
+    advanceShaperCellIndexToX(
+        0,
+        &shaped_cells,
+        &shaper_cells_i,
+        1,
+    );
+
+    try testing.expectEqual(@as(usize, shaped_cells.len), shaper_cells_i);
 }


### PR DESCRIPTION
Fixes the Ghostty-side root cause for https://github.com/manaflow-ai/cmux/issues/3557.\n\nThe embedded adapter suppressed same-position cursor callbacks to avoid phantom macOS mouse moves. That also hid stationary modifier transitions from core, so a pointer parked over an OSC 8 hyperlink did not refresh link hover/open state when Command was pressed before click release.\n\nThis keeps same-position suppression only when both coordinates and modifier state are unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes embedded mouse state when modifiers change so stationary Cmd-clicks on OSC 8 links work in embedded mode. Also fixes a renderer crash, adds a crash report subdirectory option, improves spaced file path link detection, and adds a cursor-line selection API. Addresses `cmux` issues 3557 and 3369.

- **New Features**
  - Configurable crash report path via `--crash-report-subdir`; exported as `build_config.crash_report_subdir` and used by crash dir lookup. Validates non-empty, relative paths.
  - Cursor line selection: new C API `ghostty_surface_select_cursor_line` selects the semantic line under the cursor.

- **Bug Fixes**
  - Embedded: track `cursor_pos_mods` and fire `cursorPosCallback` on mod changes; skip only when both position and mods are unchanged.
  - Renderer: bound IME preedit catch-up to shaped glyphs; adds a helper and a regression test.
  - URL parsing: bound spaced file path links, handle dotted spaced prefixes, and avoid capturing trailing punctuation/colons; adds tests.

<sup>Written for commit 5b0b60b95113cc848cf0c08dbc2cc85e65a4cfc3. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/54?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Optimized cursor tracking to detect modifier key changes and avoid redundant input updates when cursor and modifiers are unchanged.
* **Bug Fixes**
  * Improved text-input/preedit rendering to better handle cases where shaped cells produce empty tails, reducing misalignment.
* **Tests**
  * Added a unit test validating preedit catch-up behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/ghostty/pull/54)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->