### PR TITLE
Notify selection changes after renderer unlock

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -2489,34 +2489,13 @@ fn copySelectionToClipboards(
     };
 }
 
-/// Set the active selection and notify the apprt on a genuine state
-/// transition. All selection mutations route through here rather than
-/// `screen.select` directly so the notification fires consistently. To
-/// also copy per `copy_on_select`, use `setSelectionAndCopy`.
+/// Set the active selection. The renderer observes the screen's selection
+/// activity token and notifies the apprt after releasing the terminal mutex.
+/// To also copy per `copy_on_select`, use `setSelectionAndCopy`.
 ///
 /// This must be called with the renderer mutex held.
 fn setSelection(self: *Surface, sel_: ?terminal.Selection) !void {
-    // Compute the transition before `select` below, which untracks (frees)
-    // the previous selection's tracked pins; reading them after would be a
-    // use-after-free.
-    const prev_ = self.io.terminal.screens.active.selection;
-    const changed = changed: {
-        const prev = prev_ orelse break :changed sel_ != null;
-        const sel = sel_ orelse break :changed true;
-        break :changed !sel.eql(prev);
-    };
-
     try self.io.terminal.screens.active.select(sel_);
-
-    if (changed) {
-        _ = self.rt_app.performAction(
-            .{ .surface = self },
-            .selection_changed,
-            {},
-        ) catch |err| {
-            log.warn("apprt failed selection_changed notification err={}", .{err});
-        };
-    }
 }
 
 /// Set a selection and, per `copy_on_select`, copy it to the clipboard.

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -2495,7 +2495,15 @@ fn copySelectionToClipboards(
 ///
 /// This must be called with the renderer mutex held.
 fn setSelection(self: *Surface, sel_: ?terminal.Selection) !void {
+    const activity = self.io.terminal.screens.active.selection_activity;
     try self.io.terminal.screens.active.select(sel_);
+
+    // Some selection callers return without otherwise scheduling a render.
+    // Always wake the renderer after a genuine transition so it can deliver
+    // the deferred apprt notification once the terminal mutex is released.
+    if (activity != self.io.terminal.screens.active.selection_activity) {
+        try self.queueRender();
+    }
 }
 
 /// Set a selection and, per `copy_on_select`, copy it to the clipboard.

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -5928,13 +5928,7 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
             defer self.renderer_state.mutex.unlock();
 
             const screen: *terminal.Screen = self.io.terminal.screens.active;
-            const sel = if (screen.selection) |*sel| sel else {
-                // If we don't have a selection we do not perform this
-                // action, allowing the keybind to fall through to the
-                // terminal.
-                return false;
-            };
-            sel.adjust(screen, switch (direction) {
+            const sel = screen.adjustSelection(switch (direction) {
                 .left => .left,
                 .right => .right,
                 .up => .up,
@@ -5945,7 +5939,12 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
                 .end => .end,
                 .beginning_of_line => .beginning_of_line,
                 .end_of_line => .end_of_line,
-            });
+            }) orelse {
+                // If we don't have a selection we do not perform this
+                // action, allowing the keybind to fall through to the
+                // terminal.
+                return false;
+            };
 
             // If the selection endpoint is outside of the current viewpoint,
             // scroll it in to view. Note we always specifically use sel.end
@@ -5968,7 +5967,6 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
             }
 
             // Queue a render so its shown
-            screen.dirty.selection = true;
             try self.queueRender();
         },
     }

