### PR TITLE
font: guard null CTFontCopyDisplayName in DeferredFace.name

### DIFF
--- a/pkg/macos/text/font.zig
+++ b/pkg/macos/text/font.zig
@@ -156,7 +156,7 @@ pub const Font = opaque {
         return @ptrFromInt(@intFromPtr(c.CTFontCopyFamilyName(@ptrCast(self))));
     }
 
-    pub fn copyDisplayName(self: *Font) *foundation.String {
+    pub fn copyDisplayName(self: *Font) ?*foundation.String {
         return @ptrFromInt(@intFromPtr(c.CTFontCopyDisplayName(@ptrCast(self))));
     }
 

--- a/src/font/DeferredFace.zig
+++ b/src/font/DeferredFace.zig
@@ -184,7 +184,13 @@ pub fn name(self: DeferredFace, buf: []u8) ![]const u8 {
         .coretext_harfbuzz,
         .coretext_noshape,
         => if (self.ct) |ct| {
-            const display_name = ct.font.copyDisplayName();
+            const display_name = ct.font.copyDisplayName() orelse {
+                log.warn("CoreText display name unavailable font_ptr=0x{x} variations={}", .{
+                    @intFromPtr(ct.font),
+                    ct.variations.len,
+                });
+                return "";
+            };
             return display_name.cstringPtr(.utf8) orelse unsupported: {
                 // "NULL if the internal storage of theString does not allow
                 // this to be returned efficiently." In this case, we need


### PR DESCRIPTION
CTFontCopyDisplayName can return NULL; the `@ptrFromInt(@intFromPtr(...))` laundering turned that into a non-optional pointer at address 0, and the subsequent CFStringGetCStringPtr deref crashed with EXC_BAD_ACCESS (Sentry CMUXTERM-MACOS-1C0Z, https://github.com/manaflow-ai/cmux/issues/7312).

`copyDisplayName` now returns an optional and `DeferredFace.name` falls back to an empty name with a warning log. The only non-test caller is the CoreText branch of `DeferredFace.name`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785752579&installation_id=133855650&pr_number=94&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F94&signature=5dddde68597607a5c5a1e1cc56b447b90dbb7e54c6d1a17dd17cff9b75c0bd2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a macOS crash in the CoreText path when CTFontCopyDisplayName returns NULL. copyDisplayName now returns an optional; DeferredFace.name logs a warning and falls back to an empty string to prevent EXC_BAD_ACCESS.

- **Bug Fixes**
  - Make Font.copyDisplayName return an optional to reflect possible NULL from CoreText.
  - In DeferredFace.name, guard NULL, warn, and return an empty name instead of dereferencing.

<sup>Written for commit 64c9c97c69400d3afa592bcaeb4c0f8e37324240. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/94?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when a font display name is unavailable, preventing unexpected failures.
  * Added a fallback to return an empty font name and log a warning when no display name can be retrieved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->