### PR TITLE
Fix compressed render-grid page replacement on OOM

### DIFF
--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -2254,8 +2254,9 @@ pub const CAPI = struct {
                 // resident again. Decode each compressed node once into a
                 // temporary page and reuse it for every row from that node.
                 if (preserved_node != row_pin.node) {
+                    const next_page = try row_pin.node.pagePreservingState(alloc);
                     if (preserved_page) |*page_| page_.deinit();
-                    preserved_page = try row_pin.node.pagePreservingState(alloc);
+                    preserved_page = next_page;
                     preserved_node = row_pin.node;
                 }
                 const p = if (preserved_page) |*page_| page_.page() else unreachable;


### PR DESCRIPTION
Fixes the cmux render-grid compressed-page transition introduced by https://github.com/manaflow-ai/ghostty/pull/96.

The loop previously deinitialized the current `PreservedPage` before allocating its replacement. If `pagePreservingState` returned `OutOfMemory`, the stale non-null optional reached the scope defer and deinitialized the same owned page again.

The replacement is now acquired first. Allocation failure leaves the current page owned by the optional, so its defer releases it exactly once; success releases the old page before installing the replacement.

Verified with Zig 0.15.2:

- `zig build test -Dapp-runtime=none -Demit-macos-app=false -Demit-xcframework=false -Dtest-filter='preserving state'`
- `CMUX_GHOSTTYKIT_NO_PREBUILT=1 ./scripts/ensure-ghosttykit.sh`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786229474&installation_id=133855650&pr_number=99&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F99&signature=3735440f447f971b305651b0271746bd790a28f2c175526e3c8b1886d6ed70a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix page replacement in the render grid when decoding compressed nodes. We now allocate the replacement page first and only release the old page on success, preventing double free and crashes on OOM.

<sup>Written for commit 4117298e4bc198ce0ae8f522357e3121e98a9a2b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/99?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling while rendering grid data.
  * Preserved previously decoded page state when preparing the next page fails, preventing unnecessary data loss.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->