### PR TITLE
Add ghostty_surface_set_userdata setter

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1115,6 +1115,7 @@ GHOSTTY_API ghostty_surface_t ghostty_surface_new(ghostty_app_t,
                                                      const ghostty_surface_config_s*);
 GHOSTTY_API void ghostty_surface_free(ghostty_surface_t);
 GHOSTTY_API void* ghostty_surface_userdata(ghostty_surface_t);
+GHOSTTY_API void ghostty_surface_set_userdata(ghostty_surface_t, void*);
 GHOSTTY_API ghostty_app_t ghostty_surface_app(ghostty_surface_t);
 GHOSTTY_API ghostty_surface_config_s ghostty_surface_inherited_config(ghostty_surface_t, ghostty_surface_context_e);
 GHOSTTY_API void ghostty_surface_update_config(ghostty_surface_t, ghostty_config_t);

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1616,6 +1616,17 @@ pub const CAPI = struct {
         return surface.userdata;
     }
 
+    /// Sets the userdata associated with the surface.
+    ///
+    /// Hosts that retain a heap object as the surface userdata must be able to
+    /// clear it before that object is freed: the surface can outlive the
+    /// userdata (e.g. a queued mailbox action drains after the host released
+    /// its callback context), and callbacks would otherwise hand back a
+    /// dangling pointer. Passing null detaches the userdata.
+    export fn ghostty_surface_set_userdata(surface: *Surface, userdata: ?*anyopaque) void {
+        surface.userdata = userdata;
+    }
+
     /// Returns the app associated with a surface.
     export fn ghostty_surface_app(surface: *Surface) *App {
         return surface.app;


### PR DESCRIPTION
## Summary

Adds a `ghostty_surface_set_userdata` C API export so embedders can **clear** (or change) the userdata pointer associated with a surface. The embedded apprt already exposed `ghostty_surface_userdata` (getter) but no setter.

```c
GHOSTTY_API void  ghostty_surface_set_userdata(ghostty_surface_t, void*);
```
```zig
export fn ghostty_surface_set_userdata(surface: *Surface, userdata: ?*anyopaque) void {
    surface.userdata = userdata;
}
```

## Motivation

A host that stores a **retained heap object** as the surface userdata has no way to detach it before freeing that object. This matters because a surface can outlive the host-side userdata:

- The host releases its callback-context object (e.g. on surface re-create or teardown) while the native `Surface` is still alive.
- A previously-queued mailbox action (e.g. `scrollbar` from `Surface.updateScrollbar`) then drains in `App.drainMailbox` → `surfaceMessage` (which validates the `*Surface` with `hasSurface()`, so it passes) → the host action callback.
- The callback calls `ghostty_surface_userdata()` and gets the **freed** pointer back, then dereferences it → use-after-free crash.

`hasSurface()` guards the *surface* pointer but cannot know the host freed the *userdata*. With a setter, the host can null the userdata at release time and callbacks safely see `null`.

This is the upstream half of a fix for an intermittent `EXC_BAD_ACCESS` we hit in cmux (`GhosttyApp.handleAction` → freed callback context). The cmux side calls `ghostty_surface_set_userdata(surface, nil)` before releasing its context on the paths where the surface survives.

## Changes
- `src/apprt/embedded.zig` — new `ghostty_surface_set_userdata` export next to the existing getter.
- `include/ghostty.h` — matching declaration.

## Risk
Minimal: a single field assignment, additive API, no behavior change for existing callers. `null` is a valid value (detaches userdata).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783006864&installation_id=133855650&pr_number=70&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F70&signature=f5dfe1ce0c6fb837fb375265e8837a958328431a3c75b07eb489e4bdc2ed8f41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `ghostty_surface_set_userdata(ghostty_surface_t, void*)` C API so embedders can clear or change a surface’s userdata. This lets hosts detach freed callback contexts and prevents use‑after‑free when queued callbacks read `ghostty_surface_userdata()` after teardown.

<sup>Written for commit 9254edcbf5616bdd862db3fbe2a4d694acb842bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/70?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `ghostty_surface_set_userdata()` C API function for embedded development. This new function enables developers to set and manage custom userdata pointers associated with surface objects. It complements the existing userdata getter functionality, providing bidirectional access to surface-attached data. The function supports null values for detaching custom data associations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->