### PR TITLE
Preserve compressed scrollback during reads

### DIFF
--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -78,13 +78,7 @@ compression: Compression = undefined,
 
 /// Last selection activity delivered to the apprt. This is renderer-owned so
 /// callbacks can run after the terminal mutex is released.
-selection_activity: terminalpkg.Terminal.SelectionActivity = .{
-    // Every terminal initializes with the primary screen active and no
-    // selection changes. Thread.init runs before terminal state exists, so the
-    // known initial token is safer than dereferencing renderer state there.
-    .screen = .primary,
-    .serial = 0,
-},
+selection_activity: terminalpkg.Terminal.SelectionActivity = 0,
 
 /// The surface we're rendering to.
 surface: *apprt.Surface,
@@ -800,9 +794,8 @@ fn renderCallback(
     };
     if (t.externalDrainActive()) return .disarm;
 
-    // Selection notifications are independent of visibility. Hidden surfaces
-    // still need to invalidate accessibility state even though they skip the
-    // more expensive frame rebuild below.
+    // Selection activity is a lock-free terminal-wide epoch, so hidden
+    // surfaces can keep accessibility state current without rebuilding.
     t.notifySelectionChanged();
 
     // If we're not visible there's no point spending CPU rebuilding cells —
@@ -822,18 +815,10 @@ fn renderCallback(
     return .disarm;
 }
 
