### PR TITLE
Merge upstream Ghostty for cmux

### DIFF
--- a/.github/VOUCHED.td
+++ b/.github/VOUCHED.td
@@ -211,6 +211,7 @@ prakhar54-byte
 priyans-hu
 puzza007
 qwerasd205
+raphamorim
 reo101
 rgehan
 rhodes-b

--- a/.github/VOUCHED.td
+++ b/.github/VOUCHED.td
@@ -216,6 +216,7 @@ rmengelbrecht
 rmunn
 rockorager
 rpfaeffle
+samasaur1
 sandydoo
 secrus
 seruman

--- a/.github/VOUCHED.td
+++ b/.github/VOUCHED.td
@@ -91,6 +91,7 @@ elias8
 enzowilliam
 ephemera
 eriksremess
+erral
 faukah
 filip7
 flou

--- a/.github/VOUCHED.td
+++ b/.github/VOUCHED.td
@@ -28,6 +28,7 @@ aaron-ang
 abdurrahmanski
 abudvytis
 adrum
+agoodkind
 aindriu80
 ajiblock
 akimiojr

--- a/.github/VOUCHED.td
+++ b/.github/VOUCHED.td
@@ -176,6 +176,7 @@ mitchellh
 miupa
 molechowski
 moonmao42
+-morgengeluk Appears to be using AI inappropriately even after it was requested they abide by the AI policy (there is clear evidence of the person-in-the-loop not attempting to clean up AI generated text, and their AI disclosure itself reads like AI-generated text and shows no signs of remorse or intent to improve).
 mpatankar6
 mrconnorkenway
 mrmage

--- a/.github/VOUCHED.td
+++ b/.github/VOUCHED.td
@@ -175,6 +175,7 @@ misairuzame
 mischief
 mitchellh
 miupa
+mohshami
 molechowski
 moonmao42
 -morgengeluk Appears to be using AI inappropriately even after it was requested they abide by the AI policy (there is clear evidence of the person-in-the-loop not attempting to clean up AI generated text, and their AI disclosure itself reads like AI-generated text and shows no signs of remorse or intent to improve).

--- a/.github/VOUCHED.td
+++ b/.github/VOUCHED.td
@@ -46,6 +46,7 @@ anmitalidev
 anthonyzhoon
 athaapa
 atomk
+b1nar10
 balazs-szucs
 barutsrb
 bch

--- a/.github/VOUCHED.td
+++ b/.github/VOUCHED.td
@@ -47,6 +47,7 @@ anthonyzhoon
 athaapa
 atomk
 b1nar10
+backnotprop
 balazs-szucs
 barutsrb
 bch

--- a/.github/VOUCHED.td
+++ b/.github/VOUCHED.td
@@ -255,6 +255,7 @@ wyounas
 yabbal
 yamshta
 ydah
+-zaviro
 zenyr
 zeshi09
 zubb

--- a/.github/VOUCHED.td
+++ b/.github/VOUCHED.td
@@ -43,6 +43,7 @@ andrejdaskalov
 anhthang
 anmitalidev
 anthonyzhoon
+athaapa
 atomk
 balazs-szucs
 barutsrb

--- a/.github/VOUCHED.td
+++ b/.github/VOUCHED.td
@@ -20,6 +20,7 @@
 # "!denounce" or "!denounce [username]" on a discussion.
 00-kat
 007hacky007
+00jciv00
 04cb
 0xdvc
 -4rh1t3ct0r7

--- a/.github/VOUCHED.td
+++ b/.github/VOUCHED.td
@@ -195,6 +195,7 @@ nicholas-ochoa
 nicosuave
 nmggithub
 noib3
+nolinmcfarland
 nouritsu
 nwehg
 ocean6954

--- a/.github/VOUCHED.td
+++ b/.github/VOUCHED.td
@@ -234,6 +234,7 @@ sunshine-syz
 tbrundige
 tdgroot
 tdslot
+thirstycrow
 thoutbeckers
 ticclick
 tnagatomi

--- a/.github/VOUCHED.td
+++ b/.github/VOUCHED.td
@@ -47,7 +47,6 @@ anthonyzhoon
 athaapa
 atomk
 b1nar10
-backnotprop
 balazs-szucs
 barutsrb
 bch

--- a/.github/VOUCHED.td
+++ b/.github/VOUCHED.td
@@ -93,6 +93,7 @@ enzowilliam
 ephemera
 eriksremess
 erral
+-f1813483-netizen
 faukah
 filip7
 flou

--- a/.github/VOUCHED.td
+++ b/.github/VOUCHED.td
@@ -247,6 +247,7 @@ tweedbeetle
 uhojin
 unphased
 uzaaft
+vancluever
 vaughanandrews
 viruslobster
 vlsi

--- a/.github/VOUCHED.td
+++ b/.github/VOUCHED.td
@@ -218,6 +218,7 @@ puzza007
 qwerasd205
 raphamorim
 reo101
+rewdy
 rgehan
 rhodes-b
 rightaditya

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -47,7 +47,7 @@ jobs:
             /nix
             /zig
       - name: Setup Nix
-        uses: cachix/install-nix-action@ab739621df7a23f52766f9ccc97f38da6b7af14f # v31.10.5
+        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -50,7 +50,7 @@ jobs:
         uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           nix_path: nixpkgs=channel:nixos-unstable
-      - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
+      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
         with:
           name: ghostty
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -89,7 +89,7 @@ jobs:
             /nix
             /zig
 
-      - uses: cachix/install-nix-action@ab739621df7a23f52766f9ccc97f38da6b7af14f # v31.10.5
+      - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           nix_path: nixpkgs=channel:nixos-unstable
 

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -93,7 +93,7 @@ jobs:
         with:
           nix_path: nixpkgs=channel:nixos-unstable
 
-      - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
+      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
         with:
           name: ghostty
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
@@ -147,7 +147,7 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@main
         with:
           determinate: true
-      - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
+      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
         with:
           name: ghostty
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"

--- a/.github/workflows/release-tip.yml
+++ b/.github/workflows/release-tip.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           path: |
             /nix
-      - uses: cachix/install-nix-action@ab739621df7a23f52766f9ccc97f38da6b7af14f # v31.10.5
+      - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
@@ -175,7 +175,7 @@ jobs:
           path: |
             /nix
             /zig
-      - uses: cachix/install-nix-action@ab739621df7a23f52766f9ccc97f38da6b7af14f # v31.10.5
+      - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
@@ -230,7 +230,7 @@ jobs:
           path: |
             /nix
             /zig
-      - uses: cachix/install-nix-action@ab739621df7a23f52766f9ccc97f38da6b7af14f # v31.10.5
+      - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17

--- a/.github/workflows/release-tip.yml
+++ b/.github/workflows/release-tip.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           nix_path: nixpkgs=channel:nixos-unstable
-      - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
+      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
         with:
           name: ghostty
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
@@ -178,7 +178,7 @@ jobs:
       - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           nix_path: nixpkgs=channel:nixos-unstable
-      - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
+      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
         with:
           name: ghostty
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
@@ -233,7 +233,7 @@ jobs:
       - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           nix_path: nixpkgs=channel:nixos-unstable
-      - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
+      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
         with:
           name: ghostty
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
@@ -312,7 +312,7 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@main
         with:
           determinate: true
-      - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
+      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
         with:
           name: ghostty
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
@@ -404,7 +404,7 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@main
         with:
           determinate: true
-      - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
+      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
         with:
           name: ghostty
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
@@ -660,7 +660,7 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@main
         with:
           determinate: true
-      - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
+      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
         with:
           name: ghostty
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
@@ -857,7 +857,7 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@main
         with:
           determinate: true
-      - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
+      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
         with:
           name: ghostty
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -166,7 +166,7 @@ jobs:
             /zig
 
       # Install Nix and use that to run our tests so our environment matches exactly.
-      - uses: cachix/install-nix-action@ab739621df7a23f52766f9ccc97f38da6b7af14f # v31.10.5
+      - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
@@ -224,7 +224,7 @@ jobs:
             /zig
 
       # Install Nix and use that to run our tests so our environment matches exactly.
-      - uses: cachix/install-nix-action@ab739621df7a23f52766f9ccc97f38da6b7af14f # v31.10.5
+      - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
@@ -260,7 +260,7 @@ jobs:
             /zig
 
       # Install Nix and use that to run our tests so our environment matches exactly.
-      - uses: cachix/install-nix-action@ab739621df7a23f52766f9ccc97f38da6b7af14f # v31.10.5
+      - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
@@ -366,7 +366,7 @@ jobs:
             /zig
 
       # Install Nix and use that to run our tests so our environment matches exactly.
-      - uses: cachix/install-nix-action@ab739621df7a23f52766f9ccc97f38da6b7af14f # v31.10.5
+      - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
@@ -404,7 +404,7 @@ jobs:
             /zig
 
       # Install Nix and use that to run our tests so our environment matches exactly.
-      - uses: cachix/install-nix-action@ab739621df7a23f52766f9ccc97f38da6b7af14f # v31.10.5
+      - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
@@ -521,7 +521,7 @@ jobs:
             /zig
 
       # Install Nix and use that to run our tests so our environment matches exactly.
-      - uses: cachix/install-nix-action@ab739621df7a23f52766f9ccc97f38da6b7af14f # v31.10.5
+      - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
@@ -555,7 +555,7 @@ jobs:
             /zig
 
       # Install Nix and use that to run our tests so our environment matches exactly.
-      - uses: cachix/install-nix-action@ab739621df7a23f52766f9ccc97f38da6b7af14f # v31.10.5
+      - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
@@ -600,7 +600,7 @@ jobs:
             /zig
 
       # Install Nix and use that to run our tests so our environment matches exactly.
-      - uses: cachix/install-nix-action@ab739621df7a23f52766f9ccc97f38da6b7af14f # v31.10.5
+      - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
@@ -676,7 +676,7 @@ jobs:
             /zig
 
       # Install Nix and use that to run our tests so our environment matches exactly.
-      - uses: cachix/install-nix-action@ab739621df7a23f52766f9ccc97f38da6b7af14f # v31.10.5
+      - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
@@ -753,7 +753,7 @@ jobs:
             /zig
 
       # Install Nix and use that to run our tests so our environment matches exactly.
-      - uses: cachix/install-nix-action@ab739621df7a23f52766f9ccc97f38da6b7af14f # v31.10.5
+      - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
@@ -782,7 +782,7 @@ jobs:
             /zig
 
       # Install Nix and use that to run our tests so our environment matches exactly.
-      - uses: cachix/install-nix-action@ab739621df7a23f52766f9ccc97f38da6b7af14f # v31.10.5
+      - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
@@ -815,7 +815,7 @@ jobs:
             /zig
 
       # Install Nix and use that to run our tests so our environment matches exactly.
-      - uses: cachix/install-nix-action@ab739621df7a23f52766f9ccc97f38da6b7af14f # v31.10.5
+      - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
@@ -897,7 +897,7 @@ jobs:
             /zig
 
       # Install Nix and use that to run our tests so our environment matches exactly.
-      - uses: cachix/install-nix-action@ab739621df7a23f52766f9ccc97f38da6b7af14f # v31.10.5
+      - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
@@ -937,7 +937,7 @@ jobs:
             /zig
 
       # Install Nix and use that to run our tests so our environment matches exactly.
-      - uses: cachix/install-nix-action@ab739621df7a23f52766f9ccc97f38da6b7af14f # v31.10.5
+      - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
@@ -1005,7 +1005,7 @@ jobs:
   #       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
   #     # Install Nix and use that to run our tests so our environment matches exactly.
-  #     - uses: cachix/install-nix-action@ab739621df7a23f52766f9ccc97f38da6b7af14f # v31.10.5
+  #     - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
   #       with:
   #         nix_path: nixpkgs=channel:nixos-unstable
   #     - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
@@ -1182,7 +1182,7 @@ jobs:
             /zig
 
       # Install Nix and use that to run our tests so our environment matches exactly.
-      - uses: cachix/install-nix-action@ab739621df7a23f52766f9ccc97f38da6b7af14f # v31.10.5
+      - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
@@ -1219,7 +1219,7 @@ jobs:
             /zig
 
       # Install Nix and use that to run our tests so our environment matches exactly.
-      - uses: cachix/install-nix-action@ab739621df7a23f52766f9ccc97f38da6b7af14f # v31.10.5
+      - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
@@ -1254,7 +1254,7 @@ jobs:
             /zig
 
       # Install Nix and use that to run our tests so our environment matches exactly.
-      - uses: cachix/install-nix-action@ab739621df7a23f52766f9ccc97f38da6b7af14f # v31.10.5
+      - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
@@ -1302,7 +1302,7 @@ jobs:
             /zig
 
       # Install Nix and use that to run our tests so our environment matches exactly.
-      - uses: cachix/install-nix-action@ab739621df7a23f52766f9ccc97f38da6b7af14f # v31.10.5
+      - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
@@ -1337,7 +1337,7 @@ jobs:
             /zig
 
       # Install Nix and use that to run our tests so our environment matches exactly.
-      - uses: cachix/install-nix-action@ab739621df7a23f52766f9ccc97f38da6b7af14f # v31.10.5
+      - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
@@ -1427,7 +1427,7 @@ jobs:
             /zig
 
       # Install Nix and use that to run our tests so our environment matches exactly.
-      - uses: cachix/install-nix-action@ab739621df7a23f52766f9ccc97f38da6b7af14f # v31.10.5
+      - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
@@ -1458,7 +1458,7 @@ jobs:
             /zig
 
       # Install Nix and use that to run our tests so our environment matches exactly.
-      - uses: cachix/install-nix-action@ab739621df7a23f52766f9ccc97f38da6b7af14f # v31.10.5
+      - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
@@ -1500,7 +1500,7 @@ jobs:
           path: |
             /nix
             /zig
-      - uses: cachix/install-nix-action@ab739621df7a23f52766f9ccc97f38da6b7af14f # v31.10.5
+      - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
@@ -1531,7 +1531,7 @@ jobs:
           path: |
             /nix
             /zig
-      - uses: cachix/install-nix-action@ab739621df7a23f52766f9ccc97f38da6b7af14f # v31.10.5
+      - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
@@ -1561,7 +1561,7 @@ jobs:
           path: |
             /nix
             /zig
-      - uses: cachix/install-nix-action@ab739621df7a23f52766f9ccc97f38da6b7af14f # v31.10.5
+      - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
@@ -1619,7 +1619,7 @@ jobs:
           path: |
             /nix
             /zig
-      - uses: cachix/install-nix-action@ab739621df7a23f52766f9ccc97f38da6b7af14f # v31.10.5
+      - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
@@ -1647,7 +1647,7 @@ jobs:
           path: |
             /nix
             /zig
-      - uses: cachix/install-nix-action@ab739621df7a23f52766f9ccc97f38da6b7af14f # v31.10.5
+      - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
@@ -1675,7 +1675,7 @@ jobs:
           path: |
             /nix
             /zig
-      - uses: cachix/install-nix-action@ab739621df7a23f52766f9ccc97f38da6b7af14f # v31.10.5
+      - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
@@ -1708,7 +1708,7 @@ jobs:
           path: |
             /nix
             /zig
-      - uses: cachix/install-nix-action@ab739621df7a23f52766f9ccc97f38da6b7af14f # v31.10.5
+      - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
@@ -1736,7 +1736,7 @@ jobs:
           path: |
             /nix
             /zig
-      - uses: cachix/install-nix-action@ab739621df7a23f52766f9ccc97f38da6b7af14f # v31.10.5
+      - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
@@ -1773,7 +1773,7 @@ jobs:
             /zig
 
       # Install Nix and use that to run our tests so our environment matches exactly.
-      - uses: cachix/install-nix-action@ab739621df7a23f52766f9ccc97f38da6b7af14f # v31.10.5
+      - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
@@ -1835,7 +1835,7 @@ jobs:
             /zig
 
       # Install Nix and use that to run our tests so our environment matches exactly.
-      - uses: cachix/install-nix-action@ab739621df7a23f52766f9ccc97f38da6b7af14f # v31.10.5
+      - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -169,7 +169,7 @@ jobs:
       - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           nix_path: nixpkgs=channel:nixos-unstable
-      - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
+      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
         with:
           name: ghostty
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
@@ -227,7 +227,7 @@ jobs:
       - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           nix_path: nixpkgs=channel:nixos-unstable
-      - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
+      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
         with:
           name: ghostty
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
@@ -263,7 +263,7 @@ jobs:
       - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           nix_path: nixpkgs=channel:nixos-unstable
