### PR TITLE
Add embedded tmux control callback on main

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -886,21 +886,13 @@ typedef struct {
   ssize_t selected;
 } ghostty_action_search_selected_s;
 
-// apprt.action.TmuxControl.Event
+// apprt.surface.Message.TmuxControlMsg.Event
 typedef enum {
   GHOSTTY_TMUX_ENTER,
   GHOSTTY_TMUX_EXIT,
   GHOSTTY_TMUX_WINDOWS_CHANGED,
   GHOSTTY_TMUX_PANE_OUTPUT,
 } ghostty_tmux_event_e;
-
-// apprt.action.TmuxControl
-typedef struct {
-  ghostty_tmux_event_e event;
-  uint32_t id;
-  const uint8_t *data;
-  uintptr_t data_len;
-} ghostty_action_tmux_control_s;
 
 // terminal.Scrollbar
 typedef struct {
@@ -976,7 +968,6 @@ typedef enum {
   GHOSTTY_ACTION_SEARCH_SELECTED,
   GHOSTTY_ACTION_READONLY,
   GHOSTTY_ACTION_COPY_TITLE_TO_CLIPBOARD,
-  GHOSTTY_ACTION_TMUX_CONTROL,
 } ghostty_action_tag_e;
 
 typedef union {
@@ -1018,7 +1009,6 @@ typedef union {
   ghostty_action_search_total_s search_total;
   ghostty_action_search_selected_s search_selected;
   ghostty_action_readonly_e readonly;
-  ghostty_action_tmux_control_s tmux_control;
 } ghostty_action_u;
 
 typedef struct {
@@ -1044,6 +1034,11 @@ typedef void (*ghostty_runtime_close_surface_cb)(void*, bool);
 typedef bool (*ghostty_runtime_action_cb)(ghostty_app_t,
                                           ghostty_target_s,
                                           ghostty_action_s);
+typedef void (*ghostty_runtime_tmux_control_cb)(void*,
+                                                ghostty_tmux_event_e,
+                                                uint32_t,
+                                                const uint8_t*,
+                                                uintptr_t);
 
 typedef struct {
   void* userdata;
@@ -1054,6 +1049,7 @@ typedef struct {
   ghostty_runtime_confirm_read_clipboard_cb confirm_read_clipboard_cb;
   ghostty_runtime_write_clipboard_cb write_clipboard_cb;
   ghostty_runtime_close_surface_cb close_surface_cb;
+  ghostty_runtime_tmux_control_cb tmux_control_cb;
 } ghostty_runtime_config_s;
 
 // apprt.ipc.Target.Key

--- a/macos/Sources/Ghostty/Ghostty.App.swift
+++ b/macos/Sources/Ghostty/Ghostty.App.swift
@@ -66,7 +66,8 @@ extension Ghostty {
                 confirm_read_clipboard_cb: { userdata, str, state, request in App.confirmReadClipboard(userdata, string: str, state: state, request: request ) },
                 write_clipboard_cb: { userdata, loc, content, len, confirm in
                     App.writeClipboard(userdata, location: loc, content: content, len: len, confirm: confirm) },
-                close_surface_cb: { userdata, processAlive in App.closeSurface(userdata, processAlive: processAlive) }
+                close_surface_cb: { userdata, processAlive in App.closeSurface(userdata, processAlive: processAlive) },
+                tmux_control_cb: nil
             )
 
             // Create the ghostty app.

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -1156,17 +1156,14 @@ pub fn handleMessage(self: *Surface, msg: Message) !void {
 
         .tmux_control => |v| {
             defer v.data.deinit();
-            _ = self.rt_app.performAction(
-                .{ .surface = self },
-                .tmux_control,
-                .{
-                    .event = v.event,
-                    .id = v.id,
-                    .data = v.data.slice(),
-                },
-            ) catch |err| {
-                log.warn("apprt failed to report tmux control event err={}", .{err});
-            };
+            if (comptime @hasDecl(apprt.runtime.Surface, "tmuxControl")) {
+                self.rt_surface.tmuxControl(v.event, v.id, v.data.slice());
+            } else {
+                log.debug(
+                    "apprt ignored tmux control event={s} id={} data_len={}",
+                    .{ @tagName(v.event), v.id, v.data.slice().len },
+                );
+            }
         },
 
         .selection_scroll_tick => |active| {

--- a/src/apprt/action.zig
+++ b/src/apprt/action.zig
@@ -343,9 +343,6 @@ pub const Action = union(Key) {
     /// otherwise the terminal-set title.
     copy_title_to_clipboard,
 
-    /// Read-only tmux control-mode state surfaced to embedded runtimes.
-    tmux_control: TmuxControl,
-
     /// Sync with: ghostty_action_tag_e
     pub const Key = enum(c_int) {
         quit,
@@ -413,7 +410,6 @@ pub const Action = union(Key) {
         search_selected,
         readonly,
         copy_title_to_clipboard,
-        tmux_control,
 
         test "ghostty.h Action.Key" {
             try lib.checkGhosttyHEnum(Key, "GHOSTTY_ACTION_");
@@ -629,40 +625,6 @@ pub const Readonly = enum(c_int) {
 
     test "ghostty.h Readonly" {
         try lib.checkGhosttyHEnum(Readonly, "GHOSTTY_READONLY_");
-    }
-};
-
-pub const TmuxControl = struct {
-    event: Event,
-    id: u32 = 0,
-    data: []const u8 = &.{},
-
-    pub const Event = enum(c_int) {
-        enter,
-        exit,
-        windows_changed,
-        pane_output,
-
-        test "ghostty.h TmuxControl.Event" {
-            try lib.checkGhosttyHEnum(Event, "GHOSTTY_TMUX_");
-        }
-    };
-
-    // Sync with: ghostty_action_tmux_control_s
-    pub const C = extern struct {
-        event: Event,
-        id: u32,
-        data: [*]const u8,
-        data_len: usize,
-    };
-
-    pub fn cval(self: TmuxControl) C {
-        return .{
-            .event = self.event,
-            .id = self.id,
-            .data = self.data.ptr,
-            .data_len = self.data.len,
-        };
     }
 };
 

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -78,6 +78,15 @@ pub const App = struct {
 
         /// Close the current surface given by this function.
         close_surface: ?*const fn (SurfaceUD, bool) callconv(.c) void = null,
+
+        /// Report read-only tmux control-mode state for the surface.
+        tmux_control: ?*const fn (
+            SurfaceUD,
+            apprt.surface.Message.TmuxControlMsg.Event,
+            u32,
+            [*]const u8,
+            usize,
+        ) callconv(.c) void = null,
     };
 
     /// This is the key event sent for ghostty_surface_key and
@@ -274,23 +283,11 @@ pub const App = struct {
         // embedded apprt.
         self.performPreAction(target, action, value);
 
-        switch (action) {
-            .tmux_control => log.debug(
-                "dispatching action target={t} action={} event={s} id={} data_len={}",
-                .{
-                    target,
-                    action,
-                    @tagName(value.event),
-                    value.id,
-                    value.data.len,
-                },
-            ),
-            else => log.debug("dispatching action target={t} action={} value={any}", .{
-                target,
-                action,
-                value,
-            }),
-        }
+        log.debug("dispatching action target={t} action={} value={any}", .{
+            target,
+            action,
+            value,
+        });
         return self.opts.action(
             self,
             target.cval(),
@@ -683,6 +680,16 @@ pub const Surface = struct {
         };
 
         func(self.userdata, process_alive);
+    }
+
+    pub fn tmuxControl(
+        self: *const Surface,
+        event: apprt.surface.Message.TmuxControlMsg.Event,
+        id: u32,
+        data: []const u8,
+    ) void {
+        const func = self.app.opts.tmux_control orelse return;
+        func(self.userdata, event, id, data.ptr, data.len);
     }
 
     pub fn getContentScale(self: *const Surface) !apprt.ContentScale {

--- a/src/apprt/gtk/class/application.zig
+++ b/src/apprt/gtk/class/application.zig
@@ -769,7 +769,6 @@ pub const Application = extern struct {
             .end_search => Action.endSearch(target),
             .search_total => Action.searchTotal(target, value),
             .search_selected => Action.searchSelected(target, value),
-            .tmux_control => return true,
 
             // Unimplemented
             .secure_input,

--- a/src/apprt/surface.zig
+++ b/src/apprt/surface.zig
@@ -9,6 +9,7 @@ const renderer = @import("../renderer.zig");
 const terminal = @import("../terminal/main.zig");
 const Config = @import("../config.zig").Config;
 const MessageData = @import("../datastruct/main.zig").MessageData;
+const lib = @import("../lib/main.zig");
 
 /// The message types that can be sent to a single surface.
 pub const Message = union(enum) {
@@ -118,9 +119,20 @@ pub const Message = union(enum) {
     };
 
     pub const TmuxControlMsg = struct {
-        event: apprt.action.TmuxControl.Event,
+        event: Event,
         id: u32 = 0,
         data: WriteReq = .{ .stable = "" },
+
+        pub const Event = enum(c_int) {
+            enter,
+            exit,
+            windows_changed,
+            pane_output,
+
+            test "ghostty.h TmuxControlMsg.Event" {
+                try lib.checkGhosttyHEnum(Event, "GHOSTTY_TMUX_");
+            }
+        };
     };
 
     pub const ChildExited = extern struct {

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -707,10 +707,15 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             };
 
             const display_link: ?DisplayLink = switch (builtin.os.tag) {
-                .macos => if (options.config.vsync)
-                    try macos.video.DisplayLink.createWithActiveCGDisplays()
-                else
-                    null,
+                .macos => if (options.config.vsync) display_link: {
+                    break :display_link macos.video.DisplayLink.createWithActiveCGDisplays() catch |err| {
+                        log.warn(
+                            "error creating display link, falling back to non-vsync renderer loop err={}",
+                            .{err},
+                        );
+                        break :display_link null;
+                    };
+                } else null,
                 else => null,
             };
             errdefer if (display_link) |v| v.release();


### PR DESCRIPTION
Updates the embedded tmux control callback patch on top of the current Ghostty fork main so cmux can pin a main-reachable commit while preserving the pane-output cap work from https://github.com/manaflow-ai/ghostty/pull/66.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782534088&installation_id=133855650&pr_number=69&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F69&signature=94300cd04d159d953512240bf5ad229daf2118359d1f77b36584ae2fb288f0d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a per-surface tmux control callback to the runtime, replacing the old action-based path so embedded clients can receive control-mode events directly. Aligns with Linear issue-560 (tmux control bridge v2) and preserves the pane-output cap behavior.

- New Features
  - Added `ghostty_runtime_tmux_control_cb` and `tmux_control_cb` in `ghostty_runtime_config_s`.
  - Wired `tmux_control` through `apprt.embedded.App` and `Surface.tmuxControl(event, id, data)`.
  - `Surface` now emits tmux control events via the callback; logs if not implemented.
  - macOS: renderer falls back to non-vsync if DisplayLink creation fails (with a warning).

- Migration
  - Removed `GHOSTTY_ACTION_TMUX_CONTROL` and `ghostty_action_tmux_control_s`; `apprt.action.TmuxControl` is removed.
  - Use `apprt.surface.Message.TmuxControlMsg` for event types.
  - Implement `tmux_control_cb` in the host runtime to receive events: `(userdata, event, id, data_ptr, data_len)`.
  - macOS app currently sets `tmux_control_cb: nil`; no behavior change until you implement it.

<sup>Written for commit 3bc3ef04d7e130bf91615cf495798fc60ffc2f9c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/69?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential renderer failure on macOS when vsync display link initialization encounters an error. The application now gracefully falls back to a non-vsync rendering loop instead of crashing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/ghostty/pull/69?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->