### PR TITLE
Expose tmux control-mode embedder events

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -886,6 +886,22 @@ typedef struct {
   ssize_t selected;
 } ghostty_action_search_selected_s;
 
+// apprt.action.TmuxControl.Event
+typedef enum {
+  GHOSTTY_TMUX_ENTER,
+  GHOSTTY_TMUX_EXIT,
+  GHOSTTY_TMUX_WINDOWS_CHANGED,
+  GHOSTTY_TMUX_PANE_OUTPUT,
+} ghostty_tmux_event_e;
+
+// apprt.action.TmuxControl
+typedef struct {
+  ghostty_tmux_event_e event;
+  uint32_t id;
+  const uint8_t *data;
+  uintptr_t data_len;
+} ghostty_action_tmux_control_s;
+
 // terminal.Scrollbar
 typedef struct {
   uint64_t total;
@@ -960,6 +976,7 @@ typedef enum {
   GHOSTTY_ACTION_SEARCH_SELECTED,
   GHOSTTY_ACTION_READONLY,
   GHOSTTY_ACTION_COPY_TITLE_TO_CLIPBOARD,
+  GHOSTTY_ACTION_TMUX_CONTROL,
 } ghostty_action_tag_e;
 
 typedef union {
@@ -1001,6 +1018,7 @@ typedef union {
   ghostty_action_search_total_s search_total;
   ghostty_action_search_selected_s search_selected;
   ghostty_action_readonly_e readonly;
+  ghostty_action_tmux_control_s tmux_control;
 } ghostty_action_u;
 
 typedef struct {

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -1154,6 +1154,21 @@ pub fn handleMessage(self: *Surface, msg: Message) !void {
             };
         },
 
+        .tmux_control => |v| {
+            defer v.data.deinit();
+            _ = self.rt_app.performAction(
+                .{ .surface = self },
+                .tmux_control,
+                .{
+                    .event = v.event,
+                    .id = v.id,
+                    .data = v.data.slice(),
+                },
+            ) catch |err| {
+                log.warn("apprt failed to report tmux control event err={}", .{err});
+            };
+        },
+
         .selection_scroll_tick => |active| {
             self.selection_scroll_active = active;
             try self.selectionScrollTick();

--- a/src/apprt/action.zig
+++ b/src/apprt/action.zig
@@ -343,6 +343,9 @@ pub const Action = union(Key) {
     /// otherwise the terminal-set title.
     copy_title_to_clipboard,
 
+    /// Read-only tmux control-mode state surfaced to embedded runtimes.
+    tmux_control: TmuxControl,
+
     /// Sync with: ghostty_action_tag_e
     pub const Key = enum(c_int) {
         quit,
@@ -410,6 +413,7 @@ pub const Action = union(Key) {
         search_selected,
         readonly,
         copy_title_to_clipboard,
+        tmux_control,
 
         test "ghostty.h Action.Key" {
             try lib.checkGhosttyHEnum(Key, "GHOSTTY_ACTION_");
@@ -625,6 +629,40 @@ pub const Readonly = enum(c_int) {
 
     test "ghostty.h Readonly" {
         try lib.checkGhosttyHEnum(Readonly, "GHOSTTY_READONLY_");
+    }
+};
+
+pub const TmuxControl = struct {
+    event: Event,
+    id: u32 = 0,
+    data: []const u8 = &.{},
+
+    pub const Event = enum(c_int) {
+        enter,
+        exit,
+        windows_changed,
+        pane_output,
+
+        test "ghostty.h TmuxControl.Event" {
+            try lib.checkGhosttyHEnum(Event, "GHOSTTY_TMUX_");
+        }
+    };
+
+    // Sync with: ghostty_action_tmux_control_s
+    pub const C = extern struct {
+        event: Event,
+        id: u32,
+        data: [*]const u8,
+        data_len: usize,
+    };
+
+    pub fn cval(self: TmuxControl) C {
+        return .{
+            .event = self.event,
+            .id = self.id,
+            .data = self.data.ptr,
+            .data_len = self.data.len,
+        };
     }
 };
 

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -274,11 +274,23 @@ pub const App = struct {
         // embedded apprt.
         self.performPreAction(target, action, value);
 
-        log.debug("dispatching action target={t} action={} value={any}", .{
-            target,
-            action,
-            value,
-        });
+        switch (action) {
+            .tmux_control => log.debug(
+                "dispatching action target={t} action={} event={s} id={} data_len={}",
+                .{
+                    target,
+                    action,
+                    @tagName(value.event),
+                    value.id,
+                    value.data.len,
+                },
+            ),
+            else => log.debug("dispatching action target={t} action={} value={any}", .{
+                target,
+                action,
+                value,
+            }),
+        }
         return self.opts.action(
             self,
             target.cval(),

--- a/src/apprt/gtk/class/application.zig
+++ b/src/apprt/gtk/class/application.zig
@@ -769,6 +769,7 @@ pub const Application = extern struct {
             .end_search => Action.endSearch(target),
             .search_total => Action.searchTotal(target, value),
             .search_selected => Action.searchSelected(target, value),
+            .tmux_control => return true,
 
             // Unimplemented
             .secure_input,
@@ -784,7 +785,6 @@ pub const Application = extern struct {
             .check_for_updates,
             .undo,
             .redo,
-            .tmux_control,
             => {
                 log.warn("unimplemented action={}", .{action});
                 return false;

--- a/src/apprt/gtk/class/application.zig
+++ b/src/apprt/gtk/class/application.zig
@@ -784,6 +784,7 @@ pub const Application = extern struct {
             .check_for_updates,
             .undo,
             .redo,
+            .tmux_control,
             => {
                 log.warn("unimplemented action={}", .{action});
                 return false;

--- a/src/apprt/surface.zig
+++ b/src/apprt/surface.zig
@@ -91,6 +91,9 @@ pub const Message = union(enum) {
     /// Report the progress of an action using a GUI element
     progress_report: terminal.osc.Command.ProgressReport,
 
+    /// Read-only tmux control-mode state for embedded runtimes.
+    tmux_control: TmuxControlMsg,
+
     /// A command has started in the shell, start a timer.
     start_command,
 
@@ -112,6 +115,12 @@ pub const Message = union(enum) {
         csi_21_t,
 
         // This enum is a placeholder for future title styles.
+    };
+
+    pub const TmuxControlMsg = struct {
+        event: apprt.action.TmuxControl.Event,
+        id: u32 = 0,
+        data: WriteReq = .{ .stable = "" },
     };
 
     pub const ChildExited = extern struct {

--- a/src/terminal/tmux/control.zig
+++ b/src/terminal/tmux/control.zig
@@ -129,7 +129,7 @@ pub const Parser = struct {
                     switch (terminator) {
                         .end => return .{ .block_end = output },
                         .err => {
-                            log.warn("tmux control mode error={s}", .{output});
+                            log.warn("tmux control mode error data_len={}", .{output.len});
                             return .{ .block_err = output };
                         },
                     }
@@ -584,8 +584,13 @@ pub const Notification = union(enum) {
             inline for (info.fields) |u_field| {
                 if (self == @field(TagType, u_field.name)) {
                     const value = @field(self, u_field.name);
-                    switch (u_field.type) {
-                        []const u8 => try writer.print("\"{s}\"", .{std.mem.trim(u8, value, " \t\r\n")}),
+                    if (comptime std.mem.eql(u8, u_field.name, "output")) {
+                        try writer.print(
+                            ".{{ .pane_id = {}, .data_len = {} }}",
+                            .{ value.pane_id, value.data.len },
+                        );
+                    } else switch (u_field.type) {
+                        []const u8 => try writer.print(".{{ .data_len = {} }}", .{value.len}),
                         else => try writer.print("{any}", .{value}),
                     }
                 }
@@ -595,6 +600,30 @@ pub const Notification = union(enum) {
         }
     }
 };
+
+test "tmux notification format redacts pane and block data" {
+    const testing = std.testing;
+
+    var writer: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer writer.deinit();
+
+    try (Notification{ .output = .{
+        .pane_id = 7,
+        .data = "secret-pane-output",
+    } }).format(&writer.writer);
+    try writer.writer.writeByte('\n');
+    try (Notification{ .block_end = "secret-block-output" }).format(&writer.writer);
+    try writer.writer.writeByte('\n');
+    try (Notification{ .block_err = "secret-error-output" }).format(&writer.writer);
+
+    const formatted = writer.written();
+    try testing.expect(std.mem.containsAtLeast(u8, formatted, 1, "pane_id = 7"));
+    try testing.expect(std.mem.containsAtLeast(u8, formatted, 1, "data_len = 18"));
+    try testing.expect(std.mem.containsAtLeast(u8, formatted, 1, "data_len = 19"));
+    try testing.expect(!std.mem.containsAtLeast(u8, formatted, 1, "secret-pane-output"));
+    try testing.expect(!std.mem.containsAtLeast(u8, formatted, 1, "secret-block-output"));
+    try testing.expect(!std.mem.containsAtLeast(u8, formatted, 1, "secret-error-output"));
+}
 
 test "tmux begin/end empty" {
     const testing = std.testing;

--- a/src/terminal/tmux/layout.zig
+++ b/src/terminal/tmux/layout.zig
@@ -28,6 +28,38 @@ pub const Layout = struct {
         vertical: []const Layout,
     };
 
+    /// Custom JSON serialization for embedder-side topology reporting.
+    pub fn jsonStringify(self: Layout, jw: anytype) !void {
+        try jw.beginObject();
+        try jw.objectField("width");
+        try jw.write(self.width);
+        try jw.objectField("height");
+        try jw.write(self.height);
+        try jw.objectField("x");
+        try jw.write(self.x);
+        try jw.objectField("y");
+        try jw.write(self.y);
+        switch (self.content) {
+            .pane => |id| {
+                try jw.objectField("pane");
+                try jw.write(id);
+            },
+            .horizontal => |children| {
+                try jw.objectField("horizontal");
+                try jw.beginArray();
+                for (children) |child| try child.jsonStringify(jw);
+                try jw.endArray();
+            },
+            .vertical => |children| {
+                try jw.objectField("vertical");
+                try jw.beginArray();
+                for (children) |child| try child.jsonStringify(jw);
+                try jw.endArray();
+            },
+        }
+        try jw.endObject();
+    }
+
     pub const ParseError = Allocator.Error || error{SyntaxError};
 
     /// Parse a layout string that includes a 4-character checksum prefix.

--- a/src/terminal/tmux/viewer.zig
+++ b/src/terminal/tmux/viewer.zig
@@ -230,6 +230,10 @@ pub const Viewer = struct {
                         const value = @field(self, u_field.name);
                         switch (u_field.type) {
                             []const u8 => try writer.print("\"{s}\"", .{std.mem.trim(u8, value, " \t\r\n")}),
+                            PaneOutput => try writer.print(
+                                ".{{ .pane_id = {}, .data_len = {} }}",
+                                .{ value.pane_id, value.data.len },
+                            ),
                             else => try writer.print("{any}", .{value}),
                         }
                     }
@@ -244,6 +248,22 @@ pub const Viewer = struct {
         pane_id: usize,
         data: []const u8,
     };
+
+    test "pane output action format redacts data" {
+        var writer: std.Io.Writer.Allocating = .init(testing.allocator);
+        defer writer.deinit();
+
+        try (Action{ .pane_output = .{
+            .pane_id = 7,
+            .data = "secret-pane-output",
+        } }).format(&writer.writer);
+
+        const formatted = writer.written();
+        try testing.expect(std.mem.containsAtLeast(u8, formatted, 1, "pane_output"));
+        try testing.expect(std.mem.containsAtLeast(u8, formatted, 1, "pane_id = 7"));
+        try testing.expect(std.mem.containsAtLeast(u8, formatted, 1, "data_len = 18"));
+        try testing.expect(!std.mem.containsAtLeast(u8, formatted, 1, "secret-pane-output"));
+    }
 
     pub const Input = union(enum) {
         /// Data from tmux was received that needs to be processed.

--- a/src/terminal/tmux/viewer.zig
+++ b/src/terminal/tmux/viewer.zig
@@ -211,6 +211,10 @@ pub const Viewer = struct {
         /// never reuses window IDs within a server process lifetime.
         windows: []const Window,
 
+        /// A pane produced output. The caller can use this as a read-only
+        /// observation channel while the viewer maintains pane terminal state.
+        pane_output: PaneOutput,
+
         pub fn format(self: Action, writer: *std.Io.Writer) !void {
             const T = Action;
             const info = @typeInfo(T).@"union";
@@ -234,6 +238,11 @@ pub const Viewer = struct {
                 try writer.writeAll(" }");
             }
         }
+    };
+
+    pub const PaneOutput = struct {
+        pane_id: usize,
+        data: []const u8,
     };
 
     pub const Input = union(enum) {
@@ -459,7 +468,7 @@ pub const Viewer = struct {
                 command_consumed = true;
             },
 
-            .output => |out| self.receivedOutput(
+            .output => |out| return self.receivedOutput(
                 out.pane_id,
                 out.data,
             ) catch |err| {
@@ -467,6 +476,7 @@ pub const Viewer = struct {
                     "failed to process output for pane id={}: {}",
                     .{ out.pane_id, err },
                 );
+                return &.{};
             },
 
             // Session changed means we switched to a different tmux session.
@@ -600,12 +610,11 @@ pub const Viewer = struct {
         defer self.action_arena = arena.state;
         const arena_alloc = arena.allocator();
 
-        // Our initial action is to definitely let the caller know that
-        // some windows changed.
-        try actions.append(arena_alloc, .{ .windows = self.windows.items });
-
         // Sync up our panes
         try self.syncLayouts(self.windows.items);
+
+        // Let the caller know after pane/window state has been synchronized.
+        try actions.append(arena_alloc, .{ .windows = self.windows.items });
     }
 
     /// When a window is added to the session, we need to refresh our window
@@ -893,12 +902,12 @@ pub const Viewer = struct {
             });
         }
 
-        // Setup our windows action so the caller can process GUI
-        // window changes.
-        try actions.append(arena_alloc, .{ .windows = windows.items });
-
         // Sync up our layouts. This will populate unknown panes, prune, etc.
         try self.syncLayouts(windows.items);
+
+        // Setup our windows action so the caller can process GUI
+        // window changes.
+        try actions.append(arena_alloc, .{ .windows = self.windows.items });
     }
 
     fn receivedPaneState(
@@ -1101,10 +1110,10 @@ pub const Viewer = struct {
         self: *Viewer,
         id: usize,
         data: []const u8,
-    ) !void {
+    ) ![]const Action {
         const entry = self.panes.getEntry(id) orelse {
             log.info("received output for untracked pane id={}", .{id});
-            return;
+            return &.{};
         };
         const pane: *Pane = entry.value_ptr;
         const t: *Terminal = &pane.terminal;
@@ -1112,6 +1121,12 @@ pub const Viewer = struct {
         var stream = t.vtStream();
         defer stream.deinit();
         stream.nextSlice(data);
+
+        self.action_single[0] = .{ .pane_output = .{
+            .pane_id = id,
+            .data = data,
+        } };
+        return self.action_single[0..];
     }
 
     fn initLayout(
@@ -1758,7 +1773,14 @@ test "initial flow" {
             .input = .{ .tmux = .{ .output = .{ .pane_id = 0, .data = "new output" } } },
             .check = (struct {
                 fn check(v: *Viewer, actions: []const Viewer.Action) anyerror!void {
-                    try testing.expectEqual(0, actions.len);
+                    try testing.expectEqual(1, actions.len);
+                    switch (actions[0]) {
+                        .pane_output => |out| {
+                            try testing.expectEqual(0, out.pane_id);
+                            try testing.expectEqualStrings("new output", out.data);
+                        },
+                        else => return error.UnexpectedAction,
+                    }
                     const pane: *Viewer.Pane = v.panes.getEntry(0).?.value_ptr;
                     const screen: *Screen = pane.terminal.screens.active;
                     const str = try screen.dumpStringAlloc(

--- a/src/terminal/tmux/viewer.zig
+++ b/src/terminal/tmux/viewer.zig
@@ -833,17 +833,33 @@ pub const Viewer = struct {
                 content,
             ),
 
-            .pane_history => |cap| try self.receivedPaneHistory(
-                cap.screen_key,
-                cap.id,
-                content,
-            ),
+            .pane_history => |cap| {
+                try self.receivedPaneHistory(
+                    cap.screen_key,
+                    cap.id,
+                    content,
+                );
+                if (!is_err) try appendPaneOutputAction(
+                    arena_alloc,
+                    actions,
+                    cap.id,
+                    content,
+                );
+            },
 
-            .pane_visible => |cap| try self.receivedPaneVisible(
-                cap.screen_key,
-                cap.id,
-                content,
-            ),
+            .pane_visible => |cap| {
+                try self.receivedPaneVisible(
+                    cap.screen_key,
+                    cap.id,
+                    content,
+                );
+                if (!is_err) try appendPaneOutputAction(
+                    arena_alloc,
+                    actions,
+                    cap.id,
+                    content,
+                );
+            },
 
             .tmux_version => try self.receivedTmuxVersion(content),
         }
@@ -1147,6 +1163,19 @@ pub const Viewer = struct {
             .data = data,
         } };
         return self.action_single[0..];
+    }
+
+    fn appendPaneOutputAction(
+        arena_alloc: Allocator,
+        actions: *std.ArrayList(Action),
+        id: usize,
+        data: []const u8,
+    ) Allocator.Error!void {
+        if (data.len == 0) return;
+        try actions.append(arena_alloc, .{ .pane_output = .{
+            .pane_id = id,
+            .data = data,
+        } });
     }
 
     fn initLayout(
@@ -1698,7 +1727,19 @@ test "initial flow" {
                 }
             }).check,
             .check = (struct {
-                fn check(v: *Viewer, _: []const Viewer.Action) anyerror!void {
+                fn check(v: *Viewer, actions: []const Viewer.Action) anyerror!void {
+                    var found_capture = false;
+                    for (actions) |action| switch (action) {
+                        .pane_output => |out| {
+                            if (out.pane_id == 0) {
+                                try testing.expectEqualStrings("Hello, world!", out.data);
+                                found_capture = true;
+                            }
+                        },
+                        else => {},
+                    };
+                    try testing.expect(found_capture);
+
                     const pane: *Viewer.Pane = v.panes.getEntry(0).?.value_ptr;
                     const screen: *Screen = pane.terminal.screens.active;
                     {

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -401,6 +401,9 @@ pub const StreamHandler = struct {
                         viewer.* = try .init(self.alloc);
                         errdefer viewer.deinit();
                         self.tmux_viewer = viewer;
+                        self.surfaceMessageWriter(.{
+                            .tmux_control = .{ .event = .enter },
+                        });
                         break :tmux;
                     },
 
@@ -411,6 +414,10 @@ pub const StreamHandler = struct {
                             self.alloc.destroy(viewer);
                             self.tmux_viewer = null;
                         }
+
+                        self.surfaceMessageWriter(.{
+                            .tmux_control = .{ .event = .exit },
+                        });
 
                         // And always break since we assert below
                         // that we're not handling an exit command.
@@ -438,10 +445,9 @@ pub const StreamHandler = struct {
                     log.info("tmux viewer action={f}", .{action});
                     switch (action) {
                         .exit => {
-                            // We ignore this because we will fully exit when
-                            // our DCS connection ends. We may want to handle
-                            // this in the future to notify our GUI we're
-                            // disconnected though.
+                            self.surfaceMessageWriter(.{
+                                .tmux_control = .{ .event = .exit },
+                            });
                         },
 
                         .command => |command| {
@@ -453,8 +459,39 @@ pub const StreamHandler = struct {
                             ));
                         },
 
-                        .windows => {
-                            // TODO
+                        .windows => |windows| {
+                            const json = serializeTmuxWindows(
+                                self.alloc,
+                                viewer,
+                                windows,
+                            ) catch |err| {
+                                log.warn("failed to serialize tmux windows: {}", .{err});
+                                break :tmux;
+                            };
+                            defer self.alloc.free(json);
+
+                            self.surfaceMessageWriter(.{
+                                .tmux_control = .{
+                                    .event = .windows_changed,
+                                    .data = try apprt.surface.Message.WriteReq.init(
+                                        self.alloc,
+                                        json,
+                                    ),
+                                },
+                            });
+                        },
+
+                        .pane_output => |out| {
+                            self.surfaceMessageWriter(.{
+                                .tmux_control = .{
+                                    .event = .pane_output,
+                                    .id = @intCast(out.pane_id),
+                                    .data = try apprt.surface.Message.WriteReq.init(
+                                        self.alloc,
+                                        out.data,
+                                    ),
+                                },
+                            });
                         },
                     }
                 }
@@ -1554,3 +1591,46 @@ pub const StreamHandler = struct {
         self.surfaceMessageWriter(.{ .progress_report = report });
     }
 };
+
+/// Serialize tmux Viewer window topology to JSON for embedded runtimes.
+fn serializeTmuxWindows(
+    alloc: Allocator,
+    viewer: *const terminal.tmux.Viewer,
+    windows: []const terminal.tmux.Viewer.Window,
+) (Allocator.Error || std.Io.Writer.Error)![]const u8 {
+    var buf: std.Io.Writer.Allocating = .init(alloc);
+    errdefer buf.deinit();
+
+    var jw: std.json.Stringify = .{ .writer = &buf.writer };
+    try jw.beginObject();
+
+    try jw.objectField("session_id");
+    try jw.write(viewer.session_id);
+
+    try jw.objectField("tmux_version");
+    try jw.write(viewer.tmux_version);
+
+    try jw.objectField("pane_ids");
+    try jw.beginArray();
+    for (viewer.panes.keys()) |pane_id| try jw.write(pane_id);
+    try jw.endArray();
+
+    try jw.objectField("windows");
+    try jw.beginArray();
+    for (windows) |window| {
+        try jw.beginObject();
+        try jw.objectField("id");
+        try jw.write(window.id);
+        try jw.objectField("width");
+        try jw.write(window.width);
+        try jw.objectField("height");
+        try jw.write(window.height);
+        try jw.objectField("layout");
+        try window.layout.jsonStringify(&jw);
+        try jw.endObject();
+    }
+    try jw.endArray();
+
+    try jw.endObject();
+    return try buf.toOwnedSlice();
+}

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -413,11 +413,11 @@ pub const StreamHandler = struct {
                             viewer.deinit();
                             self.alloc.destroy(viewer);
                             self.tmux_viewer = null;
-                        }
 
-                        self.surfaceMessageWriter(.{
-                            .tmux_control = .{ .event = .exit },
-                        });
+                            self.surfaceMessageWriter(.{
+                                .tmux_control = .{ .event = .exit },
+                            });
+                        }
 
                         // And always break since we assert below
                         // that we're not handling an exit command.
@@ -448,9 +448,16 @@ pub const StreamHandler = struct {
                     }
                     switch (action) {
                         .exit => {
+                            if (self.tmux_viewer) |viewer_to_close| {
+                                viewer_to_close.deinit();
+                                self.alloc.destroy(viewer_to_close);
+                                self.tmux_viewer = null;
+                            }
+
                             self.surfaceMessageWriter(.{
                                 .tmux_control = .{ .event = .exit },
                             });
+                            break :tmux;
                         },
 
                         .command => |command| {
@@ -469,7 +476,7 @@ pub const StreamHandler = struct {
                                 windows,
                             ) catch |err| {
                                 log.warn("failed to serialize tmux windows: {}", .{err});
-                                break :tmux;
+                                continue;
                             };
                             defer self.alloc.free(json);
 
@@ -485,10 +492,15 @@ pub const StreamHandler = struct {
                         },
 
                         .pane_output => |out| {
+                            const pane_id = std.math.cast(u32, out.pane_id) orelse {
+                                log.warn("tmux pane id={} overflows u32, skipping", .{out.pane_id});
+                                continue;
+                            };
+
                             self.surfaceMessageWriter(.{
                                 .tmux_control = .{
                                     .event = .pane_output,
-                                    .id = @intCast(out.pane_id),
+                                    .id = pane_id,
                                     .data = try apprt.surface.Message.WriteReq.init(
                                         self.alloc,
                                         out.data,

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -442,7 +442,10 @@ pub const StreamHandler = struct {
                 };
 
                 for (viewer.next(.{ .tmux = tmux })) |action| {
-                    log.info("tmux viewer action={f}", .{action});
+                    switch (action) {
+                        .pane_output => {},
+                        else => log.info("tmux viewer action={f}", .{action}),
+                    }
                     switch (action) {
                         .exit => {
                             self.surfaceMessageWriter(.{


### PR DESCRIPTION
Supports the cmux read-only tmux control bridge for https://github.com/manaflow-ai/cmux/issues/560.\n\nThis keeps Ghostty's existing terminal/tmux viewer as the owner of control-mode parsing, adds embedder actions for enter/exit/topology/pane output, handles the GTK apprt action as unsupported, and redacts pane output bytes from formatted viewer logs.\n\nParent cmux PR: https://github.com/manaflow-ai/cmux/pull/4810

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782428157&installation_id=133855650&pr_number=65&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F65&signature=aca7a99c9760f0c4e4100838884dda2cf11f2df03de37a7fa886deed98700a6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose read-only tmux control-mode events to embedders: enter/exit, windows topology JSON, and pane output (live and captured). Enables the `cmux` read-only tmux control bridge for manaflow-ai/cmux#560.

- **New Features**
  - C API: add `GHOSTTY_ACTION_TMUX_CONTROL`, `ghostty_action_tmux_control_s`, and event enum (`GHOSTTY_TMUX_ENTER`, `GHOSTTY_TMUX_EXIT`, `GHOSTTY_TMUX_WINDOWS_CHANGED`, `GHOSTTY_TMUX_PANE_OUTPUT`).
  - Surface/apprt: forward `tmux_control` messages; embedded apprt logs redact to event/id/data_len; GTK apprt no-op.
  - Viewer: emit `pane_output` for live output and captured history/visible blocks; emit `windows` after pane/window sync; redact pane-output in logs.
  - Stream handler: publish `enter`/`exit` on DCS start/stop and viewer exit; send `windows_changed` with topology JSON (session_id, tmux_version, `pane_ids`, windows+layout); forward `pane_output` (pane id + bytes); skip info logs for `pane_output`.
  - Layout: add JSON serialization for window layouts used in topology payloads.
  - Control: redact notification logs (pane/block data replaced with lengths; error logs show data_len only).

<sup>Written for commit a99713e1e39fe69e5cd820725a852b23152829ca. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/65?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tmux control-mode for embedded sessions: enter/exit, windows-changed, and pane-output events; topology can be serialized to JSON and sent to embeds.
  * Surface and viewer now forward tmux control events and pane-output notifications.

* **Bug Fixes**
  * Ensure windows/layouts are synchronized before reporting window/topology updates.
  * Redact large/secret payloads from notification logs.

* **Tests**
  * Updated tests to validate tmux control events, pane-output forwarding, and synchronized windows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/ghostty/pull/65?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->