### PR TITLE
lib-vt: answer OSC 4/10/11/12 color queries via write_pty

### DIFF
--- a/src/terminal/stream_terminal.zig
+++ b/src/terminal/stream_terminal.zig
@@ -9,6 +9,7 @@ const stream = @import("stream.zig");
 const Action = stream.Action;
 const Screen = @import("Screen.zig");
 const modes = @import("modes.zig");
+const osc = @import("osc.zig");
 const osc_color = @import("osc/parsers/color.zig");
 const kitty_color = @import("kitty/color.zig");
 const size_report = @import("size_report.zig");
@@ -233,7 +234,7 @@ pub const Handler = struct {
             .end_hyperlink => self.terminal.screens.active.endHyperlink(),
             .semantic_prompt => try self.terminal.semanticPrompt(value),
             .mouse_shape => self.terminal.mouse_shape = value,
-            .color_operation => try self.colorOperation(value.op, &value.requests),
+            .color_operation => try self.colorOperation(value.op, &value.requests, value.terminator),
             .kitty_color_report => try self.kittyColorOperation(value),
 
             // APC
@@ -552,6 +553,7 @@ pub const Handler = struct {
         self: *Handler,
         op: osc_color.Operation,
         requests: *const osc_color.List,
+        terminator: osc.Terminator,
     ) !void {
         _ = op;
         if (requests.count() == 0) return;
@@ -613,11 +615,71 @@ pub const Handler = struct {
                     mask.* = .initEmpty();
                 },
 
-                .query,
-                .reset_special,
-                => {},
+                .query => |kind| self.reportColorQuery(kind, terminator),
+
+                .reset_special => {},
             }
         }
