### PR TITLE
cmux fork: ghostty_surface_set_pty_tap C export

### DIFF
--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1799,6 +1799,28 @@ pub const CAPI = struct {
         return .fromSlice(copy);
     }
 
+    /// cmux fork: install or clear a callback that fires with raw PTY
+    /// output bytes BEFORE the terminal emulator processes them. Used
+    /// by the embedded cmuxd-host server in cmux-Mac so the phone can
+    /// see byte-faithful output (colors, cursor moves, OSC sequences).
+    ///
+    /// Pass null callback to remove a previously-installed tap. The
+    /// callback fires on the I/O reader thread; consumers must marshal
+    /// to whatever thread they want to do work on themselves.
+    ///
+    /// Ordering: userdata is stored first (release), then callback
+    /// (release), so a concurrent reader that sees a non-null
+    /// callback after an acquire load is guaranteed to see the
+    /// matching userdata.
+    export fn ghostty_surface_set_pty_tap(
+        surface: *Surface,
+        callback: ?*const fn (?*anyopaque, [*]const u8, usize) callconv(.c) void,
+        userdata: ?*anyopaque,
+    ) void {
+        surface.core_surface.io.pty_tap_userdata.store(userdata, .release);
+        surface.core_surface.io.pty_tap_callback.store(callback, .release);
+    }
+
     /// Update the color scheme of the surface.
     export fn ghostty_surface_set_color_scheme(surface: *Surface, scheme_raw: c_int) void {
         const scheme = std.meta.intToEnum(apprt.ColorScheme, scheme_raw) catch {

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -1335,6 +1335,14 @@ pub const ReadThread = struct {
                 if (n == 0) break;
 
                 // log.info("DATA: {d}", .{n});
+                // cmux fork: fire the PTY tap (if installed) with raw
+                // pre-emulator bytes BEFORE processing. Ordered load:
+                // callback first, then userdata (matches the setter's
+                // release order — see Termio.zig).
+                if (io.pty_tap_callback.load(.acquire)) |tap_cb| {
+                    const tap_ud = io.pty_tap_userdata.load(.acquire);
+                    tap_cb(tap_ud, buf[0..n].ptr, n);
+                }
                 @call(.always_inline, termio.Termio.processOutput, .{ io, buf[0..n] });
             }
 
@@ -1387,6 +1395,12 @@ pub const ReadThread = struct {
                     }
                 }
 
+                // cmux fork: same PTY tap as the posix branch, see
+                // Termio.zig's pty_tap_callback for the ordering contract.
+                if (io.pty_tap_callback.load(.acquire)) |tap_cb| {
+                    const tap_ud = io.pty_tap_userdata.load(.acquire);
+                    tap_cb(tap_ud, buf[0..n].ptr, n);
+                }
                 @call(.always_inline, termio.Termio.processOutput, .{ io, buf[0..n] });
             }
 

--- a/src/termio/Termio.zig
+++ b/src/termio/Termio.zig
@@ -64,6 +64,26 @@ mailbox: termio.Mailbox,
 /// Delete when upstream supports manual backend writes without this path.
 manual_linefeed_mode: std.atomic.Value(bool) = .{ .raw = false },
 
+/// cmux fork: optional tap on raw PTY output bytes, fired BEFORE the
+/// terminal emulator processes them. Used by the embedded cmuxd-host
+/// server (Mac app) to stream faithful PTY bytes to remote clients
+/// (the phone) so the receiving end can drive its own emulator —
+/// colors, cursor positioning, OSC sequences, all preserved.
+///
+/// Two separate atomic pointer fields rather than one atomic struct
+/// because Zig has no built-in atomic for arbitrary-sized payloads.
+/// Setter MUST write userdata first, then callback (release order);
+/// reader MUST load callback first, then userdata (acquire order).
+/// That ordering keeps a concurrent setter from leaving the reader
+/// with a fresh callback pointing at a stale userdata.
+///
+/// Fires on the I/O reader thread, NOT the main thread; consumers
+/// marshal cross-thread themselves. Delete when upstream offers a
+/// generic stream-observer hook.
+pty_tap_callback: std.atomic.Value(?*const fn (?*anyopaque, [*]const u8, usize) callconv(.c) void) =
+    .{ .raw = null },
+pty_tap_userdata: std.atomic.Value(?*anyopaque) = .{ .raw = null },
+
 /// The stream parser. This parses the stream of escape codes and so on
 /// from the child process and calls callbacks in the stream handler.
 terminal_stream: StreamHandler.Stream,


