### PR TITLE
Avoid blocking iOS surface mailbox during stream handling

### DIFF
--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -130,9 +130,26 @@ pub const StreamHandler = struct {
         // See messageWriter which has similar logic and explains why
         // we may have to do this.
         if (self.surface_mailbox.push(msg, .{ .instant = {} }) == 0) {
+            if (comptime builtin.os.tag == .ios) {
+                self.deinitDroppedSurfaceMessage(msg);
+                return;
+            }
             self.renderer_state.mutex.unlock();
             defer self.renderer_state.mutex.lock();
             _ = self.surface_mailbox.push(msg, .{ .forever = {} });
+        }
+    }
+
+    inline fn deinitDroppedSurfaceMessage(
+        self: *StreamHandler,
+        msg: apprt.surface.Message,
+    ) void {
+        _ = self;
+        switch (msg) {
+            .clipboard_write => |w| w.req.deinit(),
+            .pwd_change => |w| w.deinit(),
+            .tmux_control => |w| w.data.deinit(),
+            else => {},
         }
     }
 


### PR DESCRIPTION
Pins the Ghostty-side part of the cmux iOS render-stall fix.\n\nChanges:\n- On iOS, avoid falling back to a forever mailbox push when the surface mailbox is saturated.\n- Deinitialize owned payloads for dropped surface messages to avoid leaks.\n\nParent cmux PR: https://github.com/manaflow-ai/cmux/pull/6543

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784942488&installation_id=133855650&pr_number=87&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F87&signature=babafd757c5504580994e1e0b6f5cd0637bcea81b2e57b7500d5c3204064296d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Avoids render stalls on iOS by not blocking when the surface mailbox is full; instead, we drop the message and deinit its owned payloads to prevent leaks. Aligns with the parent `cmux` fix: https://github.com/manaflow-ai/cmux/pull/6543

- **Bug Fixes**
  - Clean up dropped surface messages by deiniting `clipboard_write.req`, `pwd_change`, and `tmux_control.data`.

<sup>Written for commit 0b1cb1d3b624cfaa47e8596ab61dd7e7a2dae3b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/87?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