+    }
+
+    fn reportColorQuery(
+        self: *Handler,
+        kind: osc_color.Target,
+        terminator: osc.Terminator,
+    ) void {
+        if (self.effects.write_pty == null) return;
+
+        const color = switch (kind) {
+            .palette => |i| self.terminal.colors.palette.current[i],
+            .dynamic => |dynamic| switch (dynamic) {
+                .foreground => self.terminal.colors.foreground.get() orelse return,
+                .background => self.terminal.colors.background.get() orelse return,
+                .cursor => self.terminal.colors.cursor.get() orelse
+                    self.terminal.colors.foreground.get() orelse return,
+                .pointer_foreground,
+                .pointer_background,
+                .tektronix_foreground,
+                .tektronix_background,
+                .highlight_background,
+                .tektronix_cursor,
+                .highlight_foreground,
+                => return,
+            },
+            .special => return,
+        };
+
+        var stack = std.heap.stackFallback(128, self.terminal.gpa());
+        const alloc = stack.get();
+
+        var aw: std.Io.Writer.Allocating = .init(alloc);
+        defer aw.deinit();
+
+        switch (kind) {
+            .palette => |i| aw.writer.print(
+                "\x1b]4;{d};rgb:{x:0>4}/{x:0>4}/{x:0>4}",
+                .{
+                    i,
+                    @as(u16, color.r) * 257,
+                    @as(u16, color.g) * 257,
+                    @as(u16, color.b) * 257,
+                },
+            ) catch return,
+            .dynamic => |dynamic| aw.writer.print(
+                "\x1b]{d};rgb:{x:0>4}/{x:0>4}/{x:0>4}",
+                .{
+                    @intFromEnum(dynamic),
+                    @as(u16, color.r) * 257,
+                    @as(u16, color.g) * 257,
+                    @as(u16, color.b) * 257,
+                },
+            ) catch return,
+            .special => unreachable,
+        }
+        aw.writer.writeAll(terminator.string()) catch return;
+
+        const resp = aw.toOwnedSliceSentinel(0) catch return;
+        defer alloc.free(resp);
+        self.writePty(resp);
     }
 
     fn kittyColorOperation(
@@ -1037,6 +1099,150 @@ test "OSC 12 set and reset cursor color" {
     // Reset cursor
     s.nextSlice("\x1b]112\x1b\\");
     // After reset, cursor might be null (using default)
+}
+
+test "OSC 11 query without default writes no response" {
+    var t: Terminal = try .init(testing.allocator, .{ .cols = 10, .rows = 10 });
+    defer t.deinit(testing.allocator);
+
+    const S = struct {
+        var buf: [1024]u8 = undefined;
+        var len: usize = 0;
+
+        fn writePty(_: *Handler, data: [:0]const u8) void {
+            @memcpy(buf[len..][0..data.len], data);
+            len += data.len;
+        }
+    };
+    S.len = 0;
+
+    var handler: Handler = .init(&t);
+    handler.effects.write_pty = &S.writePty;
+
+    var s: Stream = .initAlloc(testing.allocator, handler);
+    defer s.deinit();
+
+    s.nextSlice("\x1b]11;?\x07");
+    try testing.expectEqual(@as(usize, 0), S.len);
+}
+
+test "OSC 11 query reports default background with query terminator" {
+    var t: Terminal = try .init(testing.allocator, .{ .cols = 10, .rows = 10 });
+    defer t.deinit(testing.allocator);
+
+    t.colors.background.default = .{ .r = 0x13, .g = 0x14, .b = 0x15 };
+
+    const S = struct {
+        var buf: [1024]u8 = undefined;
+        var len: usize = 0;
+
+        fn reset() void {
+            len = 0;
+        }
+
+        fn written() []const u8 {
+            return buf[0..len];
+        }
+
+        fn writePty(_: *Handler, data: [:0]const u8) void {
+            @memcpy(buf[len..][0..data.len], data);
+            len += data.len;
+        }
+    };
+    S.reset();
+
+    var handler: Handler = .init(&t);
+    handler.effects.write_pty = &S.writePty;
+
+    var s: Stream = .initAlloc(testing.allocator, handler);
+    defer s.deinit();
+
+    s.nextSlice("\x1b]11;?\x07");
+    try testing.expectEqualStrings("\x1b]11;rgb:1313/1414/1515\x07", S.written());
+
+    S.reset();
+    s.nextSlice("\x1b]11;?\x1b\\");
+    try testing.expectEqualStrings("\x1b]11;rgb:1313/1414/1515\x1b\\", S.written());
+}
+
+test "OSC 4 palette query reports current palette color" {
+    var t: Terminal = try .init(testing.allocator, .{ .cols = 10, .rows = 10 });
+    defer t.deinit(testing.allocator);
+
+    const S = struct {
+        var buf: [1024]u8 = undefined;
+        var len: usize = 0;
+
+        fn written() []const u8 {
+            return buf[0..len];
+        }
+
+        fn writePty(_: *Handler, data: [:0]const u8) void {
+            @memcpy(buf[len..][0..data.len], data);
+            len += data.len;
+        }
+    };
+    S.len = 0;
+
+    var handler: Handler = .init(&t);
+    handler.effects.write_pty = &S.writePty;
+
+    var s: Stream = .initAlloc(testing.allocator, handler);
+    defer s.deinit();
+
+    s.nextSlice("\x1b]4;1;?\x07");
+    const color = t.colors.palette.current[1];
+    var expected_buf: [64]u8 = undefined;
+    const expected = try std.fmt.bufPrint(
+        &expected_buf,
+        "\x1b]4;1;rgb:{x:0>4}/{x:0>4}/{x:0>4}\x07",
+        .{
+            @as(u16, color.r) * 257,
+            @as(u16, color.g) * 257,
+            @as(u16, color.b) * 257,
+        },
+    );
+    try testing.expectEqualStrings(expected, S.written());
+}
+
+test "OSC 10 query reports override and OSC 12 falls back to foreground" {
+    var t: Terminal = try .init(testing.allocator, .{ .cols = 10, .rows = 10 });
+    defer t.deinit(testing.allocator);
+
+    t.colors.foreground.default = .{ .r = 0x01, .g = 0x02, .b = 0x03 };
+
+    const S = struct {
+        var buf: [1024]u8 = undefined;
+        var len: usize = 0;
+
+        fn reset() void {
+            len = 0;
+        }
+
+        fn written() []const u8 {
+            return buf[0..len];
+        }
+
+        fn writePty(_: *Handler, data: [:0]const u8) void {
+            @memcpy(buf[len..][0..data.len], data);
+            len += data.len;
+        }
+    };
+    S.reset();
+
+    var handler: Handler = .init(&t);
+    handler.effects.write_pty = &S.writePty;
+
+    var s: Stream = .initAlloc(testing.allocator, handler);
+    defer s.deinit();
+
+    s.nextSlice("\x1b]10;rgb:20/40/60\x07");
+    s.nextSlice("\x1b]10;?\x07");
+    try testing.expectEqualStrings("\x1b]10;rgb:2020/4040/6060\x07", S.written());
+
+    S.reset();
+    s.nextSlice("\x1b]12;?\x07");
+    try testing.expectEqualStrings("\x1b]12;rgb:2020/4040/6060\x07", S.written());
 }
 
 test "kitty color protocol set palette" {


### PR DESCRIPTION
The terminal-attached stream handler parsed OSC color queries but dropped them (`.query => {}`), so programs inside libghostty-vt embedders never learned the terminal's colors. Codex's TUI derives its user-message background from the OSC 11 reply and rendered no background inside cmux-mux, while tmux and zellij both answer.

Replies use the xterm 16-bit `rgb:` format through the existing write_pty effect, echoing the query's own terminator (BEL or ST). Palette queries answer from the current palette; dynamic fg/bg answer only when an override or host-set default (`GHOSTTY_TERMINAL_OPT_COLOR_*`) exists; cursor falls back to foreground; unknown colors stay silent. Byte-exact zig tests cover set-then-query, default-then-query, no-default silence, and BEL vs ST.

Consumed by manaflow-ai/cmux PR https://github.com/manaflow-ai/cmux/pull/7180 (mux TUI seeds these defaults from the host terminal at startup). Upstreamable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785740031&installation_id=133855650&pr_number=92&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F92&signature=4fd0d0d6c72972e261a3c3b381cfac9c5e469a04dc4f0cfff44ac276ef297e52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Answer OSC 4/10/11/12 color queries via write_pty, returning xterm 16-bit rgb: values and preserving the query terminator. This lets apps inside lib-vt embedders learn terminal colors (e.g., no more missing backgrounds in TUIs).

- New Features
  - Reply to OSC 4 (palette), 10 (foreground), 11 (background), 12 (cursor) using `rgb:RRRR/GGGG/BBBB`, echoing BEL or ST.
  - Sources: palette from current palette; dynamic fg/bg only if override or default exists; cursor falls back to foreground; unknown targets stay silent. 
  - Added byte-exact tests for set-then-query, default-then-query, no-default silence, and BEL vs ST.

<sup>Written for commit a78fe53efaaea56b80d47569d85e0d7b76512aa7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/92?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal color query responses to use the correct OSC terminator and return the expected result for palette and dynamic color queries.
  * Added fallback behavior so foreground-related queries resolve more consistently when specific colors are unavailable.
  * Suppressed background query responses when no default background is set.

* **Tests**
  * Added coverage for color query handling, including different terminators and fallback cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->