-      - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
+      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
         with:
           name: ghostty
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
@@ -329,7 +329,7 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@main
         with:
           determinate: true
-      - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
+      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
         with:
           name: ghostty
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
@@ -369,7 +369,7 @@ jobs:
       - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           nix_path: nixpkgs=channel:nixos-unstable
-      - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
+      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
         with:
           name: ghostty
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
@@ -407,7 +407,7 @@ jobs:
       - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           nix_path: nixpkgs=channel:nixos-unstable
-      - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
+      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
         with:
           name: ghostty
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
@@ -524,7 +524,7 @@ jobs:
       - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           nix_path: nixpkgs=channel:nixos-unstable
-      - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
+      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
         with:
           name: ghostty
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
@@ -558,7 +558,7 @@ jobs:
       - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           nix_path: nixpkgs=channel:nixos-unstable
-      - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
+      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
         with:
           name: ghostty
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
@@ -603,7 +603,7 @@ jobs:
       - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           nix_path: nixpkgs=channel:nixos-unstable
-      - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
+      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
         with:
           name: ghostty
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
@@ -639,7 +639,7 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@main
         with:
           determinate: true
-      - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
+      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
         with:
           name: ghostty
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
@@ -679,7 +679,7 @@ jobs:
       - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           nix_path: nixpkgs=channel:nixos-unstable
-      - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
+      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
         with:
           name: ghostty
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
@@ -756,7 +756,7 @@ jobs:
       - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           nix_path: nixpkgs=channel:nixos-unstable
-      - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
+      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
         with:
           name: ghostty
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
@@ -785,7 +785,7 @@ jobs:
       - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           nix_path: nixpkgs=channel:nixos-unstable
-      - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
+      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
         with:
           name: ghostty
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
@@ -818,7 +818,7 @@ jobs:
       - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           nix_path: nixpkgs=channel:nixos-unstable
-      - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
+      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
         with:
           name: ghostty
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
@@ -900,7 +900,7 @@ jobs:
       - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           nix_path: nixpkgs=channel:nixos-unstable
-      - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
+      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
         with:
           name: ghostty
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
@@ -940,7 +940,7 @@ jobs:
       - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           nix_path: nixpkgs=channel:nixos-unstable
-      - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
+      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
         with:
           name: ghostty
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
@@ -1008,7 +1008,7 @@ jobs:
   #     - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
   #       with:
   #         nix_path: nixpkgs=channel:nixos-unstable
-  #     - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
+  #     - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
   #       with:
   #         name: ghostty
   #         authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
@@ -1071,7 +1071,7 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@main
         with:
           determinate: true
-      - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
+      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
         with:
           name: ghostty
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
@@ -1131,7 +1131,7 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@main
         with:
           determinate: true
-      - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
+      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
         with:
           name: ghostty
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
@@ -1185,7 +1185,7 @@ jobs:
       - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           nix_path: nixpkgs=channel:nixos-unstable
-      - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
+      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
         with:
           name: ghostty
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
@@ -1222,7 +1222,7 @@ jobs:
       - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           nix_path: nixpkgs=channel:nixos-unstable
-      - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
+      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
         with:
           name: ghostty
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
@@ -1257,7 +1257,7 @@ jobs:
       - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           nix_path: nixpkgs=channel:nixos-unstable
-      - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
+      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
         with:
           name: ghostty
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
@@ -1305,7 +1305,7 @@ jobs:
       - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           nix_path: nixpkgs=channel:nixos-unstable
-      - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
+      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
         with:
           name: ghostty
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
@@ -1340,7 +1340,7 @@ jobs:
       - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           nix_path: nixpkgs=channel:nixos-unstable
-      - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
+      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
         with:
           name: ghostty
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
@@ -1371,7 +1371,7 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@main
         with:
           determinate: true
-      - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
+      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
         with:
           name: ghostty
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
@@ -1430,7 +1430,7 @@ jobs:
       - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           nix_path: nixpkgs=channel:nixos-unstable
-      - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
+      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
         with:
           name: ghostty
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
@@ -1461,7 +1461,7 @@ jobs:
       - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           nix_path: nixpkgs=channel:nixos-unstable
-      - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
+      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
         with:
           name: ghostty
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
@@ -1503,7 +1503,7 @@ jobs:
       - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           nix_path: nixpkgs=channel:nixos-unstable
-      - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
+      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
         with:
           name: ghostty
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
@@ -1534,7 +1534,7 @@ jobs:
       - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           nix_path: nixpkgs=channel:nixos-unstable
-      - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
+      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
         with:
           name: ghostty
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
@@ -1564,7 +1564,7 @@ jobs:
       - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           nix_path: nixpkgs=channel:nixos-unstable
-      - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
+      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
         with:
           name: ghostty
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
@@ -1593,7 +1593,7 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@main
         with:
           determinate: true
-      - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
+      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
         with:
           name: ghostty
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
@@ -1622,7 +1622,7 @@ jobs:
       - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           nix_path: nixpkgs=channel:nixos-unstable
-      - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
+      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
         with:
           name: ghostty
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
@@ -1650,7 +1650,7 @@ jobs:
       - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           nix_path: nixpkgs=channel:nixos-unstable
-      - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
+      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
         with:
           name: ghostty
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
@@ -1678,7 +1678,7 @@ jobs:
       - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           nix_path: nixpkgs=channel:nixos-unstable
-      - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
+      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
         with:
           name: ghostty
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
@@ -1711,7 +1711,7 @@ jobs:
       - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           nix_path: nixpkgs=channel:nixos-unstable
-      - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
+      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
         with:
           name: ghostty
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
@@ -1739,7 +1739,7 @@ jobs:
       - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           nix_path: nixpkgs=channel:nixos-unstable
-      - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
+      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
         with:
           name: ghostty
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
@@ -1776,7 +1776,7 @@ jobs:
       - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           nix_path: nixpkgs=channel:nixos-unstable
-      - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
+      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
         with:
           name: ghostty
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
@@ -1838,7 +1838,7 @@ jobs:
       - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           nix_path: nixpkgs=channel:nixos-unstable
-      - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
+      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
         with:
           name: ghostty
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"

--- a/.github/workflows/update-colorschemes.yml
+++ b/.github/workflows/update-colorschemes.yml
@@ -29,7 +29,7 @@ jobs:
             /zig
 
       - name: Setup Nix
-        uses: cachix/install-nix-action@ab739621df7a23f52766f9ccc97f38da6b7af14f # v31.10.5
+        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17

--- a/.github/workflows/update-colorschemes.yml
+++ b/.github/workflows/update-colorschemes.yml
@@ -32,7 +32,7 @@ jobs:
         uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           nix_path: nixpkgs=channel:nixos-unstable
-      - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
+      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
         with:
           name: ghostty
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"

--- a/.github/workflows/vouch-check-issue.yml
+++ b/.github/workflows/vouch-check-issue.yml
@@ -8,7 +8,7 @@ jobs:
   check:
     runs-on: namespace-profile-ghostty-xsm
     steps:
-      - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
           app-id: ${{ secrets.VOUCH_APP_ID }}

--- a/.github/workflows/vouch-check-pr.yml
+++ b/.github/workflows/vouch-check-pr.yml
@@ -8,7 +8,7 @@ jobs:
   check:
     runs-on: namespace-profile-ghostty-xsm
     steps:
-      - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
           app-id: ${{ secrets.VOUCH_APP_ID }}

--- a/.github/workflows/vouch-manage-by-discussion.yml
+++ b/.github/workflows/vouch-manage-by-discussion.yml
@@ -12,7 +12,7 @@ jobs:
   manage:
     runs-on: namespace-profile-ghostty-xsm
     steps:
-      - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
           app-id: ${{ secrets.VOUCH_APP_ID }}

--- a/.github/workflows/vouch-manage-by-issue.yml
+++ b/.github/workflows/vouch-manage-by-issue.yml
@@ -12,7 +12,7 @@ jobs:
   manage:
     runs-on: namespace-profile-ghostty-xsm
     steps:
-      - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
           app-id: ${{ secrets.VOUCH_APP_ID }}

--- a/.github/workflows/vouch-sync-codeowners.yml
+++ b/.github/workflows/vouch-sync-codeowners.yml
@@ -13,7 +13,7 @@ jobs:
   sync:
     runs-on: namespace-profile-ghostty-xsm
     steps:
-      - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
           app-id: ${{ secrets.VOUCH_APP_ID }}

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -172,6 +172,7 @@
 /po/es_AR.po @ghostty-org/es_AR
 /po/es_BO.po @ghostty-org/es_BO
 /po/es_ES.po @ghostty-org/es_ES
+/po/eu.po @ghostty-org/eu_ES
 /po/fr.po @ghostty-org/fr_FR
 /po/ga.po @ghostty-org/ga_IE
 /po/he.po @ghostty-org/he_IL

--- a/build.zig
+++ b/build.zig
@@ -263,7 +263,8 @@ pub fn build(b: *std.Build) !void {
 
         // On macOS we can run the macOS app. For "run" we always force
         // a native-only build so that we can run as quickly as possible.
-        if (config.target.result.os.tag.isDarwin() and
+        if (!config.emit_lib_vt and
+            config.target.result.os.tag.isDarwin() and
             (config.emit_xcframework or config.emit_macos_app))
         {
             const xcframework_native = try buildpkg.GhosttyXCFramework.init(

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -116,8 +116,8 @@
         .apple_sdk = .{ .path = "./pkg/apple-sdk" },
         .android_ndk = .{ .path = "./pkg/android-ndk" },
         .iterm2_themes = .{
-            .url = "https://deps.files.ghostty.org/ghostty-themes-release-20260323-152405-a2c7b60.tgz",
-            .hash = "N-V-__8AAL6FAwBDPampKgDjoxlJYDIn2jv0VaINS4W6CXJN",
+            .url = "https://deps.files.ghostty.org/ghostty-themes-release-20260427-153600-5e4d1de.tgz",
+            .hash = "N-V-__8AAG6jAwDWij8XfaQ0fy-HAQqvl1b6kZb4GfbHjbkZ",
             .lazy = true,
         },
     },

--- a/build.zig.zon.json
+++ b/build.zig.zon.json
@@ -54,10 +54,10 @@
     "url": "https://github.com/ocornut/imgui/archive/refs/tags/v1.92.5-docking.tar.gz",
     "hash": "sha256-yBbCDox18+Fa6Gc1DnmSVQLRpqhZOLsac7iSfl8x+cs="
   },
-  "N-V-__8AAL6FAwBDPampKgDjoxlJYDIn2jv0VaINS4W6CXJN": {
+  "N-V-__8AAG6jAwDWij8XfaQ0fy-HAQqvl1b6kZb4GfbHjbkZ": {
     "name": "iterm2_themes",
-    "url": "https://deps.files.ghostty.org/ghostty-themes-release-20260323-152405-a2c7b60.tgz",
-    "hash": "sha256-fWgXdUXh2/dNZqERzEu9hz4xyy4nl+GUjLMpUMrsRnA="
+    "url": "https://deps.files.ghostty.org/ghostty-themes-release-20260427-153600-5e4d1de.tgz",
+    "hash": "sha256-3iY7YiCQrhLGcH1nVNozirX1DW9/WyRNaJCElJzcKwU="
   },
   "N-V-__8AAIC5lwAVPJJzxnCAahSvZTIlG-HhtOvnM1uh-66x": {
     "name": "jetbrains_mono",

--- a/build.zig.zon.nix
+++ b/build.zig.zon.nix
@@ -193,11 +193,11 @@ in
       };
     }
     {
-      name = "N-V-__8AAL6FAwBDPampKgDjoxlJYDIn2jv0VaINS4W6CXJN";
+      name = "N-V-__8AAG6jAwDWij8XfaQ0fy-HAQqvl1b6kZb4GfbHjbkZ";
       path = fetchZigArtifact {
         name = "iterm2_themes";
-        url = "https://deps.files.ghostty.org/ghostty-themes-release-20260323-152405-a2c7b60.tgz";
-        hash = "sha256-fWgXdUXh2/dNZqERzEu9hz4xyy4nl+GUjLMpUMrsRnA=";
+        url = "https://deps.files.ghostty.org/ghostty-themes-release-20260427-153600-5e4d1de.tgz";
+        hash = "sha256-3iY7YiCQrhLGcH1nVNozirX1DW9/WyRNaJCElJzcKwU=";
         unpack = false;
       };
     }

--- a/build.zig.zon.txt
+++ b/build.zig.zon.txt
@@ -6,7 +6,7 @@ https://deps.files.ghostty.org/breakpad-b99f444ba5f6b98cac261cbb391d8766b34a5918
 https://deps.files.ghostty.org/fontconfig-2.14.2.tar.gz
 https://deps.files.ghostty.org/freetype-1220b81f6ecfb3fd222f76cf9106fecfa6554ab07ec7fdc4124b9bb063ae2adf969d.tar.gz
 https://deps.files.ghostty.org/gettext-0.24.tar.gz
-https://deps.files.ghostty.org/ghostty-themes-release-20260323-152405-a2c7b60.tgz
+https://deps.files.ghostty.org/ghostty-themes-release-20260427-153600-5e4d1de.tgz
 https://deps.files.ghostty.org/glslang-12201278a1a05c0ce0b6eb6026c65cd3e9247aa041b1c260324bf29cee559dd23ba1.tar.gz
 https://deps.files.ghostty.org/gobject-2025-11-08-23-1.tar.zst
 https://deps.files.ghostty.org/gtk4-layer-shell-1.1.0.tar.gz

--- a/flatpak/zig-packages.json
+++ b/flatpak/zig-packages.json
@@ -67,9 +67,9 @@
   },
   {
     "type": "archive",
-    "url": "https://deps.files.ghostty.org/ghostty-themes-release-20260323-152405-a2c7b60.tgz",
-    "dest": "vendor/p/N-V-__8AAL6FAwBDPampKgDjoxlJYDIn2jv0VaINS4W6CXJN",
-    "sha256": "7d68177545e1dbf74d66a111cc4bbd873e31cb2e2797e1948cb32950caec4670"
+    "url": "https://deps.files.ghostty.org/ghostty-themes-release-20260427-153600-5e4d1de.tgz",
+    "dest": "vendor/p/N-V-__8AAG6jAwDWij8XfaQ0fy-HAQqvl1b6kZb4GfbHjbkZ",
+    "sha256": "de263b622090ae12c6707d6754da338ab5f50d6f7f5b244d689084949cdc2b05"
   },
   {
     "type": "archive",

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1054,6 +1054,7 @@ typedef union {
 // apprt.ipc.Action.Key
 typedef enum {
   GHOSTTY_IPC_ACTION_NEW_WINDOW,
+  GHOSTTY_IPC_ACTION_TOGGLE_QUICK_TERMINAL,
 } ghostty_ipc_action_tag_e;
 
 //-------------------------------------------------------------------

--- a/macos/Ghostty.xcodeproj/project.pbxproj
+++ b/macos/Ghostty.xcodeproj/project.pbxproj
@@ -73,7 +73,6 @@
 		3B39CAA42B33949B00DABEB8 /* GhosttyReleaseLocal.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = GhosttyReleaseLocal.entitlements; sourceTree = "<group>"; };
 		55154BDF2B33911F001622DC /* ghostty */ = {isa = PBXFileReference; lastKnownFileType = folder; name = ghostty; path = "../zig-out/share/ghostty"; sourceTree = "<group>"; };
 		552964E52B34A9B400030505 /* vim */ = {isa = PBXFileReference; lastKnownFileType = folder; name = vim; path = "../zig-out/share/vim"; sourceTree = "<group>"; };
-		80B155F32F9E3FF90040F9D8 /* Ghostty.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = file; path = Ghostty.xctestplan; sourceTree = "<group>"; };
 		810ACC9F2E9D3301004F8F92 /* GhosttyUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GhosttyUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		8193244D2F24E6C000A9ED8F /* DockTilePlugin.plugin */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DockTilePlugin.plugin; sourceTree = BUILT_PRODUCTS_DIR; };
 		8F3A9B4B2FA6B88000A18D13 /* Ghostty.sdef */ = {isa = PBXFileReference; lastKnownFileType = text.sdef; path = Ghostty.sdef; sourceTree = "<group>"; };
@@ -338,7 +337,6 @@
 		A5B30528299BEAAA0047F10C = {
 			isa = PBXGroup;
 			children = (
-				80B155F32F9E3FF90040F9D8 /* Ghostty.xctestplan */,
 				A571AB1C2A206FC600248498 /* Ghostty-Info.plist */,
 				8F3A9B4B2FA6B88000A18D13 /* Ghostty.sdef */,
 				A5B30538299BEAAB0047F10C /* Assets.xcassets */,

--- a/macos/Sources/Features/Terminal/BaseTerminalController.swift
+++ b/macos/Sources/Features/Terminal/BaseTerminalController.swift
@@ -1396,6 +1396,21 @@ class BaseTerminalController: NSWindowController,
 
     @IBAction func toggleCommandPalette(_ sender: Any?) {
         commandPaletteIsShowing.toggle()
+        if commandPaletteIsShowing {
+            // Fix the incorrect focus when toggling from InlineTitleEditor
+            // When toggling the command palette from the inline title editor,
+            // the first responder state of the surface is changed quickly from true to false.
+
+            // `makeFirstResponder:` is called by the title editor when finishing,
+            // but it happens **after** the command palette is shown,
+            // so the `focused` is set to `true` while the command palette is shown.
+            // (Could be an AppKit issue as well, since the resign is not called after but the command palette is receiving `keyDown`).
+
+            // Since `performKeyEquivalent(with:)` is called on all of the subviews
+            // until one of the return `true` so the paste action is consumed by the surface
+            // instead of the first responder (command palette).
+            _ = focusedSurface?.resignFirstResponder()
+        }
     }
 
     @IBAction func find(_ sender: Any) {

--- a/macos/Sources/Features/Terminal/BaseTerminalController.swift
+++ b/macos/Sources/Features/Terminal/BaseTerminalController.swift
@@ -767,7 +767,7 @@ class BaseTerminalController: NSWindowController,
             tree: newTree,
             position: notification.userInfo?[Notification.Name.ghosttySurfaceDragEndedNoTargetPointKey] as? NSPoint,
             confirmUndo: false,
-            inheritBackgroundOpacityFrom: self as? TerminalController)
+            inheritBackgroundOpacity: isBackgroundOpaque)
     }
 
     // MARK: Local Events
@@ -991,11 +991,15 @@ class BaseTerminalController: NSWindowController,
         // Do nothing if in fullscreen (transparency doesn't apply in fullscreen)
         guard let window, !window.styleMask.contains(.fullScreen) else { return }
 
-        // Toggle between transparent and opaque
-        isBackgroundOpaque.toggle()
+        let newValue = !isBackgroundOpaque
+        let controllers = NSApplication.shared.windows.compactMap {
+            $0.windowController as? BaseTerminalController
+        }
 
-        // Update our appearance
-        syncAppearance()
+        for controller in controllers {
+            controller.isBackgroundOpaque = newValue
+            controller.syncAppearance()
+        }
     }
 
     /// Override this to resync any appearance related properties. This will be called automatically

--- a/macos/Sources/Features/Terminal/BaseTerminalController.swift
+++ b/macos/Sources/Features/Terminal/BaseTerminalController.swift
@@ -766,7 +766,8 @@ class BaseTerminalController: NSWindowController,
             ghostty,
             tree: newTree,
             position: notification.userInfo?[Notification.Name.ghosttySurfaceDragEndedNoTargetPointKey] as? NSPoint,
-            confirmUndo: false)
+            confirmUndo: false,
+            inheritBackgroundOpacityFrom: self as? TerminalController)
     }
 
     // MARK: Local Events

