### PR TITLE
ghostty: add ghostty_surface_set_selection_range C API

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1180,6 +1180,12 @@ GHOSTTY_API void ghostty_surface_complete_clipboard_request(ghostty_surface_t,
 GHOSTTY_API bool ghostty_surface_has_selection(ghostty_surface_t);
 GHOSTTY_API bool ghostty_surface_select_cursor_cell(ghostty_surface_t);
 GHOSTTY_API bool ghostty_surface_select_cursor_line(ghostty_surface_t);
+GHOSTTY_API bool ghostty_surface_set_selection_range(ghostty_surface_t,
+                                                      uint32_t,
+                                                      uint32_t,
+                                                      uint32_t,
+                                                      uint32_t,
+                                                      bool);
 GHOSTTY_API bool ghostty_surface_clear_selection(ghostty_surface_t);
 GHOSTTY_API bool ghostty_surface_read_selection(ghostty_surface_t, ghostty_text_s*);
 GHOSTTY_API bool ghostty_surface_read_text(ghostty_surface_t,

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1181,11 +1181,11 @@ GHOSTTY_API bool ghostty_surface_has_selection(ghostty_surface_t);
 GHOSTTY_API bool ghostty_surface_select_cursor_cell(ghostty_surface_t);
 GHOSTTY_API bool ghostty_surface_select_cursor_line(ghostty_surface_t);
 GHOSTTY_API bool ghostty_surface_set_selection_range(ghostty_surface_t,
-                                                      uint32_t,
-                                                      uint32_t,
-                                                      uint32_t,
-                                                      uint32_t,
-                                                      bool);
+                                                      uint32_t row_start,
+                                                      uint32_t col_start,
+                                                      uint32_t row_end,
+                                                      uint32_t col_end,
+                                                      bool is_rectangular);
 GHOSTTY_API bool ghostty_surface_clear_selection(ghostty_surface_t);
 GHOSTTY_API bool ghostty_surface_read_selection(ghostty_surface_t, ghostty_text_s*);
 GHOSTTY_API bool ghostty_surface_read_text(ghostty_surface_t,

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -2118,6 +2118,30 @@ pub fn selectCursorLine(self: *Surface) !bool {
     return true;
 }
 
+/// Set a selection range from buffer (screen) coordinates (cmux-specific).
+pub fn setSelectionRange(
+    self: *Surface,
+    row_start: u32,
+    col_start: u32,
+    row_end: u32,
+    col_end: u32,
+    is_rectangular: bool,
+) !bool {
+    self.renderer_state.mutex.lock();
+    defer self.renderer_state.mutex.unlock();
+
+    const screen: *terminal.Screen = self.io.terminal.screens.active;
+    const col_start_cell = std.math.cast(terminal.size.CellCountInt, col_start) orelse return false;
+    const col_end_cell = std.math.cast(terminal.size.CellCountInt, col_end) orelse return false;
+    const start_pin = screen.pages.pin(.{ .screen = .{ .x = col_start_cell, .y = row_start } }) orelse return false;
+    const end_pin = screen.pages.pin(.{ .screen = .{ .x = col_end_cell, .y = row_end } }) orelse return false;
+
+    try self.setSelection(terminal.Selection.init(start_pin, end_pin, is_rectangular));
+    screen.dirty.selection = true;
+    try self.queueRender();
+    return true;
+}
+
 /// Clear the active selection (cmux-specific).
 pub fn clearSelection(self: *Surface) !bool {
     self.renderer_state.mutex.lock();

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1684,6 +1684,27 @@ pub const CAPI = struct {
         };
     }
 
+    /// Set a selection range from buffer (screen) coordinates (cmux-specific).
+    export fn ghostty_surface_set_selection_range(
+        surface: *Surface,
+        row_start: u32,
+        col_start: u32,
+        row_end: u32,
+        col_end: u32,
+        is_rectangular: bool,
+    ) bool {
+        return surface.core_surface.setSelectionRange(
+            row_start,
+            col_start,
+            row_end,
+            col_end,
+            is_rectangular,
+        ) catch |err| {
+            log.warn("error setting selection range err={}", .{err});
+            return false;
+        };
+    }
+
     /// Same as ghostty_surface_read_text but reads from the user selection,
     /// if any.
     export fn ghostty_surface_read_selection(


### PR DESCRIPTION
Adds the `ghostty_surface_set_selection_range` C API function for programmatic selection control in embedded mode.

This is needed by cmux for the copy-mode cursor UX slices (see plans/2026-05-22-copy-mode-cursor-ux-slices.md Slice 0).

Changes:
- `include/ghostty.h`: Declare `ghostty_surface_set_selection_range`
- `src/Surface.zig`: Implement `setSelectionRange` public method
- `src/apprt/embedded.zig`: Implement `setSelectionRange` on embedded surface

Acceptance:
- Function is exported in the C API
- Existing behavior unchanged

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782274061&installation_id=133855650&pr_number=64&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F64&signature=8ea588efb3b41dc139f08abb78a4eceb6b67210d9d3b88fdc461fba2f9229421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `ghostty_surface_set_selection_range` to the embedded C API to set text selections using screen coordinates (supports rectangular). Enables cmux copy-mode cursor UX Slice 0 while keeping existing selection APIs unchanged.

- **New Features**
  - New C API: `ghostty_surface_set_selection_range(ghostty_surface_t, row_start, col_start, row_end, col_end, is_rectangular)`.
  - Validates and pins inputs, updates selection, marks dirty, queues render; returns false and logs on error.

<sup>Written for commit 0a650e9258af25c2dbbbddd81005d3e79ce074a2. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/64?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public API to set text selection by specifying start/end row and column coordinates.
  * Supports both linear and rectangular selection modes for precise programmatic control; operations report success/failure so callers can react.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/ghostty/pull/64?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->