### PR TITLE
renderer: align custom shader fix with cmux Ghostty base

### DIFF
--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -58,7 +58,8 @@ const BackgroundSourceOptions = struct {
 fn resolveBackgroundSource(options: BackgroundSourceOptions) BackgroundSource {
     if (!options.is_macos or
         !options.macos_background_from_layer or
-        options.has_background_image)
+        options.has_background_image or
+        options.has_custom_shaders)
     {
         return .renderer;
     }
@@ -1494,11 +1495,9 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 // zero bg_color alpha so that per-cell backgrounds in the
                 // shaders composite to transparent instead of the terminal
                 // background (the host layer provides the background).
-                // When a background image is active, keep bg_color alpha so
-                // the bg_image shader can composite and opacity-scale it.
-                // The fullscreen background color draw call is still skipped
-                // for layer-background mode when no image is present (see
-                // the draw pass below).
+                // Background images and custom shaders need a complete
+                // renderer-owned frame, so they keep bg_color alpha and the
+                // fullscreen background draw (see the draw pass below).
                 if (comptime builtin.os.tag == .macos) {
                     switch (self.config.background_blur) {
                         .@"macos-glass-regular",
@@ -1714,8 +1713,8 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 //
                 // When the host app provides the plain background via a
                 // CALayer (macos_background_from_layer), skip only the
-                // fullscreen color fill — background images still need to
-                // be rendered by Ghostty.
+                // fullscreen color fill. Background images and custom
+                // shaders still require a complete renderer-owned frame.
                 //
                 // NOTE: We don't use the clear_color for this because that
                 //       would require us to do color space conversion on the

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -43,6 +43,29 @@ const DisplayLink = switch (builtin.os.tag) {
 
 const log = std.log.scoped(.generic_renderer);
 
+const BackgroundSource = enum {
+    renderer,
+    host_layer,
+};
+
+const BackgroundSourceOptions = struct {
+    is_macos: bool,
+    macos_background_from_layer: bool,
+    has_background_image: bool,
+    has_custom_shaders: bool,
+};
+
+fn resolveBackgroundSource(options: BackgroundSourceOptions) BackgroundSource {
+    if (!options.is_macos or
+        !options.macos_background_from_layer or
+        options.has_background_image)
+    {
+        return .renderer;
+    }
+
+    return .host_layer;
+}
+
 fn advanceShaperCellIndexToX(
     run_offset: usize,
     shaped_cells: []const font.shape.Cell,
@@ -898,6 +921,15 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             self.shaders.deinit(self.alloc);
         }
 
+        fn backgroundSource(self: *const Self) BackgroundSource {
+            return resolveBackgroundSource(.{
+                .is_macos = builtin.os.tag == .macos,
+                .macos_background_from_layer = self.config.macos_background_from_layer,
+                .has_background_image = self.config.bg_image != null,
+                .has_custom_shaders = self.has_custom_shaders,
+            });
+        }
+
         fn initShaders(self: *Self) !void {
             var arena = ArenaAllocator.init(self.alloc);
             defer arena.deinit();
@@ -1475,7 +1507,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
 
                         else => {},
                     }
-                    if (self.config.macos_background_from_layer and self.config.bg_image == null)
+                    if (self.backgroundSource() == .host_layer)
                         self.uniforms.bg_color[3] = 0;
                 }
 
@@ -1689,10 +1721,6 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 //       would require us to do color space conversion on the
                 //       CPU-side. In the future when we have utilities for
                 //       that we should remove this step and use clear_color.
-                const skip_bg_fill = if (comptime builtin.os.tag == .macos)
-                    self.config.macos_background_from_layer
-                else
-                    false;
                 if (self.bg_image) |img| switch (img) {
                     .ready => |texture| pass.step(.{
                         .pipeline = self.shaders.pipelines.bg_image,
@@ -1703,7 +1731,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                     }),
                     else => {},
                 } else {
-                    if (!skip_bg_fill) {
+                    if (self.backgroundSource() == .renderer) {
                         pass.step(.{
                             .pipeline = self.shaders.pipelines.bg_color,
                             .uniforms = frame.uniforms.buffer,
@@ -3489,4 +3517,15 @@ test "renderer rebuild row preedit catch-up tolerates empty tail after covered g
     );
 
     try testing.expectEqual(@as(usize, shaped_cells.len), shaper_cells_i);
+}
+
+test "custom shaders require renderer-owned background" {
+    const testing = std.testing;
+
+    try testing.expectEqual(BackgroundSource.renderer, resolveBackgroundSource(.{
+        .is_macos = true,
+        .macos_background_from_layer = true,
+        .has_background_image = false,
+        .has_custom_shaders = true,
+    }));
 }


### PR DESCRIPTION
## Summary

This reapplies the already-reviewed custom-shader background-source fix from #97 onto the Ghostty revision now used by `manaflow-ai/cmux` main (`dd726a9a6`). It keeps the cmux submodule update narrow instead of advancing across hundreds of unrelated upstream Ghostty commits.

- regression commit `fa3753c24`
- fix commit `49f82cea4`
- no semantic change from #97

## Test

`zig build test -Demit-macos-app=false -Dtest-filter='custom shaders require renderer-owned background'`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786229439&installation_id=133855650&pr_number=98&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F98&signature=c2ad76b3cba026f51881c905bf5136e050bf9e9be2bf2c2a9b1d54816374de27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes incorrect compositing with custom shaders on macOS by ensuring the renderer owns the background when shaders or a background image are active. Aligns background handling with the `cmux` Ghostty base.

- **Bug Fixes**
  - Centralized background source logic; use host layer only when macOS layer is enabled and no background image or custom shaders are present.
  - Preserve bg alpha and perform fullscreen background fill when the renderer owns the frame; skip only when the host layer is the source.
  - Added unit test to lock the behavior for custom shaders.

<sup>Written for commit 49f82cea427301eba6f6c1e624b96bed6500e326. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/98?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

