### PR TITLE
surface: track absolute screen row selections

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1216,6 +1216,14 @@ GHOSTTY_API bool ghostty_surface_has_selection(ghostty_surface_t);
 GHOSTTY_API bool ghostty_surface_select_cursor_cell(ghostty_surface_t);
 GHOSTTY_API bool ghostty_surface_select_cursor_line(ghostty_surface_t);
 GHOSTTY_API bool ghostty_surface_clear_selection(ghostty_surface_t);
+// cmux fork: set/query the active selection from inclusive absolute screen rows.
+// The setter updates Ghostty's tracked selection pins without writing clipboards.
+GHOSTTY_API bool ghostty_surface_select_screen_rows(ghostty_surface_t,
+                                                    uint32_t,
+                                                    uint32_t);
+GHOSTTY_API bool ghostty_surface_selection_screen_rows(ghostty_surface_t,
+                                                       uint32_t*,
+                                                       uint32_t*);
 GHOSTTY_API bool ghostty_surface_read_selection(ghostty_surface_t, ghostty_text_s*);
 GHOSTTY_API bool ghostty_surface_read_text(ghostty_surface_t,
                                               ghostty_selection_s,

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -2167,6 +2167,51 @@ pub fn clearSelection(self: *Surface) !bool {
     return true;
 }
 
+/// Select inclusive absolute screen rows without writing copy-on-select
+/// clipboards.
+pub fn selectScreenRows(self: *Surface, top_y: u32, bottom_y: u32) !bool {
+    self.renderer_state.mutex.lock();
+    defer self.renderer_state.mutex.unlock();
+
+    if (top_y > bottom_y) return false;
+
+    const screen: *terminal.Screen = self.io.terminal.screens.active;
+    const pages = &screen.pages;
+    if (pages.cols == 0) return false;
+
+    const top_left = pages.pin(.{
+        .screen = .{ .x = 0, .y = top_y },
+    }) orelse return false;
+    const bottom_right = pages.pin(.{
+        .screen = .{ .x = pages.cols -| 1, .y = bottom_y },
+    }) orelse return false;
+
+    try screen.select(terminal.Selection.init(top_left, bottom_right, false));
+    screen.dirty.selection = true;
+    try self.queueRender();
+    return true;
+}
+
+/// Query the active tracked selection as inclusive absolute screen rows.
+pub fn selectionScreenRows(self: *Surface, top_y: *u32, bottom_y: *u32) bool {
+    self.renderer_state.mutex.lock();
+    defer self.renderer_state.mutex.unlock();
+
+    const screen: *terminal.Screen = self.io.terminal.screens.active;
+    const selection = screen.selection orelse return false;
+    const start = selection.start();
+    const end = selection.end();
+    if (start.garbage and end.garbage) return false;
+
+    const top_left = selection.topLeft(screen);
+    const bottom_right = selection.bottomRight(screen);
+    const top = screen.pages.pointFromPin(.screen, top_left) orelse return false;
+    const bottom = screen.pages.pointFromPin(.screen, bottom_right) orelse return false;
+    top_y.* = top.screen.y;
+    bottom_y.* = bottom.screen.y;
+    return true;
+}
+
 /// Returns the pwd of the terminal, if any. This is always copied because
 /// the pwd can change at any point from termio. If we are calling from the IO
 /// thread you should just check the terminal directly.
@@ -6183,8 +6228,8 @@ const WriteScreenLoc = enum {
     history, // History (scrollback)
     selection, // Selected text
     active, // Just the active area (no history). Used by the cmux mobile
-            // snapshot path to emit ANSI-styled rows that line up with the
-            // POINT_ACTIVE plain text the iOS render compares against.
+    // snapshot path to emit ANSI-styled rows that line up with the
+    // POINT_ACTIVE plain text the iOS render compares against.
 };
 
 fn writeScreenFile(

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1704,6 +1704,29 @@ pub const CAPI = struct {
         };
     }
 
+    /// Select inclusive absolute screen rows without writing clipboards
+    /// (cmux-specific).
+    export fn ghostty_surface_select_screen_rows(
+        surface: *Surface,
+        top_y: u32,
+        bottom_y: u32,
+    ) bool {
+        return surface.core_surface.selectScreenRows(top_y, bottom_y) catch |err| {
+            log.warn("error selecting screen rows err={}", .{err});
+            return false;
+        };
+    }
+
+    /// Query the active tracked selection as inclusive absolute screen rows
+    /// (cmux-specific).
+    export fn ghostty_surface_selection_screen_rows(
+        surface: *Surface,
+        top_y: *u32,
+        bottom_y: *u32,
+    ) bool {
+        return surface.core_surface.selectionScreenRows(top_y, bottom_y);
+    }
+
     /// Same as ghostty_surface_read_text but reads from the user selection,
     /// if any.
     export fn ghostty_surface_read_selection(


### PR DESCRIPTION
Adds cmux fork C APIs to set and query active selections by inclusive absolute screen rows while keeping the selection in Ghostty tracked pins. cmux keyboard visual-line copy mode uses this so scrollback pruning can clip/move the active selection before copy reads it, without writing copy-on-select clipboards during intermediate keyboard selection updates.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784726704&installation_id=133855650&pr_number=86&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F86&signature=cc3e16fb7388075821b2afc67113de2715e7ca2497af26ce976dc12890582dcd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds C APIs to select and query selections by inclusive absolute screen rows, keeping Ghostty’s selection pinned without writing clipboards. This supports issue 6170 by letting cmux visual-line copy survive scrollback pruning before the copy reads the selection.

- **New Features**
  - `ghostty_surface_select_screen_rows(top_y, bottom_y)` selects rows and queues a render without copy-on-select side effects.
  - `ghostty_surface_selection_screen_rows(*top_y, *bottom_y)` returns the active selection’s inclusive row range.
  - Uses Ghostty’s tracked pins so scrollback pruning can clip/move the selection safely.
  - Validates input (top ≤ bottom, non-zero cols); returns false on invalid cases.

<sup>Written for commit 4a685586814523af09046a663cdef0a31e6577af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/86?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new selection API functions to query and modify text selection by screen row coordinates. These enable external applications and plugins to programmatically interact with terminal selection state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->