### PR TITLE
Merge Ghostty cmux theme picker ctrl navigation

### DIFF
--- a/src/cli/list_themes.zig
+++ b/src/cli/list_themes.zig
@@ -841,15 +841,19 @@ const Preview = struct {
                             self.current = self.filtered.items.len - 1;
                             try self.applyCmuxSelectionForCurrentTheme();
                         }
-                        if (key.matchesAny(&.{ 'j', '+', vaxis.Key.down, vaxis.Key.kp_down, vaxis.Key.kp_add }, .{})) {
+                        if (key.matches('n', .{ .ctrl = true }) or
+                            key.matchesAny(&.{ 'j', '+', vaxis.Key.down, vaxis.Key.kp_down, vaxis.Key.kp_add }, .{}))
+                        {
                             self.down(1);
                             try self.applyCmuxSelectionForCurrentTheme();
                         }
-                        if (key.matchesAny(&.{ vaxis.Key.page_down, vaxis.Key.kp_down }, .{})) {
+                        if (key.matchesAny(&.{ vaxis.Key.page_down, vaxis.Key.kp_page_down }, .{})) {
                             self.down(20);
                             try self.applyCmuxSelectionForCurrentTheme();
                         }
-                        if (key.matchesAny(&.{ 'k', '-', vaxis.Key.up, vaxis.Key.kp_up, vaxis.Key.kp_subtract }, .{})) {
+                        if (key.matches('p', .{ .ctrl = true }) or
+                            key.matchesAny(&.{ 'k', '-', vaxis.Key.up, vaxis.Key.kp_up, vaxis.Key.kp_subtract }, .{}))
+                        {
                             self.up(1);
                             try self.applyCmuxSelectionForCurrentTheme();
                         }
@@ -919,6 +923,16 @@ const Preview = struct {
                         if (key.matchesAny(&.{ 'x', '/' }, .{ .ctrl = true })) {
                             self.text_input.clearRetainingCapacity();
                             try self.updateFiltered();
+                            try self.applyCmuxSelectionForCurrentTheme();
+                            break :search;
+                        }
+                        if (key.matches('n', .{ .ctrl = true })) {
+                            self.down(1);
+                            try self.applyCmuxSelectionForCurrentTheme();
+                            break :search;
+                        }
+                        if (key.matches('p', .{ .ctrl = true })) {
+                            self.up(1);
                             try self.applyCmuxSelectionForCurrentTheme();
                             break :search;
                         }
@@ -1208,10 +1222,10 @@ const Preview = struct {
                     .{ .keys = "^C, q, ESC", .help = "Quit." },
                     .{ .keys = "F1, ?, ^H", .help = "Toggle help window." },
                     .{ .keys = "f", .help = "Cycle through theme filters." },
-                    .{ .keys = "k, ↑", .help = "Move up 1 theme." },
+                    .{ .keys = "^P, k, ↑", .help = "Move up 1 theme." },
                     .{ .keys = "ScrollUp", .help = "Move up 1 theme." },
                     .{ .keys = "PgUp", .help = "Move up 20 themes." },
-                    .{ .keys = "j, ↓", .help = "Move down 1 theme." },
+                    .{ .keys = "^N, j, ↓", .help = "Move down 1 theme." },
                     .{ .keys = "ScrollDown", .help = "Move down 1 theme." },
                     .{ .keys = "PgDown", .help = "Move down 20 themes." },
                     .{ .keys = "h, x", .help = "Show palette numbers in hexadecimal." },


### PR DESCRIPTION
This branch contains the Ctrl+N/Ctrl+P themes picker commit from branch issue-themes-broken-ctrl-np (176bd550...) merged onto fork main for durability.

It should be safe to fast-review and merge so cmux parent can repoint the submodule to a durable commit on ghostty main.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782123665&installation_id=133855650&pr_number=62&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F62&signature=272acc795e9c587d72720e1258846dd87f7414852ae3027b33e1f0298e59d7bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `Ctrl+N` and `Ctrl+P` keyboard shortcuts for navigating themes in both normal and search modes. Shortcuts apply the selected theme when navigation occurs.

* **Documentation**
  * Updated help overlay to document the new keyboard shortcuts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/ghostty/pull/62?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->