### PR TITLE
fix: suppress motion reports during a cmd-clicked link drag (follow-up to #74)

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -4749,6 +4749,18 @@ pub fn cursorPosCallback(
             }
         }
 
+        // The ctrl/super link-activation chord reserves the whole click for
+        // the terminal (link activation / smart-select; see
+        // mouseButtonCallback), so a drag while it is held must not leak
+        // button-motion reports to a mouse-grabbing program either. Mirror the
+        // shift override above: only suppress while a button is pressed so pure
+        // movement reports are unaffected. Part of manaflow-ai/cmux#5128.
+        if (self.mouse.mods.equal(input.ctrlOrSuper(.{}))) {
+            for (self.mouse.click_state) |state| {
+                if (state != .release) break :report;
+            }
+        }
+
         // We use the first mouse button we find pressed in order to report
         // since the spec (afaict) does not say...
         const button: ?input.MouseButton = button: for (self.mouse.click_state, 0..) |state, i| {


### PR DESCRIPTION
Final follow-up to #71/#74 for manaflow-ai/cmux#5128.

#71 made Cmd-click open links under mouse reporting; #74 stopped the press/release of that click from leaking to a mouse-grabbing alt-screen TUI by suppressing the report whenever the ctrl/super link chord is held. This closes the last leak path: `cursorPosCallback` still emitted `.motion` reports while a button was held during the chord (it sees `click_state == .press`), so a slight drag during link activation leaked button-motion to the program.

Mirror the existing shift "grab override" for the ctrl/super chord in the motion-report path — suppressing only while a button is pressed, so pure movement reports are unaffected. With this, the link-activation chord suppresses the whole click+drag (press, release, and motion) consistently, matching iTerm2 / macOS Terminal.

`zig fmt`/`ast-check` clean. Behavior is integration-level (live `Surface` + mouse-reporting program), verified by cmux dogfood.

---
*AI disclosure (per AI_POLICY.md): developed with Claude Code (Claude Opus 4.8); reviewed by a maintainer.*

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783213228&installation_id=133855650&pr_number=75&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F75&signature=a4fe0fcf1423cc242cbe02a684ee0ce13f0132299547b6b88b3baeb52c9e8d67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent button-motion events from leaking to mouse-grabbing programs when cmd/super-clicking a link and dragging. The link-activation chord now suppresses press, release, and motion consistently, closing the last leak in manaflow-ai/cmux#5128.

- **Bug Fixes**
  - In `cursorPosCallback`, suppress motion while a button is pressed and the ctrl/super chord is held (mirrors the shift override). Pure movement without a pressed button is unaffected.

<sup>Written for commit 76ead3eaef32f85c3020d587b76ce21a1f3fb839. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/75?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

