### PR TITLE
Avoid blocking iOS surface mailbox writes

### DIFF
--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -130,9 +130,36 @@ pub const StreamHandler = struct {
         // See messageWriter which has similar logic and explains why
         // we may have to do this.
         if (self.surface_mailbox.push(msg, .{ .instant = {} }) == 0) {
+            // cmux iOS fork: on iOS the app/surface mailbox is drained by the
+            // embedder's main-thread `ghostty_app_tick`, while this writer can
+            // run inside `ghostty_surface_process_output` on the same Swift serial
+            // queue that owns `render_now` and text reads. A `.forever` push here
+            // can therefore park the only local surface queue behind a mailbox
+            // that a busy main actor has not drained yet. The phone keeps
+            // forwarding scroll to the Mac, but local render/snapshot work queued
+            // behind this call never runs. Surface messages emitted from the VT
+            // stream are UI side effects (title, cwd, color notification, bell,
+            // progress); under mailbox saturation they are less important than
+            // preserving terminal render liveness. Drop on full and free any
+            // owned payload, matching the existing iOS nonblocking renderer
+            // mailbox invariant.
+            if (comptime builtin.os.tag == .ios) {
+                var dropped = msg;
+                deinitDroppedSurfaceMessage(&dropped);
+                return;
+            }
             self.renderer_state.mutex.unlock();
             defer self.renderer_state.mutex.lock();
             _ = self.surface_mailbox.push(msg, .{ .forever = {} });
+        }
+    }
+
+    fn deinitDroppedSurfaceMessage(msg: *apprt.surface.Message) void {
+        switch (msg.*) {
+            .pwd_change => |*w| w.deinit(),
+            .clipboard_write => |*w| w.req.deinit(),
+            .tmux_control => |*v| v.data.deinit(),
+            else => {},
         }
     }
 


### PR DESCRIPTION
## Summary
- Keep iOS surface output processing nonblocking when the app/surface mailbox is saturated.
- Drop lossy UI side-effect messages on iOS instead of parking the Ghostty surface queue behind ghostty_app_tick.
- Free owned payloads for dropped pwd, clipboard, and tmux-control messages.

## Verification
- Built GhosttyKit with `zig build -Demit-xcframework=true -Dxcframework-target=universal -Doptimize=ReleaseFast` from cmux.
- cmux iOS XCUITest: `testScrollForwardingDoesNotOutliveLocalRenderLiveness` passed after the parent cmux harness reproduced the pre-fix busy snapshot state.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785474823&installation_id=133855650&pr_number=90&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F90&signature=03f8af436e294ddacded6dfe19230041dac5e9d5811e64ab42a22c1f061edde7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep iOS surface output nonblocking when the app/surface mailbox is saturated to avoid parking the surface queue behind `ghostty_app_tick`. This preserves render and snapshot liveness on a busy main thread.

- **Bug Fixes**
  - On iOS, drop UI side-effect surface messages when the mailbox is full instead of blocking.
  - Deinit payloads for dropped messages: `pwd_change`, `clipboard_write`, and `tmux_control`.

<sup>Written for commit 95fa65e65bb4954045adeed9bd85807d399b4af6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/90?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message delivery handling when the queue is full on iOS, preventing unnecessary retries.
  * Ensured any pending message data is released before dropped messages are discarded, reducing leak risk.
  * Kept existing behavior unchanged on non-iOS platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->