### PR TITLE
config: expand repeatable path C query coverage

### DIFF
--- a/src/config/CApi.zig
+++ b/src/config/CApi.zig
@@ -244,6 +244,24 @@ test "ghostty_config_get: float" {
     try testing.expectApproxEqAbs(@as(f64, 0.42), out, 0.000001);
 }
 
+test "ghostty_config_get: repeatable path count uses C unsigned int" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var cfg = try Config.default(alloc);
+    defer cfg.deinit();
+    try cfg.loadString(
+        alloc,
+        "custom-shader = /tmp/first.glsl\ncustom-shader = /tmp/second.glsl\n",
+        "/tmp/ghostty-config",
+    );
+
+    var out: c_uint = 0;
+    const key = "custom-shader";
+    try testing.expect(ghostty_config_get(&cfg, &out, key, key.len));
+    try testing.expectEqual(@as(c_uint, 2), out);
+}
+
 test "ghostty_config_get: struct cval conversion" {
     const testing = std.testing;
     const alloc = testing.allocator;

--- a/src/config/c_get.zig
+++ b/src/config/c_get.zig
@@ -229,15 +229,26 @@ test "c_get: repeatable path count" {
 
     var c = try Config.default(alloc);
     defer c.deinit();
+
+    var count: c_uint = std.math.maxInt(c_uint);
+    try testing.expect(get(&c, .@"custom-shader", &count));
+    try testing.expectEqual(@as(c_uint, 0), count);
+
     try c.loadString(
         alloc,
         "custom-shader = /tmp/custom.glsl\n",
         "/tmp/ghostty-config",
     );
-
-    var count: c_uint = 0;
     try testing.expect(get(&c, .@"custom-shader", &count));
     try testing.expectEqual(@as(c_uint, 1), count);
+
+    try c.loadString(
+        alloc,
+        "custom-shader = /tmp/second.glsl\n",
+        "/tmp/ghostty-config",
+    );
+    try testing.expect(get(&c, .@"custom-shader", &count));
+    try testing.expectEqual(@as(c_uint, 2), count);
 }
 
 test "c_get: split-preserve-zoom" {


### PR DESCRIPTION
Follow-up coverage for manaflow-ai/cmux#7720.

- Covers empty, single, and multiple `RepeatablePath` values through `c_get`.
- Exercises the exported `ghostty_config_get` boundary with a `c_uint` output, matching the Swift `UInt32` consumer ABI.

Verification:
- `zig build test -Demit-macos-app=false -Dtest-filter='c_get: repeatable path count'`
- `zig build test -Demit-macos-app=false -Dtest-filter='ghostty_config_get: repeatable path count'`
- `zig fmt --check src/config/c_get.zig src/config/CApi.zig`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/102"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786232785&installation_id=133855650&pr_number=102&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F102&signature=4d601b71e17e0551d02d9cb373d7d9a5536af1419a316d6de1c4ddaa7f8270e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expand C API coverage for repeatable path counts. Adds tests for empty, single, and multiple values via `c_get`, and verifies `ghostty_config_get` returns a `c_uint` count compatible with Swift `UInt32`.

<sup>Written for commit 1742928f4dbba4075d76d4b5d962fc3ce0f010d3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/102?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