### PR DESCRIPTION
Adds an optional callback fired with raw PTY output bytes BEFORE the terminal emulator processes them. Used by the embedded cmuxd-host server in cmux-Mac (cmux PR #23) so a remote client (the phone) can drive its own emulator faithful to the original byte stream — colors, cursor moves, OSC sequences, bracketed paste state, all preserved.

## API shape

```c
ghostty_surface_set_pty_tap(
    Surface*,
    void (*callback)(void *userdata, const uint8_t *bytes, size_t len),
    void *userdata
);
```

Pass a non-null callback to install a tap; pass null to remove a previously-installed one. The callback fires on the I/O reader thread; consumers marshal cross-thread themselves.

## Implementation

- Two atomic pointer fields on `Termio`: `pty_tap_callback` + `pty_tap_userdata`. Setter writes userdata first then callback (release order); reader loads callback first then userdata (acquire order). With this ordering a reader that sees a non-null callback after an acquire load is guaranteed to see the matching userdata, so a concurrent setter can never leave a reader with a fresh callback + stale userdata.
- One read-loop hook in `termio/Exec.zig`'s `threadMainPosix` AND `threadMainWindows`, immediately before the existing `Termio.processOutput` call. Cost when no tap is installed: one relaxed atomic-pointer load per PTY read chunk, branch-predicts to "no tap" on every iteration. Effectively free for users who never set a tap.
- One C export in `apprt/embedded.zig::ghostty_surface_set_pty_tap`. Just calls `.store()` on the two atomics in the documented order.

## Why this lives in our fork (not upstream)

The cmuxd-host design treats Mac terminals as cmuxd-host sessions the phone can attach to. Mac-side Ghostty surfaces are the PTYs; without this hook the phone can either re-serialize the rendered grid back to ANSI (lossy) or proxy via a separate child process (extra layer, extra moving parts). A C-level tap callback is the cleanest path.

Open to landing upstream as a generic stream-observer hook in a follow-up if the maintainers want it.

## Verified

```
zig build -Demit-xcframework=true -Dxcframework-target=universal \
          -Doptimize=ReleaseFast
```

EXIT=0, new symbol present:

```
nm macos/GhosttyKit.xcframework/macos-arm64_x86_64/ghostty-internal.a \
  | grep ghostty_surface_set_pty_tap
→ 000000000030e79c T _ghostty_surface_set_pty_tap
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a C API to tap raw PTY output before the emulator processes it. This lets cmuxd-host stream byte-accurate output so the phone client can run its own emulator faithfully.

- **New Features**
  - Export `ghostty_surface_set_pty_tap(surface, callback, userdata)`; pass `NULL` to remove.
  - Callback fires on the I/O reader thread with raw bytes before `Termio.processOutput` (POSIX and Windows).
  - Atomic ordering guarantees matching `userdata` for any observed non-null callback.
  - Near-zero overhead when unused (one atomic load per read chunk).
  - Used by cmux-Mac `cmuxd-host` to preserve colors, cursor moves, OSC, and bracketed paste.

<sup>Written for commit b4d06e12c7d1eb13f6e59f1deed67a011c71d20c. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/57?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new C API function to install or clear PTY output callbacks on terminal surfaces.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/ghostty/pull/57?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->