### PR TITLE
fix: open latched link on release with press-time chord + defer-clear latch (#71 follow-up)

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -3899,10 +3899,17 @@ pub fn mouseButtonCallback(
     // path for its whole lifecycle. We latch the decision here (rather than
     // re-checking live modifiers in each report path) so that releasing the
     // modifier before the mouse button can't leak the release as a half-click.
-    // Cleared when the left button is released (see the report path below).
     if (button == .left and action == .press) {
         self.mouse.link_click_active = self.mouse.mods.equal(input.ctrlOrSuper(.{}));
     }
+
+    // Clear the latch on every left-button release, on all return paths — the
+    // link-open and prompt-click branches below return early, so a plain
+    // statement after them would be skipped and leave the latch stale. The
+    // press above is the only setter; this defer is the only reset.
+    defer if (button == .left and action == .release) {
+        self.mouse.link_click_active = false;
+    };
 
     // Shift-click continues the previous mouse state if we have a selection.
     // cursorPosCallback will also do a mouse report so we don't need to do any
@@ -3971,8 +3978,12 @@ pub fn mouseButtonCallback(
 
         // Handle link clicking. We want to do this before we do mouse
         // reporting or any other mouse handling because a successfully
-        // clicked link will swallow the event.
-        if (self.mouse.over_link) {
+        // clicked link will swallow the event. We also attempt this when a
+        // link click is latched (link_click_active) even if over_link was
+        // cleared between press and release (e.g. the modifier was released or
+        // the cursor drifted), so the latched click still opens its link
+        // rather than being swallowed by the report-suppression below.
+        if (self.mouse.over_link or self.mouse.link_click_active) {
             const pos = try self.rt_surface.getCursorPos();
             self.renderer_state.mutex.lock();
             defer self.renderer_state.mutex.unlock();
@@ -4047,12 +4058,6 @@ pub fn mouseButtonCallback(
             return true;
         }
     }
-
-    // Always clear the link-click latch when the left button is released, even
-    // if mouse reporting was disabled mid-click (so the release skipped the
-    // report block above) — otherwise the latch could go stale and suppress a
-    // later click. The press sets it; this is the single unconditional reset.
-    if (button == .left and action == .release) self.mouse.link_click_active = false;
 
     // For left button clicks we always record some information for
     // selection/highlighting purposes.
@@ -4449,8 +4454,16 @@ fn linkAtPos(
         break :mouse_pin pin;
     };
 
-    // Get our comparison mods
-    const mouse_mods = self.mouseModsWithCapture(self.mouse.mods);
+    // Get our comparison mods. When a left link-click is in flight (the
+    // ctrl/super link chord was held at press; see mouseButtonCallback), use
+    // that chord even if the modifier was released before the button came up,
+    // so the latched click still resolves and opens its link instead of being
+    // swallowed. Outside an active link click this is just the live mods.
+    const effective_mods = if (self.mouse.link_click_active)
+        input.ctrlOrSuper(.{})
+    else
+        self.mouse.mods;
+    const mouse_mods = self.mouseModsWithCapture(effective_mods);
 
     // If we have the proper modifiers set then we can check for OSC8 links.
     if (mouse_mods.equal(input.ctrlOrSuper(.{}))) hyperlink: {


### PR DESCRIPTION
Two review follow-ups (codex) on the link-under-mouse-reporting work (#71/#74/#75/#76/#77, manaflow-ai/cmux#5128), unifying the link-click decision so the *open* path and the *report-suppression* path use the same press-time chord.

1. **Swallowed click (P2).** When the ctrl/super modifier was released before the left button, the report was still suppressed (latched at press), but `processLinks` re-derived `linkAtPos` from the now-empty live mods — so the link no longer matched and the click was swallowed (link never opened, nothing reached the program). `linkAtPos` now uses the latched chord while `link_click_active` is set, and the release path attempts `processLinks` whenever the click is latched (not only while `over_link` is still set). The latched click opens its link instead of being dropped.

2. **Stale latch (P3).** The unconditional reset was placed after the report block, but the successful-link (`if (processed) return true`) and prompt-click branches return early and never reached it. The latch is now cleared with a function-level `defer`, so it resets on every left-release return path. The press remains the only setter.

Net: a single press-time decision drives press/drag/release suppression *and* link opening, consistently — closing the modifier-timing edge cases. `zig fmt`/`ast-check` clean; behavior is integration-level, verified by cmux dogfood.

---
*AI disclosure (per AI_POLICY.md): developed with Claude Code (Claude Opus 4.8); reviewed by a maintainer.*

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783216739&installation_id=133855650&pr_number=78&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F78&signature=b732eebba9f0f02c4364b3b601ce99cd4d4fe2439566ef3fdcc26510a5eae4bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes swallowed link clicks when ctrl/super is released before the left mouse button. We latch the press-time chord for the full click and always clear it on release, so latched clicks open reliably. Addresses `manaflow-ai/cmux#5128`.

- **Bug Fixes**
  - Use the press-time modifier chord while `link_click_active` to resolve `linkAtPos`, and attempt open on release even if `over_link` changed.
  - Clear the latch on every left-button release via a function-level defer to avoid stale suppression on early returns.

<sup>Written for commit 9f014e98b7154405d8ba406e19f0f9b8529cdc8b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/78?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency of modifier-key link clicking. Fixed an issue where Ctrl/Cmd-clicking links could fail if hover state changed between mouse press and release events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->