### PR TITLE
[codex] Enable alternate screen scrollback

### DIFF
--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -2988,7 +2988,9 @@ pub fn switchScreen(self: *Terminal, key: ScreenSet.Key) !?*Screen {
                 .rows = self.rows,
                 .max_scrollback = switch (key) {
                     .primary => primary.pages.explicit_max_size,
-                    .alternate => 0,
+                    // Keep alternate-screen TUI output scrollable using the
+                    // same configured history limit as the primary screen.
+                    .alternate => primary.pages.explicit_max_size,
                 },
 
                 // Inherit our Kitty image settings from the primary
@@ -13110,6 +13112,22 @@ test "Terminal: mode 1049 alt screen plain" {
         defer testing.allocator.free(str);
         try testing.expectEqualStrings("", str);
     }
+}
+
+test "Terminal: alternate screen keeps configured scrollback" {
+    const alloc = testing.allocator;
+    var t = try init(alloc, .{ .rows = 3, .cols = 10, .max_scrollback = 10_000 });
+    defer t.deinit(alloc);
+
+    const primary = t.screens.get(.primary).?;
+    try t.switchScreenMode(.@"1049", true);
+    try testing.expectEqual(.alternate, t.screens.active_key);
+    try testing.expectEqual(primary.pages.explicit_max_size, t.screens.active.pages.explicit_max_size);
+
+    try t.printString("line1\nline2\nline3\nline4\nline5\n");
+
+    const scrollbar = t.screens.active.pages.scrollbar();
+    try testing.expect(scrollbar.total > scrollbar.len);
 }
 
 // Reproduces a crash found by AFL++ fuzzer (afl-out/stream/default/crashes/


### PR DESCRIPTION
## Summary
- make alternate screens inherit the configured scrollback limit instead of forcing zero
- add a regression test that overflows alternate-screen output and verifies a scrollback scrollbar is exposed

## Why
cmux users running agent TUIs such as Claude Code need to scroll back through long alternate-screen output. The cmux issue is https://github.com/manaflow-ai/cmux/issues/2334.

## Validation
- Podman Alpine arm64: /repo/.tools/zig-linux-0.15.2/zig build test-lib-vt -Demit-lib-vt=true -Dtest-filter="Terminal: alternate screen keeps configured scrollback"
- /tmp/zig-aarch64-macos-0.15.2/zig fmt --check src/terminal/Terminal.zig
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782236568&installation_id=133855650&pr_number=63&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F63&signature=dfff8918c9fd4fffa74774702a33b5e64b758f5c664fa1fe1937841720909881"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Alternate screens now inherit the configured scrollback limit from the primary screen, so TUI output stays scrollable.
Added a regression test that overflows alternate-screen output and verifies a scrollbar appears.

<sup>Written for commit d42e4939ec15f05729437f4270890ff1f1915b86. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/63?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