--- a/src/apprt/action.zig
+++ b/src/apprt/action.zig
@@ -295,8 +295,9 @@ pub const Action = union(Key) {
     /// it needs to ring the bell. This is usually a sound or visual effect.
     ring_bell,
 
-    /// Called when the active selection changes. The apprt should read the
-    /// current selection itself; this carries no payload.
+    /// Called when the active selection changes. This callback runs without
+    /// the terminal mutex held, so the apprt may read the current selection
+    /// through the normal surface APIs. This carries no payload.
     selection_changed,
 
     /// Undo the last action. See the "undo" keybinding for more

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -78,7 +78,13 @@ compression: Compression = undefined,
 
 /// Last selection activity delivered to the apprt. This is renderer-owned so
 /// callbacks can run after the terminal mutex is released.
-selection_activity: terminalpkg.Terminal.SelectionActivity,
+selection_activity: terminalpkg.Terminal.SelectionActivity = .{
+    // Every terminal initializes with the primary screen active and no
+    // selection changes. Thread.init runs before terminal state exists, so the
+    // known initial token is safer than dereferencing renderer state there.
+    .screen = .primary,
+    .serial = 0,
+},
 
 /// The surface we're rendering to.
 surface: *apprt.Surface,
@@ -201,9 +207,6 @@ pub fn init(
         .state = state,
         .mailbox = mailbox,
         .app_mailbox = app_mailbox,
-        // No worker thread can mutate terminal state until initialization
-        // completes, so this establishes the baseline without a lock.
-        .selection_activity = state.terminal.selectionActivity(),
     };
 
     // Only enable compression if we have it enabled... save some
@@ -824,8 +827,10 @@ fn renderCallback(
 /// consumers may safely call the normal selection read APIs synchronously.
 fn notifySelectionChanged(self: *Thread) void {
     const activity = activity: {
-        self.state.mutex.lock();
-        defer self.state.mutex.unlock();
+        // Use the renderer demand path so sustained PTY output cannot starve
+        // this snapshot ahead of updateFrame's own demanding acquisition.
+        self.state.lockDemand();
+        defer self.state.unlockDemand();
         break :activity self.state.terminal.selectionActivity();
     };
 

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -76,6 +76,10 @@ cursor_c_cancel: xev.Completion = .{},
 /// Incremental scrollback compression scheduling.
 compression: Compression = undefined,
 
+/// Last selection activity delivered to the apprt. This is renderer-owned so
+/// callbacks can run after the terminal mutex is released.
+selection_activity: ?terminalpkg.Terminal.SelectionActivity = null,
+
 /// The surface we're rendering to.
 surface: *apprt.Surface,
 
@@ -240,6 +244,8 @@ pub fn renderNow(self: *Thread) void {
         log.warn("renderNow: error updating frame err={}", .{err});
         return;
     };
+
+    self.notifySelectionChanged();
 
     self.drawFrame(true);
 }
@@ -471,6 +477,7 @@ fn drainMailbox(self: *Thread) !void {
                         self.flags.cursor_blink_visible,
                     ) catch |err|
                         log.warn("error rendering on visibility regain err={}", .{err});
+                    self.notifySelectionChanged();
                     self.drawFrame(false);
                 }
 
@@ -799,10 +806,38 @@ fn renderCallback(
     ) catch |err|
         log.warn("error rendering err={}", .{err});
 
+    t.notifySelectionChanged();
+
     // Draw
     t.drawFrame(false);
 
     return .disarm;
+}
+
+/// Notify the apprt when the active selection changes. The activity snapshot
+/// is read under the terminal mutex, but the callback runs only after unlock so
+/// consumers may safely call the normal selection read APIs synchronously.
+fn notifySelectionChanged(self: *Thread) void {
+    const activity = activity: {
+        self.state.mutex.lock();
+        defer self.state.mutex.unlock();
+        break :activity self.state.terminal.selectionActivity();
+    };
+
+    const previous = self.selection_activity orelse {
+        self.selection_activity = activity;
+        return;
+    };
+    if (std.meta.eql(previous, activity)) return;
+    self.selection_activity = activity;
+
+    _ = self.surface.rtApp().performAction(
+        .{ .surface = self.surface.core() },
+        .selection_changed,
+        {},
+    ) catch |err| {
+        log.warn("apprt failed selection_changed notification err={}", .{err});
+    };
 }
 
 fn cursorTimerCallback(

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -78,7 +78,7 @@ compression: Compression = undefined,
 
 /// Last selection activity delivered to the apprt. This is renderer-owned so
 /// callbacks can run after the terminal mutex is released.
-selection_activity: ?terminalpkg.Terminal.SelectionActivity = null,
+selection_activity: terminalpkg.Terminal.SelectionActivity,
 
 /// The surface we're rendering to.
 surface: *apprt.Surface,
@@ -201,6 +201,9 @@ pub fn init(
         .state = state,
         .mailbox = mailbox,
         .app_mailbox = app_mailbox,
+        // No worker thread can mutate terminal state until initialization
+        // completes, so this establishes the baseline without a lock.
+        .selection_activity = state.terminal.selectionActivity(),
     };
 
     // Only enable compression if we have it enabled... save some
@@ -237,6 +240,8 @@ pub fn renderNow(self: *Thread) void {
     self.drainMailbox() catch |err|
         log.err("renderNow: error draining mailbox err={}", .{err});
 
+    self.notifySelectionChanged();
+
     self.renderer.updateFrame(
         self.state,
         self.effectiveCursorBlinkVisible(),
@@ -244,8 +249,6 @@ pub fn renderNow(self: *Thread) void {
         log.warn("renderNow: error updating frame err={}", .{err});
         return;
     };
-
-    self.notifySelectionChanged();
 
     self.drawFrame(true);
 }
@@ -477,7 +480,6 @@ fn drainMailbox(self: *Thread) !void {
                         self.flags.cursor_blink_visible,
                     ) catch |err|
                         log.warn("error rendering on visibility regain err={}", .{err});
-                    self.notifySelectionChanged();
                     self.drawFrame(false);
                 }
 
@@ -795,6 +797,11 @@ fn renderCallback(
     };
     if (t.externalDrainActive()) return .disarm;
 
+    // Selection notifications are independent of visibility. Hidden surfaces
+    // still need to invalidate accessibility state even though they skip the
+    // more expensive frame rebuild below.
+    t.notifySelectionChanged();
+
     // If we're not visible there's no point spending CPU rebuilding cells —
     // we'll catch up when the .visible mailbox message flips us back on.
     if (!t.flags.visible) return .disarm;
@@ -805,8 +812,6 @@ fn renderCallback(
         t.flags.cursor_blink_visible,
     ) catch |err|
         log.warn("error rendering err={}", .{err});
-
-    t.notifySelectionChanged();
 
     // Draw
     t.drawFrame(false);
@@ -824,11 +829,7 @@ fn notifySelectionChanged(self: *Thread) void {
         break :activity self.state.terminal.selectionActivity();
     };
 
-    const previous = self.selection_activity orelse {
-        self.selection_activity = activity;
-        return;
-    };
-    if (std.meta.eql(previous, activity)) return;
+    if (std.meta.eql(self.selection_activity, activity)) return;
     self.selection_activity = activity;
 
     _ = self.surface.rtApp().performAction(

--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -56,6 +56,10 @@ saved_cursor: ?SavedCursor = null,
 /// automatically setup tracking.
 selection: ?Selection = null,
 
+/// Opaque activity token that changes whenever the logical selection changes.
+/// Renderers use this to notify apprts after releasing the terminal mutex.
+selection_activity: u64 = 0,
+
 /// The charset state
 charset: CharsetState = .{},
 
@@ -560,6 +564,7 @@ pub fn clone(
         .no_scrollback = self.no_scrollback,
         .cursor = cursor,
         .selection = sel,
+        .selection_activity = self.selection_activity,
         .dirty = self.dirty,
     };
     result.assertIntegrity();
@@ -2608,6 +2613,11 @@ pub fn select(self: *Screen, sel_: ?Selection) Allocator.Error!void {
         return;
     };
 
+    const changed = if (self.selection) |previous|
+        !sel.eql(previous)
+    else
+        true;
+
     // If this selection is untracked then we track it.
     const tracked_sel = if (sel.tracked()) sel else try sel.track(self);
     errdefer if (!sel.tracked()) tracked_sel.deinit(self);
@@ -2616,6 +2626,7 @@ pub fn select(self: *Screen, sel_: ?Selection) Allocator.Error!void {
     if (self.selection) |*old| old.deinit(self);
     self.selection = tracked_sel;
     self.dirty.selection = true;
+    if (changed) self.selection_activity +%= 1;
 }
 
 /// Same as select(null) but can't fail.
@@ -2623,6 +2634,7 @@ pub fn clearSelection(self: *Screen) void {
     if (self.selection) |*sel| {
         sel.deinit(self);
         self.dirty.selection = true;
+        self.selection_activity +%= 1;
     }
     self.selection = null;
 }
@@ -8114,6 +8126,41 @@ test "Screen: select replaces existing pins" {
     try testing.expectEqual(tracked + 2, s.pages.countTrackedPins());
 }
 
+test "Screen: selection activity tracks genuine transitions" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var s = try init(alloc, .{ .cols = 10, .rows = 10, .max_scrollback = 0 });
+    defer s.deinit();
+    try s.testWriteString("ABC  DEF\n 123\n456");
+
+    try testing.expectEqual(@as(u64, 0), s.selection_activity);
+
+    const first = Selection.init(
+        s.pages.pin(.{ .active = .{ .x = 0, .y = 0 } }).?,
+        s.pages.pin(.{ .active = .{ .x = 3, .y = 0 } }).?,
+        false,
+    );
+    try s.select(first);
+    try testing.expectEqual(@as(u64, 1), s.selection_activity);
+
+    // Replacing tracked pins with the same logical range is not a change.
+    try s.select(first);
+    try testing.expectEqual(@as(u64, 1), s.selection_activity);
+
+    try s.select(Selection.init(
+        s.pages.pin(.{ .active = .{ .x = 0, .y = 1 } }).?,
+        s.pages.pin(.{ .active = .{ .x = 2, .y = 1 } }).?,
+        false,
+    ));
+    try testing.expectEqual(@as(u64, 2), s.selection_activity);
+
+    s.clearSelection();
+    try testing.expectEqual(@as(u64, 3), s.selection_activity);
+    s.clearSelection();
+    try testing.expectEqual(@as(u64, 3), s.selection_activity);
+}
+
 test "Screen: selectAll" {
     const testing = std.testing;
     const alloc = testing.allocator;
@@ -8848,8 +8895,10 @@ test "Screen: selectWord" {
 
     // Default boundary codepoints for word selection
     const boundary_codepoints = &[_]u21{
-        0,   ' ', '\t', '\'', '"', '│', '`', '|', ':', ';',
-        ',', '(', ')',  '[',  ']', '{',   '}', '<', '>', '$',
+        0,     ' ', '\t', '\'', '"',
+        '│', '`', '|',  ':',  ';',
+        ',',   '(', ')',  '[',  ']',
+        '{',   '}', '<',  '>',  '$',
     };
 
     // Outside of active area
@@ -8969,8 +9018,10 @@ test "Screen: selectWord across soft-wrap" {
 
     // Default boundary codepoints for word selection
     const boundary_codepoints = &[_]u21{
-        0,   ' ', '\t', '\'', '"', '│', '`', '|', ':', ';',
-        ',', '(', ')',  '[',  ']', '{',   '}', '<', '>', '$',
+        0,     ' ', '\t', '\'', '"',
+        '│', '`', '|',  ':',  ';',
+        ',',   '(', ')',  '[',  ']',
+        '{',   '}', '<',  '>',  '$',
     };
 
     {
@@ -9041,8 +9092,10 @@ test "Screen: selectWord whitespace across soft-wrap" {
 
     // Default boundary codepoints for word selection
     const boundary_codepoints = &[_]u21{
-        0,   ' ', '\t', '\'', '"', '│', '`', '|', ':', ';',
-        ',', '(', ')',  '[',  ']', '{',   '}', '<', '>', '$',
+        0,     ' ', '\t', '\'', '"',
+        '│', '`', '|',  ':',  ';',
+        ',',   '(', ')',  '[',  ']',
+        '{',   '}', '<',  '>',  '$',
     };
 
     // Going forward
@@ -9103,8 +9156,10 @@ test "Screen: selectWord with character boundary" {
 
     // Default boundary codepoints for word selection
     const boundary_codepoints = &[_]u21{
-        0,   ' ', '\t', '\'', '"', '│', '`', '|', ':', ';',
-        ',', '(', ')',  '[',  ']', '{',   '}', '<', '>', '$',
+        0,     ' ', '\t', '\'', '"',
+        '│', '`', '|',  ':',  ';',
+        ',',   '(', ')',  '[',  ']',
+        '{',   '}', '<',  '>',  '$',
     };
 
     const cases = [_][]const u8{

--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -2639,6 +2639,20 @@ pub fn clearSelection(self: *Screen) void {
     self.selection = null;
 }
 
+/// Adjust the active selection and return it, or null if none exists.
+/// Selection activity advances only when the logical endpoint moves.
+pub fn adjustSelection(
+    self: *Screen,
+    adjustment: Selection.Adjustment,
+) ?*Selection {
+    const selection = if (self.selection) |*selection| selection else return null;
+    const previous_end = selection.end();
+    selection.adjust(self, adjustment);
+    self.dirty.selection = true;
+    if (!previous_end.eql(selection.end())) self.selection_activity +%= 1;
+    return selection;
+}
+
 pub const SelectionString = struct {
     /// The selection to convert to a string.
     sel: Selection,
@@ -8148,17 +8162,25 @@ test "Screen: selection activity tracks genuine transitions" {
     try s.select(first);
     try testing.expectEqual(@as(u64, 1), s.selection_activity);
 
+    _ = s.adjustSelection(.right).?;
+    try testing.expectEqual(@as(u64, 2), s.selection_activity);
+
+    _ = s.adjustSelection(.end_of_line).?;
+    try testing.expectEqual(@as(u64, 3), s.selection_activity);
+    _ = s.adjustSelection(.end_of_line).?;
+    try testing.expectEqual(@as(u64, 3), s.selection_activity);
+
     try s.select(Selection.init(
         s.pages.pin(.{ .active = .{ .x = 0, .y = 1 } }).?,
         s.pages.pin(.{ .active = .{ .x = 2, .y = 1 } }).?,
         false,
     ));
-    try testing.expectEqual(@as(u64, 2), s.selection_activity);
+    try testing.expectEqual(@as(u64, 4), s.selection_activity);
 
     s.clearSelection();
-    try testing.expectEqual(@as(u64, 3), s.selection_activity);
+    try testing.expectEqual(@as(u64, 5), s.selection_activity);
     s.clearSelection();
-    try testing.expectEqual(@as(u64, 3), s.selection_activity);
+    try testing.expectEqual(@as(u64, 5), s.selection_activity);
 }
 
 test "Screen: selectAll" {

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -2314,6 +2314,64 @@ pub fn compressionActivity(self: *const Terminal) u64 {
     return @as(u64, state.activity_serial);
 }
 
+/// Return the active screen's opaque selection activity token.
+///
+/// Callers compare this after renderer updates so apprt notifications can be
+/// delivered without holding the terminal mutex. The screen key is part of the
+/// token because switching screens can change the active selection even when
+/// both screens have the same local activity serial.
+pub fn selectionActivity(self: *const Terminal) SelectionActivity {
+    return .{
+        .screen = self.screens.active_key,
+        .serial = self.screens.active.selection_activity,
+    };
+}
+
+pub const SelectionActivity = struct {
+    screen: ScreenSet.Key,
+    serial: u64,
+};
+
+test "Terminal: selection activity follows screen switches and resets" {
+    const alloc = testing.allocator;
+    var t = try init(alloc, .{ .cols = 10, .rows = 5 });
+    defer t.deinit(alloc);
+
+    try testing.expectEqualDeep(SelectionActivity{
+        .screen = .primary,
+        .serial = 0,
+    }, t.selectionActivity());
+
+    const screen = t.screens.active;
+    try screen.select(.init(
+        screen.pages.pin(.{ .active = .{ .x = 0, .y = 0 } }).?,
+        screen.pages.pin(.{ .active = .{ .x = 1, .y = 0 } }).?,
+        false,
+    ));
+    try testing.expectEqualDeep(SelectionActivity{
+        .screen = .primary,
+        .serial = 1,
+    }, t.selectionActivity());
+
+    _ = try t.switchScreen(.alternate);
+    try testing.expectEqualDeep(SelectionActivity{
+        .screen = .alternate,
+        .serial = 0,
+    }, t.selectionActivity());
+
+    _ = try t.switchScreen(.primary);
+    try testing.expectEqualDeep(SelectionActivity{
+        .screen = .primary,
+        .serial = 1,
+    }, t.selectionActivity());
+
+    t.screens.active.reset();
+    try testing.expectEqualDeep(SelectionActivity{
+        .screen = .primary,
+        .serial = 2,
+    }, t.selectionActivity());
+}
+
 /// The amount of compression work performed by `compress` before returning.
 ///
 /// The declaration order is part of the libghostty-vt C ABI. Removed values
@@ -12403,11 +12461,12 @@ fn testPrintSliceDifferential(
     // Alphabet of interesting codepoints: ascii, latin-1, combining
     // marks, CJK (wide), emoji (wide), ZWJ, variation selectors.
     const alphabet = [_]u21{
-        'a',     'b',     'Z',     '0',    ' ',    0x10,    0x1F,   0x7F,
-        'é',    0xFF,    0x301,   0x4E00, 0x4E01, 0x1F600, 0x200D, 0xFE0F,
-        'x',     'y',     0x1F9D1, 0x0308, 0xAD,   0x3042,  0xAC00, 'q',
-        'r',     's',     't',     'u',    'v',    'w',     '1',    '2',
-        0x1F1E6, 0x1F1E7, 0x1100,  0x1161, 0x11A8, 0x200C,  0x0430, 0x03B1,
+        'a',     'b',     'Z',    '0',    ' ',     0x10,   0x1F,   0x7F,
+        'é',
+        0xFF,    0x301,   0x4E00, 0x4E01, 0x1F600, 0x200D, 0xFE0F, 'x',
+        'y',     0x1F9D1, 0x0308, 0xAD,   0x3042,  0xAC00, 'q',    'r',
+        's',     't',     'u',    'v',    'w',     '1',    '2',    0x1F1E6,
+        0x1F1E7, 0x1100,  0x1161, 0x11A8, 0x200C,  0x0430, 0x03B1,
     };
 
     var cps_buf: [64]u32 = undefined;


### PR DESCRIPTION
Moves `selection_changed` delivery to the renderer boundary so callbacks run after `renderer_state.mutex` is released. Consumers can synchronously call the documented selection read APIs without self-deadlocking.

Adds an opaque per-screen selection activity token. The renderer compares the active screen key and token after each frame update, which also catches terminal-driven clears from screen resets and alternate-screen transitions.

Tests cover genuine selection transitions, duplicate logical selections, repeated clears, screen switches, and reset-driven clears.

Verification:

- `zig fmt` passes with Zig 0.15.2.
- Focused tests were attempted with Zig 0.15.2, but the local macOS 26 build runner fails before project compilation with unresolved Darwin libc symbols. The matching GhosttyKit build and cmux tagged reload will provide the supported build-host check.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/104"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786241924&installation_id=133855650&pr_number=104&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F104&signature=206b5707cc818e4d0c25e185fbb7fc7d0d18aa98029be19ebac0aaa339a91d3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Notify selection changes after the renderer releases the terminal mutex so callbacks can read selection synchronously. Track only real changes and wake the renderer so callbacks fire even when rendering is deferred or the surface is hidden.

- **Bug Fixes**
  - Deliver `selection_changed` from the renderer after unlock; callbacks can read selection via normal APIs.
  - Track selection activity with screen key + serial; increment on new selections, clears, screen switches/resets, and in-place endpoint moves; ignore duplicates and no-ops.
  - Preserve notifications during mailbox drains and hidden surfaces, and wake the renderer after genuine selection changes when no frame is scheduled; initialize renderer selection tracking safely.

<sup>Written for commit bdf4baa802746a49d60648b402cafbff50cdd8b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/104?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved selection-change detection so notifications occur only when the active selection meaningfully changes or is cleared.
  - Selection state is now tracked consistently when switching between terminal screens.
  - Selection updates are reported reliably during rendering and when the terminal becomes visible again.

- **Tests**
  - Added coverage for repeated selections, changed selection ranges, clearing selections, and screen switching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->