-/// Notify the apprt when the active selection changes. The activity snapshot
-/// is read under the terminal mutex, but the callback runs only after unlock so
-/// consumers may safely call the normal selection read APIs synchronously.
+/// Notify the apprt when the active selection changes. The activity epoch is
+/// atomic, so this path never acquires the terminal mutex.
 fn notifySelectionChanged(self: *Thread) void {
-    const activity = activity: {
-        // Use the renderer demand path so sustained PTY output cannot starve
-        // this snapshot ahead of updateFrame's own demanding acquisition.
-        self.state.lockDemand();
-        defer self.state.unlockDemand();
-        break :activity self.state.terminal.selectionActivity();
-    };
-
+    const activity = self.state.terminal.selectionActivity();
     if (std.meta.eql(self.selection_activity, activity)) return;
     self.selection_activity = activity;
 

--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -60,6 +60,10 @@ selection: ?Selection = null,
 /// Renderers use this to notify apprts after releasing the terminal mutex.
 selection_activity: u64 = 0,
 
+/// Terminal-owned lock-free activity epoch. Standalone screens leave this
+/// null and retain only their local activity counter.
+selection_activity_shared: ?*std.atomic.Value(u64) = null,
+
 /// The charset state
 charset: CharsetState = .{},
 
@@ -258,6 +262,9 @@ pub const Options = struct {
     /// other value will be clamped to support a minimum of the active area.
     max_scrollback: usize = 0,
 
+    /// Shared activity epoch owned by ScreenSet.
+    selection_activity_shared: ?*std.atomic.Value(u64) = null,
+
     /// The total storage limit for Kitty images in bytes for this
     /// screen. Kitty image storage is per-screen.
     kitty_image_storage_limit: usize = switch (build_options.artifact) {
@@ -310,6 +317,7 @@ pub fn init(
         .alloc = alloc,
         .pages = pages,
         .no_scrollback = opts.max_scrollback == 0,
+        .selection_activity_shared = opts.selection_activity_shared,
         .cursor = .{
             .x = 0,
             .y = 0,
@@ -565,6 +573,7 @@ pub fn clone(
         .cursor = cursor,
         .selection = sel,
         .selection_activity = self.selection_activity,
+        .selection_activity_shared = null,
         .dirty = self.dirty,
     };
     result.assertIntegrity();
@@ -2626,7 +2635,7 @@ pub fn select(self: *Screen, sel_: ?Selection) Allocator.Error!void {
     if (self.selection) |*old| old.deinit(self);
     self.selection = tracked_sel;
     self.dirty.selection = true;
-    if (changed) self.selection_activity +%= 1;
+    if (changed) self.advanceSelectionActivity();
 }
 
 /// Same as select(null) but can't fail.
@@ -2634,7 +2643,7 @@ pub fn clearSelection(self: *Screen) void {
     if (self.selection) |*sel| {
         sel.deinit(self);
         self.dirty.selection = true;
-        self.selection_activity +%= 1;
+        self.advanceSelectionActivity();
     }
     self.selection = null;
 }
@@ -2649,8 +2658,14 @@ pub fn adjustSelection(
     const previous_end = selection.end();
     selection.adjust(self, adjustment);
     self.dirty.selection = true;
-    if (!previous_end.eql(selection.end())) self.selection_activity +%= 1;
+    if (!previous_end.eql(selection.end())) self.advanceSelectionActivity();
     return selection;
+}
+
+fn advanceSelectionActivity(self: *Screen) void {
+    self.selection_activity +%= 1;
+    if (self.selection_activity_shared) |shared|
+        _ = shared.fetchAdd(1, .release);
 }
 
 pub const SelectionString = struct {
@@ -3369,7 +3384,7 @@ pub fn dumpString(
         /// dump the screen as it is visually seen in a rendered window.
         unwrap: bool = true,
     },
-) std.Io.Writer.Error!void {
+) (std.Io.Writer.Error || Allocator.Error)!void {
     // Create a formatter and use that to emit our text.
     var formatter: ScreenFormatter = .init(self, .{
         .emit = .plain,

--- a/src/terminal/ScreenSet.zig
+++ b/src/terminal/ScreenSet.zig
@@ -35,19 +35,30 @@ all: std.EnumMap(Key, *Screen),
 /// screen from stale references into destroyed screen storage.
 generations: std.EnumMap(Key, usize),
 
+/// Lock-free epoch shared by every screen in this terminal. This lets the
+/// renderer observe selection changes without acquiring the terminal mutex.
+selection_activity: *std.atomic.Value(u64),
+
 pub fn init(
     alloc: Allocator,
     opts: Screen.Options,
 ) Allocator.Error!ScreenSet {
+    const selection_activity = try alloc.create(std.atomic.Value(u64));
+    errdefer alloc.destroy(selection_activity);
+    selection_activity.* = .init(0);
+
     // We need to initialize our initial primary screen
     const screen = try alloc.create(Screen);
     errdefer alloc.destroy(screen);
-    screen.* = try .init(alloc, opts);
+    var screen_opts = opts;
+    screen_opts.selection_activity_shared = selection_activity;
+    screen.* = try .init(alloc, screen_opts);
     return .{
         .active_key = .primary,
         .active = screen,
         .all = .init(.{ .primary = screen }),
         .generations = .initFull(0),
+        .selection_activity = selection_activity,
     };
 }
 
@@ -58,6 +69,7 @@ pub fn deinit(self: *ScreenSet, alloc: Allocator) void {
         entry.value.*.deinit();
         alloc.destroy(entry.value.*);
     }
+    alloc.destroy(self.selection_activity);
 }
 
 /// Get the screen for the given key, if it is initialized.
@@ -80,7 +92,9 @@ pub fn getInit(
     if (self.get(key)) |screen| return screen;
     const screen = try alloc.create(Screen);
     errdefer alloc.destroy(screen);
-    screen.* = try .init(alloc, opts);
+    var screen_opts = opts;
+    screen_opts.selection_activity_shared = self.selection_activity;
+    screen.* = try .init(alloc, screen_opts);
     self.all.put(key, screen);
     return screen;
 }
@@ -102,8 +116,10 @@ pub fn remove(
 /// Switch the active screen to the given key. Requires that the
 /// screen is initialized.
 pub fn switchTo(self: *ScreenSet, key: Key) void {
+    const changed = self.active_key != key;
     self.active_key = key;
     self.active = self.all.get(key).?;
+    if (changed) _ = self.selection_activity.fetchAdd(1, .release);
 }
 
 test ScreenSet {

--- a/src/terminal/ScreenSet.zig
+++ b/src/terminal/ScreenSet.zig
@@ -108,6 +108,7 @@ pub fn remove(
     assert(key != .primary);
     if (self.all.fetchRemove(key)) |screen| {
         self.generations.put(key, self.generation(key) +% 1);
+        _ = self.selection_activity.fetchAdd(1, .release);
         screen.deinit();
         alloc.destroy(screen);
     }
@@ -155,8 +156,13 @@ test "ScreenSet generations" {
     try testing.expectEqual(@as(usize, 0), set.generation(.alternate));
 
     const alternate_generation = set.generation(.alternate);
+    const selection_activity = set.selection_activity.load(.acquire);
     set.remove(alloc, .alternate);
     try testing.expectEqual(alternate_generation +% 1, set.generation(.alternate));
+    try testing.expectEqual(
+        selection_activity +% 1,
+        set.selection_activity.load(.acquire),
+    );
 
     // Reinitializing keeps the generation from the last removal, so stale
     // handles can distinguish the new screen from the destroyed screen.

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -2314,33 +2314,21 @@ pub fn compressionActivity(self: *const Terminal) u64 {
     return @as(u64, state.activity_serial);
 }
 
-/// Return the active screen's opaque selection activity token.
-///
-/// Callers compare this after renderer updates so apprt notifications can be
-/// delivered without holding the terminal mutex. The screen key is part of the
-/// token because switching screens can change the active selection even when
-/// both screens have the same local activity serial.
+/// Return the terminal-wide opaque selection activity token. Screen selection
+/// changes and active-screen switches advance this lock-free epoch, allowing
+/// renderer notifications without acquiring the terminal mutex.
 pub fn selectionActivity(self: *const Terminal) SelectionActivity {
-    return .{
-        .screen = self.screens.active_key,
-        .serial = self.screens.active.selection_activity,
-    };
+    return self.screens.selection_activity.load(.acquire);
 }
 
-pub const SelectionActivity = struct {
-    screen: ScreenSet.Key,
-    serial: u64,
-};
+pub const SelectionActivity = u64;
 
 test "Terminal: selection activity follows screen switches and resets" {
     const alloc = testing.allocator;
     var t = try init(alloc, .{ .cols = 10, .rows = 5 });
     defer t.deinit(alloc);
 
-    try testing.expectEqualDeep(SelectionActivity{
-        .screen = .primary,
-        .serial = 0,
-    }, t.selectionActivity());
+    try testing.expectEqual(@as(SelectionActivity, 0), t.selectionActivity());
 
     const screen = t.screens.active;
     try screen.select(.init(
@@ -2348,28 +2336,16 @@ test "Terminal: selection activity follows screen switches and resets" {
         screen.pages.pin(.{ .active = .{ .x = 1, .y = 0 } }).?,
         false,
     ));
-    try testing.expectEqualDeep(SelectionActivity{
-        .screen = .primary,
-        .serial = 1,
-    }, t.selectionActivity());
+    try testing.expectEqual(@as(SelectionActivity, 1), t.selectionActivity());
 
     _ = try t.switchScreen(.alternate);
-    try testing.expectEqualDeep(SelectionActivity{
-        .screen = .alternate,
-        .serial = 0,
-    }, t.selectionActivity());
+    try testing.expectEqual(@as(SelectionActivity, 2), t.selectionActivity());
 
     _ = try t.switchScreen(.primary);
-    try testing.expectEqualDeep(SelectionActivity{
-        .screen = .primary,
-        .serial = 1,
-    }, t.selectionActivity());
+    try testing.expectEqual(@as(SelectionActivity, 3), t.selectionActivity());
 
     t.screens.active.reset();
-    try testing.expectEqualDeep(SelectionActivity{
-        .screen = .primary,
-        .serial = 2,
-    }, t.selectionActivity());
+    try testing.expectEqual(@as(SelectionActivity, 4), t.selectionActivity());
 }
 
 /// The amount of compression work performed by `compress` before returning.
@@ -12461,12 +12437,11 @@ fn testPrintSliceDifferential(
     // Alphabet of interesting codepoints: ascii, latin-1, combining
     // marks, CJK (wide), emoji (wide), ZWJ, variation selectors.
     const alphabet = [_]u21{
-        'a',     'b',     'Z',    '0',    ' ',     0x10,   0x1F,   0x7F,
-        'é',
-        0xFF,    0x301,   0x4E00, 0x4E01, 0x1F600, 0x200D, 0xFE0F, 'x',
-        'y',     0x1F9D1, 0x0308, 0xAD,   0x3042,  0xAC00, 'q',    'r',
-        's',     't',     'u',    'v',    'w',     '1',    '2',    0x1F1E6,
-        0x1F1E7, 0x1100,  0x1161, 0x11A8, 0x200C,  0x0430, 0x03B1,
+        'a',     'b',     'Z',     '0',    ' ',    0x10,    0x1F,   0x7F,
+        'é',    0xFF,    0x301,   0x4E00, 0x4E01, 0x1F600, 0x200D, 0xFE0F,
+        'x',     'y',     0x1F9D1, 0x0308, 0xAD,   0x3042,  0xAC00, 'q',
+        'r',     's',     't',     'u',    'v',    'w',     '1',    '2',
+        0x1F1E6, 0x1F1E7, 0x1100,  0x1161, 0x11A8, 0x200C,  0x0430, 0x03B1,
     };
 
     var cps_buf: [64]u32 = undefined;

--- a/src/terminal/c/formatter.zig
+++ b/src/terminal/c/formatter.zig
@@ -175,11 +175,15 @@ pub fn format_buf(
 
     switch (wrapper.kind) {
         .terminal => |*t| t.format(&writer) catch |err| switch (err) {
+            error.OutOfMemory => return .out_of_memory,
             error.WriteFailed => {
                 // On write failed we always report how much
                 // space we actually needed.
                 var discarding: std.Io.Writer.Discarding = .init(&.{});
-                t.format(&discarding.writer) catch unreachable;
+                t.format(&discarding.writer) catch |retry_err| switch (retry_err) {
+                    error.OutOfMemory => return .out_of_memory,
+                    error.WriteFailed => unreachable,
+                };
                 out_written.* = @intCast(discarding.count);
                 return .out_of_space;
             },

--- a/src/terminal/c/selection.zig
+++ b/src/terminal/c/selection.zig
@@ -189,6 +189,7 @@ pub fn format_buf(
         formatSelection(t, opts, &discarding.writer) catch |err| return switch (err) {
             error.InvalidValue => .invalid_value,
             error.NoValue => .no_value,
+            error.OutOfMemory => .out_of_memory,
             error.WriteFailed => unreachable,
         };
         out_written.* = @intCast(discarding.count);
@@ -199,9 +200,15 @@ pub fn format_buf(
     formatSelection(t, opts, &writer) catch |err| switch (err) {
         error.InvalidValue => return .invalid_value,
         error.NoValue => return .no_value,
+        error.OutOfMemory => return .out_of_memory,
         error.WriteFailed => {
             var discarding: std.Io.Writer.Discarding = .init(&.{});
-            formatSelection(t, opts, &discarding.writer) catch unreachable;
+            formatSelection(t, opts, &discarding.writer) catch |retry_err| return switch (retry_err) {
+                error.InvalidValue => .invalid_value,
+                error.NoValue => .no_value,
+                error.OutOfMemory => .out_of_memory,
+                error.WriteFailed => unreachable,
+            };
             out_written.* = @intCast(discarding.count);
             return .out_of_space;
         },
@@ -230,6 +237,7 @@ pub fn format_alloc(
     formatSelection(t, opts, &aw.writer) catch |err| return switch (err) {
         error.InvalidValue => .invalid_value,
         error.NoValue => .no_value,
+        error.OutOfMemory => .out_of_memory,
         error.WriteFailed => .out_of_memory,
     };
 
@@ -243,7 +251,7 @@ fn formatSelection(
     t: *terminal_c.ZigTerminal,
     opts: FormatOptions,
     writer: *std.Io.Writer,
-) error{ InvalidValue, NoValue, WriteFailed }!void {
+) error{ InvalidValue, NoValue, OutOfMemory, WriteFailed }!void {
     var formatter = selectionFormatter(t, opts) catch |err| return err;
     try formatter.format(writer);
 }

--- a/src/terminal/formatter.zig
+++ b/src/terminal/formatter.zig
@@ -246,7 +246,7 @@ pub const TerminalFormatter = struct {
     pub fn format(
         self: TerminalFormatter,
         writer: *std.Io.Writer,
-    ) std.Io.Writer.Error!void {
+    ) (std.Io.Writer.Error || Allocator.Error)!void {
         // Emit palette before screen content if using VT format. Technically
         // we could do this after but this way if replay is slow for whatever
         // reason the colors will be right right away.
@@ -534,7 +534,7 @@ pub const ScreenFormatter = struct {
     pub fn format(
         self: ScreenFormatter,
         writer: *std.Io.Writer,
-    ) std.Io.Writer.Error!void {
+    ) (std.Io.Writer.Error || Allocator.Error)!void {
         switch (self.content) {
             .none => {},
 
@@ -733,7 +733,7 @@ pub const PageListFormatter = struct {
     pub fn format(
         self: PageListFormatter,
         writer: *std.Io.Writer,
-    ) std.Io.Writer.Error!void {
+    ) (std.Io.Writer.Error || Allocator.Error)!void {
         const tl: PageList.Pin = self.top_left orelse self.list.getTopLeft(.screen);
         const br: PageList.Pin = self.bottom_right orelse self.list.getBottomRight(.screen).?;
 
@@ -747,7 +747,13 @@ pub const PageListFormatter = struct {
             assert(chunk.start < chunk.end);
             assert(chunk.end > 0);
 
-            var formatter: PageFormatter = .init(chunk.node.page(), self.opts);
+            // Formatting is observational. Decode compressed pages into
+            // temporary storage so full scrollback reads don't make cold
+            // history resident again.
+            var preserved = try chunk.node.pagePreservingState(self.list.pool.alloc);
+            defer preserved.deinit();
+
+            var formatter: PageFormatter = .init(preserved.page(), self.opts);
             formatter.start_y = chunk.start;
             formatter.end_y = chunk.end - 1;
             formatter.trailing_state = page_state;
@@ -3678,6 +3684,62 @@ test "PageList plain spanning two pages" {
         try testing.expectEqual(last_node, pin_map.items[idx].node);
         try testing.expectEqual(@as(size.CellCountInt, @intCast(i)), pin_map.items[idx].x);
     }
+}
+
+test "PageList formatting preserves compressed page storage" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var builder: std.Io.Writer.Allocating = .init(alloc);
+    defer builder.deinit();
+
+    var t = try Terminal.init(alloc, .{
+        .cols = 80,
+        .rows = 24,
+    });
+    defer t.deinit(alloc);
+
+    var stream = t.vtStream();
+    defer stream.deinit();
+
+    const pages = &t.screens.active.pages;
+    const first_page_rows = pages.pages.first.?.capacity().rows;
+    for (0..first_page_rows + 24) |_| stream.nextSlice("history\r\n");
+
+    _ = pages.compress(.full);
+    const before = pages.memoryStats();
+    try testing.expect(before.decommitted_raw_bytes > 0);
+
+    var formatter: PageListFormatter = .init(pages, .plain);
+    try formatter.format(&builder.writer);
+
+    try testing.expect(std.mem.indexOf(u8, builder.writer.buffered(), "history") != null);
+    try testing.expectEqual(before.decommitted_raw_bytes, pages.memoryStats().decommitted_raw_bytes);
+}
+
+test "PageList formatting reports temporary decode allocation failure" {
+    const testing = std.testing;
+
+    var failing = testing.FailingAllocator.init(testing.allocator, .{});
+    var t = try Terminal.init(failing.allocator(), .{
+        .cols = 80,
+        .rows = 24,
+    });
+    defer t.deinit(failing.allocator());
+
+    var stream = t.vtStream();
+    defer stream.deinit();
+
+    const pages = &t.screens.active.pages;
+    const first_page_rows = pages.pages.first.?.capacity().rows;
+    for (0..first_page_rows + 24) |_| stream.nextSlice("history\r\n");
+    _ = pages.compress(.full);
+    try testing.expect(pages.memoryStats().decommitted_raw_bytes > 0);
+
+    failing.fail_index = failing.alloc_index;
+    var discarding: std.Io.Writer.Discarding = .init(&.{});
+    var formatter: PageListFormatter = .init(pages, .plain);
+    try testing.expectError(error.OutOfMemory, formatter.format(&discarding.writer));
 }
 
 test "PageList soft-wrapped line spanning two pages without unwrap" {

--- a/src/terminal/tmux/viewer.zig
+++ b/src/terminal/tmux/viewer.zig
@@ -1109,10 +1109,10 @@ pub const Viewer = struct {
         // Our active area should be empty
         if (comptime std.debug.runtime_safety) {
             var discarding: std.Io.Writer.Discarding = .init(&.{});
-            screen.dumpString(&discarding.writer, .{
+            try screen.dumpString(&discarding.writer, .{
                 .tl = screen.pages.getTopLeft(.active),
                 .unwrap = false,
-            }) catch unreachable;
+            });
             assert(discarding.count == 0);
         }
     }
@@ -1739,7 +1739,6 @@ test "initial flow" {
                         else => {},
                     };
                     try testing.expect(found_capture);
-
                     const pane: *Viewer.Pane = v.panes.getEntry(0).?.value_ptr;
                     const screen: *Screen = pane.terminal.screens.active;
                     {


### PR DESCRIPTION
Full scrollback formatting now decodes compressed pages into temporary storage without restoring their resident backing. Allocation failures propagate as OutOfMemory through Zig and C formatter APIs.

Selection notifications use a terminal-wide atomic activity epoch, avoiding a terminal mutex acquisition on every renderer wake while preserving notifications for hidden surfaces.

Tests:
- zig build test -Demit-macos-app=false -Dtest-filter="PageList formatting"
- zig build test -Demit-macos-app=false -Dtest-filter="selection activity"
- zig build -Demit-macos-app=false
- canonical autoreview clean

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/106"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786249800&installation_id=133855650&pr_number=106&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F106&signature=b0ba497f89849bf6fc07da2075147e2eccea3b46a182aa08625e99dcd0d232b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Full-scrollback reads now decode compressed pages into temporary storage so history stays compressed. Selection notifications use a terminal-wide atomic epoch (advanced on selection changes, screen switches, and screen removal) to notify hidden surfaces without locking, and OOMs propagate through Zig and C formatter/selection APIs.

- **New Features**
  - Preserve compressed scrollback during `PageList` formatting by decoding into temporary buffers instead of restoring resident backing.
  - OOM propagation: Zig formatters now include Allocator.Error; C `formatter` and `selection` return `out_of_memory`.

- **Refactors**
  - Lock-free selection activity via a shared atomic epoch in `ScreenSet`; incremented on selection changes, screen switches, and screen removal, and read by the renderer without the terminal mutex.

<sup>Written for commit 2a1b44696c832206c2e0700b8af09c2407228e14. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Accessibility**
  - Improved selection-state updates across active and hidden terminal surfaces, helping accessibility information remain current without unnecessary redraws.

- **Bug Fixes**
  - Improved handling of memory-allocation failures during terminal and selection formatting.
  - Preserved compressed page data during formatting operations.
  - Improved error reporting when displaying pane history and terminal content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->