### PR TITLE
Add WriteScreenLoc.active + write_active_file binding

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -5578,6 +5578,11 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
             v,
         ),
 
+        .write_active_file => |v| try self.writeScreenFile(
+            .active,
+            v,
+        ),
+
         .new_tab => return try self.rt_app.performAction(
             .{ .surface = self },
             .new_tab,
@@ -5962,6 +5967,9 @@ const WriteScreenLoc = enum {
     screen, // Full screen
     history, // History (scrollback)
     selection, // Selected text
+    active, // Just the active area (no history). Used by the cmux mobile
+            // snapshot path to emit ANSI-styled rows that line up with the
+            // POINT_ACTIVE plain text the iOS render compares against.
 };
 
 fn writeScreenFile(
@@ -6031,6 +6039,15 @@ fn writeScreenFile(
                     pages.getTopLeft(.screen),
                     pages.getBottomRight(.screen) orelse
                         break :screen null,
+                    false,
+                );
+            },
+
+            .active => active: {
+                break :active terminal.Selection.init(
+                    pages.getTopLeft(.active),
+                    pages.getBottomRight(.active) orelse
+                        break :active null,
                     false,
                 );
             },

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -525,6 +525,14 @@ pub const Action = union(enum) {
     /// Does nothing when no text is selected.
     write_selection_file: WriteScreen,
 
+    /// Write the active area (the visible viewport, excluding scrollback)
+    /// into a temporary file with the specified action. Used by the cmux
+    /// mobile snapshot path so the iOS render receives ANSI-styled rows
+    /// that line up with the plain text returned by GHOSTTY_POINT_ACTIVE.
+    ///
+    /// See `write_scrollback_file` for possible actions.
+    write_active_file: WriteScreen,
+
     /// Open a new window.
     ///
     /// If the application isn't currently focused,
@@ -1351,6 +1359,7 @@ pub const Action = union(enum) {
             .write_scrollback_file,
             .write_screen_file,
             .write_selection_file,
+            .write_active_file,
             .close_surface,
             .close_tab,
             .close_window,

--- a/src/input/command.zig
+++ b/src/input/command.zig
@@ -339,6 +339,10 @@ fn actionCommands(action: Action.Key) []const Command {
             },
         },
 
+        // No command palette entries; this is invoked programmatically by
+        // the cmux mobile snapshot path.
+        .write_active_file => comptime &.{},
+
         .write_selection_file => comptime &.{
             .{
                 .action = .{ .write_selection_file = .copy },


### PR DESCRIPTION
cmux's iOS sync renders styled cells from the active area only.
`write_screen_file` dumps the whole buffer (history + active) so
tail-N-lines drifts off the active rows when scrollback is present.

Adds:
- `WriteScreenLoc.active` — selection from `pages.getTopLeft(.active)` to `pages.getBottomRight(.active)`.
- `write_active_file: WriteScreen` binding action, routes through `writeScreenFile(.active, ...)`.
- Empty command palette entry for the new action so the exhaustive switch in `src/input/command.zig` compiles.

Used by manaflow-ai/cmux#4055 to keep the mobile snapshot's VT export aligned with `GHOSTTY_POINT_ACTIVE` plain text rows.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782514797&installation_id=133855650&pr_number=67&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F67&signature=818dcb88204b41db06a3b0ca3f9dbb55b2d9cfc38284beffb9f89a51ec340dde"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables exporting only the active viewport by adding `WriteScreenLoc.active` and a `write_active_file` binding. This keeps the cmux iOS snapshot VT output aligned with visible rows and prevents drift when scrollback is present.

- New Features
  - Added `WriteScreenLoc.active` (top-left `.active` to bottom-right `.active`).
  - Added `write_active_file: WriteScreen` action routing to `writeScreenFile(.active, ...)`.
  - No command palette entry; invoked programmatically by the cmux mobile snapshot path.

<sup>Written for commit 8a05929ddf46ccc9aeecf485872d11eb9502d679. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/67?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added a new binding action that writes the active terminal area (excluding history) to a temporary file, enabling quick snapshot and export functionality for mobile users.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/ghostty/pull/67?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->