### PR TITLE
fix: suppress mouse reporting for the full cmd-clicked link click (follow-up to #71)

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -3981,6 +3981,18 @@ pub fn mouseButtonCallback(
             // then we do not do a mouse report.
             if (mods.shift and !shift_capture) break :report;
 
+            // If the ctrl/super link-activation modifier is held over a link,
+            // the release will open the link locally (see
+            // mouseLinkRefreshAllowed / processLinks), so suppress the entire
+            // click — press *and* release — from the program. Otherwise the
+            // press is reported here while only the release is swallowed by the
+            // link path above, leaking a half-click (press with no matching
+            // release) to mouse-grabbing alt-screen TUIs like Claude Code and
+            // Codex. Mirrors the shift-release-from-capture path above.
+            // Fixes manaflow-ai/cmux#5128.
+            if (self.mouse.over_link and
+                self.mouse.mods.equal(input.ctrlOrSuper(.{}))) break :report;
+
             // In any other mouse button scenario without shift pressed we
             // clear the selection since the underlying application can handle
             // that in any way (i.e. "scrolling").

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -3981,17 +3981,21 @@ pub fn mouseButtonCallback(
             // then we do not do a mouse report.
             if (mods.shift and !shift_capture) break :report;
 
-            // If the ctrl/super link-activation modifier is held over a link,
-            // the release will open the link locally (see
-            // mouseLinkRefreshAllowed / processLinks), so suppress the entire
-            // click — press *and* release — from the program. Otherwise the
-            // press is reported here while only the release is swallowed by the
-            // link path above, leaking a half-click (press with no matching
-            // release) to mouse-grabbing alt-screen TUIs like Claude Code and
-            // Codex. Mirrors the shift-release-from-capture path above.
-            // Fixes manaflow-ai/cmux#5128.
-            if (self.mouse.over_link and
-                self.mouse.mods.equal(input.ctrlOrSuper(.{}))) break :report;
+            // If the ctrl/super link-activation chord is held, this click
+            // belongs to the terminal (link activation / smart-select), not the
+            // program — the release opens the link locally (see
+            // mouseLinkRefreshAllowed / processLinks). Suppress the entire click,
+            // press *and* release, from the program. We key on the modifier
+            // rather than the current over_link flag — exactly like the
+            // shift-release-from-capture path above — so that a press and its
+            // release are reported (or suppressed) symmetrically even if the
+            // cursor drifts off the link cell mid-click; otherwise either the
+            // press (cursor on link at press) or the release (cursor off link at
+            // release) would leak a half-click to mouse-grabbing alt-screen TUIs
+            // like Claude Code and Codex. Matches iTerm2 / macOS Terminal, where
+            // the link modifier is reserved for the terminal. Fixes
+            // manaflow-ai/cmux#5128.
+            if (self.mouse.mods.equal(input.ctrlOrSuper(.{}))) break :report;
 
             // In any other mouse button scenario without shift pressed we
             // clear the selection since the underlying application can handle


### PR DESCRIPTION
Follow-up to #71 (which fixed Cmd-click opening links under mouse reporting).

## Problem
With #71, holding the ctrl/super link-activation modifier over a link in a mouse-reporting alt-screen app (Claude Code, Codex) lets `over_link` become true and the **release** opens the link via `processLinks`. But `mouseButtonCallback` still reports the left-button **press** to the program — the link-handling block runs only inside the `action == .release` branch, while the mouse-report block runs for both press and release and only breaks out for the shift-release-from-capture case.

Net effect: the program receives a press with no matching release — a half-click leak — exactly in the mouse-grabbing-TUI scenario #71 targets. The link opens, but the TUI can be left in a stuck/dragging state. (Flagged as P1 by codex review on the cmux side.)

## Fix
Break out of the mouse-report path when the cursor is over a link and the ctrl/super link chord is held, suppressing **both** press and release from the program — mirroring the existing `if (mods.shift and !shift_capture) break :report;` suppression. The release still opens the link locally.

## Tests
`zig fmt`/`ast-check` clean. The press/release suppression lives in `mouseButtonCallback`, which is integration-level (needs a live `Surface` + mouse-reporting program); the pure link-refresh decision logic remains covered by the `mouseLinkRefreshAllowedState` unit test from #71. End-to-end behavior is exercised by cmux dogfood (Cmd-click a link in Claude/Codex → opens per the cmux setting, no stray click reaches the TUI).

Fixes manaflow-ai/cmux#5128.

---
*AI disclosure (per AI_POLICY.md): developed with Claude Code (Claude Opus 4.8); reviewed by a maintainer.*

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783212026&installation_id=133855650&pr_number=74&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F74&signature=3b68c735d881770332f935e0f986ddab68bd3ccdbbab3c55eb004bc4bc86e46a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suppress mouse reporting for the entire click when the ctrl/super (Cmd) link modifier is held, so TUIs don’t receive a stray press or release while the link opens. Eliminates the half-click leak in mouse-reporting alt-screen apps like Claude Code and Codex; fixes manaflow-ai/cmux#5128.

- **Bug Fixes**
  - In mouseButtonCallback, suppress both press and release whenever the ctrl/super chord is held (modifier-based, not over_link), ensuring symmetric suppression even if the cursor drifts; mirrors shift-capture behavior.

<sup>Written for commit d1dbbec9b885baf0e6603250b4dc9b7289c20d55. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/74?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where mouse clicks on links could cause unexpected behavior in full-screen terminal applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->