### PR TITLE
Remove unbounded screen text export

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1220,18 +1220,10 @@ GHOSTTY_API bool ghostty_surface_read_selection(ghostty_surface_t, ghostty_text_
 GHOSTTY_API bool ghostty_surface_read_text(ghostty_surface_t,
                                               ghostty_selection_s,
                                               ghostty_text_s*);
-// cmux fork: read full-width text from inclusive absolute screen rows without
-// routing through ghostty_point_s, whose embedded wrapper clamps exact screen
-// y-coordinates to the visible active row count.
-GHOSTTY_API bool ghostty_surface_read_screen_text(ghostty_surface_t,
-                                                  uint32_t,
-                                                  uint32_t,
-                                                  ghostty_text_s*);
-// cmux fork: like ghostty_surface_read_screen_text, but returns the plain-text
-// clipboard formatter output for the selected rows. This preserves clipboard
-// trimming and codepoint-map settings for off-viewport copy-mode fallback
-// copies while avoiding active selection mutation. Formatting stops before
-// allocating more than max_bytes of output.
+// cmux fork: read clipboard-formatted plain text from inclusive absolute screen
+// rows without mutating the active selection. This preserves clipboard trimming
+// and codepoint-map settings for off-viewport copy-mode fallback copies.
+// Formatting stops before allocating more than max_bytes of output.
 GHOSTTY_API bool ghostty_surface_read_screen_clipboard_text(ghostty_surface_t,
                                                             uint32_t,
                                                             uint32_t,

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1741,35 +1741,6 @@ pub const CAPI = struct {
         return readTextLocked(surface, core_sel, result);
     }
 
-    /// cmux fork: read full-width text from inclusive absolute screen rows
-    /// without mutating the active selection. This bypasses Point.pin's visible
-    /// row clamp so embedders can read scrollback rows through screen coords.
-    export fn ghostty_surface_read_screen_text(
-        surface: *Surface,
-        top_y: u32,
-        bottom_y: u32,
-        result: *Text,
-    ) bool {
-        surface.core_surface.renderer_state.mutex.lock();
-        defer surface.core_surface.renderer_state.mutex.unlock();
-
-        if (top_y > bottom_y) return false;
-
-        const screen = surface.core_surface.renderer_state.terminal.screens.active;
-        const pages = &screen.pages;
-        if (pages.cols == 0) return false;
-
-        const top_left = pages.pin(.{
-            .screen = .{ .x = 0, .y = top_y },
-        }) orelse return false;
-        const bottom_right = pages.pin(.{
-            .screen = .{ .x = pages.cols -| 1, .y = bottom_y },
-        }) orelse return false;
-        const core_sel = terminal.Selection.init(top_left, bottom_right, false);
-
-        return readTextLocked(surface, core_sel, result);
-    }
-
     /// cmux fork: read clipboard-formatted plain text from inclusive absolute
     /// screen rows without mutating the active selection.
     export fn ghostty_surface_read_screen_clipboard_text(


### PR DESCRIPTION
## Summary
- remove the unused raw absolute screen-row text export
- keep the bounded clipboard text export used by cmux copy-mode

## Validation
- zig fmt src/apprt/embedded.zig
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784721036&installation_id=133855650&pr_number=85&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F85&signature=cb70c168a7794a879300e3a3b9db44cafea054801f4f8cf4e8742f3c4e7f6bad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the unused unbounded absolute screen-row text export `ghostty_surface_read_screen_text`, consolidating on the bounded clipboard-formatted export. Aligns with issue-6170 and preserves cmux copy-mode behavior for off-viewport copies.

- **Refactors**
  - Removed `ghostty_surface_read_screen_text` from `src/apprt/embedded.zig` and `include/ghostty.h`.
  - Retained `ghostty_surface_read_screen_clipboard_text` and clarified header docs (formatting, max_bytes).

<sup>Written for commit 681427bab98300f9cb015b1ac029cfff5c5a7aff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/85?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed deprecated screen text reading function from the API.
  * Enhanced clipboard text reading functionality with improved documentation and behavior specification, including byte limits and selection preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->