### PR TITLE
Add absolute screen row text read

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1220,6 +1220,13 @@ GHOSTTY_API bool ghostty_surface_read_selection(ghostty_surface_t, ghostty_text_
 GHOSTTY_API bool ghostty_surface_read_text(ghostty_surface_t,
                                               ghostty_selection_s,
                                               ghostty_text_s*);
+// cmux fork: read full-width text from inclusive absolute screen rows without
+// routing through ghostty_point_s, whose embedded wrapper clamps exact screen
+// y-coordinates to the visible active row count.
+GHOSTTY_API bool ghostty_surface_read_screen_text(ghostty_surface_t,
+                                                  uint32_t,
+                                                  uint32_t,
+                                                  ghostty_text_s*);
 GHOSTTY_API void ghostty_surface_free_text(ghostty_surface_t, ghostty_text_s*);
 
 #ifdef __APPLE__

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1741,6 +1741,35 @@ pub const CAPI = struct {
         return readTextLocked(surface, core_sel, result);
     }
 
+    /// cmux fork: read full-width text from inclusive absolute screen rows
+    /// without mutating the active selection. This bypasses Point.pin's visible
+    /// row clamp so embedders can read scrollback rows through screen coords.
+    export fn ghostty_surface_read_screen_text(
+        surface: *Surface,
+        top_y: u32,
+        bottom_y: u32,
+        result: *Text,
+    ) bool {
+        surface.core_surface.renderer_state.mutex.lock();
+        defer surface.core_surface.renderer_state.mutex.unlock();
+
+        if (top_y > bottom_y) return false;
+
+        const screen = surface.core_surface.renderer_state.terminal.screens.active;
+        const pages = &screen.pages;
+        if (pages.cols == 0) return false;
+
+        const top_left = pages.pin(.{
+            .screen = .{ .x = 0, .y = top_y },
+        }) orelse return false;
+        const bottom_right = pages.pin(.{
+            .screen = .{ .x = pages.cols -| 1, .y = bottom_y },
+        }) orelse return false;
+        const core_sel = terminal.Selection.init(top_left, bottom_right, false);
+
+        return readTextLocked(surface, core_sel, result);
+    }
+
     fn readTextLocked(
         surface: *Surface,
         core_sel: terminal.Selection,


### PR DESCRIPTION
Adds a narrow embedded API for cmux copy-mode visual line fallback reads from absolute screen rows. This lets cmux read bounded screen-row ranges without going through the visible-row clamp used by point selection reads.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784679348&installation_id=133855650&pr_number=82&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F82&signature=778424957abe848f5774478baeff0e3beaf5709952aeaa0207e09eb91c0701c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `ghostty_surface_read_screen_text` to read full‑width text by an inclusive absolute screen row range, bypassing the visible-row clamp. This enables cmux copy‑mode to read scrollback rows directly (addresses Linear 6170).

- **New Features**
  - New C API: `bool ghostty_surface_read_screen_text(ghostty_surface_t, uint32_t top_y, uint32_t bottom_y, ghostty_text_s*)`.
  - Reads using absolute `.screen` coordinates and does not change the active selection.

<sup>Written for commit 46bd03a7dafb28302090c6f2a8e42513d2fed54c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/82?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added C API function to read full-width text directly from screen rows. Enables developers to efficiently retrieve terminal content from specified row ranges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->