--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -316,11 +316,11 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
         tree: SplitTree<Ghostty.SurfaceView>,
         position: NSPoint? = nil,
         confirmUndo: Bool = true,
-        inheritBackgroundOpacityFrom parentController: TerminalController? = nil
+        inheritBackgroundOpacity: Bool? = nil
     ) -> TerminalController {
         let c = TerminalController.init(ghostty, withSurfaceTree: tree)
-        if let parentController {
-            c.isBackgroundOpaque = parentController.isBackgroundOpaque
+        if let inheritBackgroundOpacity {
+            c.isBackgroundOpaque = inheritBackgroundOpacity
         }
 
         // Calculate the target frame based on the tree's view bounds
@@ -369,7 +369,7 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
                     _ = TerminalController.newWindow(
                         ghostty,
                         tree: tree,
-                        inheritBackgroundOpacityFrom: parentController
+                        inheritBackgroundOpacity: inheritBackgroundOpacity
                     )
                 }
             }
@@ -501,30 +501,6 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
         }
 
         return controller
-    }
-
-    override func toggleBackgroundOpacity() {
-        // Do nothing if config is already fully opaque
-        guard ghostty.config.backgroundOpacity < 1 else { return }
-
-        // Do nothing if in fullscreen (transparency doesn't apply in fullscreen)
-        guard let window, !window.styleMask.contains(.fullScreen) else { return }
-
-        let newValue = !isBackgroundOpaque
-        let controllers: [TerminalController]
-
-        if let tabGroup = window.tabGroup {
-            controllers = tabGroup.windows.compactMap {
-                $0.windowController as? TerminalController
-            }
-        } else {
-            controllers = [self]
-        }
-
-        for controller in controllers {
-            controller.isBackgroundOpaque = newValue
-            controller.syncAppearance()
-        }
     }
 
     // MARK: - Methods

--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -230,6 +230,9 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
         // Get our parent. Our parent is the one explicitly given to us,
         // otherwise the focused terminal, otherwise an arbitrary one.
         let parent: NSWindow? = explicitParent ?? preferredParent?.window
+        if let parentController = parent?.windowController as? TerminalController {
+            c.isBackgroundOpaque = parentController.isBackgroundOpaque
+        }
 
         if let parent, parent.styleMask.contains(.fullScreen) {
             // If our previous window was fullscreen then we want our new window to
@@ -313,8 +316,12 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
         tree: SplitTree<Ghostty.SurfaceView>,
         position: NSPoint? = nil,
         confirmUndo: Bool = true,
+        inheritBackgroundOpacityFrom parentController: TerminalController? = nil
     ) -> TerminalController {
         let c = TerminalController.init(ghostty, withSurfaceTree: tree)
+        if let parentController {
+            c.isBackgroundOpaque = parentController.isBackgroundOpaque
+        }
 
         // Calculate the target frame based on the tree's view bounds
         let treeSize: CGSize? = tree.root?.viewBounds()
@@ -359,7 +366,11 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
                     withTarget: ghostty,
                     expiresAfter: target.undoExpiration
                 ) { ghostty in
-                    _ = TerminalController.newWindow(ghostty, tree: tree)
+                    _ = TerminalController.newWindow(
+                        ghostty,
+                        tree: tree,
+                        inheritBackgroundOpacityFrom: parentController
+                    )
                 }
             }
         }
@@ -394,6 +405,7 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
 
         // Create a new window and add it to the parent
         let controller = TerminalController.init(ghostty, withBaseConfig: baseConfig)
+        controller.isBackgroundOpaque = parentController.isBackgroundOpaque
         guard let window = controller.window else { return controller }
 
         // If the parent is miniaturized, then macOS exhibits really strange behaviors
@@ -489,6 +501,30 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
         }
 
         return controller
+    }
+
+    override func toggleBackgroundOpacity() {
+        // Do nothing if config is already fully opaque
+        guard ghostty.config.backgroundOpacity < 1 else { return }
+
+        // Do nothing if in fullscreen (transparency doesn't apply in fullscreen)
+        guard let window, !window.styleMask.contains(.fullScreen) else { return }
+
+        let newValue = !isBackgroundOpaque
+        let controllers: [TerminalController]
+
+        if let tabGroup = window.tabGroup {
+            controllers = tabGroup.windows.compactMap {
+                $0.windowController as? TerminalController
+            }
+        } else {
+            controllers = [self]
+        }
+
+        for controller in controllers {
+            controller.isBackgroundOpaque = newValue
+            controller.syncAppearance()
+        }
     }
 
     // MARK: - Methods

