### PR TITLE
Format screen-row clipboard text

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1227,6 +1227,14 @@ GHOSTTY_API bool ghostty_surface_read_screen_text(ghostty_surface_t,
                                                   uint32_t,
                                                   uint32_t,
                                                   ghostty_text_s*);
+// cmux fork: like ghostty_surface_read_screen_text, but returns the plain-text
+// clipboard formatter output for the selected rows. This preserves clipboard
+// trimming and codepoint-map settings for off-viewport copy-mode fallback
+// copies while avoiding active selection mutation.
+GHOSTTY_API bool ghostty_surface_read_screen_clipboard_text(ghostty_surface_t,
+                                                            uint32_t,
+                                                            uint32_t,
+                                                            ghostty_text_s*);
 GHOSTTY_API void ghostty_surface_free_text(ghostty_surface_t, ghostty_text_s*);
 
 #ifdef __APPLE__

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1770,6 +1770,34 @@ pub const CAPI = struct {
         return readTextLocked(surface, core_sel, result);
     }
 
+    /// cmux fork: read clipboard-formatted plain text from inclusive absolute
+    /// screen rows without mutating the active selection.
+    export fn ghostty_surface_read_screen_clipboard_text(
+        surface: *Surface,
+        top_y: u32,
+        bottom_y: u32,
+        result: *Text,
+    ) bool {
+        surface.core_surface.renderer_state.mutex.lock();
+        defer surface.core_surface.renderer_state.mutex.unlock();
+
+        if (top_y > bottom_y) return false;
+
+        const screen = surface.core_surface.renderer_state.terminal.screens.active;
+        const pages = &screen.pages;
+        if (pages.cols == 0) return false;
+
+        const top_left = pages.pin(.{
+            .screen = .{ .x = 0, .y = top_y },
+        }) orelse return false;
+        const bottom_right = pages.pin(.{
+            .screen = .{ .x = pages.cols -| 1, .y = bottom_y },
+        }) orelse return false;
+        const core_sel = terminal.Selection.init(top_left, bottom_right, false);
+
+        return readClipboardTextLocked(surface, core_sel, result);
+    }
+
     fn readTextLocked(
         surface: *Surface,
         core_sel: terminal.Selection,
@@ -1800,6 +1828,51 @@ pub const CAPI = struct {
             .offset_len = vp.offset_len,
             .text = text.text.ptr,
             .text_len = text.text.len,
+        };
+
+        return true;
+    }
+
+    fn readClipboardTextLocked(
+        surface: *Surface,
+        core_sel: terminal.Selection,
+        result: *Text,
+    ) bool {
+        const core_surface = &surface.core_surface;
+        const opts: terminal.formatter.Options = .{
+            .emit = .plain,
+            .unwrap = true,
+            .trim = core_surface.config.clipboard_trim_trailing_spaces,
+            .codepoint_map = core_surface.config.clipboard_codepoint_map.map.list,
+            .background = core_surface.io.terminal.colors.background.get(),
+            .foreground = core_surface.io.terminal.colors.foreground.get(),
+            .palette = &core_surface.io.terminal.colors.palette.current,
+        };
+
+        var formatter: terminal.formatter.ScreenFormatter = .init(
+            core_surface.io.terminal.screens.active,
+            opts,
+        );
+        formatter.content = .{ .selection = core_sel };
+
+        var writer: std.Io.Writer.Allocating = .init(global.alloc);
+        defer writer.deinit();
+        formatter.format(&writer.writer) catch |err| {
+            log.warn("error formatting clipboard text err={}", .{err});
+            return false;
+        };
+        const formatted = writer.toOwnedSliceSentinel(0) catch |err| {
+            log.warn("error allocating clipboard text err={}", .{err});
+            return false;
+        };
+
+        result.* = .{
+            .tl_px_x = -1,
+            .tl_px_y = -1,
+            .offset_start = 0,
+            .offset_len = 0,
+            .text = formatted.ptr,
+            .text_len = formatted.len,
         };
 
         return true;


### PR DESCRIPTION
Adds a formatter-backed embedded API for cmux off-viewport visual-line copy fallback. The new API reads absolute screen rows without mutating selection while applying Ghostty's plain clipboard formatting options, including trailing-space trimming and clipboard codepoint maps.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784680858&installation_id=133855650&pr_number=83&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F83&signature=d1be2628169322851901021b25b5c483b68667ebe35b7246e42b49887332cb79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `ghostty_surface_read_screen_clipboard_text`, a C API to read clipboard-formatted plain text for a range of absolute screen rows without changing the active selection. This keeps Ghostty’s trimming and codepoint-map behavior so off-viewport copies (cmux visual-line fallback) match normal clipboard output and supports Linear issue 6170.

- **New Features**
  - New API in `include/ghostty.h`; implemented in the embedded runtime.
  - Reads inclusive `top_y`/`bottom_y` rows and returns a `ghostty_text_s`; free with `ghostty_surface_free_text`.
  - Uses the formatter with `.emit = .plain`, respects `clipboard_trim_trailing_spaces` and `clipboard_codepoint_map`, and locks renderer state for safe reads.

<sup>Written for commit edad0cfecf2991d808aa22055dff1ad0cc3711a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/83?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

