### PR TITLE
Split render-grid nontrivial cells into own spans

### DIFF
--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -2102,6 +2102,10 @@ pub const CAPI = struct {
         }
     }
 
+    fn renderGridCellNeedsOwnSpan(cell: *const terminal.Cell) bool {
+        return cell.gridWidth() != 1 or cell.hasGrapheme();
+    }
+
     fn writeRenderGridColor(
         jw: *std.json.Stringify,
         color: terminal.color.RGB,
@@ -2267,6 +2271,8 @@ pub const CAPI = struct {
                         continue;
                     }
 
+                    const owns_span = has_text and renderGridCellNeedsOwnSpan(cell);
+                    if (owns_span) try builder.close();
                     try builder.ensure(out_row, @intCast(x), style_id);
                     if (has_text) {
                         try appendRenderGridCellText(builder, p, cell);
@@ -2275,6 +2281,7 @@ pub const CAPI = struct {
                         try builder.text.writer.writeByte(' ');
                         builder.appendCellWidth(1);
                     }
+                    if (owns_span) try builder.close();
                 }
                 try builder.close();
                 if (in_viewport) {


### PR DESCRIPTION
## Summary\n- split render-grid spans around wide/grapheme-backed cells\n- preserve exact producer columns and cell widths for mobile replay\n\n## Context\nNeeded by manaflow-ai/cmux#7115 to avoid iOS inferring per-grapheme columns from aggregate span cell_width.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785442761&installation_id=133855650&pr_number=89&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F89&signature=492f8ecec8563cde32a3b87a60a75d33a5141ad4084abef9293ef2f488c2d8b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split render-grid spans so wide or grapheme-backed cells render in their own spans. This preserves exact cell widths and producer column positions for mobile replay, avoiding iOS per-grapheme column inference (needed by manaflow-ai/cmux#7115).

- **Bug Fixes**
  - For cells where `gridWidth() != 1` or `hasGrapheme()`, close the current span, write the cell, then close again to isolate the span.

<sup>Written for commit 79b5bb6eed3ef77ab9a96dab0c7fc91c1fd40805. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/89?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved embedded terminal rendering so cells with wider widths or special characters are kept separate instead of being merged together.
  * Fixed grid export behavior to produce cleaner, more accurate row grouping in affected terminal output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->