### PR TITLE
fix: scope cmd-click link suppression to left button + clear stale hover (#71 follow-up)

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -3981,9 +3981,9 @@ pub fn mouseButtonCallback(
             // then we do not do a mouse report.
             if (mods.shift and !shift_capture) break :report;
 
-            // If the ctrl/super link-activation chord is held, this click
-            // belongs to the terminal (link activation / smart-select), not the
-            // program — the release opens the link locally (see
+            // If the ctrl/super link-activation chord is held on a left click,
+            // that click belongs to the terminal (link activation / smart-select),
+            // not the program — the release opens the link locally (see
             // mouseLinkRefreshAllowed / processLinks). Suppress the entire click,
             // press *and* release, from the program. We key on the modifier
             // rather than the current over_link flag — exactly like the
@@ -3992,10 +3992,13 @@ pub fn mouseButtonCallback(
             // cursor drifts off the link cell mid-click; otherwise either the
             // press (cursor on link at press) or the release (cursor off link at
             // release) would leak a half-click to mouse-grabbing alt-screen TUIs
-            // like Claude Code and Codex. Matches iTerm2 / macOS Terminal, where
-            // the link modifier is reserved for the terminal. Fixes
-            // manaflow-ai/cmux#5128.
-            if (self.mouse.mods.equal(input.ctrlOrSuper(.{}))) break :report;
+            // like Claude Code and Codex. Scoped to the left button because link
+            // activation is only attempted on left-button release, so ctrl/super
+            // right/middle clicks still reach the program. Matches iTerm2 / macOS
+            // Terminal, where the link modifier is reserved for the terminal.
+            // Fixes manaflow-ai/cmux#5128.
+            if (button == .left and
+                self.mouse.mods.equal(input.ctrlOrSuper(.{}))) break :report;
 
             // In any other mouse button scenario without shift pressed we
             // clear the selection since the underlying application can handle
@@ -4727,11 +4730,15 @@ pub fn cursorPosCallback(
     //    changed)
     // AND
     // local link handling is allowed for the current mouse-reporting state
-    // and mods (see mouseLinkRefreshAllowed)
+    // and mods (see mouseLinkRefreshAllowed) — OR we were over a link, so we
+    // can clear a stale highlight/cursor when the ctrl/super chord is released
+    // via this path (some platforms deliver modifier changes through
+    // cursorPosCallback's mods rather than a separate key callback). Refreshing
+    // with the chord dropped finds no link and resets the hover state.
     if ((over_link or
         self.mouse.link_point == null or
         (self.mouse.link_point != null and !self.mouse.link_point.?.eql(pos_vp))) and
-        self.mouseLinkRefreshAllowed())
+        (self.mouseLinkRefreshAllowed() or over_link))
     {
         // If we were previously over a link, we always update. We do this so that if the text
         // changed underneath us, even if the mouse didn't move, we update the URL hints and state
@@ -4749,16 +4756,16 @@ pub fn cursorPosCallback(
             }
         }
 
-        // The ctrl/super link-activation chord reserves the whole click for
-        // the terminal (link activation / smart-select; see
-        // mouseButtonCallback), so a drag while it is held must not leak
-        // button-motion reports to a mouse-grabbing program either. Mirror the
-        // shift override above: only suppress while a button is pressed so pure
-        // movement reports are unaffected. Part of manaflow-ai/cmux#5128.
-        if (self.mouse.mods.equal(input.ctrlOrSuper(.{}))) {
-            for (self.mouse.click_state) |state| {
-                if (state != .release) break :report;
-            }
+        // The ctrl/super link-activation chord reserves a left click for the
+        // terminal (link activation / smart-select; see mouseButtonCallback), so
+        // a left drag while it is held must not leak button-motion reports to a
+        // mouse-grabbing program either. Like the shift override above, only
+        // suppress while the left button is pressed, so pure movement reports and
+        // other-button drags are unaffected. Part of manaflow-ai/cmux#5128.
+        if (self.mouse.mods.equal(input.ctrlOrSuper(.{})) and
+            self.mouse.click_state[@intFromEnum(input.MouseButton.left)] == .press)
+        {
+            break :report;
         }
 
         // We use the first mouse button we find pressed in order to report


### PR DESCRIPTION
Two review follow-ups (codex P2) on the link-under-mouse-reporting work from #71/#74/#75 (manaflow-ai/cmux#5128).

1. **Scope the suppression to the left button.** #74/#75 broke out of the mouse-report path whenever the ctrl/super link chord was held, for *any* button. But link activation is only attempted on left-button release, so a ctrl/super right- or middle-click was being swallowed instead of delivered to the mouse-reporting program. Gate the press/release (`mouseButtonCallback`) and motion (`cursorPosCallback`) suppression on the left button.

2. **Clear stale link hover when the chord drops via cursor mods.** When ctrl/super release is observed only through `cursorPosCallback`'s `mods` argument (some platforms/events don't route it through a separate key callback), the refresh gate went false while `over_link` was still set, so the hand cursor / highlight was never cleared. `keyCallback` already handles this in its `else` branch; mirror it by also refreshing when `over_link` is set — with the chord dropped that finds no link and resets the hover state.

With this, the link chord cleanly owns only the left click+drag (press/release/motion), other-button modified clicks still reach the program, and hover state never gets stuck. `zig fmt`/`ast-check` clean; behavior is integration-level, verified by cmux dogfood.

---
*AI disclosure (per AI_POLICY.md): developed with Claude Code (Claude Opus 4.8); reviewed by a maintainer.*

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783214175&installation_id=133855650&pr_number=76&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F76&signature=93cdfc8afb7f2b8d95b6818cd08eef50d5faad5c6227c7b52e041c8ed501fb87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes link-chord handling so cmd/ctrl-click only intercepts left clicks and hover state clears when modifiers change via cursor events. Restores right/middle clicks to mouse-reporting apps and prevents stuck hand cursor/highlight (part of manaflow-ai/cmux#5128).

- **Bug Fixes**
  - Scope suppression to the left button in `mouseButtonCallback` and `cursorPosCallback`; right/middle clicks and drags now reach the program.
  - When the chord is released via `cursorPosCallback.mods`, refresh if `over_link` is set to clear the hover state.

<sup>Written for commit f2419527162185a76d49ffda911f881e2bdec95a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/76?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

