### PR TITLE
fix: only open a latched link click that started on a link (#71 follow-up)

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -269,6 +269,14 @@ const Mouse = struct {
     /// program. See `mouseButtonCallback` / `cursorPosCallback`.
     link_click_active: bool = false,
 
+    /// Whether the cursor was over a link when a latched link click
+    /// (`link_click_active`) began. Captured at left-button press. The latched
+    /// release only opens a link when this is true, so a ctrl/super drag that
+    /// *starts off* a link and happens to release over one does not open the
+    /// release-time link (its press is still suppressed). A click that starts
+    /// on a link opens whatever link is under the release cursor.
+    link_press_over_link: bool = false,
+
     /// The last x/y in the cursor position for links. We use this to
     /// only process link hover events when the mouse actually moves cells.
     link_point: ?terminal.point.Coordinate = null,
@@ -3901,6 +3909,7 @@ pub fn mouseButtonCallback(
     // modifier before the mouse button can't leak the release as a half-click.
     if (button == .left and action == .press) {
         self.mouse.link_click_active = self.mouse.mods.equal(input.ctrlOrSuper(.{}));
+        self.mouse.link_press_over_link = self.mouse.over_link;
     }
 
     // Clear the latch on every left-button release, on all return paths — the
@@ -3982,8 +3991,15 @@ pub fn mouseButtonCallback(
         // link click is latched (link_click_active) even if over_link was
         // cleared between press and release (e.g. the modifier was released or
         // the cursor drifted), so the latched click still opens its link
-        // rather than being swallowed by the report-suppression below.
-        if (self.mouse.over_link or self.mouse.link_click_active) {
+        // rather than being swallowed by the report-suppression below — but
+        // only when the click started on a link. A latched ctrl/super drag that
+        // began *off* a link does not open a link it merely released over (its
+        // press was already withheld from the program); that click is swallowed.
+        const armed_off_link = self.mouse.link_click_active and
+            !self.mouse.link_press_over_link;
+        if ((self.mouse.over_link or self.mouse.link_click_active) and
+            !armed_off_link)
+        {
             const pos = try self.rt_surface.getCursorPos();
             self.renderer_state.mutex.lock();
             defer self.renderer_state.mutex.unlock();


### PR DESCRIPTION
Review follow-up (codex) on the link-under-mouse-reporting work (#71/#74/#75/#76/#77/#78, manaflow-ai/cmux#5128).

After #78 the latched link-open path opened the link under the *release* cursor whenever a ctrl/super click was in flight. So a chord **drag** that started *off* a link and released over one would open that release-time link, even though the press never targeted it (and the press had already been suppressed from the program).

Capture whether the cursor was over a link at press (`link_press_over_link`) and skip the latched open when the click started off a link — that drag is simply swallowed rather than opening a link the user only dragged onto. Clicks that start on a link still open whatever link is under the release cursor (matching upstream release-time behavior), and non-chord / `always`-highlight links are unaffected. Leak-free: armed clicks still suppress press/release/motion regardless.

`zig fmt`/`ast-check` clean; integration-level behavior, verified by cmux dogfood.

---
*AI disclosure (per AI_POLICY.md): developed with Claude Code (Claude Opus 4.8); reviewed by a maintainer.*

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783218781&installation_id=133855650&pr_number=79&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F79&signature=507f947220cb5a2a5fb005fb2a158cc5774f78fa44c9aaac9d2cfee6a7b8ab50"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix latched link clicks so a link opens on release only if the click started over a link. Prevents ctrl/super drags that start off a link from opening on release; clicks that start on a link still open the link under the release cursor.

<sup>Written for commit df789cd4ba1419ffb3c1c39865ad0400b2676e10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/79?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