--- a/macos/Sources/Ghostty/Surface View/SurfaceView.swift
+++ b/macos/Sources/Ghostty/Surface View/SurfaceView.swift
@@ -612,20 +612,13 @@ extension Ghostty {
         /// Explicit font size to use in points
         var fontSize: Float32?
 
-        private var normalizedWorkingDirectory: String?
-        /// Explicit working directory to set
+        /// Explicit working directory. This is normalized on assignment to
+        /// remove any redundant and trailing path separators.
         var workingDirectory: String? {
             get { normalizedWorkingDirectory }
-            set {
-                guard let newValue else {
-                    normalizedWorkingDirectory = nil
-                    return
-                }
-                // We use FilePath to normalize separators by removing redundant intermediary separators
-                // and stripping any trailing separators.
-                normalizedWorkingDirectory = FilePath(newValue).string
-            }
+            set { normalizedWorkingDirectory = newValue.map { FilePath($0).string } }
         }
+        private var normalizedWorkingDirectory: String?
 
         /// Explicit command to set
         var command: String?

--- a/macos/Sources/Ghostty/Surface View/SurfaceView.swift
+++ b/macos/Sources/Ghostty/Surface View/SurfaceView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import UserNotifications
 import GhosttyKit
+import System
 
 extension Ghostty {
     /// Render a terminal for the active app in the environment.
@@ -611,8 +612,20 @@ extension Ghostty {
         /// Explicit font size to use in points
         var fontSize: Float32?
 
+        private var normalizedWorkingDirectory: String?
         /// Explicit working directory to set
-        var workingDirectory: String?
+        var workingDirectory: String? {
+            get { normalizedWorkingDirectory }
+            set {
+                guard let newValue else {
+                    normalizedWorkingDirectory = nil
+                    return
+                }
+                // We use FilePath to normalize separators by removing redundant intermediary separators
+                // and stripping any trailing separators.
+                normalizedWorkingDirectory = FilePath(newValue).string
+            }
+        }
 
         /// Explicit command to set
         var command: String?

--- a/macos/Sources/Ghostty/Surface View/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/Surface View/SurfaceView_AppKit.swift
@@ -1130,6 +1130,14 @@ extension Ghostty {
             // we control the preedit state only through the preedit API.
             syncPreedit(clearIfNeeded: markedTextBefore)
 
+            // We're composing if we have preedit (the obvious case). But we're also
+            // composing if we don't have preedit and we had marked text before,
+            // because this input probably just reset the preedit state. It shouldn't
+            // be encoded. Example: Japanese begin composing, then press backspace
+            // or ctrl+h. This should only cancel the composing state but not
+            // actually delete the prior input characters (prior to the composing).
+            let composing = markedText.length > 0 || markedTextBefore
+
             // Korean IMEs on macOS may commit preedit text via insertText
             // while handling an arrow key. Send that committed text separately
             // before replaying arrow movement, except for plain left-arrow
@@ -1157,10 +1165,20 @@ extension Ghostty {
             }
 
             if let list = keyTextAccumulator, list.count > 0 {
-                // If we have text, then we've composed a character, send that down.
-                // These never have "composing" set to true because these are the
-                // result of a composition.
+                // Accumulated text from interpretKeyEvents (committed by the IME).
                 for text in list {
+                    // Drop bare control characters the IME accumulated while
+                    // composing so they don't leak through to the terminal.
+                    if Ghostty.SurfaceView.shouldSuppressComposingControlInput(
+                        text,
+                        composing: composing
+                    ) {
+                        continue
+                    }
+
+                    // We've composed a character; send it down. keyAction's
+                    // default composing=false applies because this is the
+                    // committed result of a composition, not in-progress preedit.
                     _ = keyAction(
                         action,
                         event: event,
@@ -1169,20 +1187,22 @@ extension Ghostty {
                     )
                 }
             } else {
+                // Raw control characters (e.g. ctrl+h) arriving during
+                // composition belong to the IME, not the terminal.
+                if Ghostty.SurfaceView.shouldSuppressComposingControlInput(
+                    event.characters,
+                    composing: composing
+                ) {
+                    return
+                }
+
                 // We have no accumulated text so this is a normal key event.
                 _ = keyAction(
                     action,
                     event: event,
                     translationEvent: translationEvent,
                     text: translationEvent.ghosttyCharacters,
-
-                    // We're composing if we have preedit (the obvious case). But we're also
-                    // composing if we don't have preedit and we had marked text before,
-                    // because this input probably just reset the preedit state. It shouldn't
-                    // be encoded. Example: Japanese begin composing, the press backspace.
-                    // This should only cancel the composing state but not actually delete
-                    // the prior input characters (prior to the composing).
-                    composing: markedText.length > 0 || markedTextBefore
+                    composing: composing
                 )
             }
         }
@@ -2024,6 +2044,22 @@ extension Ghostty.SurfaceView: NSTextInputClient {
             // in a preedit state so we can clear it.
             ghostty_surface_preedit(surface, nil, 0)
         }
+    }
+
+    /// True when `text` is a single C0 control character (U+0000-U+001F)
+    /// arriving while the IME is composing. Such input belongs to the IME
+    /// and must not be forwarded to the terminal.
+    static func shouldSuppressComposingControlInput(
+        _ text: String?,
+        composing: Bool
+    ) -> Bool {
+        guard composing, let text else { return false }
+        let scalars = text.unicodeScalars
+        guard let scalar = scalars.first,
+              scalars.index(after: scalars.startIndex) == scalars.endIndex else {
+            return false
+        }
+        return scalar.value < 0x20
     }
 }
 

--- a/macos/Sources/Ghostty/Surface View/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/Surface View/SurfaceView_AppKit.swift
@@ -2121,6 +2121,14 @@ extension Ghostty.SurfaceView: NSMenuItemValidation {
             item.state = readonly ? .on : .off
             return true
 
+        case #selector(copy(_:)):
+            // We only enable copy menu item when there're actual selected text
+            if let text = self.accessibilitySelectedText(), text.count > 0 {
+                return true
+            } else {
+                return false
+            }
+
         default:
             return true
         }

--- a/macos/Sources/Ghostty/Surface View/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/Surface View/SurfaceView_AppKit.swift
@@ -1138,22 +1138,25 @@ extension Ghostty {
             // actually delete the prior input characters (prior to the composing).
             let composing = markedText.length > 0 || markedTextBefore
 
-            // Korean IMEs on macOS may commit preedit text via insertText
-            // while handling an arrow key. Send that committed text separately
-            // before replaying arrow movement, except for plain left-arrow
-            // where AppKit already leaves the caret in place.
+            // The input method may commit all or part of the preedit text via
+            // insertText while handling a key that should not itself be
+            // encoded. Send that committed text separately, then only replay
+            // keys that should still affect the terminal after committing.
             if markedTextBefore,
-               markedText.length == 0,
                let list = keyTextAccumulator,
-               list.count > 0,
-               let preeditCommitArrow = preeditCommitArrowKey(translationEvent) {
+               list.count > 0 {
                 for text in list {
+                    if Ghostty.SurfaceView.shouldSuppressComposingControlInput(
+                        text,
+                        composing: composing
+                    ) {
+                        continue
+                    }
+
                     _ = committedPreeditTextAction(action, text: text)
                 }
 
-                let isPlainLeftArrow = preeditCommitArrow == .arrowLeft &&
-                    event.modifierFlags.isDisjoint(with: [.shift, .control, .option, .command])
-                if !isPlainLeftArrow {
+                if shouldReplayCommittedPreeditKey(translationEvent) {
                     _ = keyAction(
                         action,
                         event: event,
@@ -1436,13 +1439,17 @@ extension Ghostty {
             }
         }
 
-        private func preeditCommitArrowKey(_ event: NSEvent) -> Ghostty.Input.Key? {
-            guard let key = Ghostty.Input.Key(keyCode: event.keyCode) else { return nil }
+        private func shouldReplayCommittedPreeditKey(_ event: NSEvent) -> Bool {
+            guard let key = Ghostty.Input.Key(keyCode: event.keyCode) else { return false }
             switch key {
-            case .arrowDown, .arrowLeft, .arrowRight, .arrowUp:
-                return key
+            case .arrowDown, .arrowRight, .arrowUp:
+                return true
+            case .arrowLeft:
+                // Don't replay plain left-arrow because AppKit already leaves
+                // the caret in place after Korean IMEs commit preedit text.
+                return !event.modifierFlags.isDisjoint(with: [.shift, .control, .option, .command])
             default:
-                return nil
+                return false
             }
         }
 

--- a/macos/Tests/Ghostty/SurfaceViewAppKitTests.swift
+++ b/macos/Tests/Ghostty/SurfaceViewAppKitTests.swift
@@ -1,0 +1,44 @@
+@testable import Ghostty
+import Testing
+
+struct SurfaceViewAppKitTests {
+    @Test(arguments: [
+        ("\u{0008}", true),
+        ("\u{001F}", true),
+        ("\u{007F}", false),
+        (" ", false),
+        ("h", false),
+        ("", false),
+        ("\u{0009}x", false),
+        ("\u{0009}\u{0009}", false),
+    ])
+    func suppressesOnlySingleC0ControlTextWhileComposing(
+        text: String,
+        expected: Bool
+    ) {
+        #expect(
+            Ghostty.SurfaceView.shouldSuppressComposingControlInput(
+                text,
+                composing: true
+            ) == expected
+        )
+    }
+
+    @Test func doesNotSuppressControlTextWhenNotComposing() {
+        #expect(
+            Ghostty.SurfaceView.shouldSuppressComposingControlInput(
+                "\u{0008}",
+                composing: false
+            ) == false
+        )
+    }
+
+    @Test func doesNotSuppressMissingText() {
+        #expect(
+            Ghostty.SurfaceView.shouldSuppressComposingControlInput(
+                nil,
+                composing: true
+            ) == false
+        )
+    }
+}

--- a/nix/libghostty-vt.nix
+++ b/nix/libghostty-vt.nix
@@ -37,7 +37,23 @@ stdenv.mkDerivation (finalAttrs: {
     );
   };
 
-  deps = callPackage ../build.zig.zon.nix {name = "${finalAttrs.pname}-cache-${finalAttrs.version}";};
+  # Zig's build runner computes relative paths from `cwd` to the build directory.
+  # The logic is purely lexical, so if the `cwd` is a symlink that resolves to a different depth during `chdir`, the computed path becomes incorrect.
+  #
+  # See: https://codeberg.org/ziglang/zig/issues/32121
+  #
+  # Workaround: override `linkFarm` with a copy-farm so deps are real directories, not symlinks.
+  deps = callPackage ../build.zig.zon.nix {
+    name = "${finalAttrs.pname}-cache-${finalAttrs.version}";
+    linkFarm = name: entries:
+      runCommand name {} ''
+        mkdir -p $out
+        ${lib.concatMapStringsSep "\n" (e: ''
+            cp -rL ${e.path} $out/${e.name}
+          '')
+          entries}
+      '';
+  };
 
   nativeBuildInputs =
     [

--- a/nix/libghostty-vt.nix
+++ b/nix/libghostty-vt.nix
@@ -103,14 +103,25 @@ stdenv.mkDerivation (finalAttrs: {
       --replace-fail "$out" "$dev"
   '';
 
-  passthru.tests = {
+  passthru.tests = let
+    sharedExt = stdenv.hostPlatform.extensions.sharedLibrary;
+    sharedLibName = version:
+      if stdenv.hostPlatform.isDarwin
+      then "libghostty-vt.${version}${sharedExt}"
+      else "libghostty-vt${sharedExt}.${version}";
+    linkCheck = bin: pat:
+      if stdenv.hostPlatform.isDarwin
+      then ''otool -L "${bin}" | grep -q ${pat}''
+      else ''ldd "${bin}" 2>/dev/null | grep -q ${pat}'';
+  in {
     sanity-check = let
       version = "${lib.versions.major finalAttrs.version}.${lib.versions.minor finalAttrs.version}.${lib.versions.patch finalAttrs.version}";
     in
       runCommand "sanity-check" {} (builtins.concatStringsSep "\n" [
         ''
-          ${lib.getExe' stdenv.cc "nm"} "${finalAttrs.finalPackage}/lib/libghostty-vt.so.${version}" | grep -q 'T ghostty_terminal_new'
-          ${lib.getExe' stdenv.cc "nm"} "${finalAttrs.finalPackage.dev}/lib/libghostty-vt.a" | grep -q 'T ghostty_terminal_new'
+          set +o pipefail
+          ${lib.getExe' stdenv.cc "nm"} "${finalAttrs.finalPackage}/lib/${sharedLibName version}" | grep -qE 'T _?ghostty_terminal_new'
+          ${lib.getExe' stdenv.cc "nm"} "${finalAttrs.finalPackage.dev}/lib/libghostty-vt.a" | grep -qE 'T _?ghostty_terminal_new'
         ''
         (
           lib.optionalString simd
@@ -167,7 +178,7 @@ stdenv.mkDerivation (finalAttrs: {
           then "yes"
           else "no"
         }"
-        ldd "$out/bin/test" 2>/dev/null | grep -q libghostty-vt
+        ${linkCheck "$out/bin/test" "libghostty-vt"}
 
         runHook postInstallCheckHooks
       '';
@@ -205,7 +216,7 @@ stdenv.mkDerivation (finalAttrs: {
           then "yes"
           else "no"
         }"
-        ! ldd "$out/bin/test" 2>/dev/null | grep -q libghostty-vt
+        ! ${linkCheck "$out/bin/test" "libghostty-vt"}
 
         runHook postInstallCheckHooks
       '';
@@ -240,7 +251,7 @@ stdenv.mkDerivation (finalAttrs: {
       installCheckPhase = ''
         runHook preInstallCheckHooks
 
-        ldd "$out/bin/test" 2>/dev/null | grep -q libghostty-vt
+        ${linkCheck "$out/bin/test" "libghostty-vt"}
 
         runHook postInstallCheckHooks
       '';

--- a/nix/libghostty-vt.nix
+++ b/nix/libghostty-vt.nix
@@ -7,7 +7,10 @@
   runCommand,
   stdenv,
   testers,
+  fixDarwinDylibNames,
   versionCheckHook,
+  darwin,
+  xcbuild,
   zig_0_15,
   revision ? "dirty",
   optimize ? "Debug",
@@ -18,10 +21,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.1.0-dev+${revision}-nix";
 
   # We limit source like this to try and reduce the amount of rebuilds as possible
-  # thus we only provide the source that is needed for the build
-  #
-  # NOTE: as of the current moment only linux files are provided,
-  # since darwin support is not finished
+  # thus we only provide the source that is needed for the build.
   src = lib.fileset.toSource {
     root = ../.;
     fileset = lib.fileset.intersection (lib.fileset.fromSource (lib.sources.cleanSource ../.)) (
@@ -39,27 +39,37 @@ stdenv.mkDerivation (finalAttrs: {
 
   deps = callPackage ../build.zig.zon.nix {name = "${finalAttrs.pname}-cache-${finalAttrs.version}";};
 
-  nativeBuildInputs = [
-    git
-    pkg-config
-    zig_0_15
-  ];
+  nativeBuildInputs =
+    [
+      git
+      pkg-config
+      zig_0_15
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      darwin.cctools
+      fixDarwinDylibNames
+      xcbuild
+    ];
 
   buildInputs = [];
 
   doCheck = false;
   dontSetZigDefaultFlags = true;
 
-  zigBuildFlags = [
-    "--system"
-    "${finalAttrs.deps}"
-    "-Dlib-version-string=${finalAttrs.version}"
-    "-Dcpu=baseline"
-    "-Doptimize=${optimize}"
-    "-Dapp-runtime=none"
-    "-Demit-lib-vt=true"
-    "-Dsimd=${lib.boolToString simd}"
-  ];
+  zigBuildFlags =
+    [
+      "--system"
+      "${finalAttrs.deps}"
+      "-Dlib-version-string=${finalAttrs.version}"
+      "-Dcpu=baseline"
+      "-Doptimize=${optimize}"
+      "-Dapp-runtime=none"
+      "-Demit-lib-vt=true"
+      "-Dsimd=${lib.boolToString simd}"
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      "-Demit-xcframework=false"
+    ];
   zigCheckFlags = finalAttrs.zigBuildFlags ++ ["test-lib-vt"];
 
   outputs = [

--- a/pkg/apple-sdk/build.zig
+++ b/pkg/apple-sdk/build.zig
@@ -49,15 +49,15 @@ pub fn addPaths(
     });
 
     if (!gop.found_existing) init: {
-        if (comptime builtin.os.tag.isDarwin()) {
+        if (comptime builtin.os.tag.isDarwin()) darwin: {
             // Detect our SDK using the "findNative" Zig stdlib function.
             // This is really important because it forces using `xcrun` to
             // find the SDK path.
-            const libc = try std.zig.LibCInstallation.findNative(.{
+            const libc = std.zig.LibCInstallation.findNative(.{
                 .allocator = b.allocator,
                 .target = &step.rootModuleTarget(),
                 .verbose = false,
-            });
+            }) catch break :darwin;
 
             // Render the file compatible with the `--libc` Zig flag.
             var stream: std.io.Writer.Allocating = .init(b.allocator);

--- a/po/eu.po
+++ b/po/eu.po
@@ -1,0 +1,353 @@
+# Language X translations for com.mitchellh.ghostty package.
+# Copyright (C) 2026 "Mitchell Hashimoto, Ghostty contributors"
+# This file is distributed under the same license as the com.mitchellh.ghostty package.
+# Mikel Larreategi <mlarreategi@codesyntax.com>, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: com.mitchellh.ghostty\n"
+"Report-Msgid-Bugs-To: m@mitchellh.com\n"
+"POT-Creation-Date: 2026-02-17 23:16+0100\n"
+"PO-Revision-Date: 2026-05-01 12:56+0200\n"
+"Last-Translator: Mikel Larreategi <mlarreategi@codesyntax.com>\n"
+"Language-Team: Language eu\n"
+"Language: eu\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: dist/linux/ghostty_nautilus.py:53
+msgid "Open in Ghostty"
+msgstr "Ireki Ghostty-n"
+
+#: src/apprt/gtk/ui/1.0/clipboard-confirmation-dialog.blp:12
+#: src/apprt/gtk/ui/1.4/clipboard-confirmation-dialog.blp:12
+#: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:197
+#: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:201
+msgid "Authorize Clipboard Access"
+msgstr "Baimendu arbelera sartzea"
+
+#: src/apprt/gtk/ui/1.0/clipboard-confirmation-dialog.blp:17
+#: src/apprt/gtk/ui/1.4/clipboard-confirmation-dialog.blp:17
+msgid "Deny"
+msgstr "Ukatu"
+
+#: src/apprt/gtk/ui/1.0/clipboard-confirmation-dialog.blp:18
+#: src/apprt/gtk/ui/1.4/clipboard-confirmation-dialog.blp:18
+msgid "Allow"
+msgstr "Baimendu"
+
+#: src/apprt/gtk/ui/1.4/clipboard-confirmation-dialog.blp:92
+msgid "Remember choice for this split"
+msgstr "Gogoratu zatiketa-aukera hau"
+
+#: src/apprt/gtk/ui/1.4/clipboard-confirmation-dialog.blp:93
+msgid "Reload configuration to show this prompt again"
+msgstr "Birkargatu konfigurazioa eta erakutsi hau berriz"
+
+#: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
+#: src/apprt/gtk/ui/1.5/title-dialog.blp:8
+msgid "Cancel"
+msgstr "Utzi"
+
+#: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:8
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:85
+#: src/apprt/gtk/ui/1.3/surface-child-exited.blp:17
+msgid "Close"
+msgstr "Itxi"
+
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:6
+msgid "Configuration Errors"
+msgstr "Konfigurazio erroreak"
+
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:7
+msgid ""
+"One or more configuration errors were found. Please review the errors below, "
+"and either reload your configuration or ignore these errors."
+msgstr ""
+"Konfigurazio erroreren bat aurkitu da. Begiratu erroreak azpian, eta "
+"birkargatu konfigurazioa edo baztertu erroreak."
+
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:10
+msgid "Ignore"
+msgstr "Baztertu"
+
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:11
+#: src/apprt/gtk/ui/1.2/surface.blp:366 src/apprt/gtk/ui/1.5/window.blp:300
+msgid "Reload Configuration"
+msgstr "Birkargatu konfigurazioa"
+
+#: src/apprt/gtk/ui/1.2/debug-warning.blp:7
+#: src/apprt/gtk/ui/1.3/debug-warning.blp:6
+msgid ""
+"⚠️ You're running a debug build of Ghostty! Performance will be degraded."
+msgstr ""
+"⚠️ Garapeneko Ghostty bertsio bat erabiltzen ari zara! Errendimendua ez da "
+"ona izango"
+
+#: src/apprt/gtk/ui/1.5/inspector-window.blp:5
+msgid "Ghostty: Terminal Inspector"
+msgstr "Ghostty: terminal ikuskatzailea"
+
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:29
+msgid "Find…"
+msgstr "Bilatu…"
+
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:64
+msgid "Previous Match"
+msgstr "Aurreko bilaketa"
+
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:74
+msgid "Next Match"
+msgstr "Hurrengo bilaketa"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:6
+msgid "Oh, no."
+msgstr "Oh, ez!"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:7
+msgid "Unable to acquire an OpenGL context for rendering."
+msgstr "Ezin izan da OpenGL kontestua erabili."
+
+#: src/apprt/gtk/ui/1.2/surface.blp:97
+msgid ""
+"This terminal is in read-only mode. You can still view, select, and scroll "
+"through the content, but no input events will be sent to the running "
+"application."
+msgstr ""
+"Terminal hau irakurtzeko moduan dago. Ikusi, aukeratu eta kontestuan zehar "
+"gora eta behera ibili zaitezke, baina ez da sarrera ekintzarik bidaliko."
+
+#: src/apprt/gtk/ui/1.2/surface.blp:107
+msgid "Read-only"
+msgstr "Irakurtzeko-bakarrik"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:260 src/apprt/gtk/ui/1.5/window.blp:200
+msgid "Copy"
+msgstr "Kopiatu"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:265 src/apprt/gtk/ui/1.5/window.blp:205
+msgid "Paste"
+msgstr "Itsatsi"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:270
+msgid "Notify on Next Command Finish"
+msgstr "Jakinarazi hurrengo komandoa amiatzean"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:277 src/apprt/gtk/ui/1.5/window.blp:273
+msgid "Clear"
+msgstr "Garbitu"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:282 src/apprt/gtk/ui/1.5/window.blp:278
+msgid "Reset"
+msgstr "Berrezarri"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:289 src/apprt/gtk/ui/1.5/window.blp:242
+msgid "Split"
+msgstr "Zatitu"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:292 src/apprt/gtk/ui/1.5/window.blp:245
+msgid "Change Title…"
+msgstr "Aldatu izenburua…"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:297 src/apprt/gtk/ui/1.5/window.blp:177
+#: src/apprt/gtk/ui/1.5/window.blp:250
+msgid "Split Up"
+msgstr "Zatitu gorantz"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:303 src/apprt/gtk/ui/1.5/window.blp:182
+#: src/apprt/gtk/ui/1.5/window.blp:255
+msgid "Split Down"
+msgstr "Zatitu beherantz"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:309 src/apprt/gtk/ui/1.5/window.blp:187
+#: src/apprt/gtk/ui/1.5/window.blp:260
+msgid "Split Left"
+msgstr "Zatitu ezkerrera"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:315 src/apprt/gtk/ui/1.5/window.blp:192
+#: src/apprt/gtk/ui/1.5/window.blp:265
+msgid "Split Right"
+msgstr "Zatitu eskumara"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:322
+msgid "Tab"
+msgstr "Fitxa"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:325 src/apprt/gtk/ui/1.5/window.blp:224
+#: src/apprt/gtk/ui/1.5/window.blp:320
+msgid "Change Tab Title…"
+msgstr "Aldatu fitxaren izenburua…"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:330 src/apprt/gtk/ui/1.5/window.blp:57
+#: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
+msgid "New Tab"
+msgstr "Fitxa berria"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:335 src/apprt/gtk/ui/1.5/window.blp:234
+msgid "Close Tab"
+msgstr "Itxi fitxa"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:342
+msgid "Window"
+msgstr "Leihoa"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:345 src/apprt/gtk/ui/1.5/window.blp:212
+msgid "New Window"
+msgstr "Leiho berria"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:350 src/apprt/gtk/ui/1.5/window.blp:217
+msgid "Close Window"
+msgstr "Itxi leihoa"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:358
+msgid "Config"
+msgstr "Konfigurazioa"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:361 src/apprt/gtk/ui/1.5/window.blp:295
+msgid "Open Configuration"
+msgstr "Ireki konfigurazioa"
+
+#: src/apprt/gtk/ui/1.5/title-dialog.blp:5
+msgid "Leave blank to restore the default title."
+msgstr "Utzi hutsik defektuzko izenburua berrezartzeko"
+
+#: src/apprt/gtk/ui/1.5/title-dialog.blp:9
+msgid "OK"
+msgstr "OK"
+
+#: src/apprt/gtk/ui/1.5/window.blp:58 src/apprt/gtk/ui/1.5/window.blp:108
+msgid "New Split"
+msgstr "Zatitu"
+
+#: src/apprt/gtk/ui/1.5/window.blp:68 src/apprt/gtk/ui/1.5/window.blp:126
+msgid "View Open Tabs"
+msgstr "Ikusi irekitako fitxak"
+
+#: src/apprt/gtk/ui/1.5/window.blp:78 src/apprt/gtk/ui/1.5/window.blp:140
+msgid "Main Menu"
+msgstr "Menu nagusia"
+
+#: src/apprt/gtk/ui/1.5/window.blp:285
+msgid "Command Palette"
+msgstr "Komando paleta"
+
+#: src/apprt/gtk/ui/1.5/window.blp:290
+msgid "Terminal Inspector"
+msgstr "Terminal ikuskatzailea"
+
+#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1727
+msgid "About Ghostty"
+msgstr "Ghosttyri buruz"
+
+#: src/apprt/gtk/ui/1.5/window.blp:312
+msgid "Quit"
+msgstr "Irten"
+
+#: src/apprt/gtk/ui/1.5/command-palette.blp:17
+msgid "Execute a command…"
+msgstr "Exekutatu komando bat…"
+
+#: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
+msgid ""
+"An application is attempting to write to the clipboard. The current "
+"clipboard contents are shown below."
+msgstr ""
+"Aplikazio bat arbelean idatzi nahian dabil. Hau da arbelaren gaur egungo "
+"edukia."
+
+#: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:202
+msgid ""
+"An application is attempting to read from the clipboard. The current "
+"clipboard contents are shown below."
+msgstr ""
+"Aplikazio bat arbeletik irakurri nahian dabil. Hau da arbelaren gaur egungo "
+"edukia."
+
+#: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:205
+msgid "Warning: Potentially Unsafe Paste"
+msgstr "Oharra: hau itsastea ez da segurua"
+
+#: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:206
+msgid ""
+"Pasting this text into the terminal may be dangerous as it looks like some "
+"commands may be executed."
+msgstr ""
+"Testu hau terminalean itsastea arriskutsua izan daiteke komandoren batzuk "
+"exekutatzea ekar dezakeelako."
+
+#: src/apprt/gtk/class/close_confirmation_dialog.zig:184
+msgid "Quit Ghostty?"
+msgstr "Ghostty itxi?"
+
+#: src/apprt/gtk/class/close_confirmation_dialog.zig:185
+msgid "Close Tab?"
+msgstr "Fitxa itxi?"
+
+#: src/apprt/gtk/class/close_confirmation_dialog.zig:186
+msgid "Close Window?"
+msgstr "Leihoa itxi?"
+
+#: src/apprt/gtk/class/close_confirmation_dialog.zig:187
+msgid "Close Split?"
+msgstr "Zatikatzea itxi?"
+
+#: src/apprt/gtk/class/close_confirmation_dialog.zig:193
+msgid "All terminal sessions will be terminated."
+msgstr "Terminal saio guztiak itxi egingo dira."
+
+#: src/apprt/gtk/class/close_confirmation_dialog.zig:194
+msgid "All terminal sessions in this tab will be terminated."
+msgstr "Fitxa honetako terminal saioa itxi egingo da."
+
+#: src/apprt/gtk/class/close_confirmation_dialog.zig:195
+msgid "All terminal sessions in this window will be terminated."
+msgstr "Leiho honetako terminal saio guztiak itxi egingo dira."
+
+#: src/apprt/gtk/class/close_confirmation_dialog.zig:196
+msgid "The currently running process in this split will be terminated."
+msgstr "Zatikatze honetan martxan dagoen prozesua itxi egingo da."
+
+#: src/apprt/gtk/class/surface.zig:1108
+msgid "Command Finished"
+msgstr "Komandoa amaitu da"
+
+#: src/apprt/gtk/class/surface.zig:1109
+msgid "Command Succeeded"
+msgstr "Komandoa ondo amaitu da"
+
+#: src/apprt/gtk/class/surface.zig:1110
+msgid "Command Failed"
+msgstr "Komandoak huts egin du"
+
+#: src/apprt/gtk/class/surface_child_exited.zig:109
+msgid "Command succeeded"
+msgstr "Komandoa ondo amaitu da"
+
+#: src/apprt/gtk/class/surface_child_exited.zig:113
+msgid "Command failed"
+msgstr "Komandoak huts egin du"
+
+#: src/apprt/gtk/class/title_dialog.zig:225
+msgid "Change Terminal Title"
+msgstr "Aldatu terminalaren izenburua"
+
+#: src/apprt/gtk/class/title_dialog.zig:226
+msgid "Change Tab Title"
+msgstr "Aldatu fitxaren izenburua"
+
+#: src/apprt/gtk/class/window.zig:1007
+msgid "Reloaded the configuration"
+msgstr "Konfigurazioa berriz kargatu da"
+
+#: src/apprt/gtk/class/window.zig:1566
+msgid "Copied to clipboard"
+msgstr "Arbelera kopiatu da"
+
+#: src/apprt/gtk/class/window.zig:1568
+msgid "Cleared clipboard"
+msgstr "Arbela garbitu da"
+
+#: src/apprt/gtk/class/window.zig:1708
+msgid "Ghostty Developers"
+msgstr "Ghostty garatzaileak"

--- a/po/eu.po
+++ b/po/eu.po
@@ -1,4 +1,4 @@
-# Language X translations for com.mitchellh.ghostty package.
+# Basque translations for com.mitchellh.ghostty package.
 # Copyright (C) 2026 "Mitchell Hashimoto, Ghostty contributors"
 # This file is distributed under the same license as the com.mitchellh.ghostty package.
 # Mikel Larreategi <mlarreategi@codesyntax.com>, 2026.

--- a/po/eu.po
+++ b/po/eu.po
@@ -132,7 +132,7 @@ msgstr "Itsatsi"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:270
 msgid "Notify on Next Command Finish"
-msgstr "Jakinarazi hurrengo komandoa amiatzean"
+msgstr "Jakinarazi hurrengo komandoa amaitzean"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:277 src/apprt/gtk/ui/1.5/window.blp:273
 msgid "Clear"
@@ -253,7 +253,7 @@ msgid ""
 "An application is attempting to write to the clipboard. The current "
 "clipboard contents are shown below."
 msgstr ""
-"Aplikazio bat arbelean idatzi nahian dabil. Hau da arbelaren gaur egungo "
+"Aplikazio bat arbelean idatzi nahian dabil. Hau da arbelaren uneko "
 "edukia."
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:202

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -336,6 +336,7 @@ pub const App = struct {
     ) (Allocator.Error || std.posix.WriteError || apprt.ipc.Errors)!bool {
         switch (action) {
             .new_window => return false,
+            .toggle_quick_terminal => return false,
         }
     }
 };

--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -13,6 +13,7 @@ const CoreApp = @import("../../App.zig");
 const Application = @import("class/application.zig").Application;
 const Surface = @import("Surface.zig");
 const ipcNewWindow = @import("ipc/new_window.zig").newWindow;
+const ipcToggleQuickTerminal = @import("ipc/toggle_quick_terminal.zig").toggleQuickTerminal;
 
 const log = std.log.scoped(.gtk);
 
@@ -84,6 +85,7 @@ pub fn performIpc(
 ) !bool {
     switch (action) {
         .new_window => return try ipcNewWindow(alloc, target, value),
+        .toggle_quick_terminal => return try ipcToggleQuickTerminal(alloc, target),
     }
 }
 

--- a/src/apprt/gtk/class/application.zig
+++ b/src/apprt/gtk/class/application.zig
@@ -1419,6 +1419,7 @@ pub const Application = extern struct {
             .init("present-surface", actionPresentSurface, t_variant_type),
             .init("quit", actionQuit, null),
             .init("reload-config", actionReloadConfig, null),
+            .init("toggle-quick-terminal", actionToggleQuickTerminal, null),
         };
 
         ext.actions.add(Self, self, &actions);
@@ -1666,6 +1667,17 @@ pub const Application = extern struct {
         const priv = self.private();
         priv.core_app.performAction(self.rt(), .reload_config) catch |err| {
             log.warn("error reloading config err={}", .{err});
+        };
+    }
+
+    fn actionToggleQuickTerminal(
+        _: *gio.SimpleAction,
+        _: ?*glib.Variant,
+        self: *Self,
+    ) callconv(.c) void {
+        const priv = self.private();
+        priv.core_app.performAction(self.rt(), .toggle_quick_terminal) catch |err| {
+            log.warn("error toggling quick terminal err={}", .{err});
         };
     }
 

--- a/src/apprt/gtk/class/split_tree.zig
+++ b/src/apprt/gtk/class/split_tree.zig
@@ -1102,11 +1102,14 @@ const SplitTreeSplit = extern struct {
         /// Assumed to be correct.
         handle: Surface.Tree.Node.Handle,
 
-        /// Source to handle repositioning the split when its size changes.
-        idle_max_pos: ?c_uint = null,
-        /// Source to write back the updated split ratio to the split tree
-        /// when the user manually drags the divider.
-        idle_drag: ?c_uint = null,
+        /// Source to handle repositioning the split when properties change.
+        idle: ?c_uint = null,
+
+        /// Whether the max-position/position property of the gtk.Paned widget
+        /// changed. We use these to distinguish between a resize and the user
+        /// manually moving the split divider. See the "on-idle" function.
+        max_changed: bool = false,
+        pos_changed: bool = false,
 
         // Template bindings
         paned: *gtk.Paned,
@@ -1147,13 +1150,37 @@ const SplitTreeSplit = extern struct {
         gtk.Widget.initTemplate(self.as(gtk.Widget));
     }
 
-    fn onIdleMaxPos(ud: ?*anyopaque) callconv(.c) c_int {
+    // We need to keep the split ratios from the tree datastructure and
+    // widget tree in sync. Using the max-position and position properties
+    // of the gtk.Paned widget, we can distinguish a resize from a manual
+    // update (e.g. the user dragging the divider).If max-position changes,
+    // we always have a widget resize. Usually position will change as well
+    // but it might not if the size change is small enough. If only position
+    // changes, we have a manual human update.
+    //
+    // This is a hack, it relies on the timing of property notifcations.
+    // From looking at the GTK source code, it should not be possible that we
+    // erroneously interpret a position change from a resize as a manual update.
+    // When a gtk.Paned is resized, internally the gtk_paned_calc_position function
+    // will change both max-position and position and synchronously call our
+    // propMaxPosition and propPosition functions. I.e. when the widget is resized,
+    // it should not be possible for onIdle to run before we have been notified of
+    // both property changes.
+    fn onIdle(ud: ?*anyopaque) callconv(.c) c_int {
         const self: *Self = @ptrCast(@alignCast(ud orelse return 0));
         const priv = self.private();
         const paned = priv.paned;
 
-        // Our idle source is always over.
-        priv.idle_max_pos = null;
+        // Clear source and fields at the end. Otherwise if setPosition is called
+        // below, propPosition is triggered and would add another idle callback
+        // before this one is finished.
+        defer priv.idle = null;
+        defer priv.max_changed = false;
+        defer priv.pos_changed = false;
+
+        if (!priv.max_changed and !priv.pos_changed) {
+            return 0;
+        }
 
         // Get our split. This is the most dangerous part of this entire
         // widget. We assume that this widget is always a child of a
@@ -1166,105 +1193,7 @@ const SplitTreeSplit = extern struct {
         const tree = split_tree.getTree() orelse return 0;
         const split: *const Surface.Tree.Split = &tree.nodes[priv.handle.idx()].split;
 
-        const pos, const max = positions: {
-            const p = self.getPanedPositions();
-            break :positions .{ p.pos, p.max };
-        };
-
-        // If our max is zero then we can't do any math. I don't know
-        // if this is possible but I suspect it can be if you make a nested
-        // split completely minimized.
-        if (max == 0) return 0;
-
-        // Determine our current ratio.
-        const current_ratio: f64 = ratio: {
-            const pos_f64: f64 = @floatFromInt(pos);
-            const max_f64: f64 = @floatFromInt(max);
-            break :ratio pos_f64 / max_f64;
-        };
-        const desired_ratio: f64 = @floatCast(split.ratio);
-
-        // If our ratio is close enough to our desired ratio, then
-        // we ignore the update. This is to avoid constant split updates
-        // for lossy floating point math.
-        if (std.math.approxEqAbs(
-            f64,
-            current_ratio,
-            desired_ratio,
-            0.001,
-        )) {
-            return 0;
-        }
-
-        // Note that if max is small, it might not be possible to accurately
-        // set the desired ratio. E.g. with max=2 you can only set ratios
-        // of 0, 0.5 and 1.
-        const desired_pos: c_int = desired_pos: {
-            const max_f64: f64 = @floatFromInt(max);
-            break :desired_pos @intFromFloat(@round(max_f64 * desired_ratio));
-        };
-        paned.setPosition(desired_pos);
-        return 0;
-    }
-
-    fn onIdleDrag(ud: ?*anyopaque) callconv(.c) c_int {
-        const self: *Self = @ptrCast(@alignCast(ud orelse return 0));
-        const priv = self.private();
-
-        // Our idle source is always over.
-        priv.idle_drag = null;
-
-        const split_tree = ext.getAncestor(
-            SplitTree,
-            self.as(gtk.Widget),
-        ) orelse return 0;
-        const tree = split_tree.getTree() orelse return 0;
-        const split: *const Surface.Tree.Split = &tree.nodes[priv.handle.idx()].split;
-
-        const pos, const max = positions: {
-            const p = self.getPanedPositions();
-            break :positions .{ p.pos, p.max };
-        };
-
-        if (max == 0) return 0;
-
-        // Determine our current ratio.
-        const current_ratio: f64 = ratio: {
-            const pos_f64: f64 = @floatFromInt(pos);
-            const max_f64: f64 = @floatFromInt(max);
-            break :ratio pos_f64 / max_f64;
-        };
-        const old_ratio: f64 = @floatCast(split.ratio);
-
-        // If our ratio is close enough to the old ratio, then
-        // we ignore the update.
-        if (std.math.approxEqAbs(
-            f64,
-            current_ratio,
-            old_ratio,
-            0.001,
-        )) {
-            return 0;
-        }
-
-        // Write our update back to the tree.
-        tree.resizeInPlace(priv.handle, @floatCast(current_ratio));
-
-        return 0;
-    }
-
-    const PanedPositions = struct {
-        pos: c_int,
-        min: c_int,
-        max: c_int,
-    };
-
-    // Returns the current, min, and max positions of the gtk.Paned
-    // this widget wraps.
-    fn getPanedPositions(self: *Self) PanedPositions {
-        const priv = self.private();
-        const paned = priv.paned;
-
+        // Current, min, and max positions as pixels.
         const pos = paned.getPosition();
         const min = min: {
             var val = gobject.ext.Value.new(c_int);
@@ -1291,11 +1220,47 @@ const SplitTreeSplit = extern struct {
         // be non-zero, so let's add an assert to ensure that.
         assert(min == 0);
 
-        return .{
-            .pos = pos,
-            .min = min,
-            .max = max,
+        // If our max is zero then we can't do any math. I don't know
+        // if this is possible but I suspect it can be if you make a nested
+        // split completely minimized.
+        if (max == 0) return 0;
+
+        // Determine our current ratio.
+        const current_ratio: f64 = ratio: {
+            const pos_f64: f64 = @floatFromInt(pos);
+            const max_f64: f64 = @floatFromInt(max);
+            break :ratio pos_f64 / max_f64;
         };
+        const desired_ratio: f64 = @floatCast(split.ratio);
+
+        // If our ratio is close enough to our desired ratio, then
+        // we ignore the update. This is to avoid constant split updates
+        // for lossy floating point math.
+        if (std.math.approxEqAbs(
+            f64,
+            current_ratio,
+            desired_ratio,
+            0.001,
+        )) {
+            return 0;
+        }
+
+        if (priv.max_changed) {
+            // Widget got resized, update position to match desired ratio.
+            // Note that if max-position is small, it might not be possible
+            // to accurately set the desired ratio. E.g. with max-position=2
+            // you can only have ratios 0, 0.5 and 1.
+            const desired_pos: c_int = desired_pos: {
+                const max_f64: f64 = @floatFromInt(max);
+                break :desired_pos @intFromFloat(@round(max_f64 * desired_ratio));
+            };
+            paned.setPosition(desired_pos);
+        } else {
+            // If only position changed, this is a manual human update and
+            // we need to write our update back to the tree.
+            tree.resizeInPlace(priv.handle, @floatCast(current_ratio));
+        }
+        return 0;
     }
 
     //---------------------------------------------------------------
@@ -1307,21 +1272,22 @@ const SplitTreeSplit = extern struct {
         self: *Self,
     ) callconv(.c) void {
         const priv = self.private();
-        if (priv.idle_max_pos == null) priv.idle_max_pos = glib.idleAdd(
-            onIdleMaxPos,
+        priv.max_changed = true;
+        if (priv.idle == null) priv.idle = glib.idleAdd(
+            onIdle,
             self,
         );
     }
 
-    fn onDragEnd(
-        _: *gtk.GestureDrag,
-        _: f64,
-        _: f64,
+    fn propPosition(
+        _: *gtk.Paned,
+        _: *gobject.ParamSpec,
         self: *Self,
     ) callconv(.c) void {
         const priv = self.private();
-        if (priv.idle_drag == null) priv.idle_drag = glib.idleAdd(
-            onIdleDrag,
+        priv.pos_changed = true;
+        if (priv.idle == null) priv.idle = glib.idleAdd(
+            onIdle,
             self,
         );
     }
@@ -1331,17 +1297,11 @@ const SplitTreeSplit = extern struct {
 
     fn dispose(self: *Self) callconv(.c) void {
         const priv = self.private();
-        if (priv.idle_max_pos) |v| {
+        if (priv.idle) |v| {
             if (glib.Source.remove(v) == 0) {
-                log.warn("unable to remove idle_max_pos source", .{});
+                log.warn("unable to remove idle source", .{});
             }
-            priv.idle_max_pos = null;
-        }
-        if (priv.idle_drag) |v| {
-            if (glib.Source.remove(v) == 0) {
-                log.warn("unable to remove idle_drag source", .{});
-            }
-            priv.idle_drag = null;
+            priv.idle = null;
         }
 
         gtk.Widget.disposeTemplate(
@@ -1388,7 +1348,7 @@ const SplitTreeSplit = extern struct {
 
             // Template Callbacks
             class.bindTemplateCallback("notify_max_position", &propMaxPosition);
-            class.bindTemplateCallback("on_drag_end", &onDragEnd);
+            class.bindTemplateCallback("notify_position", &propPosition);
 
             // Virtual methods
             gobject.Object.virtual_methods.dispose.implement(class, &dispose);

--- a/src/apprt/gtk/class/split_tree.zig
+++ b/src/apprt/gtk/class/split_tree.zig
@@ -969,6 +969,7 @@ pub const SplitTree = extern struct {
                 defer left.deinit();
                 const right = self.buildTree(tree, s.right);
                 defer right.deinit();
+
                 break :split .initNew(SplitTreeSplit.new(
                     current,
                     &s,

--- a/src/apprt/gtk/class/split_tree.zig
+++ b/src/apprt/gtk/class/split_tree.zig
@@ -158,6 +158,12 @@ pub const SplitTree = extern struct {
         /// used to debounce updates.
         rebuild_source: ?c_uint = null,
 
+        // The source that we use to restore focus. With enough splits, some
+        // surfaces are initially allocated a width/height of 0 which causes
+        // them to get unmapped and lose focus. We can reliably restore focus
+        // to the last focused surface only once it is mapped again.
+        restore_focus_source: ?c_uint = null,
+
         /// Used to store state about a pending surface close for the
         /// close dialog.
         pending_close: ?Surface.Tree.Node.Handle,
@@ -415,6 +421,13 @@ pub const SplitTree = extern struct {
                 self,
                 .{ .detail = "focused" },
             );
+            _ = gobject.Object.signals.notify.connect(
+                surface,
+                *Self,
+                propSurfaceMapped,
+                self,
+                .{ .detail = "mapped" },
+            );
         }
     }
 
@@ -570,6 +583,12 @@ pub const SplitTree = extern struct {
                 log.warn("unable to remove rebuild source", .{});
             }
             priv.rebuild_source = null;
+        }
+        if (priv.restore_focus_source) |v| {
+            if (glib.Source.remove(v) == 0) {
+                log.warn("unable to remove restore_focus source", .{});
+            }
+            priv.restore_focus_source = null;
         }
 
         gtk.Widget.disposeTemplate(
@@ -766,6 +785,23 @@ pub const SplitTree = extern struct {
         self.as(gobject.Object).notifyByPspec(properties.@"active-surface".impl.param_spec);
     }
 
+    fn propSurfaceMapped(
+        surface: *Surface,
+        _: *gobject.ParamSpec,
+        self: *Self,
+    ) callconv(.c) void {
+        if (!surface.getMapped()) return;
+
+        // We could add the idle callback only if this is actually the last focused
+        // surface. But we can avoid that check because usually all the surfaces get
+        // mapped at once, so the idle callback will run only once anyway.
+        const priv = self.private();
+        if (priv.restore_focus_source == null) priv.restore_focus_source = glib.idleAdd(
+            onRestoreFocus,
+            self,
+        );
+    }
+
     fn propTree(
         self: *Self,
         _: *gobject.ParamSpec,
@@ -779,13 +815,19 @@ pub const SplitTree = extern struct {
         self.as(gobject.Object).notifyByPspec(properties.@"has-surfaces".impl.param_spec);
         self.as(gobject.Object).notifyByPspec(properties.@"is-zoomed".impl.param_spec);
 
-        // If we were planning a rebuild, always remove that so we can
-        // start from a clean slate.
+        // If we were planning a rebuild or focus restore, always remove
+        // that so we can start from a clean slate.
         if (priv.rebuild_source) |v| {
             if (glib.Source.remove(v) == 0) {
                 log.warn("unable to remove rebuild source", .{});
             }
             priv.rebuild_source = null;
+        }
+        if (priv.restore_focus_source) |v| {
+            if (glib.Source.remove(v) == 0) {
+                log.warn("unable to remove restore_focus source", .{});
+            }
+            priv.restore_focus_source = null;
         }
 
         // If we transitioned to an empty tree, clear immediately instead of
@@ -839,6 +881,26 @@ pub const SplitTree = extern struct {
         // Our active surface may have changed
         self.as(gobject.Object).notifyByPspec(properties.@"active-surface".impl.param_spec);
 
+        return 0;
+    }
+
+    fn onRestoreFocus(ud: ?*anyopaque) callconv(.c) c_int {
+        const self: *Self = @ptrCast(@alignCast(ud orelse return 0));
+
+        // Always mark our source as null since we're done.
+        const priv = self.private();
+        priv.restore_focus_source = null;
+
+        // If we have a last-focused surface and it is mapped, restore focus to it.
+        // Depending on the available size, the surface might already have focus
+        // because it never got unmapped. In that case grabbing focus will have no
+        // effect.
+        if (priv.last_focused.get()) |v| {
+            defer v.unref();
+            if (v.getMapped()) {
+                v.grabFocus();
+            }
+        }
         return 0;
     }
 
@@ -905,7 +967,6 @@ pub const SplitTree = extern struct {
                 defer left.deinit();
                 const right = self.buildTree(tree, s.right);
                 defer right.deinit();
-
                 break :split .initNew(SplitTreeSplit.new(
                     current,
                     &s,
@@ -1041,8 +1102,11 @@ const SplitTreeSplit = extern struct {
         /// Assumed to be correct.
         handle: Surface.Tree.Node.Handle,
 
-        /// Source to handle repositioning the split when properties change.
-        idle: ?c_uint = null,
+        /// Source to handle repositioning the split when its size changes.
+        idle_max_pos: ?c_uint = null,
+        /// Source to write back the updated split ratio to the split tree
+        /// when the user manually drags the divider.
+        idle_drag: ?c_uint = null,
 
         // Template bindings
         paned: *gtk.Paned,
@@ -1083,21 +1147,13 @@ const SplitTreeSplit = extern struct {
         gtk.Widget.initTemplate(self.as(gtk.Widget));
     }
 
-    fn refresh(self: *Self) void {
-        const priv = self.private();
-        if (priv.idle == null) priv.idle = glib.idleAdd(
-            onIdle,
-            self,
-        );
-    }
-
-    fn onIdle(ud: ?*anyopaque) callconv(.c) c_int {
+    fn onIdleMaxPos(ud: ?*anyopaque) callconv(.c) c_int {
         const self: *Self = @ptrCast(@alignCast(ud orelse return 0));
         const priv = self.private();
         const paned = priv.paned;
 
-        // Our idle source is always over
-        priv.idle = null;
+        // Our idle source is always over.
+        priv.idle_max_pos = null;
 
         // Get our split. This is the most dangerous part of this entire
         // widget. We assume that this widget is always a child of a
@@ -1110,42 +1166,10 @@ const SplitTreeSplit = extern struct {
         const tree = split_tree.getTree() orelse return 0;
         const split: *const Surface.Tree.Split = &tree.nodes[priv.handle.idx()].split;
 
-        // Current, min, and max positions as pixels.
-        const pos = paned.getPosition();
-        const min = min: {
-            var val = gobject.ext.Value.new(c_int);
-            defer val.unset();
-            gobject.Object.getProperty(
-                paned.as(gobject.Object),
-                "min-position",
-                &val,
-            );
-            break :min gobject.ext.Value.get(&val, c_int);
+        const pos, const max = positions: {
+            const p = self.getPanedPositions();
+            break :positions .{ p.pos, p.max };
         };
-        const max = max: {
-            var val = gobject.ext.Value.new(c_int);
-            defer val.unset();
-            gobject.Object.getProperty(
-                paned.as(gobject.Object),
-                "max-position",
-                &val,
-            );
-            break :max gobject.ext.Value.get(&val, c_int);
-        };
-        const pos_set: bool = max: {
-            var val = gobject.ext.Value.new(c_int);
-            defer val.unset();
-            gobject.Object.getProperty(
-                paned.as(gobject.Object),
-                "position-set",
-                &val,
-            );
-            break :max gobject.ext.Value.get(&val, c_int) != 0;
-        };
-
-        // We don't actually use min, but we don't expect this to ever
-        // be non-zero, so let's add an assert to ensure that.
-        assert(min == 0);
 
         // If our max is zero then we can't do any math. I don't know
         // if this is possible but I suspect it can be if you make a nested
@@ -1172,51 +1196,134 @@ const SplitTreeSplit = extern struct {
             return 0;
         }
 
-        // If we're out of bounds, then we need to either set the position
-        // to what we expect OR update our expected ratio.
+        // Note that if max is small, it might not be possible to accurately
+        // set the desired ratio. E.g. with max=2 you can only set ratios
+        // of 0, 0.5 and 1.
+        const desired_pos: c_int = desired_pos: {
+            const max_f64: f64 = @floatFromInt(max);
+            break :desired_pos @intFromFloat(@round(max_f64 * desired_ratio));
+        };
+        paned.setPosition(desired_pos);
+        return 0;
+    }
 
-        // If we've never set the position, then we set it to the desired.
-        if (!pos_set) {
-            const desired_pos: c_int = desired_pos: {
-                const max_f64: f64 = @floatFromInt(max);
-                break :desired_pos @intFromFloat(@round(max_f64 * desired_ratio));
-            };
-            paned.setPosition(desired_pos);
+    fn onIdleDrag(ud: ?*anyopaque) callconv(.c) c_int {
+        const self: *Self = @ptrCast(@alignCast(ud orelse return 0));
+        const priv = self.private();
+
+        // Our idle source is always over.
+        priv.idle_drag = null;
+
+        const split_tree = ext.getAncestor(
+            SplitTree,
+            self.as(gtk.Widget),
+        ) orelse return 0;
+        const tree = split_tree.getTree() orelse return 0;
+        const split: *const Surface.Tree.Split = &tree.nodes[priv.handle.idx()].split;
+
+        const pos, const max = positions: {
+            const p = self.getPanedPositions();
+            break :positions .{ p.pos, p.max };
+        };
+
+        if (max == 0) return 0;
+
+        // Determine our current ratio.
+        const current_ratio: f64 = ratio: {
+            const pos_f64: f64 = @floatFromInt(pos);
+            const max_f64: f64 = @floatFromInt(max);
+            break :ratio pos_f64 / max_f64;
+        };
+        const old_ratio: f64 = @floatCast(split.ratio);
+
+        // If our ratio is close enough to the old ratio, then
+        // we ignore the update.
+        if (std.math.approxEqAbs(
+            f64,
+            current_ratio,
+            old_ratio,
+            0.001,
+        )) {
             return 0;
         }
 
-        // If we've set the position, then this is a manual human update
-        // and we need to write our update back to the tree.
+        // Write our update back to the tree.
         tree.resizeInPlace(priv.handle, @floatCast(current_ratio));
 
         return 0;
     }
 
+    const PanedPositions = struct {
+        pos: c_int,
+        min: c_int,
+        max: c_int,
+    };
+
+    // Returns the current, min, and max positions of the gtk.Paned
+    // this widget wraps.
+    fn getPanedPositions(self: *Self) PanedPositions {
+        const priv = self.private();
+        const paned = priv.paned;
+
+        const pos = paned.getPosition();
+        const min = min: {
+            var val = gobject.ext.Value.new(c_int);
+            defer val.unset();
+            gobject.Object.getProperty(
+                paned.as(gobject.Object),
+                "min-position",
+                &val,
+            );
+            break :min gobject.ext.Value.get(&val, c_int);
+        };
+        const max = max: {
+            var val = gobject.ext.Value.new(c_int);
+            defer val.unset();
+            gobject.Object.getProperty(
+                paned.as(gobject.Object),
+                "max-position",
+                &val,
+            );
+            break :max gobject.ext.Value.get(&val, c_int);
+        };
+
+        // We don't actually use min, but we don't expect this to ever
+        // be non-zero, so let's add an assert to ensure that.
+        assert(min == 0);
+
+        return .{
+            .pos = pos,
+            .min = min,
+            .max = max,
+        };
+    }
+
     //---------------------------------------------------------------
     // Signal handlers
-
-    fn propPosition(
-        _: *gtk.Paned,
-        _: *gobject.ParamSpec,
-        self: *Self,
-    ) callconv(.c) void {
-        self.refresh();
-    }
 
     fn propMaxPosition(
         _: *gtk.Paned,
         _: *gobject.ParamSpec,
         self: *Self,
     ) callconv(.c) void {
-        self.refresh();
+        const priv = self.private();
+        if (priv.idle_max_pos == null) priv.idle_max_pos = glib.idleAdd(
+            onIdleMaxPos,
+            self,
+        );
     }
 
-    fn propMinPosition(
-        _: *gtk.Paned,
-        _: *gobject.ParamSpec,
+    fn onDragEnd(
+        _: *gtk.GestureDrag,
+        _: f64,
+        _: f64,
         self: *Self,
     ) callconv(.c) void {
-        self.refresh();
+        const priv = self.private();
+        if (priv.idle_drag == null) priv.idle_drag = glib.idleAdd(
+            onIdleDrag,
+            self,
+        );
     }
 
     //---------------------------------------------------------------
@@ -1224,11 +1331,17 @@ const SplitTreeSplit = extern struct {
 
     fn dispose(self: *Self) callconv(.c) void {
         const priv = self.private();
-        if (priv.idle) |v| {
+        if (priv.idle_max_pos) |v| {
             if (glib.Source.remove(v) == 0) {
-                log.warn("unable to remove idle source", .{});
+                log.warn("unable to remove idle_max_pos source", .{});
             }
-            priv.idle = null;
+            priv.idle_max_pos = null;
+        }
+        if (priv.idle_drag) |v| {
+            if (glib.Source.remove(v) == 0) {
+                log.warn("unable to remove idle_drag source", .{});
+            }
+            priv.idle_drag = null;
         }
 
         gtk.Widget.disposeTemplate(
@@ -1275,8 +1388,7 @@ const SplitTreeSplit = extern struct {
 
             // Template Callbacks
             class.bindTemplateCallback("notify_max_position", &propMaxPosition);
-            class.bindTemplateCallback("notify_min_position", &propMinPosition);
-            class.bindTemplateCallback("notify_position", &propPosition);
+            class.bindTemplateCallback("on_drag_end", &onDragEnd);
 
             // Virtual methods
             gobject.Object.virtual_methods.dispose.implement(class, &dispose);

--- a/src/apprt/gtk/class/split_tree.zig
+++ b/src/apprt/gtk/class/split_tree.zig
@@ -158,10 +158,11 @@ pub const SplitTree = extern struct {
         /// used to debounce updates.
         rebuild_source: ?c_uint = null,
 
-        // The source that we use to restore focus. With enough splits, some
-        // surfaces are initially allocated a width/height of 0 which causes
-        // them to get unmapped and lose focus. We can reliably restore focus
-        // to the last focused surface only once it is mapped again.
+        /// The source that we use to restore focus. With enough nested
+        /// splits, some surfaces might initially be allocated a width or
+        /// height of 0 which causes them to get unmapped and lose focus.
+        /// We can reliably restore focus to the last focused surface only
+        /// once it is mapped again.
         restore_focus_source: ?c_uint = null,
 
         /// Used to store state about a pending surface close for the
@@ -792,9 +793,10 @@ pub const SplitTree = extern struct {
     ) callconv(.c) void {
         if (!surface.getMapped()) return;
 
-        // We could add the idle callback only if this is actually the last focused
-        // surface. But we can avoid that check because usually all the surfaces get
-        // mapped at once, so the idle callback will run only once anyway.
+        // We could add the idle callback only if this is actually the last
+        // focused surface. But we can avoid that check because usually all
+        // the surfaces get mapped at once, so the idle callback will run
+        // only once anyway.
         const priv = self.private();
         if (priv.restore_focus_source == null) priv.restore_focus_source = glib.idleAdd(
             onRestoreFocus,
@@ -891,10 +893,10 @@ pub const SplitTree = extern struct {
         const priv = self.private();
         priv.restore_focus_source = null;
 
-        // If we have a last-focused surface and it is mapped, restore focus to it.
-        // Depending on the available size, the surface might already have focus
-        // because it never got unmapped. In that case grabbing focus will have no
-        // effect.
+        // If we have a last-focused surface and it is mapped, restore focus
+        // to it. Depending on the available size, the surface might already
+        // have focus because it never got unmapped. In that case grabbing
+        // focus will have no effect.
         if (priv.last_focused.get()) |v| {
             defer v.unref();
             if (v.getMapped()) {
@@ -1159,21 +1161,21 @@ const SplitTreeSplit = extern struct {
     // changes, we have a manual human update.
     //
     // This is a hack, it relies on the timing of property notifcations.
-    // From looking at the GTK source code, it should not be possible that we
-    // erroneously interpret a position change from a resize as a manual update.
-    // When a gtk.Paned is resized, internally the gtk_paned_calc_position function
-    // will change both max-position and position and synchronously call our
-    // propMaxPosition and propPosition functions. I.e. when the widget is resized,
-    // it should not be possible for onIdle to run before we have been notified of
-    // both property changes.
+    // From looking at the GTK source code, it should not be possible that
+    // we interpret a position change from a resize as a manual update.
+    // When a gtk.Paned is resized, internally the gtk_paned_calc_position
+    // function will change both max-position and position and synchronously
+    // call our propMaxPosition and propPosition functions. I.e. when the
+    // widget is resized, it should not be possible for onIdle to run before
+    // we have been notified of both property changes.
     fn onIdle(ud: ?*anyopaque) callconv(.c) c_int {
         const self: *Self = @ptrCast(@alignCast(ud orelse return 0));
         const priv = self.private();
         const paned = priv.paned;
 
-        // Clear source and fields at the end. Otherwise if setPosition is called
-        // below, propPosition is triggered and would add another idle callback
-        // before this one is finished.
+        // Clear source and fields at the end. Otherwise if setPosition is
+        // called below, propPosition is triggered and would add another
+        // idle callback before this one is finished.
         defer priv.idle = null;
         defer priv.max_changed = false;
         defer priv.pos_changed = false;

--- a/src/apprt/gtk/class/surface.zig
+++ b/src/apprt/gtk/class/surface.zig
@@ -169,6 +169,24 @@ pub const Surface = extern struct {
             );
         };
 
+        pub const mapped = struct {
+            pub const name = "mapped";
+            const impl = gobject.ext.defineProperty(
+                name,
+                Self,
+                bool,
+                .{
+                    .default = false,
+                    .accessor = gobject.ext.privateFieldAccessor(
+                        Self,
+                        Private,
+                        &Private.offset,
+                        "mapped",
+                    ),
+                },
+            );
+        };
+
         pub const @"min-size" = struct {
             pub const name = "min-size";
             const impl = gobject.ext.defineProperty(
@@ -592,11 +610,15 @@ pub const Surface = extern struct {
         /// focus events.
         focused: bool = true,
 
+        /// Whether the GLArea widget is mapped. Some operations like grabbing
+        /// focus only work if a widget is mapped.
+        mapped: bool = false,
+
         /// Whether this surface is "zoomed" or not. A zoomed surface
         /// shows up taking the full bounds of a split view.
         zoom: bool = false,
 
-        /// The GLAarea that renders the actual surface. This is a binding
+        /// The GLArea that renders the actual surface. This is a binding
         /// to the template so it doesn't have to be unrefed manually.
         gl_area: *gtk.GLArea,
 
@@ -1768,6 +1790,7 @@ pub const Surface = extern struct {
         priv.mouse_shape = .text;
         priv.mouse_hidden = false;
         priv.focused = true;
+        priv.mapped = false;
         priv.size = .{ .width = 0, .height = 0 };
         priv.vadj_signal_group = null;
 
@@ -2017,6 +2040,11 @@ pub const Surface = extern struct {
     /// Returns the focus state of this surface.
     pub fn getFocused(self: *Self) bool {
         return self.private().focused;
+    }
+
+    /// Returns true if the GLArea of this surface is mapped.
+    pub fn getMapped(self: *Self) bool {
+        return self.private().mapped;
     }
 
     /// Change the configuration for this surface.
@@ -3250,6 +3278,26 @@ pub const Surface = extern struct {
         priv.im_context.as(gtk.IMContext).setClientWidget(null);
     }
 
+    fn glareaMap(
+        _: *gtk.GLArea,
+        self: *Self,
+    ) callconv(.c) void {
+        self.updateMapped(true);
+    }
+
+    fn glareaUnmap(
+        _: *gtk.GLArea,
+        self: *Self,
+    ) callconv(.c) void {
+        self.updateMapped(false);
+    }
+
+    fn updateMapped(self: *Self, mapped: bool) void {
+        const priv = self.private();
+        priv.mapped = mapped;
+        self.as(gobject.Object).notifyByPspec(properties.mapped.impl.param_spec);
+    }
+
     fn glareaRender(
         _: *gtk.GLArea,
         _: *gdk.GLContext,
@@ -3560,6 +3608,8 @@ pub const Surface = extern struct {
             class.bindTemplateCallback("drop", &dtDrop);
             class.bindTemplateCallback("gl_realize", &glareaRealize);
             class.bindTemplateCallback("gl_unrealize", &glareaUnrealize);
+            class.bindTemplateCallback("gl_map", &glareaMap);
+            class.bindTemplateCallback("gl_unmap", &glareaUnmap);
             class.bindTemplateCallback("gl_render", &glareaRender);
             class.bindTemplateCallback("gl_resize", &glareaResize);
             class.bindTemplateCallback("im_preedit_start", &imPreeditStart);
@@ -3592,6 +3642,7 @@ pub const Surface = extern struct {
                 properties.@"error".impl,
                 properties.@"font-size-request".impl,
                 properties.focused.impl,
+                properties.mapped.impl,
                 properties.@"key-sequence".impl,
                 properties.@"key-table".impl,
                 properties.@"min-size".impl,

--- a/src/apprt/gtk/ipc/toggle_quick_terminal.zig
+++ b/src/apprt/gtk/ipc/toggle_quick_terminal.zig
@@ -1,0 +1,24 @@
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+
+const apprt = @import("../../../apprt.zig");
+const DBus = @import("DBus.zig");
+
+/// Use a D-Bus method call to toggle the quick terminal on GTK.
+///
+/// `ghostty +toggle-quick-terminal` is equivalent to the following command
+/// (on a release build):
+///
+/// ```sh
+/// gdbus call --session \
+///   --dest com.mitchellh.ghostty \
+///   --object-path /com/mitchellh/ghostty \
+///   --method org.gtk.Actions.Activate \
+///   toggle-quick-terminal [] []
+/// ```
+pub fn toggleQuickTerminal(alloc: Allocator, target: apprt.ipc.Target) (Allocator.Error || std.Io.Writer.Error || apprt.ipc.Errors)!bool {
+    var dbus = try DBus.init(alloc, target, "toggle-quick-terminal");
+    defer dbus.deinit(alloc);
+    try dbus.send();
+    return true;
+}

--- a/src/apprt/gtk/ui/1.2/surface.blp
+++ b/src/apprt/gtk/ui/1.2/surface.blp
@@ -23,6 +23,8 @@ Overlay terminal_page {
     GLArea gl_area {
       realize => $gl_realize();
       unrealize => $gl_unrealize();
+      map => $gl_map();
+      unmap => $gl_unmap();
       render => $gl_render();
       resize => $gl_resize();
       hexpand: true;

--- a/src/apprt/gtk/ui/1.5/split-tree-split.blp
+++ b/src/apprt/gtk/ui/1.5/split-tree-split.blp
@@ -13,8 +13,11 @@ template $GhosttySplitTreeSplit: Adw.Bin {
   Adw.Bin {
     Paned paned {
       notify::max-position => $notify_max_position();
-      notify::min-position => $notify_min_position();
-      notify::position => $notify_position();
+
+      GestureDrag {
+          drag-end => $on_drag_end();
+      }
     }
+
   }
 }

--- a/src/apprt/gtk/ui/1.5/split-tree-split.blp
+++ b/src/apprt/gtk/ui/1.5/split-tree-split.blp
@@ -13,11 +13,7 @@ template $GhosttySplitTreeSplit: Adw.Bin {
   Adw.Bin {
     Paned paned {
       notify::max-position => $notify_max_position();
-
-      GestureDrag {
-          drag-end => $on_drag_end();
-      }
+      notify::position => $notify_position();
     }
-
   }
 }

--- a/src/apprt/ipc.zig
+++ b/src/apprt/ipc.zig
@@ -73,6 +73,9 @@ pub const Action = union(enum) {
     /// The arguments to pass to Ghostty as the command.
     new_window: NewWindow,
 
+    /// Toggle the quick terminal.
+    toggle_quick_terminal: void,
+
     pub const NewWindow = struct {
         /// A list of command arguments to launch in the new window. If this is
         /// `null` the command configured in the config or the user's default
@@ -113,6 +116,7 @@ pub const Action = union(enum) {
     /// Sync with: ghostty_ipc_action_tag_e
     pub const Key = enum(c_int) {
         new_window,
+        toggle_quick_terminal,
 
         test "ghostty.h Action.Key" {
             try lib.checkGhosttyHEnum(Key, "GHOSTTY_IPC_ACTION_");

--- a/src/cli/ghostty.zig
+++ b/src/cli/ghostty.zig
@@ -20,6 +20,7 @@ const crash_report = @import("crash_report.zig");
 const show_face = @import("show_face.zig");
 const boo = @import("boo.zig");
 const new_window = @import("new_window.zig");
+const toggle_quick_terminal = @import("toggle_quick_terminal.zig");
 
 /// Special commands that can be invoked via CLI flags. These are all
 /// invoked by using `+<action>` as a CLI flag. The only exception is
@@ -72,6 +73,9 @@ pub const Action = enum {
 
     // Use IPC to tell the running Ghostty to open a new window.
     @"new-window",
+
+    // Use IPC to tell the running Ghostty to toggle the quick terminal.
+    @"toggle-quick-terminal",
 
     pub fn detectSpecialCase(arg: []const u8) ?SpecialCase(Action) {
         // If we see a "-e" and we haven't seen a command yet, then
@@ -152,6 +156,7 @@ pub const Action = enum {
             .@"show-face" => try show_face.run(alloc),
             .boo => try boo.run(alloc),
             .@"new-window" => try new_window.run(alloc),
+            .@"toggle-quick-terminal" => try toggle_quick_terminal.run(alloc),
         };
     }
 
@@ -192,6 +197,7 @@ pub const Action = enum {
                 .@"show-face" => show_face.Options,
                 .boo => boo.Options,
                 .@"new-window" => new_window.Options,
+                .@"toggle-quick-terminal" => toggle_quick_terminal.Options,
             };
         }
     }

--- a/src/cli/toggle_quick_terminal.zig
+++ b/src/cli/toggle_quick_terminal.zig
@@ -36,7 +36,7 @@ pub const Options = struct {
 ///   * `--class=<class>`: If set, connect to a custom instance of Ghostty.
 ///     The class must be a valid GTK application ID.
 ///
-/// Available since: 1.3.0
+/// Available since: 1.4.0
 pub fn run(alloc: Allocator) !u8 {
     var buf: [256]u8 = undefined;
     var stderr_writer = std.fs.File.stderr().writer(&buf);

--- a/src/cli/toggle_quick_terminal.zig
+++ b/src/cli/toggle_quick_terminal.zig
@@ -1,0 +1,62 @@
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const Action = @import("../cli.zig").ghostty.Action;
+const apprt = @import("../apprt.zig");
+
+pub const Options = struct {
+    /// If set, connect to a custom instance of Ghostty.
+    class: ?[:0]const u8 = null,
+
+    pub fn deinit(self: *Options) void {
+        self.* = undefined;
+    }
+
+    /// Enables "-h" and "--help" to work.
+    pub fn help(self: Options) !void {
+        _ = self;
+        return Action.help_error;
+    }
+};
+
+/// The `+toggle-quick-terminal` command will use native platform IPC to toggle
+/// the quick terminal in a running instance of Ghostty.
+///
+/// If the `--class` flag is not set, the command will try and connect to the
+/// default running Ghostty instance. Otherwise it will contact a Ghostty
+/// instance configured with the given `class`.
+///
+/// On GTK, D-Bus activation must be properly configured. Ghostty does not need
+/// to be running, as D-Bus will handle launching a new instance if it is not
+/// already running.
+///
+/// Only supported on GTK.
+///
+/// Flags:
+///
+///   * `--class=<class>`: If set, connect to a custom instance of Ghostty.
+///     The class must be a valid GTK application ID.
+///
+/// Available since: 1.3.0
+pub fn run(alloc: Allocator) !u8 {
+    var buf: [256]u8 = undefined;
+    var stderr_writer = std.fs.File.stderr().writer(&buf);
+    const stderr = &stderr_writer.interface;
+
+    if (apprt.App.performIpc(
+        alloc,
+        .detect,
+        .toggle_quick_terminal,
+        {},
+    ) catch |err| switch (err) {
+        error.IPCFailed => {
+            return 1;
+        },
+        else => {
+            try stderr.print("Sending the IPC failed: {}\n", .{err});
+            return 1;
+        },
+    }) return 0;
+
+    try stderr.print("+toggle-quick-terminal is not supported on this platform.\n", .{});
+    return 1;
+}

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -2880,9 +2880,16 @@ keybind: Keybinds = .{},
 /// command-palette-entry = title:"Ghostty",description:"Add a little Ghostty to your terminal.",action:"text:\xf0\x9f\x91\xbb"
 /// ```
 ///
+/// There are some additional special values that can be specified for
+/// command-palette-entry:
+///
+///   * `command-palette-entry=clear` will clear all command entries. Warning: this
+///     removes ALL entries up to this point, including the default
+///     entries. Available since: 1.4.0
+///
 /// By default, the command palette is preloaded with most actions that might
 /// be useful in an interactive setting yet do not have easily accessible or
-/// memorizable shortcuts. The default entries can be cleared by setting this
+/// memorizable shortcuts. The default entries can be restored by setting this
 /// setting to an empty value:
 ///
 /// ```ini
@@ -8736,6 +8743,13 @@ pub const RepeatableCommand = struct {
         // Unset or empty input clears the list
         const input = input_ orelse "";
         if (input.len == 0) {
+            log.info("config has 'command-palette-entry =', using default entries", .{});
+            try self.init(alloc);
+            return;
+        }
+
+        if (std.mem.eql(u8, input, "clear")) {
+            log.info("config has 'command-palette-entry = clear', all command entries cleared", .{});
             self.value.clearRetainingCapacity();
             self.value_c.clearRetainingCapacity();
             return;
@@ -8847,8 +8861,11 @@ pub const RepeatableCommand = struct {
         try testing.expectEqualStrings("Baz", list.value.items[3].title);
         try testing.expectEqualStrings("Raspberry Pie", list.value.items[3].description);
 
-        try list.parseCLI(alloc, "");
+        try list.parseCLI(alloc, "clear");
         try testing.expectEqual(@as(usize, 0), list.value.items.len);
+
+        try list.parseCLI(alloc, "");
+        try testing.expectEqual(inputpkg.command.defaults.len, list.value.items.len);
     }
 
     test "RepeatableCommand formatConfig empty" {
@@ -8963,7 +8980,7 @@ pub const RepeatableCommand = struct {
         try list.parseCLI(alloc, "title:Foo,action:ignore");
         try testing.expectEqual(@as(usize, 1), list.cval().len);
 
-        try list.parseCLI(alloc, "");
+        try list.parseCLI(alloc, "clear");
         try testing.expectEqual(@as(usize, 0), list.cval().len);
     }
 };

--- a/src/datastruct/split_tree.zig
+++ b/src/datastruct/split_tree.zig
@@ -860,25 +860,26 @@ pub fn SplitTree(comptime V: type) type {
             var sp = try result.spatial(gpa);
             defer sp.deinit(gpa);
 
-            // Get the ratio of the split relative to the full grid.
-            const full_ratio = full_ratio: {
-                // Our scale is the amount we need to multiply our individual
-                // ratio by to get the full ratio. Its actually a ratio on its
-                // own but I'm trying to avoid that word: its the ratio of
-                // our spatial width/height to the total.
-                const scale = switch (layout) {
-                    .horizontal => sp.slots[parent_handle.idx()].width / sp.slots[0].width,
-                    .vertical => sp.slots[parent_handle.idx()].height / sp.slots[0].height,
-                };
-
-                const current = result.nodes[parent_handle.idx()].split.ratio;
-                break :full_ratio current * scale;
+            // Our scale is the amount we need to divide our ratio delta by to
+            // get a delta relative to the split, not the entire grid.
+            // Its actually a ratio on its own but I'm trying to avoid that word:
+            // its the ratio of our spatial width/height to the total.
+            const scale = switch (layout) {
+                .horizontal => sp.slots[parent_handle.idx()].width / sp.slots[0].width,
+                .vertical => sp.slots[parent_handle.idx()].height / sp.slots[0].height,
             };
 
-            // Set the final new ratio, clamping it to [0, 1]
+            // If the split has spatial width/height 0, resizing by a percentage
+            // of the total grid size doesn't make sense.
+            if (scale == 0) return result;
+
+            // Adjust the old split ratio by the scaled ratio delta.
+            const new_ratio = result.nodes[parent_handle.idx()].split.ratio + (ratio / scale);
+
+            // Set the new ratio, clamping it to [0, 1]
             result.resizeInPlace(
                 parent_handle,
-                @min(@max(full_ratio + ratio, 0), 1),
+                @min(@max(new_ratio, 0), 1),
             );
             return result;
         }
@@ -2167,6 +2168,155 @@ test "SplitTree: resize" {
             \\+---++-------------+
             \\| A ||      B      |
             \\+---++-------------+
+            \\
+        );
+    }
+}
+
+test "SplitTree: resize nested split" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var v1: TestTree.View = .{ .label = "A" };
+    var t1: TestTree = try .init(alloc, &v1);
+    defer t1.deinit();
+    var v2: TestTree.View = .{ .label = "B" };
+    var t2: TestTree = try .init(alloc, &v2);
+    defer t2.deinit();
+    var v3: TestTree.View = .{ .label = "C" };
+    var t3: TestTree = try .init(alloc, &v3);
+    defer t3.deinit();
+
+    // A | B vertical
+    var splitAB = try t1.split(
+        alloc,
+        .root, // at root
+        .down, // split down
+        0.5,
+        &t2, // insert t2
+    );
+    defer splitAB.deinit();
+
+    var splitBC = try splitAB.split(
+        alloc,
+        at: {
+            var it = splitAB.iterator();
+            break :at while (it.next()) |entry| {
+                if (std.mem.eql(u8, entry.view.label, "B")) {
+                    break entry.handle;
+                }
+            } else return error.NotFound;
+        },
+        .down, // split down
+        0.5,
+        &t3, // insert t3
+    );
+    defer splitBC.deinit();
+
+    {
+        const str = try std.fmt.allocPrint(alloc, "{f}", .{std.fmt.alt(splitBC, .formatDiagram)});
+        defer alloc.free(str);
+        try testing.expectEqualStrings(str,
+            \\+---+
+            \\|   |
+            \\|   |
+            \\| A |
+            \\|   |
+            \\+---+
+            \\+---+
+            \\| B |
+            \\+---+
+            \\+---+
+            \\| C |
+            \\+---+
+            \\
+        );
+    }
+
+    // Resize
+    {
+        var resized = try splitBC.resize(
+            alloc,
+            at: {
+                var it = splitBC.iterator();
+                break :at while (it.next()) |entry| {
+                    if (std.mem.eql(u8, entry.view.label, "B")) {
+                        break entry.handle;
+                    }
+                } else return error.NotFound;
+            },
+            .vertical, // resize down
+            0.125,
+        );
+        defer resized.deinit();
+        const str = try std.fmt.allocPrint(alloc, "{f}", .{std.fmt.alt(resized, .formatDiagram)});
+        defer alloc.free(str);
+        try testing.expectEqualStrings(str,
+            \\+---+
+            \\|   |
+            \\|   |
+            \\|   |
+            \\|   |
+            \\|   |
+            \\| A |
+            \\|   |
+            \\|   |
+            \\|   |
+            \\|   |
+            \\+---+
+            \\+---+
+            \\|   |
+            \\|   |
+            \\|   |
+            \\| B |
+            \\|   |
+            \\|   |
+            \\|   |
+            \\+---+
+            \\+---+
+            \\| C |
+            \\+---+
+            \\
+        );
+    }
+
+    // Resize the other direction (negative ratio)
+    {
+        var resized = try splitBC.resize(
+            alloc,
+            at: {
+                var it = splitBC.iterator();
+                break :at while (it.next()) |entry| {
+                    if (std.mem.eql(u8, entry.view.label, "B")) {
+                        break entry.handle;
+                    }
+                } else return error.NotFound;
+            },
+            .vertical, // resize up
+            -0.0833,
+        );
+        defer resized.deinit();
+        const str = try std.fmt.allocPrint(alloc, "{f}", .{std.fmt.alt(resized, .formatDiagram)});
+        defer alloc.free(str);
+        try testing.expectEqualStrings(str,
+            \\+---+
+            \\|   |
+            \\|   |
+            \\|   |
+            \\| A |
+            \\|   |
+            \\|   |
+            \\|   |
+            \\+---+
+            \\+---+
+            \\| B |
+            \\+---+
+            \\+---+
+            \\|   |
+            \\|   |
+            \\| C |
+            \\|   |
+            \\+---+
             \\
         );
     }

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -423,6 +423,8 @@ pub const Action = union(enum) {
 
     /// Navigate the search results. If there is no active search, this
     /// is not performed.
+    ///
+    /// Valid arguments: `previous`, `next`.
     navigate_search: NavigateSearch,
 
     /// Start a search if it isn't started already. This doesn't set any

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -348,7 +348,7 @@ pub const Action = union(enum) {
 
     /// Copy the selected text to the clipboard.
     ///
-    /// Valid arguments:
+    /// Valid values:
     ///
     ///   - `plain`
     ///
@@ -370,8 +370,6 @@ pub const Action = union(enum) {
     ///     (e.g. plain text and HTML), each tagged with its content type
     ///     so the receiving OS or application can pick the most appropriate
     ///     representation when pasting.
-    ///
-    /// If no argument is given, defaults to `mixed`.
     copy_to_clipboard: CopyToClipboard,
 
     /// Paste the contents of the default clipboard.
@@ -424,7 +422,7 @@ pub const Action = union(enum) {
     /// Navigate the search results. If there is no active search, this
     /// is not performed.
     ///
-    /// Valid arguments: `previous`, `next`.
+    /// Valid values: `previous`, `next`.
     navigate_search: NavigateSearch,
 
     /// Start a search if it isn't started already. This doesn't set any
@@ -708,10 +706,9 @@ pub const Action = union(enum) {
     /// of the `confirm-close-surface` configuration setting.
     close_surface,
 
-    /// Close the current tab and all splits therein, close all other tabs, or
-    /// close every tab to the right of the current one depending on the mode.
+    /// Close the specified tabs and all splits therein.
     ///
-    /// Valid arguments:
+    /// Valid values:
     ///
     ///   - `this` (default)
     ///
@@ -724,8 +721,6 @@ pub const Action = union(enum) {
     ///   - `right`
     ///
     ///     Close every tab to the right of the current tab.
-    ///
-    /// If no argument is given, defaults to `this`.
     ///
     /// This might trigger a close confirmation popup, depending on the value
     /// of the `confirm-close-surface` configuration setting.

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -347,6 +347,31 @@ pub const Action = union(enum) {
     reset,
 
     /// Copy the selected text to the clipboard.
+    ///
+    /// Valid arguments:
+    ///
+    ///   - `plain`
+    ///
+    ///     Copy the selection as plain text only.
+    ///
+    ///   - `vt`
+    ///
+    ///     Copy the selection as plain text, preserving terminal escape
+    ///     sequences (such as colors and styles).
+    ///
+    ///   - `html`
+    ///
+    ///     Copy the selection as HTML, preserving colors and styles as
+    ///     HTML markup.
+    ///
+    ///   - `mixed` (default)
+    ///
+    ///     Place multiple representations on the clipboard at once
+    ///     (e.g. plain text and HTML), each tagged with its content type
+    ///     so the receiving OS or application can pick the most appropriate
+    ///     representation when pasting.
+    ///
+    /// If no argument is given, defaults to `mixed`.
     copy_to_clipboard: CopyToClipboard,
 
     /// Paste the contents of the default clipboard.

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -711,7 +711,21 @@ pub const Action = union(enum) {
     /// Close the current tab and all splits therein, close all other tabs, or
     /// close every tab to the right of the current one depending on the mode.
     ///
-    /// If the mode is not specified, defaults to closing the current tab.
+    /// Valid arguments:
+    ///
+    ///   - `this` (default)
+    ///
+    ///     Close the current tab and all splits within it.
+    ///
+    ///   - `other`
+    ///
+    ///     Close every tab in the current window except the current tab.
+    ///
+    ///   - `right`
+    ///
+    ///     Close every tab to the right of the current tab.
+    ///
+    /// If no argument is given, defaults to `this`.
     ///
     /// This might trigger a close confirmation popup, depending on the value
     /// of the `confirm-close-surface` configuration setting.

--- a/src/os/i18n_locales.zig
+++ b/src/os/i18n_locales.zig
@@ -58,4 +58,5 @@ pub const locales = [_][:0]const u8{
     "vi",
     "kk",
     "be",
+    "eu",
 };

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -573,20 +573,25 @@ pub fn print(self: *Terminal, c: u21) !void {
         // it.
         if (self.modes.get(.grapheme_cluster)) return;
 
-        // If we're at cell zero, then this is malformed data and we don't
-        // print anything or even store this. Zero-width characters are ALWAYS
-        // attached to some other non-zero-width character at the time of
-        // writing.
-        if (self.screens.active.cursor.x == 0) {
+        // If we have wraparound enabled and a pending wrap, the character
+        // we're attaching to is still under the cursor. Otherwise, it's the
+        // cell to the left.
+        const left: size.CellCountInt = if (self.modes.get(.wraparound) and self.screens.active.cursor.pending_wrap) 0 else 1;
+
+        // If we're at cell zero and not pending a wrap, then this is malformed
+        // data and we don't print anything or even store this. Zero-width
+        // characters are ALWAYS attached to some other non-zero-width
+        // character at the time of writing.
+        if (self.screens.active.cursor.x == 0 and left == 1) {
             log.warn("zero-width character with no prior character, ignoring", .{});
             return;
         }
 
         // Find our previous cell
         const prev = prev: {
-            const immediate = self.screens.active.cursorCellLeft(1);
+            const immediate = self.screens.active.cursorCellLeft(left);
             if (immediate.wide != .spacer_tail) break :prev immediate;
-            break :prev self.screens.active.cursorCellLeft(2);
+            break :prev self.screens.active.cursorCellLeft(left + 1);
         };
 
         // If our previous cell has no text, just ignore the zero-width character
@@ -3311,6 +3316,23 @@ test "Terminal: zero-width character at start" {
 
     // Should not be dirty since we changed nothing.
     try testing.expect(!t.isDirty(.{ .screen = .{ .x = 0, .y = 0 } }));
+}
+
+// https://github.com/ghostty-org/ghostty/issues/12581
+test "Terminal: zero-width character attaches to pending wrap cell" {
+    var t = try init(testing.allocator, .{ .cols = 2, .rows = 2 });
+    defer t.deinit(testing.allocator);
+
+    // Disable grapheme clustering to exercise the fallback path.
+    t.modes.set(.grapheme_cluster, false);
+
+    try t.print('x');
+    try t.print('å');
+    try t.print(0x0332); // Combining low line.
+
+    const str = try t.plainString(testing.allocator);
+    defer testing.allocator.free(str);
+    try testing.expectEqualStrings("xå̲", str);
 }
 
 // https://github.com/mitchellh/ghostty/issues/1400

--- a/src/terminal/c/terminal.zig
+++ b/src/terminal/c/terminal.zig
@@ -1052,6 +1052,29 @@ test "vt_write split escape sequence" {
     try testing.expectEqualStrings("Hello Bold", str);
 }
 
+test "vt_write split combining mark after base at right edge" {
+    var t: Terminal = null;
+    try testing.expectEqual(Result.success, new(
+        &lib.alloc.test_allocator,
+        &t,
+        .{
+            .cols = 2,
+            .rows = 2,
+            .max_scrollback = 0,
+        },
+    ));
+    defer free(t);
+
+    // Put "å" in the final column, then send its combining low line in a
+    // separate write so the mark arrives while the cursor has a pending wrap.
+    vt_write(t, "xå", 3);
+    vt_write(t, "\xcc\xb2", 2);
+
+    const str = try t.?.terminal.plainString(testing.allocator);
+    defer testing.allocator.free(str);
+    try testing.expectEqualStrings("xå̲", str);
+}
+
 test "get cols and rows" {
     var t: Terminal = null;
     try testing.expectEqual(Result.success, new(


### PR DESCRIPTION
Merges ghostty-org/ghostty main into the cmux fork pin.\n\nCurrent cmux pin: ff6e1260d2e7767de55b8d9307b328e4060545b7\nUpstream merged: 3706abab0c962d9c93c4c4af853149f9d55f4deb\nResulting fork commit: 7128cba84343946a1978364ba16ac3f82ef99528\n\nVerification so far:\n- CMUX_GHOSTTYKIT_NO_PREBUILT=1 ./scripts/ensure-ghosttykit.sh\n\ncmux parent PR will point at this commit after it is reachable from manaflow-ai/ghostty main.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sync the `cmux` Ghostty fork with the latest upstream to bring new IPC, macOS/GTK improvements, and key fixes. This keeps cmux aligned with upstream behavior and build tooling.

- **New Features**
  - Add `+toggle-quick-terminal` IPC/CLI command for GTK.
  - macOS: background opacity toggle now persists across tabs and new windows.
  - Add Basque translation (`eu`) and locale wiring.
  - Update bundled iTerm2 color schemes.

- **Bug Fixes**
  - macOS IME: suppress control-char input while composing and avoid replaying keys that commit preedit; improve focus when toggling the command palette; enable Copy only with a selection; normalize working directory paths.
  - GTK: fix invisible nested splits and lost focus; correct split ratio math and restore focus when surfaces remap.
  - Terminal: correct zero-width combining mark attachment at the right edge with pending wrap (test added).
  - Build: fall back to Zig-bundled Darwin headers if no SDK; Nix support for building `libghostty-vt` on macOS; minor CI workflow dependency bumps.

<sup>Written for commit 7128cba84343946a1978364ba16ac3f82ef99528. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/58?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added toggle quick terminal action accessible via IPC and CLI
  * Added Basque language localization support

* **Bug Fixes**
  * Fixed combining character attachment behavior at line wrap boundaries
  * Improved split divider resizing calculations for nested splits
  * Fixed background opacity inheritance when creating new windows and tabs
  * Enhanced focus management in command palette operations
  * Improved focus restoration after split tree modifications

* **Chores**
  * Updated theme asset dependencies
  * Updated GitHub Actions workflow versions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/ghostty/pull/58?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->