### PR TITLE
renderer: preserve terminal input for custom shaders

### DIFF
--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -58,7 +58,8 @@ const BackgroundSourceOptions = struct {
 fn resolveBackgroundSource(options: BackgroundSourceOptions) BackgroundSource {
     if (!options.is_macos or
         !options.macos_background_from_layer or
-        options.has_background_image)
+        options.has_background_image or
+        options.has_custom_shaders)
     {
         return .renderer;
     }
@@ -1490,11 +1491,9 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 // zero bg_color alpha so that per-cell backgrounds in the
                 // shaders composite to transparent instead of the terminal
                 // background (the host layer provides the background).
-                // When a background image is active, keep bg_color alpha so
-                // the bg_image shader can composite and opacity-scale it.
-                // The fullscreen background color draw call is still skipped
-                // for layer-background mode when no image is present (see
-                // the draw pass below).
+                // Background images and custom shaders need a complete
+                // renderer-owned frame, so they keep bg_color alpha and the
+                // fullscreen background draw (see the draw pass below).
                 if (comptime builtin.os.tag == .macos) {
                     switch (self.config.background_blur) {
                         .@"macos-glass-regular",
@@ -1710,8 +1709,8 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 //
                 // When the host app provides the plain background via a
                 // CALayer (macos_background_from_layer), skip only the
-                // fullscreen color fill — background images still need to
-                // be rendered by Ghostty.
+                // fullscreen color fill. Background images and custom
+                // shaders still require a complete renderer-owned frame.
                 //
                 // NOTE: We don't use the clear_color for this because that
                 //       would require us to do color space conversion on the

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -43,6 +43,29 @@ const DisplayLink = switch (builtin.os.tag) {
 
 const log = std.log.scoped(.generic_renderer);
 
+const BackgroundSource = enum {
+    renderer,
+    host_layer,
+};
+
+const BackgroundSourceOptions = struct {
+    is_macos: bool,
+    macos_background_from_layer: bool,
+    has_background_image: bool,
+    has_custom_shaders: bool,
+};
+
+fn resolveBackgroundSource(options: BackgroundSourceOptions) BackgroundSource {
+    if (!options.is_macos or
+        !options.macos_background_from_layer or
+        options.has_background_image)
+    {
+        return .renderer;
+    }
+
+    return .host_layer;
+}
+
 fn advanceShaperCellIndexToX(
     run_offset: usize,
     shaped_cells: []const font.shape.Cell,
@@ -894,6 +917,15 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             self.shaders.deinit(self.alloc);
         }
 
+        fn backgroundSource(self: *const Self) BackgroundSource {
+            return resolveBackgroundSource(.{
+                .is_macos = builtin.os.tag == .macos,
+                .macos_background_from_layer = self.config.macos_background_from_layer,
+                .has_background_image = self.config.bg_image != null,
+                .has_custom_shaders = self.has_custom_shaders,
+            });
+        }
+
         fn initShaders(self: *Self) !void {
             var arena = ArenaAllocator.init(self.alloc);
             defer arena.deinit();
@@ -1471,7 +1503,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
 
                         else => {},
                     }
-                    if (self.config.macos_background_from_layer and self.config.bg_image == null)
+                    if (self.backgroundSource() == .host_layer)
                         self.uniforms.bg_color[3] = 0;
                 }
 
@@ -1685,10 +1717,6 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 //       would require us to do color space conversion on the
                 //       CPU-side. In the future when we have utilities for
                 //       that we should remove this step and use clear_color.
-                const skip_bg_fill = if (comptime builtin.os.tag == .macos)
-                    self.config.macos_background_from_layer
-                else
-                    false;
                 if (self.bg_image) |img| switch (img) {
                     .ready => |texture| pass.step(.{
                         .pipeline = self.shaders.pipelines.bg_image,
@@ -1699,7 +1727,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                     }),
                     else => {},
                 } else {
-                    if (!skip_bg_fill) {
+                    if (self.backgroundSource() == .renderer) {
                         pass.step(.{
                             .pipeline = self.shaders.pipelines.bg_color,
                             .uniforms = frame.uniforms.buffer,
@@ -3485,4 +3513,15 @@ test "renderer rebuild row preedit catch-up tolerates empty tail after covered g
     );
 
     try testing.expectEqual(@as(usize, shaped_cells.len), shaper_cells_i);
+}
+
+test "custom shaders require renderer-owned background" {
+    const testing = std.testing;
+
+    try testing.expectEqual(BackgroundSource.renderer, resolveBackgroundSource(.{
+        .is_macos = true,
+        .macos_background_from_layer = true,
+        .has_background_image = false,
+        .has_custom_shaders = true,
+    }));
 }


### PR DESCRIPTION
## Summary

- centralize whether terminal background pixels come from the renderer or the macOS host layer
- require renderer-owned background pixels whenever custom postprocess shaders are active
- keep background images on the same renderer-owned path

## Root cause

cmux enables the fork-only `macos-background-from-layer` optimization. That zeroed the renderer background alpha and skipped the full-screen background draw even when the terminal was first rendered into the custom-shader input texture. The Metal pass still bound that texture at slot 0, but it contained only a partial transparent frame; common Shadertoy shaders interpreted the missing terminal background as black.

The renderer now has one background-source decision shared by both alpha setup and draw emission. A custom shader makes the background renderer-owned, so `iChannel0` receives the same complete terminal frame expected by Ghostty custom shaders.

## Test

- Regression commit `36018260f`: focused test fails 1/66 (`expected renderer, found host_layer`)
- Fix commit `5ed1936fd`: `zig build test -Demit-macos-app=false -Dtest-filter='custom shaders require renderer-owned background'` passes

Related cmux issue: manaflow-ai/cmux#7720

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786229163&installation_id=133855650&pr_number=97&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F97&signature=68f507385dc1a46659671395b74951cf8cb1556ea148ff18e1bba8b003b214ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure the renderer always supplies the terminal background when custom shaders are active, fixing black backgrounds on macOS. Background images now follow the same renderer-owned path for a complete frame to `iChannel0`.

- **Bug Fixes**
  - Centralized background-source logic with `BackgroundSource`, `resolveBackgroundSource`, and `backgroundSource()` to pick renderer vs host layer.
  - Force renderer-owned background (keep bg alpha and do fullscreen fill) when custom shaders or a background image are present; only skip fill when `macos_background_from_layer` is used without shaders/images.
  - Added a unit test to confirm custom shaders require a renderer-owned background.
  - Addresses cmux issue manaflow-ai/cmux#7720.

<sup>Written for commit 5ed1936fd316804af7a4d1978649808d8fc33ba5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/97?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fullscreen background rendering across supported macOS configurations.
  * Fixed cases where background images or custom shaders could be incorrectly omitted.
  * Updated transparency and background color handling for more consistent visual results.
* **Tests**
  * Added coverage for custom shader scenarios to ensure the renderer displays the background correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->