### PR TITLE
Expose cursor line selection API

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1178,6 +1178,7 @@ GHOSTTY_API void ghostty_surface_complete_clipboard_request(ghostty_surface_t,
                                                                bool);
 GHOSTTY_API bool ghostty_surface_has_selection(ghostty_surface_t);
 GHOSTTY_API bool ghostty_surface_select_cursor_cell(ghostty_surface_t);
+GHOSTTY_API bool ghostty_surface_select_cursor_line(ghostty_surface_t);
 GHOSTTY_API bool ghostty_surface_clear_selection(ghostty_surface_t);
 GHOSTTY_API bool ghostty_surface_read_selection(ghostty_surface_t, ghostty_text_s*);
 GHOSTTY_API bool ghostty_surface_read_text(ghostty_surface_t,

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -2098,6 +2098,26 @@ pub fn selectCursorCell(self: *Surface) !bool {
     return true;
 }
 
+/// Select the semantic line under the cursor (cmux-specific).
+pub fn selectCursorLine(self: *Surface) !bool {
+    self.renderer_state.mutex.lock();
+    defer self.renderer_state.mutex.unlock();
+
+    const screen: *terminal.Screen = self.io.terminal.screens.active;
+    const pin = screen.cursor.page_pin.*;
+    if (screen.pages.pointFromPin(.viewport, pin)) |pt| {
+        if (pt.viewport.y >= @as(u32, screen.pages.rows)) return false;
+    } else {
+        return false;
+    }
+
+    const sel = screen.selectLine(.{ .pin = pin }) orelse return false;
+    try self.setSelection(sel);
+    screen.dirty.selection = true;
+    try self.queueRender();
+    return true;
+}
+
 /// Clear the active selection (cmux-specific).
 pub fn clearSelection(self: *Surface) !bool {
     self.renderer_state.mutex.lock();

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1663,6 +1663,14 @@ pub const CAPI = struct {
         };
     }
 
+    /// Select the semantic line under the cursor (cmux-specific).
+    export fn ghostty_surface_select_cursor_line(surface: *Surface) bool {
+        return surface.core_surface.selectCursorLine() catch |err| {
+            log.warn("error selecting cursor line err={}", .{err});
+            return false;
+        };
+    }
+
     /// Clear the active selection (cmux-specific).
     export fn ghostty_surface_clear_selection(surface: *Surface) bool {
         return surface.core_surface.clearSelection() catch |err| {


### PR DESCRIPTION
Adds a cmux-used embedded C API for selecting the semantic line under the terminal cursor via Ghostty's Screen.selectLine path. This lets cmux implement terminal Cmd+A without replaying synthetic mouse clicks.\n\nRelated: manaflow-ai/cmux#3802

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose a C API to select the semantic line under the terminal cursor, enabling `cmux` to implement terminal Cmd+A without synthetic mouse clicks. Addresses manaflow-ai/cmux#3802.

- **New Features**
  - Added `ghostty_surface_select_cursor_line` to the embedded C API (`include/ghostty.h`).
  - Implemented `Surface.selectCursorLine` using `Screen.selectLine`, with proper mutex locking, selection update, and render queue.
  - Returns false when the cursor is off-screen or selection is not possible.

<sup>Written for commit 835b3ba3fecebfc7e9a60299ca547ed7e44033fd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

