### PR TITLE
renderer: align background ownership with shader intent

### DIFF
--- a/src/config/c_get.zig
+++ b/src/config/c_get.zig
@@ -223,6 +223,23 @@ test "c_get: background-blur" {
     }
 }
 
+test "c_get: repeatable path count" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var c = try Config.default(alloc);
+    defer c.deinit();
+    try c.loadString(
+        alloc,
+        "custom-shader = /tmp/custom.glsl\n",
+        "/tmp/ghostty-config",
+    );
+
+    var count: c_uint = 0;
+    try testing.expect(get(&c, .@"custom-shader", &count));
+    try testing.expectEqual(@as(c_uint, 1), count);
+}
+
 test "c_get: split-preserve-zoom" {
     const testing = std.testing;
     const alloc = testing.allocator;

--- a/src/config/path.zig
+++ b/src/config/path.zig
@@ -397,6 +397,11 @@ pub const RepeatablePath = struct {
         return true;
     }
 
+    /// Return the number of configured paths for C config consumers.
+    pub fn cval(self: RepeatablePath) c_uint {
+        return @intCast(self.value.items.len);
+    }
+
     /// Used by Formatter
     pub fn formatEntry(self: RepeatablePath, formatter: formatterpkg.EntryFormatter) !void {
         if (self.value.items.len == 0) {

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -48,23 +48,42 @@ const BackgroundSource = enum {
     host_layer,
 };
 
-const BackgroundSourceOptions = struct {
-    is_macos: bool,
-    macos_background_from_layer: bool,
-    has_background_image: bool,
-    has_custom_shaders: bool,
+const BackgroundAlpha = enum {
+    configured,
+    transparent,
 };
 
-fn resolveBackgroundSource(options: BackgroundSourceOptions) BackgroundSource {
-    if (!options.is_macos or
-        !options.macos_background_from_layer or
-        options.has_background_image or
-        options.has_custom_shaders)
-    {
-        return .renderer;
+const BackgroundComposition = struct {
+    source: BackgroundSource,
+    alpha: BackgroundAlpha,
+};
+
+const BackgroundCompositionOptions = struct {
+    is_macos: bool,
+    macos_background_from_layer: bool,
+    macos_glass_style: bool,
+    has_background_image: bool,
+    has_custom_shader_intent: bool,
+};
+
+fn resolveBackgroundComposition(options: BackgroundCompositionOptions) BackgroundComposition {
+    if (options.has_custom_shader_intent) {
+        return .{ .source = .renderer, .alpha = .configured };
     }
 
-    return .host_layer;
+    const source: BackgroundSource = if (!options.is_macos or
+        !options.macos_background_from_layer or
+        options.has_background_image)
+        .renderer
+    else
+        .host_layer;
+    const alpha: BackgroundAlpha = if (options.is_macos and
+        (options.macos_glass_style or source == .host_layer))
+        .transparent
+    else
+        .configured;
+
+    return .{ .source = source, .alpha = alpha };
 }
 
 fn advanceShaperCellIndexToX(
@@ -922,12 +941,17 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             self.shaders.deinit(self.alloc);
         }
 
-        fn backgroundSource(self: *const Self) BackgroundSource {
-            return resolveBackgroundSource(.{
+        fn backgroundComposition(self: *const Self) BackgroundComposition {
+            const macos_glass_style = switch (self.config.background_blur) {
+                .@"macos-glass-regular", .@"macos-glass-clear" => true,
+                else => false,
+            };
+            return resolveBackgroundComposition(.{
                 .is_macos = builtin.os.tag == .macos,
                 .macos_background_from_layer = self.config.macos_background_from_layer,
+                .macos_glass_style = macos_glass_style,
                 .has_background_image = self.config.bg_image != null,
-                .has_custom_shaders = self.has_custom_shaders,
+                .has_custom_shader_intent = self.config.custom_shaders.value.items.len > 0,
             });
         }
 
@@ -1491,24 +1515,11 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                     @intFromFloat(@round(self.config.background_opacity * 255.0)),
                 };
 
-                // On macOS, glass styles and plain layer-background mode
-                // zero bg_color alpha so that per-cell backgrounds in the
-                // shaders composite to transparent instead of the terminal
-                // background (the host layer provides the background).
-                // Background images and custom shaders need a complete
-                // renderer-owned frame, so they keep bg_color alpha and the
-                // fullscreen background draw (see the draw pass below).
-                if (comptime builtin.os.tag == .macos) {
-                    switch (self.config.background_blur) {
-                        .@"macos-glass-regular",
-                        .@"macos-glass-clear",
-                        => self.uniforms.bg_color[3] = 0,
-
-                        else => {},
-                    }
-                    if (self.backgroundSource() == .host_layer)
-                        self.uniforms.bg_color[3] = 0;
-                }
+                // Custom shader intent takes renderer ownership before the
+                // pipelines load, including glass configurations. Otherwise,
+                // glass and host-layer backgrounds remain transparent here.
+                if (self.backgroundComposition().alpha == .transparent)
+                    self.uniforms.bg_color[3] = 0;
 
                 // Prepare our overlay image for upload (or unload). This
                 // has to use our general allocator since it modifies
@@ -1730,7 +1741,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                     }),
                     else => {},
                 } else {
-                    if (self.backgroundSource() == .renderer) {
+                    if (self.backgroundComposition().source == .renderer) {
                         pass.step(.{
                             .pipeline = self.shaders.pipelines.bg_color,
                             .uniforms = frame.uniforms.buffer,
@@ -3518,13 +3529,77 @@ test "renderer rebuild row preedit catch-up tolerates empty tail after covered g
     try testing.expectEqual(@as(usize, shaped_cells.len), shaper_cells_i);
 }
 
-test "custom shaders require renderer-owned background" {
+test "renderer background composition" {
     const testing = std.testing;
 
-    try testing.expectEqual(BackgroundSource.renderer, resolveBackgroundSource(.{
-        .is_macos = true,
-        .macos_background_from_layer = true,
-        .has_background_image = false,
-        .has_custom_shaders = true,
-    }));
+    const Case = struct {
+        options: BackgroundCompositionOptions,
+        expected: BackgroundComposition,
+    };
+    const cases = [_]Case{
+        .{
+            .options = .{
+                .is_macos = true,
+                .macos_background_from_layer = true,
+                .macos_glass_style = false,
+                .has_background_image = false,
+                .has_custom_shader_intent = true,
+            },
+            .expected = .{ .source = .renderer, .alpha = .configured },
+        },
+        .{
+            .options = .{
+                .is_macos = true,
+                .macos_background_from_layer = true,
+                .macos_glass_style = true,
+                .has_background_image = false,
+                .has_custom_shader_intent = true,
+            },
+            .expected = .{ .source = .renderer, .alpha = .configured },
+        },
+        .{
+            .options = .{
+                .is_macos = true,
+                .macos_background_from_layer = true,
+                .macos_glass_style = true,
+                .has_background_image = true,
+                .has_custom_shader_intent = false,
+            },
+            .expected = .{ .source = .renderer, .alpha = .transparent },
+        },
+        .{
+            .options = .{
+                .is_macos = true,
+                .macos_background_from_layer = true,
+                .macos_glass_style = false,
+                .has_background_image = true,
+                .has_custom_shader_intent = false,
+            },
+            .expected = .{ .source = .renderer, .alpha = .configured },
+        },
+        .{
+            .options = .{
+                .is_macos = true,
+                .macos_background_from_layer = true,
+                .macos_glass_style = false,
+                .has_background_image = false,
+                .has_custom_shader_intent = false,
+            },
+            .expected = .{ .source = .host_layer, .alpha = .transparent },
+        },
+        .{
+            .options = .{
+                .is_macos = false,
+                .macos_background_from_layer = true,
+                .macos_glass_style = true,
+                .has_background_image = false,
+                .has_custom_shader_intent = false,
+            },
+            .expected = .{ .source = .renderer, .alpha = .configured },
+        },
+    };
+
+    for (cases) |case| {
+        try testing.expectEqual(case.expected, resolveBackgroundComposition(case.options));
+    }
 }


### PR DESCRIPTION
## Summary

- make configured custom-shader intent the source of truth for terminal background ownership
- preserve renderer-owned input across macOS glass and shader reload transitions
- expose repeatable-path counts through the C config bridge so cmux can clear its host backdrop

## Root cause

The initial fix in #97 and #98 used the successfully loaded shader pipeline flag inside the renderer. That left three ownership gaps: macOS glass still zeroed the renderer background alpha, config reload could prepare uniforms with the old pipeline flag before reinitializing shaders, and cmux still painted its host backdrop behind translucent renderer output.

This follow-up resolves background composition from config intent instead. Custom-shader intent always selects renderer source plus configured alpha, before any shader files load. Plain host-layer and glass paths retain their existing transparent-alpha behavior. Invalid or optional-missing shader files remain readable because configured intent still keeps the normal renderer background.

`RepeatablePath.cval()` exposes the configured path count through `ghostty_config_get`, allowing the embedding app to choose the same ownership mode without parsing config files or depending on renderer timing.

## Regression provenance

- `b0326b72a` adds the C config-intent test only; locally it fails 1/66 because `custom-shader` is not C-queryable.
- `f8d6c9e56` implements config-intent ownership and the C bridge; the same focused test passes.

## Verification

- `zig build test -Demit-macos-app=false -Dtest-filter='c_get: repeatable path count'`
- `zig build test -Demit-macos-app=false -Dtest-filter='renderer background composition'`
- `zig fmt --check src/config/path.zig src/config/c_get.zig src/renderer/generic.zig`
- `git diff --check`

Related: manaflow-ai/cmux#7720 and manaflow-ai/cmux#7763

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/101"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786230738&installation_id=133855650&pr_number=101&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F101&signature=c9bd4041cb969c77e83e2f44229e01785c7cb873493a49a7ae87a1085b43764d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align renderer background ownership with the configured custom-shader intent to fix transparency issues on macOS glass and during shader reloads. Also expose the repeatable-path count via the C config API so `cmux` can mirror background ownership without parsing config.

- **Bug Fixes**
  - Background composition derives from config intent (custom shaders => renderer-owned with configured alpha).
  - macOS glass/host-layer paths keep transparent alpha when the host owns the background; no flicker on shader reloads.

- **New Features**
  - `RepeatablePath.cval()` is available via `ghostty_config_get` to report the configured path count.
  - Enables `cmux` to clear its host backdrop based on the same ownership rules.

<sup>Written for commit f8d6c9e56b176875c0855ee93073bc780373bac1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/101?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

