### PR TITLE
Merge renderer-realized + binding-mods modifier tracking into main

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1224,6 +1224,7 @@ GHOSTTY_API void ghostty_surface_free_text(ghostty_surface_t, ghostty_text_s*);
 
 #ifdef __APPLE__
 GHOSTTY_API void ghostty_surface_set_display_id(ghostty_surface_t, uint32_t);
+GHOSTTY_API void ghostty_surface_set_renderer_realized(ghostty_surface_t, bool);
 GHOSTTY_API void* ghostty_surface_quicklook_font(ghostty_surface_t);
 GHOSTTY_API bool ghostty_surface_quicklook_word(ghostty_surface_t, ghostty_text_s*);
 #endif

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1224,7 +1224,7 @@ GHOSTTY_API void ghostty_surface_free_text(ghostty_surface_t, ghostty_text_s*);
 
 #ifdef __APPLE__
 GHOSTTY_API void ghostty_surface_set_display_id(ghostty_surface_t, uint32_t);
-GHOSTTY_API void ghostty_surface_set_renderer_realized(ghostty_surface_t, bool);
+GHOSTTY_API bool ghostty_surface_set_renderer_realized(ghostty_surface_t, bool);
 GHOSTTY_API void* ghostty_surface_quicklook_font(ghostty_surface_t);
 GHOSTTY_API bool ghostty_surface_quicklook_word(ghostty_surface_t, ghostty_text_s*);
 #endif

--- a/src/App.zig
+++ b/src/App.zig
@@ -20,6 +20,49 @@ const log = std.log.scoped(.app);
 
 const SurfaceList = std.ArrayListUnmanaged(*apprt.Surface);
 
+const SurfaceRegistryMutationKind = enum {
+    add,
+    delete,
+};
+
+const SurfaceRegistryMutationProbeForTesting = struct {
+    entered_count: std.atomic.Value(u32) = std.atomic.Value(u32).init(0),
+    overlap_count: std.atomic.Value(u32) = std.atomic.Value(u32).init(0),
+    first_mutation_should_wait: std.atomic.Value(bool) = std.atomic.Value(bool).init(true),
+    first_mutation_entered: std.Thread.ResetEvent = .{},
+    release_first_mutation: std.Thread.ResetEvent = .{},
+
+    fn begin(self: *SurfaceRegistryMutationProbeForTesting, kind: SurfaceRegistryMutationKind) void {
+        _ = kind;
+
+        const previous = self.entered_count.fetchAdd(1, .seq_cst);
+        if (previous > 0) {
+            _ = self.overlap_count.fetchAdd(1, .seq_cst);
+            self.release_first_mutation.set();
+            return;
+        }
+
+        if (self.first_mutation_should_wait.swap(false, .seq_cst)) {
+            self.first_mutation_entered.set();
+            self.release_first_mutation.timedWait(500 * std.time.ns_per_ms) catch {};
+        }
+    }
+
+    fn end(self: *SurfaceRegistryMutationProbeForTesting) void {
+        _ = self.entered_count.fetchSub(1, .seq_cst);
+    }
+};
+
+var surface_registry_mutation_probe_for_testing: ?*SurfaceRegistryMutationProbeForTesting = null;
+
+fn beginSurfaceRegistryMutationProbeForTesting(kind: SurfaceRegistryMutationKind) ?*SurfaceRegistryMutationProbeForTesting {
+    if (!builtin.is_test) return null;
+
+    const probe = surface_registry_mutation_probe_for_testing orelse return null;
+    probe.begin(kind);
+    return probe;
+}
+
 /// General purpose allocator
 alloc: Allocator,
 
