### PR TITLE
fix: open terminal links on cmd-click even when mouse reporting is active

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -3822,7 +3822,7 @@ fn mouseShiftCapture(self: *const Surface, lock: bool) bool {
 /// mouse, matching iTerm2 and macOS Terminal.
 fn mouseLinkRefreshAllowed(self: *const Surface) bool {
     return mouseLinkRefreshAllowedState(
-        self.io.terminal.flags.mouse_event != .none,
+        self.isMouseReporting(),
         self.mouseShiftCapture(false),
         self.mouse.mods,
     );
@@ -3831,11 +3831,11 @@ fn mouseLinkRefreshAllowed(self: *const Surface) bool {
 /// Pure decision logic for `mouseLinkRefreshAllowed`, split out so it can be
 /// unit tested without constructing a `Surface`.
 fn mouseLinkRefreshAllowedState(
-    mouse_event_active: bool,
+    mouse_reporting: bool,
     shift_capture: bool,
     mods: input.Mods,
 ) bool {
-    if (!mouse_event_active) return true;
+    if (!mouse_reporting) return true;
     if (mods.shift and !shift_capture) return true;
     return mods.equal(input.ctrlOrSuper(.{}));
 }
@@ -6572,6 +6572,10 @@ test "Surface: mouseLinkRefreshAllowedState honors ctrl/super under mouse report
     // fullscreen/alternate-screen TUI has grabbed the mouse. This is the
     // behavior that was missing in cmux issue #5128.
     try std.testing.expect(mouseLinkRefreshAllowedState(true, false, ctrl_or_super));
+
+    // Same as above but with shift-capture enabled: the ctrl/super link path
+    // must not be gated on shift_capture, since shift is not part of the chord.
+    try std.testing.expect(mouseLinkRefreshAllowedState(true, true, ctrl_or_super));
 
     // Mouse reporting on, shift held and shift-capture disallowed: evaluated
     // (pre-existing shift-release-from-capture behavior, unchanged).

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -2785,13 +2785,11 @@ pub fn keyCallback(
         // Update our modifiers, this will update mouse mods too
         self.modsChanged(event.mods);
 
-        // We only refresh links if
-        // 1. mouse reporting is off
-        // OR
-        // 2. mouse reporting is on and we are not reporting shift to the terminal
-        if (self.io.terminal.flags.mouse_event == .none or
-            (self.mouse.mods.shift and !self.mouseShiftCapture(false)))
-        {
+        // We refresh links when local link handling is allowed for the
+        // current mouse-reporting state and mods (see mouseLinkRefreshAllowed):
+        // mouse reporting off, shift releasing capture, or the ctrl/super link
+        // modifier held so Cmd-click opens links inside a mouse-grabbing TUI.
+        if (self.mouseLinkRefreshAllowed()) {
             // Refresh our link state
             const pos = self.rt_surface.getCursorPos() catch break :mouse_mods;
             self.renderer_state.mutex.lock();
@@ -3813,6 +3811,35 @@ fn mouseShiftCapture(self: *const Surface, lock: bool) bool {
     };
 }
 
+/// Returns true if link hover/highlight state should be evaluated locally
+/// instead of handing the mouse event to the running program.
+///
+/// We always evaluate links when mouse reporting is off. When a program has
+/// mouse reporting enabled we still evaluate them if the user is holding
+/// shift to release the mouse from capture, or is holding the ctrl/super
+/// link-activation modifier. The latter lets Cmd-click (macOS) or Ctrl-click
+/// open a link even while a fullscreen/alternate-screen TUI has grabbed the
+/// mouse, matching iTerm2 and macOS Terminal.
+fn mouseLinkRefreshAllowed(self: *const Surface) bool {
+    return mouseLinkRefreshAllowedState(
+        self.io.terminal.flags.mouse_event != .none,
+        self.mouseShiftCapture(false),
+        self.mouse.mods,
+    );
+}
+
+/// Pure decision logic for `mouseLinkRefreshAllowed`, split out so it can be
+/// unit tested without constructing a `Surface`.
+fn mouseLinkRefreshAllowedState(
+    mouse_event_active: bool,
+    shift_capture: bool,
+    mods: input.Mods,
+) bool {
+    if (!mouse_event_active) return true;
+    if (mods.shift and !shift_capture) return true;
+    return mods.equal(input.ctrlOrSuper(.{}));
+}
+
 /// Returns true if the mouse is currently captured by the terminal
 /// (i.e. reporting events).
 pub fn mouseCaptured(self: *Surface) bool {
@@ -4683,14 +4710,12 @@ pub fn cursorPosCallback(
     // 2. the cursor position has changed (either we have no previous state, or the state has
     //    changed)
     // AND
-    // 1. mouse reporting is off
-    // OR
-    // 2. mouse reporting is on and we are not reporting shift to the terminal
+    // local link handling is allowed for the current mouse-reporting state
+    // and mods (see mouseLinkRefreshAllowed)
     if ((over_link or
         self.mouse.link_point == null or
         (self.mouse.link_point != null and !self.mouse.link_point.?.eql(pos_vp))) and
-        (self.io.terminal.flags.mouse_event == .none or
-            (self.mouse.mods.shift and !self.mouseShiftCapture(false))))
+        self.mouseLinkRefreshAllowed())
     {
         // If we were previously over a link, we always update. We do this so that if the text
         // changed underneath us, even if the mouse didn't move, we update the URL hints and state
@@ -6529,6 +6554,35 @@ fn testMouseSelectionIsNull(
 /// not available on a particular platform.
 pub fn getProcessInfo(self: *Surface, comptime info: ProcessInfo) ?ProcessInfo.Type(info) {
     return self.io.getProcessInfo(info);
+}
+
+test "Surface: mouseLinkRefreshAllowedState honors ctrl/super under mouse reporting" {
+    const ctrl_or_super = input.ctrlOrSuper(.{});
+
+    // Mouse reporting off: links are always evaluated, regardless of mods.
+    try std.testing.expect(mouseLinkRefreshAllowedState(false, false, .{}));
+    try std.testing.expect(mouseLinkRefreshAllowedState(false, false, ctrl_or_super));
+
+    // Mouse reporting on, no relevant mods: the event is reported to the app,
+    // links are not evaluated locally.
+    try std.testing.expect(!mouseLinkRefreshAllowedState(true, false, .{}));
+
+    // Mouse reporting on, ctrl/super link modifier held: links are evaluated
+    // so Cmd-click (macOS) / Ctrl-click opens a link even while a
+    // fullscreen/alternate-screen TUI has grabbed the mouse. This is the
+    // behavior that was missing in cmux issue #5128.
+    try std.testing.expect(mouseLinkRefreshAllowedState(true, false, ctrl_or_super));
+
+    // Mouse reporting on, shift held and shift-capture disallowed: evaluated
+    // (pre-existing shift-release-from-capture behavior, unchanged).
+    try std.testing.expect(mouseLinkRefreshAllowedState(true, false, .{ .shift = true }));
+
+    // Mouse reporting on, shift held but shift-capture allowed: reported.
+    try std.testing.expect(!mouseLinkRefreshAllowedState(true, true, .{ .shift = true }));
+
+    // Mouse reporting on, ctrl/super plus a non-shift modifier: not an exact
+    // link-activation chord, so the event is reported to the app.
+    try std.testing.expect(!mouseLinkRefreshAllowedState(true, false, input.ctrlOrSuper(.{ .alt = true })));
 }
 
 test "Surface: selection logic" {


### PR DESCRIPTION
Fixes manaflow-ai/cmux#5128 — terminal links open in the external browser instead of the embedded one, but only while a fullscreen / alternate-screen TUI (which enables mouse reporting) is active.

## Cause
Link hover state is refreshed (`keyCallback`, `cursorPosCallback`) only when mouse reporting is off, or shift is releasing the mouse from capture. Holding the ctrl/super link modifier isn't considered, so under a mouse-grabbing TUI `over_link` stays `false`, the link-click branch in `mouseButtonCallback` is skipped, and the click is reported to the program instead of opening the link.

## Fix
Also refresh links when the ctrl/super link-activation modifier is held, even under mouse reporting — so cmd-click (macOS) / ctrl-click opens a link regardless of mouse capture, matching iTerm2 and macOS Terminal. The click is then swallowed by `processLinks` before the mouse-report path. The shared condition lives in `mouseLinkRefreshAllowed` (used by both gates); the pure logic is split into `mouseLinkRefreshAllowedState` for testing. That modifier is exactly what both link kinds already require to activate: OSC 8 (`linkAtPos`) and the default url link (`hover_mods = ctrlOrSuper`).

## Tests
`mouseLinkRefreshAllowedState` unit test covers the truth table, including the regression case (mouse reporting on + ctrl/super held ⇒ links handled locally). `zig fmt`/`ast-check` clean; `zig build test` compiles, but the test binary can't link `libSystem` under zig 0.15.2 on macOS 26 in my environment, so I couldn't execute it locally — CI should.

---
*AI disclosure (per AI_POLICY.md): developed with Claude Code (Claude Opus 4.8). Investigation, patch, and test were AI-assisted; I have reviewed the change and can explain it.*
