### PR TITLE
fix: support OpenGL renderer in Linux lib (embedded) builds

### DIFF
--- a/src/build/SharedDeps.zig
+++ b/src/build/SharedDeps.zig
@@ -599,7 +599,8 @@ pub fn add(
     // A Linux lib (embedded libghostty for cmux) uses the OpenGL renderer,
     // so it needs glad statically compiled just like the exe does.
     const needs_glad = step.kind != .lib or
-        (step.rootModuleTarget().os.tag == .linux);
+        (step.rootModuleTarget().os.tag == .linux and
+        self.config.renderer == .opengl);
     if (needs_glad) {
         // We always statically compile glad
         step.addIncludePath(b.path("vendor/glad/include/"));

--- a/src/build/SharedDeps.zig
+++ b/src/build/SharedDeps.zig
@@ -596,14 +596,21 @@ pub fn add(
         }
     }
 
-    // If we're building an exe then we have additional dependencies.
-    if (step.kind != .lib) {
+    // A Linux lib (embedded libghostty for cmux) uses the OpenGL renderer,
+    // so it needs glad statically compiled just like the exe does.
+    const needs_glad = step.kind != .lib or
+        (step.rootModuleTarget().os.tag == .linux);
+    if (needs_glad) {
         // We always statically compile glad
         step.addIncludePath(b.path("vendor/glad/include/"));
         step.addCSourceFile(.{
             .file = b.path("vendor/glad/src/gl.c"),
             .flags = &.{},
         });
+    }
+
+    // If we're building an exe then we have additional dependencies.
+    if (step.kind != .lib) {
 
         // When we're targeting flatpak we ALWAYS link GTK so we
         // get access to glib for dbus.

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -238,14 +238,17 @@ pub fn displayRealized(self: *const OpenGL) void {
     _ = self;
 
     switch (apprt.runtime) {
-        apprt.gtk => prepareContext(null) catch |err| {
+        // embedded: a Linux libghostty host (e.g. cmux) realizes the GL
+        // display and makes the context current before invoking us — same
+        // contract as the GTK apprt.
+        apprt.gtk, apprt.embedded => prepareContext(null) catch |err| {
             log.warn(
                 "Error preparing GL context in displayRealized, err={}",
                 .{err},
             );
         },
 
-        else => @compileError("only GTK should be calling displayRealized"),
+        else => @compileError("only GTK or embedded should be calling displayRealized"),
     }
 }
 


### PR DESCRIPTION
Building libghostty on Linux with -Dapp-runtime=none previously failed:

- glad was only compiled into non-lib artifacts, leaving
  gladLoaderLoadGLContext/gladLoaderUnloadGLContext undefined in the
  shared lib. Compile glad for Linux lib artifacts too.
- renderer/OpenGL.zig displayRealized had a comptime guard allowing only
  the GTK apprt. Allow the embedded apprt with the same contract: the
  host realizes the GL display and makes the context current before
  calling in.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786168014&installation_id=133855650&pr_number=95&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F95&signature=d6b5a49158d8be97fa4d55106a302a8f303b192fa5c7bc94fd4e1bc78b0b6fe3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes OpenGL renderer support for Linux embedded `libghostty` builds. Compiles `glad` for Linux lib targets when using the OpenGL renderer and lets the embedded runtime call `displayRealized` with the same GL-context contract as GTK.

- **Bug Fixes**
  - Compile `glad` into Linux lib artifacts on Linux when renderer is `.opengl` to provide `gladLoader*` symbols.
  - Allow `apprt.embedded` in `renderer/OpenGL.zig` so hosts pre-create and bind the GL context before calling in.

<sup>Written for commit 99256d2866d1938ba127075c31980e9b35f899f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/95?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OpenGL rendering is now supported in embedded Linux builds in addition to the standard desktop app.
  * The app prepares the graphics context during display setup for both runtime modes.

* **Bug Fixes**
  * Improved build behavior to include required OpenGL/GL loader sources only when needed, including for Linux library builds.
  * Updated runtime handling to accept both GTK and embedded callers, avoiding invalid-caller errors during display realization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->