@@ -168,6 +211,9 @@ pub fn addSurface(
     self: *App,
     rt_surface: *apprt.Surface,
 ) Allocator.Error!void {
+    const mutation_probe_for_testing = beginSurfaceRegistryMutationProbeForTesting(.add);
+    defer if (mutation_probe_for_testing) |probe| probe.end();
+
     try self.surfaces.append(self.alloc, rt_surface);
 
     // Since we have non-zero surfaces, we can cancel the quit timer.
@@ -185,6 +231,9 @@ pub fn addSurface(
 /// Delete the surface from the known surface list. This will NOT call the
 /// destructor or free the memory.
 pub fn deleteSurface(self: *App, rt_surface: *apprt.Surface) void {
+    const mutation_probe_for_testing = beginSurfaceRegistryMutationProbeForTesting(.delete);
+    defer if (mutation_probe_for_testing) |probe| probe.end();
+
     // If this surface is the focused surface then we need to clear it.
     // There was a bug where we relied on hasSurface to return false and
     // just let focused surface be but the allocator was reusing addresses
@@ -602,3 +651,77 @@ pub const Wasm = if (!builtin.target.isWasm()) struct {} else struct {
     //     }
     // }
 };
+
+const SurfaceRegistryMutationTestContext = struct {
+    app: *App,
+    surface: *apprt.Surface,
+
+    fn add(self: *SurfaceRegistryMutationTestContext) void {
+        self.app.addSurface(self.surface) catch unreachable;
+    }
+
+    fn delete(self: *SurfaceRegistryMutationTestContext) void {
+        self.app.deleteSurface(self.surface);
+    }
+};
+
+fn testWakeup(_: ?*anyopaque) callconv(.c) void {}
+
+fn testAction(_: *apprt.App, _: apprt.Target.C, _: apprt.Action.C) callconv(.c) bool {
+    return true;
+}
+
+test "surface registry mutations are serialized" {
+    if (comptime !@hasField(apprt.App, "opts")) return error.SkipZigTest;
+    if (comptime !@hasField(apprt.Surface, "app")) return error.SkipZigTest;
+
+    var app: App = undefined;
+    try app.init(std.testing.allocator);
+    defer {
+        app.surfaces.deinit(std.testing.allocator);
+        app.font_grid_set.deinit();
+    }
+
+    var rt_app: apprt.App = undefined;
+    rt_app.core_app = &app;
+    rt_app.opts = undefined;
+    rt_app.opts.action = testAction;
+    rt_app.opts.wakeup = testWakeup;
+
+    var surface: apprt.Surface = undefined;
+    surface.app = &rt_app;
+
+    var probe: SurfaceRegistryMutationProbeForTesting = .{};
+    surface_registry_mutation_probe_for_testing = &probe;
+    defer surface_registry_mutation_probe_for_testing = null;
+
+    var add_context: SurfaceRegistryMutationTestContext = .{
+        .app = &app,
+        .surface = &surface,
+    };
+    var add_thread = try std.Thread.spawn(
+        .{},
+        SurfaceRegistryMutationTestContext.add,
+        .{&add_context},
+    );
+
+    try probe.first_mutation_entered.timedWait(std.time.ns_per_s);
+
+    var delete_context: SurfaceRegistryMutationTestContext = .{
+        .app = &app,
+        .surface = &surface,
+    };
+    var delete_thread = try std.Thread.spawn(
+        .{},
+        SurfaceRegistryMutationTestContext.delete,
+        .{&delete_context},
+    );
+
+    add_thread.join();
+    delete_thread.join();
+
+    surface_registry_mutation_probe_for_testing = null;
+    if (app.hasRtSurface(&surface)) app.deleteSurface(&surface);
+
+    try std.testing.expectEqual(@as(u32, 0), probe.overlap_count.load(.seq_cst));
+}

--- a/src/App.zig
+++ b/src/App.zig
@@ -63,11 +63,39 @@ fn beginSurfaceRegistryMutationProbeForTesting(kind: SurfaceRegistryMutationKind
     return probe;
 }
 
+fn lockSurfaceRegistry(self: *const App) void {
+    @constCast(&self.surface_registry_mutex).lock();
+}
+
+fn unlockSurfaceRegistry(self: *const App) void {
+    @constCast(&self.surface_registry_mutex).unlock();
+}
+
+fn hasSurfaceLocked(self: *const App, surface: *const Surface) bool {
+    for (self.surfaces.items) |v| {
+        if (v.core() == surface) return true;
+    }
+
+    return false;
+}
+
+fn hasRtSurfaceLocked(self: *const App, surface: *apprt.Surface) bool {
+    for (self.surfaces.items) |v| {
+        if (v == surface) return true;
+    }
+
+    return false;
+}
+
 /// General purpose allocator
 alloc: Allocator,
 
 /// The list of surfaces that are currently active.
 surfaces: SurfaceList,
+
+/// Protects the native surface registry and focused surface pointer. Embedded
+/// runtimes may create on the main thread while freeing on a worker thread.
+surface_registry_mutex: std.Thread.Mutex = .{},
 
 /// This is true if the app that Ghostty is in is focused. This may
 /// mean that no surfaces (terminals) are focused but the app is still
@@ -179,8 +207,13 @@ pub fn tick(self: *App, rt_app: *apprt.App) !void {
 /// memory can be freed immediately when this returns.
 pub fn updateConfig(self: *App, rt_app: *apprt.App, config: *const Config) !void {
     // Go through and update all of the surface configurations.
-    for (self.surfaces.items) |surface| {
-        try surface.core().handleMessage(.{ .change_config = config });
+    {
+        self.lockSurfaceRegistry();
+        defer self.unlockSurfaceRegistry();
+
+        for (self.surfaces.items) |surface| {
+            try surface.core().handleMessage(.{ .change_config = config });
+        }
     }
 
     // Apply our conditional state. If we fail to apply the conditional state
@@ -211,10 +244,14 @@ pub fn addSurface(
     self: *App,
     rt_surface: *apprt.Surface,
 ) Allocator.Error!void {
-    const mutation_probe_for_testing = beginSurfaceRegistryMutationProbeForTesting(.add);
-    defer if (mutation_probe_for_testing) |probe| probe.end();
+    {
+        self.lockSurfaceRegistry();
+        defer self.unlockSurfaceRegistry();
 
-    try self.surfaces.append(self.alloc, rt_surface);
+        const mutation_probe_for_testing = beginSurfaceRegistryMutationProbeForTesting(.add);
+        defer if (mutation_probe_for_testing) |probe| probe.end();
+        try self.surfaces.append(self.alloc, rt_surface);
+    }
 
     // Since we have non-zero surfaces, we can cancel the quit timer.
     // It is up to the apprt if there is a quit timer at all and if it
@@ -231,32 +268,38 @@ pub fn addSurface(
 /// Delete the surface from the known surface list. This will NOT call the
 /// destructor or free the memory.
 pub fn deleteSurface(self: *App, rt_surface: *apprt.Surface) void {
-    const mutation_probe_for_testing = beginSurfaceRegistryMutationProbeForTesting(.delete);
-    defer if (mutation_probe_for_testing) |probe| probe.end();
+    const should_start_quit_timer = should_start: {
+        self.lockSurfaceRegistry();
+        defer self.unlockSurfaceRegistry();
 
-    // If this surface is the focused surface then we need to clear it.
-    // There was a bug where we relied on hasSurface to return false and
-    // just let focused surface be but the allocator was reusing addresses
-    // after free and giving false positives, so we must clear it.
-    if (self.focused_surface) |focused| {
-        if (focused == rt_surface.core()) {
-            self.focused_surface = null;
-        }
-    }
-
-    var i: usize = 0;
-    while (i < self.surfaces.items.len) {
-        if (self.surfaces.items[i] == rt_surface) {
-            _ = self.surfaces.swapRemove(i);
-            continue;
+        const mutation_probe_for_testing = beginSurfaceRegistryMutationProbeForTesting(.delete);
+        defer if (mutation_probe_for_testing) |probe| probe.end();
+        // If this surface is the focused surface then we need to clear it.
+        // There was a bug where we relied on hasSurface to return false and
+        // just let focused surface be but the allocator was reusing addresses
+        // after free and giving false positives, so we must clear it.
+        if (self.focused_surface) |focused| {
+            if (focused == rt_surface.core()) {
+                self.focused_surface = null;
+            }
         }
 
-        i += 1;
-    }
+        var i: usize = 0;
+        while (i < self.surfaces.items.len) {
+            if (self.surfaces.items[i] == rt_surface) {
+                _ = self.surfaces.swapRemove(i);
+                continue;
+            }
+
+            i += 1;
+        }
+
+        break :should_start self.surfaces.items.len == 0;
+    };
 
     // If we have no surfaces, we can start the quit timer. It is up to the
     // apprt to determine if this is necessary.
-    if (self.surfaces.items.len == 0) _ = rt_surface.rtApp().performAction(
+    if (should_start_quit_timer) _ = rt_surface.rtApp().performAction(
         .app,
         .quit_timer,
         .start,
@@ -268,14 +311,20 @@ pub fn deleteSurface(self: *App, rt_surface: *apprt.Surface) void {
 /// The last focused surface. This is only valid while on the main thread
 /// before tick is called.
 pub fn focusedSurface(self: *const App) ?*Surface {
+    self.lockSurfaceRegistry();
+    defer self.unlockSurfaceRegistry();
+
     const surface = self.focused_surface orelse return null;
-    if (!self.hasSurface(surface)) return null;
+    if (!self.hasSurfaceLocked(surface)) return null;
     return surface;
 }
 
 /// Returns true if confirmation is needed to quit the app. It is up to
 /// the apprt to call this.
 pub fn needsConfirmQuit(self: *const App) bool {
+    self.lockSurfaceRegistry();
+    defer self.unlockSurfaceRegistry();
+
     for (self.surfaces.items) |v| {
         if (v.core().needsConfirmQuit()) return true;
     }
@@ -319,7 +368,10 @@ pub fn closeSurface(self: *App, surface: *Surface) void {
 }
 
 pub fn focusSurface(self: *App, surface: *Surface) void {
-    if (!self.hasSurface(surface)) return;
+    self.lockSurfaceRegistry();
+    defer self.unlockSurfaceRegistry();
+
+    if (!self.hasSurfaceLocked(surface)) return;
     self.focused_surface = surface;
 }
 
@@ -547,15 +599,16 @@ fn surfaceMessage(self: *App, surface: *Surface, msg: apprt.surface.Message) !vo
 }
 
 fn hasSurface(self: *const App, surface: *const Surface) bool {
-    for (self.surfaces.items) |v| {
-        if (v.core() == surface) return true;
-    }
-
-    return false;
+    self.lockSurfaceRegistry();
+    defer self.unlockSurfaceRegistry();
+    return self.hasSurfaceLocked(surface);
 }
 
 /// Search for a surface by a 64 bit unique ID.
 pub fn findSurfaceByID(self: *const App, id: u64) ?*Surface {
+    self.lockSurfaceRegistry();
+    defer self.unlockSurfaceRegistry();
+
     for (self.surfaces.items) |v| {
         const surface: *Surface = v.core();
         if (surface.id == id) return surface;
@@ -565,11 +618,9 @@ pub fn findSurfaceByID(self: *const App, id: u64) ?*Surface {
 }
 
 fn hasRtSurface(self: *const App, surface: *apprt.Surface) bool {
-    for (self.surfaces.items) |v| {
-        if (v == surface) return true;
-    }
-
-    return false;
+    self.lockSurfaceRegistry();
+    defer self.unlockSurfaceRegistry();
+    return self.hasRtSurfaceLocked(surface);
 }
 
 /// The message types that can be sent to the app thread.

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -1589,10 +1589,15 @@ fn searchCallback_(
 /// The renderer state mutex MUST NOT be held.
 fn modsChanged(self: *Surface, mods: input.Mods) void {
     // The only place we keep track of mods currently is on the mouse.
-    if (!self.mouse.mods.equal(mods)) {
+    // Compare binding mods against binding mods: we only ever store
+    // binding modifiers, so comparing against the raw mods would re-enter
+    // this path (and re-dirty the screen) on every event while a sided
+    // modifier or lock key is held.
+    const binding_mods = mods.binding();
+    if (!self.mouse.mods.equal(binding_mods)) {
         // The mouse mods only contain binding modifiers since we don't
         // want caps/num lock or sided modifiers to affect the mouse.
-        self.mouse.mods = mods.binding();
+        self.mouse.mods = binding_mods;
 
         // We also need to update the renderer so it knows if it should
         // highlight links. Additionally, mark the screen as dirty so
@@ -2871,8 +2876,11 @@ pub fn keyCallback(
     }
 
     // If our mouse modifiers change we may need to change our
-    // link highlight state.
-    if (!self.mouse.mods.equal(event.mods)) mouse_mods: {
+    // link highlight state. Compare binding mods: stored mouse mods are
+    // binding-only, so raw key mods carrying sided modifier bits (e.g.
+    // right Option for macos-option-as-alt) would otherwise re-trigger
+    // this on every keypress while such a modifier is held.
+    if (!self.mouse.mods.equal(event.mods.binding())) mouse_mods: {
         // Update our modifiers, this will update mouse mods too
         self.modsChanged(event.mods);
 

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -2828,17 +2828,21 @@ pub const CAPI = struct {
         /// Darwin-only by placement: iOS owns occlusion via `renderingSuspended`
         /// and must not be driven through this path. The message is
         /// non-idempotent (it must strictly alternate with the swap chain's
-        /// `defunct` state), so it is pushed `.forever` and never dropped. The
-        /// caller (cmux) guarantees alternation: it never realizes an already-
-        /// realized surface (which would trip `displayRealized`'s
-        /// `assert(swap_chain.defunct)`) nor unrealizes an already-unrealized one.
-        export fn ghostty_surface_set_renderer_realized(ptr: *Surface, realized: bool) void {
+        /// `defunct` state), so the caller (cmux) must only advance its own
+        /// realize/unrealize state when this returns `true`. Even a `.forever`
+        /// push can fail to enqueue: `BlockingQueue.push` returns 0 if the queue
+        /// is still full after a (possibly spurious) wakeup. Returning the
+        /// enqueue result lets cmux keep its mirror state in sync and retry,
+        /// rather than believing an un-queued realize/unrealize took effect and
+        /// later tripping `displayRealized`'s `assert(swap_chain.defunct)`.
+        export fn ghostty_surface_set_renderer_realized(ptr: *Surface, realized: bool) bool {
             const surface = &ptr.core_surface;
-            _ = surface.renderer_thread.mailbox.push(
+            const enqueued = surface.renderer_thread.mailbox.push(
                 .{ .display_realized = realized },
                 .{ .forever = {} },
-            );
+            ) != 0;
             surface.renderer_thread.wakeup.notify() catch {};
+            return enqueued;
         }
 
         /// This returns a CTFontRef that should be used for quicklook

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -2829,17 +2829,20 @@ pub const CAPI = struct {
         /// and must not be driven through this path. The message is
         /// non-idempotent (it must strictly alternate with the swap chain's
         /// `defunct` state), so the caller (cmux) must only advance its own
-        /// realize/unrealize state when this returns `true`. Even a `.forever`
-        /// push can fail to enqueue: `BlockingQueue.push` returns 0 if the queue
-        /// is still full after a (possibly spurious) wakeup. Returning the
-        /// enqueue result lets cmux keep its mirror state in sync and retry,
-        /// rather than believing an un-queued realize/unrealize took effect and
-        /// later tripping `displayRealized`'s `assert(swap_chain.defunct)`.
+        /// realize/unrealize state when this returns `true`. The push is
+        /// `.instant` (non-blocking): this runs on the caller's main actor and
+        /// must never stall the UI waiting on the renderer thread to drain. When
+        /// the mailbox is full the push drops and returns `false`; cmux keeps its
+        /// mirror state unchanged and retries on its next reclamation pass, so a
+        /// drop is harmless rather than tripping `displayRealized`'s
+        /// `assert(swap_chain.defunct)`. On re-show the mailbox is normally empty,
+        /// so the realize enqueues immediately and the surface is never presented
+        /// against a defunct swap chain.
         export fn ghostty_surface_set_renderer_realized(ptr: *Surface, realized: bool) bool {
             const surface = &ptr.core_surface;
             const enqueued = surface.renderer_thread.mailbox.push(
                 .{ .display_realized = realized },
-                .{ .forever = {} },
+                .{ .instant = {} },
             ) != 0;
             surface.renderer_thread.wakeup.notify() catch {};
             return enqueued;

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -2819,6 +2819,28 @@ pub const CAPI = struct {
             surface.renderer_thread.wakeup.notify() catch {};
         }
 
+        /// cmux fork: release (realized=false) or recreate (realized=true) the
+        /// renderer's GPU resources (Metal swap chain / IOSurface) for a surface
+        /// without freeing the surface itself. Lets cmux reclaim the ~40MB
+        /// IOSurface of an occluded terminal while keeping its PTY/io thread and
+        /// terminal state alive; the swap chain is rebuilt on re-show.
+        ///
+        /// Darwin-only by placement: iOS owns occlusion via `renderingSuspended`
+        /// and must not be driven through this path. The message is
+        /// non-idempotent (it must strictly alternate with the swap chain's
+        /// `defunct` state), so it is pushed `.forever` and never dropped. The
+        /// caller (cmux) guarantees alternation: it never realizes an already-
+        /// realized surface (which would trip `displayRealized`'s
+        /// `assert(swap_chain.defunct)`) nor unrealizes an already-unrealized one.
+        export fn ghostty_surface_set_renderer_realized(ptr: *Surface, realized: bool) void {
+            const surface = &ptr.core_surface;
+            _ = surface.renderer_thread.mailbox.push(
+                .{ .display_realized = realized },
+                .{ .forever = {} },
+            );
+            surface.renderer_thread.wakeup.notify() catch {};
+        }
+
         /// This returns a CTFontRef that should be used for quicklook
         /// highlighted text. This is always the primary font in use
         /// regardless of the selected text. If coretext is not in use

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -520,6 +520,19 @@ fn drainMailbox(self: *Thread) !void {
                     try self.renderer.setMacOSDisplayID(v);
                 }
             },
+
+            // cmux fork: release/recreate the renderer's GPU resources (swap
+            // chain / IOSurface) without freeing the surface. Safe here because
+            // this runs on the renderer thread (so it never races a draw), the
+            // surface is occluded when this is sent (macOS `drawFrame` early-
+            // returns on `!flags.visible`), and both calls take `draw_mutex`.
+            .display_realized => |v| {
+                if (v) {
+                    try self.renderer.displayRealized();
+                } else {
+                    self.renderer.displayUnrealized();
+                }
+            },
         }
     }
 }

--- a/src/renderer/message.zig
+++ b/src/renderer/message.zig
@@ -67,6 +67,16 @@ pub const Message = union(enum) {
     /// The macOS display ID has changed for the window.
     macos_display_id: u32,
 
+    /// cmux fork: realize (true) or unrealize (false) the renderer's GPU
+    /// resources (Metal swap-chain / IOSurface) without freeing the surface.
+    /// Driven by cmux's offscreen renderer-reclamation controller so a surface
+    /// that is occluded for a while releases its ~40MB IOSurface while keeping
+    /// its PTY/io thread + terminal state alive, then rebuilds the swap chain on
+    /// re-show. Non-idempotent (must strictly alternate with the swap chain's
+    /// `defunct` state), so it is only ever pushed `.forever` from macOS, never
+    /// dropped — see `ghostty_surface_set_renderer_realized`.
+    display_realized: bool,
+
     pub const SearchMatches = struct {
         arena: ArenaAllocator,
         matches: []const terminal.highlight.Flattened,


### PR DESCRIPTION
Makes the cmux desktop GhosttyKit pin lineage reachable from main per the cmux submodule-safety rule. Includes the renderer display_realized work (existing pin 5697db813) and the binding-mods comparison fix in Surface.zig modifier tracking (05c3e2908) that cmux PR manaflow-ai/cmux#6007 pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783897110&installation_id=133855650&pr_number=81&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F81&signature=f68ba80bae4e24d315d661f87e28e939827333f12ec67affa066a3723cf05399"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Darwin-only C API to release/recreate a surface’s renderer GPU resources so `cmux` can reclaim memory for occluded terminals, and hardens surface registry updates with locking. Also fixes modifier tracking to avoid unnecessary re-renders.

- **New Features**
  - `ghostty_surface_set_renderer_realized(ghostty_surface_t, bool)`: non-blocking toggle to unrealize/realize a surface’s swap chain/IOSurface; returns whether the request was enqueued. Handled via a new renderer-thread mailbox message `display_realized`.

- **Bug Fixes**
  - Serialized surface registry mutations with a mutex (covers add/delete, focus, lookups) to prevent cross-thread races; includes a concurrency test.
  - Compare binding modifiers when tracking mouse state to prevent constant re-dirtying and link highlight churn when sided or lock keys are held.

<sup>Written for commit 05c3e2908f95892b180c3e5d770abe7a88b42c42. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/81?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added public API method for controlling renderer realization state in embedded environments.

* **Bug Fixes**
  * Fixed mouse modifier detection to prevent unnecessary visual updates caused by platform-specific modifier variations.

* **Improvements**
  * Enhanced thread safety for surface registry operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->