### PR TITLE
Cap tmux control pane output payloads

### DIFF
--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -14,6 +14,7 @@ const terminfo = @import("../terminfo/main.zig");
 const posix = std.posix;
 
 const log = std.log.scoped(.io_handler);
+const max_tmux_control_pane_output_bytes: usize = 65_536;
 
 /// This is used as the handler for the terminal.Stream type. This is
 /// stateful and is expected to live for the entire lifetime of the terminal.
@@ -496,6 +497,7 @@ pub const StreamHandler = struct {
                                 log.warn("tmux pane id={} overflows u32, skipping", .{out.pane_id});
                                 continue;
                             };
+                            const data = tmuxControlPaneOutputPayload(out.data);
 
                             self.surfaceMessageWriter(.{
                                 .tmux_control = .{
@@ -503,7 +505,7 @@ pub const StreamHandler = struct {
                                     .id = pane_id,
                                     .data = try apprt.surface.Message.WriteReq.init(
                                         self.alloc,
-                                        out.data,
+                                        data,
                                     ),
                                 },
                             });
@@ -1648,4 +1650,27 @@ fn serializeTmuxWindows(
 
     try jw.endObject();
     return try buf.toOwnedSlice();
+}
+
+fn tmuxControlPaneOutputPayload(data: []const u8) []const u8 {
+    if (data.len <= max_tmux_control_pane_output_bytes) return data;
+    return data[data.len - max_tmux_control_pane_output_bytes ..];
+}
+
+test "tmux control pane output payload keeps bounded suffix" {
+    const small = "0123456789";
+    try std.testing.expectEqualStrings(small, tmuxControlPaneOutputPayload(small));
+
+    var large: [max_tmux_control_pane_output_bytes + 3]u8 = undefined;
+    @memset(large[0..], 'a');
+    large[0] = 'x';
+    large[1] = 'y';
+    large[2] = 'z';
+    large[large.len - 1] = '!';
+
+    const capped = tmuxControlPaneOutputPayload(large[0..]);
+    try std.testing.expectEqual(@as(usize, max_tmux_control_pane_output_bytes), capped.len);
+    try std.testing.expectEqual(@as(u8, 'a'), capped[0]);
+    try std.testing.expectEqual(@as(u8, '!'), capped[capped.len - 1]);
+    try std.testing.expect(!std.mem.containsAtLeast(u8, capped, 1, "xyz"));
 }

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -498,6 +498,13 @@ pub const StreamHandler = struct {
                                 continue;
                             };
                             const data = tmuxControlPaneOutputPayload(out.data);
+                            if (data.len != out.data.len) {
+                                log.debug("tmux pane output truncated pane_id={} bytes={} capped_bytes={}", .{
+                                    out.pane_id,
+                                    out.data.len,
+                                    data.len,
+                                });
+                            }
 
                             self.surfaceMessageWriter(.{
                                 .tmux_control = .{


### PR DESCRIPTION
Follow-up for https://github.com/manaflow-ai/cmux/pull/4810.\n\nCaps tmux control-mode pane output to the embedder retention limit before dispatching it across the Ghostty surface message boundary, and adds a Zig unit test for the suffix behavior.\n\nVerification:\n- `zig fmt --check src/termio/stream_handler.zig`\n- `zig build test -Dapp-runtime=none -Demit-macos-app=false -Demit-xcframework=false --summary all`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782508717&installation_id=133855650&pr_number=66&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F66&signature=e46ea85670972d7b625f8de5655a8716a38c83e52126963b8e2e296cdc861f74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps tmux control-mode pane output to a 65,536-byte suffix before sending across the Ghostty surface boundary to match the embedder retention limit. Addresses Linear issue 560 and prevents oversized messages.

- **Bug Fixes**
  - Truncate pane output to the last 65,536 bytes with a new tmuxControlPaneOutputPayload.
  - Apply the cap and log truncations in StreamHandler when emitting `.tmux_control` `pane_output` data.
  - Add a Zig unit test to verify bounded-suffix behavior.

<sup>Written for commit 8e38caaa1ca4802a1144af383488c714dc51ab27. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/66?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

