### PR TITLE
Bound screen clipboard text formatting

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1230,10 +1230,12 @@ GHOSTTY_API bool ghostty_surface_read_screen_text(ghostty_surface_t,
 // cmux fork: like ghostty_surface_read_screen_text, but returns the plain-text
 // clipboard formatter output for the selected rows. This preserves clipboard
 // trimming and codepoint-map settings for off-viewport copy-mode fallback
-// copies while avoiding active selection mutation.
+// copies while avoiding active selection mutation. Formatting stops before
+// allocating more than max_bytes of output.
 GHOSTTY_API bool ghostty_surface_read_screen_clipboard_text(ghostty_surface_t,
                                                             uint32_t,
                                                             uint32_t,
+                                                            uintptr_t,
                                                             ghostty_text_s*);
 GHOSTTY_API void ghostty_surface_free_text(ghostty_surface_t, ghostty_text_s*);
 

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1776,6 +1776,7 @@ pub const CAPI = struct {
         surface: *Surface,
         top_y: u32,
         bottom_y: u32,
+        max_bytes: usize,
         result: *Text,
     ) bool {
         surface.core_surface.renderer_state.mutex.lock();
@@ -1795,7 +1796,7 @@ pub const CAPI = struct {
         }) orelse return false;
         const core_sel = terminal.Selection.init(top_left, bottom_right, false);
 
-        return readClipboardTextLocked(surface, core_sel, result);
+        return readClipboardTextLocked(surface, core_sel, max_bytes, result);
     }
 
     fn readTextLocked(
@@ -1836,6 +1837,7 @@ pub const CAPI = struct {
     fn readClipboardTextLocked(
         surface: *Surface,
         core_sel: terminal.Selection,
+        max_bytes: usize,
         result: *Text,
     ) bool {
         const core_surface = &surface.core_surface;
@@ -1855,13 +1857,18 @@ pub const CAPI = struct {
         );
         formatter.content = .{ .selection = core_sel };
 
-        var writer: std.Io.Writer.Allocating = .init(global.alloc);
-        defer writer.deinit();
-        formatter.format(&writer.writer) catch |err| {
+        const scratch = global.alloc.alloc(u8, max_bytes) catch |err| {
+            log.warn("error allocating bounded clipboard text buffer err={}", .{err});
+            return false;
+        };
+        defer global.alloc.free(scratch);
+
+        var writer = std.Io.Writer.fixed(scratch);
+        formatter.format(&writer) catch |err| {
             log.warn("error formatting clipboard text err={}", .{err});
             return false;
         };
-        const formatted = writer.toOwnedSliceSentinel(0) catch |err| {
+        const formatted = global.alloc.dupeZ(u8, writer.buffered()) catch |err| {
             log.warn("error allocating clipboard text err={}", .{err});
             return false;
         };


### PR DESCRIPTION
Bounds the embedded screen-row clipboard formatter with a caller-provided byte cap before allocating returned text, so cmux visual-line copy fallback cannot expand past its Swift cap via clipboard codepoint mappings.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784688705&installation_id=133855650&pr_number=84&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F84&signature=4a5e311a2d7729335c847add46fbcb03781b8e3ec109e4b520f3a6f8be1a5f1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds screen clipboard text formatting with a caller-provided byte cap to prevent oversized allocations and copy expansion from codepoint mappings. Addresses Linear issue 6170 by ensuring cmux visual-line copy fallback cannot exceed Swift clipboard limits.

- **Bug Fixes**
  - Add a `max_bytes` cap to `ghostty_surface_read_screen_clipboard_text`.
  - Write into a fixed-size buffer and duplicate the result to a NUL-terminated string.
  - Preserves trimming and codepoint-map behavior while enforcing the cap.

- **Migration**
  - Update calls to: `ghostty_surface_read_screen_clipboard_text(surface, top_y, bottom_y, max_bytes, &text)`.
  - Pass a cap aligned with your platform/pasteboard limit (e.g., the Swift cap) or a safe upper bound.

<sup>Written for commit e81fb65f6351eda2cfbe049ab30c761dfe31d46c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/84?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Clipboard text reading now enforces a configurable maximum output size limit, improving stability when processing large clipboard contents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->