### PR TITLE
Revert issue-7720 custom shader background PRs (#97, #98, #101, #102)

### DIFF
--- a/src/config/CApi.zig
+++ b/src/config/CApi.zig
@@ -244,24 +244,6 @@ test "ghostty_config_get: float" {
     try testing.expectApproxEqAbs(@as(f64, 0.42), out, 0.000001);
 }
 
-test "ghostty_config_get: repeatable path count uses C unsigned int" {
-    const testing = std.testing;
-    const alloc = testing.allocator;
-
-    var cfg = try Config.default(alloc);
-    defer cfg.deinit();
-    try cfg.loadString(
-        alloc,
-        "custom-shader = /tmp/first.glsl\ncustom-shader = /tmp/second.glsl\n",
-        "/tmp/ghostty-config",
-    );
-
-    var out: c_uint = 0;
-    const key = "custom-shader";
-    try testing.expect(ghostty_config_get(&cfg, &out, key, key.len));
-    try testing.expectEqual(@as(c_uint, 2), out);
-}
-
 test "ghostty_config_get: struct cval conversion" {
     const testing = std.testing;
     const alloc = testing.allocator;

--- a/src/config/c_get.zig
+++ b/src/config/c_get.zig
@@ -229,26 +229,15 @@ test "c_get: repeatable path count" {
 
     var c = try Config.default(alloc);
     defer c.deinit();
-
-    var count: c_uint = std.math.maxInt(c_uint);
-    try testing.expect(get(&c, .@"custom-shader", &count));
-    try testing.expectEqual(@as(c_uint, 0), count);
-
     try c.loadString(
         alloc,
         "custom-shader = /tmp/custom.glsl\n",
         "/tmp/ghostty-config",
     );
+
+    var count: c_uint = 0;
     try testing.expect(get(&c, .@"custom-shader", &count));
     try testing.expectEqual(@as(c_uint, 1), count);
-
-    try c.loadString(
-        alloc,
-        "custom-shader = /tmp/second.glsl\n",
-        "/tmp/ghostty-config",
-    );
-    try testing.expect(get(&c, .@"custom-shader", &count));
-    try testing.expectEqual(@as(c_uint, 2), count);
 }
 
 test "c_get: split-preserve-zoom" {

--- a/src/config/c_get.zig
+++ b/src/config/c_get.zig
@@ -223,23 +223,6 @@ test "c_get: background-blur" {
     }
 }
 
-test "c_get: repeatable path count" {
-    const testing = std.testing;
-    const alloc = testing.allocator;
-
-    var c = try Config.default(alloc);
-    defer c.deinit();
-    try c.loadString(
-        alloc,
-        "custom-shader = /tmp/custom.glsl\n",
-        "/tmp/ghostty-config",
-    );
-
-    var count: c_uint = 0;
-    try testing.expect(get(&c, .@"custom-shader", &count));
-    try testing.expectEqual(@as(c_uint, 1), count);
-}
-
 test "c_get: split-preserve-zoom" {
     const testing = std.testing;
     const alloc = testing.allocator;

--- a/src/config/path.zig
+++ b/src/config/path.zig
@@ -397,11 +397,6 @@ pub const RepeatablePath = struct {
         return true;
     }
 
-    /// Return the number of configured paths for C config consumers.
-    pub fn cval(self: RepeatablePath) c_uint {
-        return @intCast(self.value.items.len);
-    }
-
     /// Used by Formatter
     pub fn formatEntry(self: RepeatablePath, formatter: formatterpkg.EntryFormatter) !void {
         if (self.value.items.len == 0) {

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -43,30 +43,6 @@ const DisplayLink = switch (builtin.os.tag) {
 
 const log = std.log.scoped(.generic_renderer);
 
-const BackgroundSource = enum {
-    renderer,
-    host_layer,
-};
-
-const BackgroundSourceOptions = struct {
-    is_macos: bool,
-    macos_background_from_layer: bool,
-    has_background_image: bool,
-    has_custom_shaders: bool,
-};
-
-fn resolveBackgroundSource(options: BackgroundSourceOptions) BackgroundSource {
-    if (!options.is_macos or
-        !options.macos_background_from_layer or
-        options.has_background_image or
-        options.has_custom_shaders)
-    {
-        return .renderer;
-    }
-
-    return .host_layer;
-}
-
 fn advanceShaperCellIndexToX(
     run_offset: usize,
     shaped_cells: []const font.shape.Cell,
@@ -922,15 +898,6 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             self.shaders.deinit(self.alloc);
         }
 
-        fn backgroundSource(self: *const Self) BackgroundSource {
-            return resolveBackgroundSource(.{
-                .is_macos = builtin.os.tag == .macos,
-                .macos_background_from_layer = self.config.macos_background_from_layer,
-                .has_background_image = self.config.bg_image != null,
-                .has_custom_shaders = self.has_custom_shaders,
-            });
-        }
-
         fn initShaders(self: *Self) !void {
             var arena = ArenaAllocator.init(self.alloc);
             defer arena.deinit();
@@ -1509,9 +1476,11 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 // zero bg_color alpha so that per-cell backgrounds in the
                 // shaders composite to transparent instead of the terminal
                 // background (the host layer provides the background).
-                // Background images and custom shaders need a complete
-                // renderer-owned frame, so they keep bg_color alpha and the
-                // fullscreen background draw (see the draw pass below).
+                // When a background image is active, keep bg_color alpha so
+                // the bg_image shader can composite and opacity-scale it.
+                // The fullscreen background color draw call is still skipped
+                // for layer-background mode when no image is present (see
+                // the draw pass below).
                 if (comptime builtin.os.tag == .macos) {
                     switch (self.config.background_blur) {
                         .@"macos-glass-regular",
@@ -1520,7 +1489,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
 
                         else => {},
                     }
-                    if (self.backgroundSource() == .host_layer)
+                    if (self.config.macos_background_from_layer and self.config.bg_image == null)
                         self.uniforms.bg_color[3] = 0;
                 }
 
@@ -1727,13 +1696,17 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 //
                 // When the host app provides the plain background via a
                 // CALayer (macos_background_from_layer), skip only the
-                // fullscreen color fill. Background images and custom
-                // shaders still require a complete renderer-owned frame.
+                // fullscreen color fill — background images still need to
+                // be rendered by Ghostty.
                 //
                 // NOTE: We don't use the clear_color for this because that
                 //       would require us to do color space conversion on the
                 //       CPU-side. In the future when we have utilities for
                 //       that we should remove this step and use clear_color.
+                const skip_bg_fill = if (comptime builtin.os.tag == .macos)
+                    self.config.macos_background_from_layer
+                else
+                    false;
                 if (self.bg_image) |img| switch (img) {
                     .ready => |texture| pass.step(.{
                         .pipeline = self.shaders.pipelines.bg_image,
@@ -1744,7 +1717,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                     }),
                     else => {},
                 } else {
-                    if (self.backgroundSource() == .renderer) {
+                    if (!skip_bg_fill) {
                         pass.step(.{
                             .pipeline = self.shaders.pipelines.bg_color,
                             .uniforms = frame.uniforms.buffer,
@@ -3530,15 +3503,4 @@ test "renderer rebuild row preedit catch-up tolerates empty tail after covered g
     );
 
     try testing.expectEqual(@as(usize, shaped_cells.len), shaper_cells_i);
-}
-
-test "custom shaders require renderer-owned background" {
-    const testing = std.testing;
-
-    try testing.expectEqual(BackgroundSource.renderer, resolveBackgroundSource(.{
-        .is_macos = true,
-        .macos_background_from_layer = true,
-        .has_background_image = false,
-        .has_custom_shaders = true,
-    }));
 }

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -48,42 +48,23 @@ const BackgroundSource = enum {
     host_layer,
 };
 
-const BackgroundAlpha = enum {
-    configured,
-    transparent,
-};
-
-const BackgroundComposition = struct {
-    source: BackgroundSource,
-    alpha: BackgroundAlpha,
-};
-
-const BackgroundCompositionOptions = struct {
+const BackgroundSourceOptions = struct {
     is_macos: bool,
     macos_background_from_layer: bool,
-    macos_glass_style: bool,
     has_background_image: bool,
-    has_custom_shader_intent: bool,
+    has_custom_shaders: bool,
 };
 
-fn resolveBackgroundComposition(options: BackgroundCompositionOptions) BackgroundComposition {
-    if (options.has_custom_shader_intent) {
-        return .{ .source = .renderer, .alpha = .configured };
+fn resolveBackgroundSource(options: BackgroundSourceOptions) BackgroundSource {
+    if (!options.is_macos or
+        !options.macos_background_from_layer or
+        options.has_background_image or
+        options.has_custom_shaders)
+    {
+        return .renderer;
     }
 
-    const source: BackgroundSource = if (!options.is_macos or
-        !options.macos_background_from_layer or
-        options.has_background_image)
-        .renderer
-    else
-        .host_layer;
-    const alpha: BackgroundAlpha = if (options.is_macos and
-        (options.macos_glass_style or source == .host_layer))
-        .transparent
-    else
-        .configured;
-
-    return .{ .source = source, .alpha = alpha };
+    return .host_layer;
 }
 
 fn advanceShaperCellIndexToX(
@@ -941,17 +922,12 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             self.shaders.deinit(self.alloc);
         }
 
-        fn backgroundComposition(self: *const Self) BackgroundComposition {
-            const macos_glass_style = switch (self.config.background_blur) {
-                .@"macos-glass-regular", .@"macos-glass-clear" => true,
-                else => false,
-            };
-            return resolveBackgroundComposition(.{
+        fn backgroundSource(self: *const Self) BackgroundSource {
+            return resolveBackgroundSource(.{
                 .is_macos = builtin.os.tag == .macos,
                 .macos_background_from_layer = self.config.macos_background_from_layer,
-                .macos_glass_style = macos_glass_style,
                 .has_background_image = self.config.bg_image != null,
-                .has_custom_shader_intent = self.config.custom_shaders.value.items.len > 0,
+                .has_custom_shaders = self.has_custom_shaders,
             });
         }
 
@@ -1529,11 +1505,24 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                     @intFromFloat(@round(self.config.background_opacity * 255.0)),
                 };
 
-                // Custom shader intent takes renderer ownership before the
-                // pipelines load, including glass configurations. Otherwise,
-                // glass and host-layer backgrounds remain transparent here.
-                if (self.backgroundComposition().alpha == .transparent)
-                    self.uniforms.bg_color[3] = 0;
+                // On macOS, glass styles and plain layer-background mode
+                // zero bg_color alpha so that per-cell backgrounds in the
+                // shaders composite to transparent instead of the terminal
+                // background (the host layer provides the background).
+                // Background images and custom shaders need a complete
+                // renderer-owned frame, so they keep bg_color alpha and the
+                // fullscreen background draw (see the draw pass below).
+                if (comptime builtin.os.tag == .macos) {
+                    switch (self.config.background_blur) {
+                        .@"macos-glass-regular",
+                        .@"macos-glass-clear",
+                        => self.uniforms.bg_color[3] = 0,
+
+                        else => {},
+                    }
+                    if (self.backgroundSource() == .host_layer)
+                        self.uniforms.bg_color[3] = 0;
+                }
 
                 // Prepare our overlay image for upload (or unload). This
                 // has to use our general allocator since it modifies
@@ -1755,7 +1744,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                     }),
                     else => {},
                 } else {
-                    if (self.backgroundComposition().source == .renderer) {
+                    if (self.backgroundSource() == .renderer) {
                         pass.step(.{
                             .pipeline = self.shaders.pipelines.bg_color,
                             .uniforms = frame.uniforms.buffer,
@@ -3543,77 +3532,13 @@ test "renderer rebuild row preedit catch-up tolerates empty tail after covered g
     try testing.expectEqual(@as(usize, shaped_cells.len), shaper_cells_i);
 }
 
-test "renderer background composition" {
+test "custom shaders require renderer-owned background" {
     const testing = std.testing;
 
-    const Case = struct {
-        options: BackgroundCompositionOptions,
-        expected: BackgroundComposition,
-    };
-    const cases = [_]Case{
-        .{
-            .options = .{
-                .is_macos = true,
-                .macos_background_from_layer = true,
-                .macos_glass_style = false,
-                .has_background_image = false,
-                .has_custom_shader_intent = true,
-            },
-            .expected = .{ .source = .renderer, .alpha = .configured },
-        },
-        .{
-            .options = .{
-                .is_macos = true,
-                .macos_background_from_layer = true,
-                .macos_glass_style = true,
-                .has_background_image = false,
-                .has_custom_shader_intent = true,
-            },
-            .expected = .{ .source = .renderer, .alpha = .configured },
-        },
-        .{
-            .options = .{
-                .is_macos = true,
-                .macos_background_from_layer = true,
-                .macos_glass_style = true,
-                .has_background_image = true,
-                .has_custom_shader_intent = false,
-            },
-            .expected = .{ .source = .renderer, .alpha = .transparent },
-        },
-        .{
-            .options = .{
-                .is_macos = true,
-                .macos_background_from_layer = true,
-                .macos_glass_style = false,
-                .has_background_image = true,
-                .has_custom_shader_intent = false,
-            },
-            .expected = .{ .source = .renderer, .alpha = .configured },
-        },
-        .{
-            .options = .{
-                .is_macos = true,
-                .macos_background_from_layer = true,
-                .macos_glass_style = false,
-                .has_background_image = false,
-                .has_custom_shader_intent = false,
-            },
-            .expected = .{ .source = .host_layer, .alpha = .transparent },
-        },
-        .{
-            .options = .{
-                .is_macos = false,
-                .macos_background_from_layer = true,
-                .macos_glass_style = true,
-                .has_background_image = false,
-                .has_custom_shader_intent = false,
-            },
-            .expected = .{ .source = .renderer, .alpha = .configured },
-        },
-    };
-
-    for (cases) |case| {
-        try testing.expectEqual(case.expected, resolveBackgroundComposition(case.options));
-    }
+    try testing.expectEqual(BackgroundSource.renderer, resolveBackgroundSource(.{
+        .is_macos = true,
+        .macos_background_from_layer = true,
+        .has_background_image = false,
+        .has_custom_shaders = true,
+    }));
 }


### PR DESCRIPTION
## Summary

Reverts the four issue-7720 merges that landed on fork main without approval:

- #97 (merge cd228cc44) — renderer custom shader background source
- #98 (merge a410ad718) — cherry-pick alignment; its merge introduced no net diff, so its revert is a no-op and is omitted
- #101 (merge 63cee8e76) — background ownership followup
- #102 (merge e4a9abf7e) — repeatable path C query coverage

Restores `src/renderer/generic.zig`, `src/config/CApi.zig`, `src/config/c_get.zig`, and `src/config/path.zig` byte-for-byte to their pre-#97 state. The unrelated intervening commit c74e759bc (compressed render-grid OOM fix) is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/103"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786236097&installation_id=133855650&pr_number=103&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F103&signature=ed650ae9ab2e10e038d94ec3966d58761ceb3b50b58e4f75b7e8411fa88facd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the unapproved custom shader background changes and follow-ups to restore pre-#97 behavior in the renderer and config. Keeps the unrelated render-grid OOM fix intact.

- **Bug Fixes**
  - Revert PRs #97, #101, and #102: remove the background composition abstraction and tests; return to prior macOS background alpha and host-layer handling.
  - Remove C API helpers and tests for repeatable path counts; revert `RepeatablePath.cval` and related config code.
  - Restore `src/renderer/generic.zig`, `src/config/CApi.zig`, `src/config/c_get.zig`, and `src/config/path.zig` to their previous state.

<sup>Written for commit bcd76a09a357cf696326f187d75cb5cacbdc696c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/103?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

