### PR TITLE
Fix upstream merge regressions for cmux

### DIFF
--- a/src/cli/toggle_quick_terminal.zig
+++ b/src/cli/toggle_quick_terminal.zig
@@ -1,13 +1,19 @@
 const std = @import("std");
 const Allocator = std.mem.Allocator;
+const ArenaAllocator = std.heap.ArenaAllocator;
 const Action = @import("../cli.zig").ghostty.Action;
 const apprt = @import("../apprt.zig");
+const args = @import("args.zig");
 
 pub const Options = struct {
+    /// This is set by the CLI parser for deinit.
+    _arena: ?ArenaAllocator = null,
+
     /// If set, connect to a custom instance of Ghostty.
     class: ?[:0]const u8 = null,
 
     pub fn deinit(self: *Options) void {
+        if (self._arena) |arena| arena.deinit();
         self.* = undefined;
     }
 
@@ -38,13 +44,37 @@ pub const Options = struct {
 ///
 /// Available since: 1.4.0
 pub fn run(alloc: Allocator) !u8 {
+    var iter = try args.argsIterator(alloc);
+    defer iter.deinit();
+
     var buf: [256]u8 = undefined;
     var stderr_writer = std.fs.File.stderr().writer(&buf);
     const stderr = &stderr_writer.interface;
 
+    const result = runArgs(alloc, &iter, stderr);
+    stderr.flush() catch {};
+    return result;
+}
+
+fn runArgs(
+    alloc: Allocator,
+    argsIter: anytype,
+    stderr: *std.Io.Writer,
+) !u8 {
+    var opts: Options = .{};
+    defer opts.deinit();
+
+    args.parse(Options, alloc, &opts, argsIter) catch |err| switch (err) {
+        error.ActionHelpRequested => return err,
+        else => {
+            try stderr.print("Error parsing args: {}\n", .{err});
+            return 1;
+        },
+    };
+
     if (apprt.App.performIpc(
         alloc,
-        .detect,
+        if (opts.class) |class| .{ .class = class } else .detect,
         .toggle_quick_terminal,
         {},
     ) catch |err| switch (err) {

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -8816,7 +8816,7 @@ pub const RepeatableCommand = struct {
         formatter: formatterpkg.EntryFormatter,
     ) !void {
         if (self.value.items.len == 0) {
-            try formatter.formatEntry(void, {});
+            try formatter.formatEntry([]const u8, "clear");
             return;
         }
 
@@ -8892,7 +8892,7 @@ pub const RepeatableCommand = struct {
 
         var list: RepeatableCommand = .{};
         try list.formatEntry(formatterpkg.entryFormatter("a", &buf.writer));
-        try std.testing.expectEqualSlices(u8, "a = \n", buf.written());
+        try std.testing.expectEqualSlices(u8, "a = clear\n", buf.written());
     }
 
     test "RepeatableCommand formatConfig single item" {


### PR DESCRIPTION
Fixes review findings from the cmux Ghostty upstream update.\n\nChanges:\n- Preserve command-palette-entry = clear when formatting cleared command palette config.\n- Parse +toggle-quick-terminal --class and pass the target through IPC.\n- Flush +toggle-quick-terminal stderr before returning.\n\nMakes fffdaadcb015057d5b70dc88ea4e52e6a159efd0 available for the cmux submodule update after merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix merge regressions from the Ghostty upstream update in cmux. Preserve `command-palette-entry = clear`, add --class support to +toggle-quick-terminal, and flush stderr reliably.

- **Bug Fixes**
  - Config formatter now outputs `clear` when a command palette list is empty, preserving `command-palette-entry = clear`.
  - +toggle-quick-terminal parses `--class` and passes it through IPC to target the specified instance (instead of always using detect).
  - Flush stderr before exit, and print CLI parse errors to stderr with a non-zero status.

<sup>Written for commit fffdaadcb015057d5b70dc88ea4e52e6a159efd0. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/59?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

