### PR TITLE
render-grid: export bounded rows after viewport

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1150,13 +1150,18 @@ GHOSTTY_API uint64_t ghostty_surface_foreground_pid(ghostty_surface_t);
 GHOSTTY_API ghostty_string_s ghostty_surface_tty_name(ghostty_surface_t);
 // cmux fork: export the Ghostty grid as a compact render-grid JSON frame for
 // mobile mirrors: the visible viewport plus full restore state (active screen,
-// DEC/ANSI modes, dynamic colors, cursor) and up to the given number of
-// scrollback history rows. The returned string must be freed with
-// ghostty_string_free.
+// DEC/ANSI modes, dynamic colors, cursor), up to the given number of rows
+// before the viewport, and up to the given number of newer rows after the
+// viewport. `scrollback_rows`/`scrollback_spans` are ordered from the oldest
+// included row toward the viewport. `scrollforward_rows`/`scrollforward_spans`
+// are ordered from immediately after the viewport toward the screen bottom.
+// The final two arguments are the before-row and after-row caps, respectively.
+// The returned string must be freed with ghostty_string_free.
 GHOSTTY_API ghostty_string_s ghostty_surface_render_grid_json(ghostty_surface_t,
                                                                  const char*,
                                                                  uintptr_t,
                                                                  uint64_t,
+                                                                 uintptr_t,
                                                                  uintptr_t);
 GHOSTTY_API void ghostty_surface_set_color_scheme(ghostty_surface_t,
                                                      ghostty_color_scheme_e);

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1237,6 +1237,15 @@ GHOSTTY_API void ghostty_surface_mouse_scroll(ghostty_surface_t,
                                                  double,
                                                  double,
                                                  ghostty_input_scroll_mods_t);
+// cmux fork: applies an exact row delta to normal-screen scrollback while
+// preserving wheel semantics for alternate-screen and mouse-reporting modes.
+// Positive viewport rows scroll upward, matching the wheel y convention.
+GHOSTTY_API void ghostty_surface_mouse_scroll_with_viewport_rows(
+                                                ghostty_surface_t,
+                                                double,
+                                                double,
+                                                int32_t,
+                                                ghostty_input_scroll_mods_t);
 GHOSTTY_API void ghostty_surface_mouse_pressure(ghostty_surface_t, uint32_t, double);
 GHOSTTY_API void ghostty_surface_ime_point(ghostty_surface_t, double*, double*, double*, double*);
 GHOSTTY_API void ghostty_surface_request_close(ghostty_surface_t);

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1155,6 +1155,9 @@ GHOSTTY_API ghostty_string_s ghostty_surface_tty_name(ghostty_surface_t);
 // viewport. `scrollback_rows`/`scrollback_spans` are ordered from the oldest
 // included row toward the viewport. `scrollforward_rows`/`scrollforward_spans`
 // are ordered from immediately after the viewport toward the screen bottom.
+// When that bounded newer window does not reach the primary active screen,
+// `primary_active_rows`/`primary_active_spans` carry the missing active-screen
+// suffix separately and are capped to one viewport.
 // The final two arguments are the before-row and after-row caps, respectively.
 // The returned string must be freed with ghostty_string_free.
 GHOSTTY_API ghostty_string_s ghostty_surface_render_grid_json(ghostty_surface_t,

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1182,14 +1182,21 @@ GHOSTTY_API ghostty_string_s ghostty_surface_tty_name(ghostty_surface_t);
 // When that bounded newer window does not reach the primary active screen,
 // `primary_active_rows`/`primary_active_spans` carry the missing active-screen
 // suffix separately and are capped to one viewport.
-// The final two arguments are the before-row and after-row caps, respectively.
-// The returned string must be freed with ghostty_string_free.
+// The legacy entrypoint accepts only the before-row cap and includes no rows
+// after the viewport. The bounded entrypoint accepts before-row and after-row
+// caps, respectively. Returned strings must be freed with ghostty_string_free.
 GHOSTTY_API ghostty_string_s ghostty_surface_render_grid_json(ghostty_surface_t,
                                                                  const char*,
                                                                  uintptr_t,
                                                                  uint64_t,
-                                                                 uintptr_t,
                                                                  uintptr_t);
+GHOSTTY_API ghostty_string_s ghostty_surface_render_grid_json_bounded(
+    ghostty_surface_t,
+    const char*,
+    uintptr_t,
+    uint64_t,
+    uintptr_t,
+    uintptr_t);
 GHOSTTY_API void ghostty_surface_set_color_scheme(ghostty_surface_t,
                                                      ghostty_color_scheme_e);
 GHOSTTY_API ghostty_input_mods_e ghostty_surface_key_translation_mods(ghostty_surface_t,

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -3770,6 +3770,19 @@ pub fn scrollCallback(
     yoff: f64,
     scroll_mods: input.ScrollMods,
 ) !void {
+    return self.scrollCallbackWithViewportRows(xoff, yoff, null, scroll_mods);
+}
+
+/// Handles a mouse scroll while optionally using an exact row delta for the
+/// normal-screen viewport. Alternate-screen and mouse-reporting behavior still
+/// use the wheel offsets so applications retain their native scroll semantics.
+pub fn scrollCallbackWithViewportRows(
+    self: *Surface,
+    xoff: f64,
+    yoff: f64,
+    viewport_rows: ?i32,
+    scroll_mods: input.ScrollMods,
+) !void {
     // log.info("SCROLL: xoff={} yoff={} mods={}", .{ xoff, yoff, scroll_mods });
 
     // Crash metadata in case we crash in here
@@ -3932,11 +3945,15 @@ pub fn scrollCallback(
             return;
         }
 
-        if (y.delta != 0) {
+        const viewport_delta: isize = if (viewport_rows) |rows|
+            -@as(isize, rows)
+        else
+            y.delta * -1;
+        if (viewport_delta != 0) {
             // Modify our viewport, this requires a lock since it affects
             // rendering. We have to switch signs here because our delta
             // is negative down but our viewport is positive down.
-            self.io.terminal.scrollViewport(.{ .delta = y.delta * -1 });
+            self.io.terminal.scrollViewport(.{ .delta = viewport_delta });
         }
     }
 

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -2446,11 +2446,20 @@ pub const CAPI = struct {
             usize,
             usize,
         ) callconv(.c) String;
+        const ModeAwareScrollFn = *const fn (
+            *Surface,
+            f64,
+            f64,
+            i32,
+            c_int,
+        ) callconv(.c) void;
 
         const legacy: LegacyRenderGridFn = &ghostty_surface_render_grid_json;
         const bounded: BoundedRenderGridFn = &ghostty_surface_render_grid_json_bounded;
+        const mode_aware_scroll: ModeAwareScrollFn = &ghostty_surface_mouse_scroll_with_viewport_rows;
         _ = legacy;
         _ = bounded;
+        _ = mode_aware_scroll;
     }
 
     test "render grid bidirectional rows preserve compressed page storage" {
@@ -2508,6 +2517,40 @@ pub const CAPI = struct {
         next.id = @intCast(styles.items.len);
         try styles.append(global.alloc, next);
         return next.id;
+    }
+
+    test "render grid style lookup remains indexed at high cardinality" {
+        const testing = std.testing;
+        var styles: std.ArrayListUnmanaged(RenderGridStyle) = .empty;
+        defer styles.deinit(testing.allocator);
+        var style_index: RenderGridStyleIndex = .empty;
+        defer style_index.deinit(testing.allocator);
+
+        for (0..4096) |raw| {
+            const value: u32 = @intCast(raw);
+            const style: RenderGridStyle = .{
+                .id = 0,
+                .foreground = .{
+                    .r = @truncate(value),
+                    .g = @truncate(value >> 8),
+                    .b = @truncate(value >> 16),
+                },
+                .background = .{ .r = 1, .g = 2, .b = 3 },
+            };
+            try testing.expectEqual(
+                value,
+                try renderGridStyleID(testing.allocator, &styles, &style_index, style),
+            );
+        }
+
+        try testing.expectEqual(@as(usize, 4096), styles.items.len);
+        try testing.expectEqual(@as(u32, 2048), try renderGridStyleID(
+            testing.allocator,
+            &styles,
+            &style_index,
+            styles.items[2048],
+        ));
+        try testing.expectEqual(@as(usize, 4096), styles.items.len);
     }
 
     fn resolvedRenderGridStyle(

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -2041,6 +2041,225 @@ pub const CAPI = struct {
         }
     };
 
+    const RenderGridRowRegion = enum {
+        scrollback,
+        viewport,
+        scrollforward,
+    };
+
+    const RenderGridRow = struct {
+        pin: terminal.PageList.Pin,
+        region: RenderGridRowRegion,
+        output_row: u32,
+    };
+
+    const RenderGridRowIterator = struct {
+        rows: terminal.PageList.RowIterator,
+        viewport_top: terminal.PageList.Pin,
+        viewport_bottom: terminal.PageList.Pin,
+        region: RenderGridRowRegion,
+        scrollback_rows: u32 = 0,
+        viewport_rows: u32 = 0,
+        scrollforward_rows: u32 = 0,
+
+        fn init(
+            pages: *const terminal.PageList,
+            scrollback_lines: usize,
+            scrollforward_lines: usize,
+        ) RenderGridRowIterator {
+            const viewport_top = pages.getTopLeft(.viewport);
+            const viewport_bottom = pages.getBottomRight(.viewport) orelse viewport_top;
+            const screen_top = pages.getTopLeft(.screen);
+            const screen_bottom = pages.getBottomRight(.screen) orelse viewport_bottom;
+            const start = if (scrollback_lines == 0)
+                viewport_top
+            else
+                (viewport_top.up(scrollback_lines) orelse screen_top);
+            const end = if (scrollforward_lines == 0)
+                viewport_bottom
+            else
+                (viewport_bottom.down(scrollforward_lines) orelse screen_bottom);
+
+            return .{
+                .rows = start.rowIterator(.right_down, end),
+                .viewport_top = viewport_top,
+                .viewport_bottom = viewport_bottom,
+                .region = if (sameRenderGridRow(start, viewport_top))
+                    .viewport
+                else
+                    .scrollback,
+            };
+        }
+
+        fn next(self: *RenderGridRowIterator) ?RenderGridRow {
+            const pin = self.rows.next() orelse return null;
+            if (self.region == .scrollback and
+                sameRenderGridRow(pin, self.viewport_top))
+            {
+                self.region = .viewport;
+            }
+
+            const region = self.region;
+            const output_row = switch (region) {
+                .scrollback => row: {
+                    defer self.scrollback_rows += 1;
+                    break :row self.scrollback_rows;
+                },
+                .viewport => row: {
+                    defer self.viewport_rows += 1;
+                    break :row self.viewport_rows;
+                },
+                .scrollforward => row: {
+                    defer self.scrollforward_rows += 1;
+                    break :row self.scrollforward_rows;
+                },
+            };
+
+            if (region == .viewport and
+                sameRenderGridRow(pin, self.viewport_bottom))
+            {
+                self.region = .scrollforward;
+            }
+
+            return .{
+                .pin = pin,
+                .region = region,
+                .output_row = output_row,
+            };
+        }
+    };
+
+    fn sameRenderGridRow(
+        a: terminal.PageList.Pin,
+        b: terminal.PageList.Pin,
+    ) bool {
+        return a.node == b.node and a.y == b.y;
+    }
+
+    const RenderGridPageReader = struct {
+        alloc: Allocator,
+        node: ?*terminal.PageList.List.Node = null,
+        preserved: ?terminal.PageList.List.Node.PreservedPage = null,
+
+        fn deinit(self: *RenderGridPageReader) void {
+            if (self.preserved) |*page_| page_.deinit();
+        }
+
+        fn pageFor(
+            self: *RenderGridPageReader,
+            pin: terminal.PageList.Pin,
+        ) !*const terminal.Page {
+            if (self.node != pin.node) {
+                const next = try pin.node.pagePreservingState(self.alloc);
+                if (self.preserved) |*page_| page_.deinit();
+                self.preserved = next;
+                self.node = pin.node;
+            }
+
+            return if (self.preserved) |*page_| page_.page() else unreachable;
+        }
+    };
+
+    test "render grid row iterator bounds both viewport directions" {
+        const testing = std.testing;
+
+        var screen = try terminal.Screen.init(testing.allocator, .{
+            .cols = 5,
+            .rows = 3,
+            .max_scrollback = 1_000_000,
+        });
+        defer screen.deinit();
+        try screen.testWriteString("1\n2\n3\n4\n5\n6\n7\n8");
+        screen.scroll(.{ .delta_row = -2 });
+
+        const expected_regions = [_]RenderGridRowRegion{
+            .scrollback,
+            .scrollback,
+            .viewport,
+            .viewport,
+            .viewport,
+            .scrollforward,
+            .scrollforward,
+        };
+        const expected_output_rows = [_]u32{ 0, 1, 0, 1, 2, 0, 1 };
+        const expected_codepoints = [_]u21{ '2', '3', '4', '5', '6', '7', '8' };
+
+        var it = RenderGridRowIterator.init(&screen.pages, 2, 2);
+        var page_reader: RenderGridPageReader = .{ .alloc = testing.allocator };
+        defer page_reader.deinit();
+        var index: usize = 0;
+        while (it.next()) |row| : (index += 1) {
+            try testing.expect(index < expected_regions.len);
+            try testing.expectEqual(expected_regions[index], row.region);
+            try testing.expectEqual(expected_output_rows[index], row.output_row);
+
+            const page_ = try page_reader.pageFor(row.pin);
+            const cell = page_.getRowAndCell(0, row.pin.y).cell;
+            try testing.expectEqual(expected_codepoints[index], cell.codepoint());
+        }
+        try testing.expectEqual(expected_regions.len, index);
+        try testing.expectEqual(@as(u32, 2), it.scrollback_rows);
+        try testing.expectEqual(@as(u32, 3), it.viewport_rows);
+        try testing.expectEqual(@as(u32, 2), it.scrollforward_rows);
+
+        screen.scroll(.top);
+        var top_it = RenderGridRowIterator.init(&screen.pages, 2, 2);
+        while (top_it.next()) |_| {}
+        try testing.expectEqual(@as(u32, 0), top_it.scrollback_rows);
+        try testing.expectEqual(@as(u32, 3), top_it.viewport_rows);
+        try testing.expectEqual(@as(u32, 2), top_it.scrollforward_rows);
+
+        screen.scroll(.active);
+        var active_it = RenderGridRowIterator.init(&screen.pages, 2, 2);
+        while (active_it.next()) |_| {}
+        try testing.expectEqual(@as(u32, 2), active_it.scrollback_rows);
+        try testing.expectEqual(@as(u32, 3), active_it.viewport_rows);
+        try testing.expectEqual(@as(u32, 0), active_it.scrollforward_rows);
+    }
+
+    test "render grid bidirectional rows preserve compressed page storage" {
+        const testing = std.testing;
+
+        var screen = try terminal.Screen.init(testing.allocator, .{
+            .cols = 80,
+            .rows = 24,
+            .max_scrollback = 10_000_000,
+        });
+        defer screen.deinit();
+        for (0..700) |_| try screen.testWriteString("X\n");
+        screen.scroll(.{ .row = 240 });
+
+        if (screen.pages.compress(.full) == .unsupported) {
+            return error.SkipZigTest;
+        }
+        const before = screen.pages.memoryStats();
+        try testing.expect(before.compressed_pages > 0);
+
+        var compressed_rows: usize = 0;
+        var it = RenderGridRowIterator.init(&screen.pages, 300, 300);
+        {
+            var page_reader: RenderGridPageReader = .{ .alloc = testing.allocator };
+            defer page_reader.deinit();
+            while (it.next()) |row| {
+                const was_compressed = row.pin.node.storage() == .compressed;
+                const page_ = try page_reader.pageFor(row.pin);
+                _ = page_.getRowAndCell(0, row.pin.y).cell.codepoint();
+                if (was_compressed) {
+                    compressed_rows += 1;
+                    try testing.expectEqual(
+                        terminal.PageList.List.Node.Storage.compressed,
+                        row.pin.node.storage(),
+                    );
+                }
+            }
+        }
+
+        try testing.expect(compressed_rows > 0);
+        try testing.expectEqual(before, screen.pages.memoryStats());
+        try testing.expect(it.scrollback_rows <= 300);
+        try testing.expect(it.scrollforward_rows <= 300);
+    }
+
     fn renderGridStyleID(
         styles: *std.ArrayListUnmanaged(RenderGridStyle),
         style: RenderGridStyle,
@@ -2136,6 +2355,7 @@ pub const CAPI = struct {
         surface_id: []const u8,
         state_seq: u64,
         scrollback_lines: usize,
+        scrollforward_lines: usize,
     ) !String {
         const alloc = global.alloc;
         const core_surface = &surface.core_surface;
@@ -2153,6 +2373,11 @@ pub const CAPI = struct {
             for (scrollback_spans.items) |span| alloc.free(span.text);
             scrollback_spans.deinit(alloc);
         }
+        var scrollforward_spans: std.ArrayListUnmanaged(RenderGridSpan) = .empty;
+        defer {
+            for (scrollforward_spans.items) |span| alloc.free(span.text);
+            scrollforward_spans.deinit(alloc);
+        }
         var modes_out: std.ArrayListUnmanaged(RenderGridMode) = .empty;
         defer modes_out.deinit(alloc);
 
@@ -2168,6 +2393,7 @@ pub const CAPI = struct {
         var bg_override: ?terminal.color.RGB = null;
         var cursor_color_override: ?terminal.color.RGB = null;
         var scrollback_rows: u32 = 0;
+        var scrollforward_rows: u32 = 0;
 
         {
             core_surface.renderer_state.mutex.lock();
@@ -2219,47 +2445,38 @@ pub const CAPI = struct {
             defer vp_builder.deinit();
             var sb_builder = RenderGridSpanBuilder.init(alloc, &scrollback_spans);
             defer sb_builder.deinit();
+            var sf_builder = RenderGridSpanBuilder.init(alloc, &scrollforward_spans);
+            defer sf_builder.deinit();
 
-            // Iterate the (bounded) scrollback above the viewport plus the
-            // viewport itself in one pass. The alternate screen has no
-            // scrollback, so `up` clamps to the viewport top and no scrollback
-            // rows are emitted.
-            const vp_top = s.pages.getTopLeft(.viewport);
-            const start = if (scrollback_lines == 0)
-                vp_top
-            else
-                (vp_top.up(scrollback_lines) orelse s.pages.getTopLeft(.screen));
-            const vp_bottom = s.pages.getBottomRight(.viewport) orelse vp_top;
+            // Traverse the bounded history window, viewport, and bounded newer
+            // window in one pass. This keeps both prefetch directions capped by
+            // their caller-provided row limits.
+            var row_it = RenderGridRowIterator.init(
+                &s.pages,
+                scrollback_lines,
+                scrollforward_lines,
+            );
+            var page_reader: RenderGridPageReader = .{ .alloc = alloc };
+            defer page_reader.deinit();
+            while (row_it.next()) |render_row| {
+                const row_pin = render_row.pin;
+                const builder = switch (render_row.region) {
+                    .scrollback => &sb_builder,
+                    .viewport => &vp_builder,
+                    .scrollforward => &sf_builder,
+                };
 
-            var row_it = start.rowIterator(.right_down, vp_bottom);
-            var vp_y: u32 = 0;
-            var sb_y: u32 = 0;
-            var in_viewport = false;
-            var preserved_node: ?*terminal.PageList.List.Node = null;
-            var preserved_page: ?terminal.PageList.List.Node.PreservedPage = null;
-            defer if (preserved_page) |*page_| page_.deinit();
-            while (row_it.next()) |row_pin| {
-                if (!in_viewport and row_pin.eql(vp_top)) in_viewport = true;
-                const builder = if (in_viewport) &vp_builder else &sb_builder;
-                const out_row = if (in_viewport) vp_y else sb_y;
-
-                if (in_viewport and cursor_row == null and
+                if (render_row.region == .viewport and cursor_row == null and
                     row_pin.node == s.cursor.page_pin.node and
                     row_pin.y == s.cursor.page_pin.y)
                 {
-                    cursor_row = vp_y;
+                    cursor_row = render_row.output_row;
                 }
 
                 // Render-grid snapshots must not make compressed scrollback
                 // resident again. Decode each compressed node once into a
                 // temporary page and reuse it for every row from that node.
-                if (preserved_node != row_pin.node) {
-                    const next_page = try row_pin.node.pagePreservingState(alloc);
-                    if (preserved_page) |*page_| page_.deinit();
-                    preserved_page = next_page;
-                    preserved_node = row_pin.node;
-                }
-                const p = if (preserved_page) |*page_| page_.page() else unreachable;
+                const p = try page_reader.pageFor(row_pin);
                 const page_rac = p.getRowAndCell(row_pin.x, row_pin.y);
                 const page_cells: []const terminal.Cell = p.getCells(page_rac.row);
                 for (page_cells, 0..) |*cell, x| {
@@ -2285,7 +2502,7 @@ pub const CAPI = struct {
 
                     const owns_span = has_text and renderGridCellNeedsOwnSpan(cell);
                     if (owns_span) try builder.close();
-                    try builder.ensure(out_row, @intCast(x), style_id);
+                    try builder.ensure(render_row.output_row, @intCast(x), style_id);
                     if (has_text) {
                         try appendRenderGridCellText(builder, p, cell);
                         builder.appendCellWidth(@intCast(cell.gridWidth()));
@@ -2296,15 +2513,12 @@ pub const CAPI = struct {
                     if (owns_span) try builder.close();
                 }
                 try builder.close();
-                if (in_viewport) {
-                    vp_y += 1;
-                } else {
-                    sb_y += 1;
-                }
             }
             try vp_builder.close();
             try sb_builder.close();
-            scrollback_rows = sb_y;
+            try sf_builder.close();
+            scrollback_rows = row_it.scrollback_rows;
+            scrollforward_rows = row_it.scrollforward_rows;
         }
 
         var buf: std.Io.Writer.Allocating = .init(alloc);
@@ -2440,13 +2654,35 @@ pub const CAPI = struct {
         }
         try jw.endArray();
 
+        try jw.objectField("scrollforward_rows");
+        try jw.write(scrollforward_rows);
+
+        try jw.objectField("scrollforward_spans");
+        try jw.beginArray();
+        for (scrollforward_spans.items) |span| {
+            try jw.beginObject();
+            try jw.objectField("row");
+            try jw.write(span.row);
+            try jw.objectField("column");
+            try jw.write(span.column);
+            try jw.objectField("style_id");
+            try jw.write(span.style_id);
+            try jw.objectField("cell_width");
+            try jw.write(span.cell_width);
+            try jw.objectField("text");
+            try jw.write(span.text);
+            try jw.endObject();
+        }
+        try jw.endArray();
+
         try jw.endObject();
         return .fromSlice(try buf.toOwnedSlice());
     }
 
     /// Export the Ghostty grid as cmux mobile render-grid JSON: the visible
     /// viewport plus full restore state (active screen, DEC/ANSI modes, dynamic
-    /// colors, cursor) and up to `scrollback_lines` rows of scrollback history.
+    /// colors, cursor), up to `scrollback_lines` rows before the viewport, and
+    /// up to `scrollforward_lines` newer rows after it.
     /// This reads the terminal page grid directly instead of consuming renderer
     /// dirty state, so it does not interfere with desktop drawing.
     export fn ghostty_surface_render_grid_json(
@@ -2455,12 +2691,14 @@ pub const CAPI = struct {
         surface_id_len: usize,
         state_seq: u64,
         scrollback_lines: usize,
+        scrollforward_lines: usize,
     ) String {
         return buildRenderGridJson(
             surface,
             surface_id_ptr[0..surface_id_len],
             state_seq,
             scrollback_lines,
+            scrollforward_lines,
         ) catch |err| {
             log.warn("error exporting render grid err={}", .{err});
             return .empty;

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -2211,6 +2211,10 @@ pub const CAPI = struct {
         };
     }
 
+    fn renderGridActiveCursorRow(screen: *const terminal.Screen) u32 {
+        return @intCast(@min(screen.cursor.y, screen.pages.rows - 1));
+    }
+
     const RenderGridPageReader = struct {
         alloc: Allocator,
         node: ?*terminal.PageList.List.Node = null,
@@ -2321,6 +2325,11 @@ pub const CAPI = struct {
             RenderGridCursorLocation.above_viewport,
             renderGridCursorLocation(viewport_top.up(1).?, viewport_top, viewport_bottom),
         );
+
+        for (0..screen.pages.rows) |row| {
+            screen.cursorAbsolute(0, @intCast(row));
+            try testing.expectEqual(@as(u32, @intCast(row)), renderGridActiveCursorRow(&screen));
+        }
     }
 
     test "render grid bidirectional rows preserve compressed page storage" {
@@ -2489,6 +2498,7 @@ pub const CAPI = struct {
 
         var cursor_row: ?u32 = null;
         var cursor_column: u32 = 0;
+        var cursor_active_row: u32 = 0;
         var cursor_visible = false;
         var cursor_location: RenderGridCursorLocation = .viewport;
         var cursor_blinking = false;
@@ -2518,6 +2528,7 @@ pub const CAPI = struct {
             columns = @intCast(s.pages.cols);
             rows = @intCast(s.pages.rows);
             cursor_column = @intCast(@min(s.cursor.x, s.pages.cols - 1));
+            cursor_active_row = renderGridActiveCursorRow(s);
             cursor_visible = t.modes.get(.cursor_visible);
             cursor_location = renderGridCursorLocation(
                 s.cursor.page_pin.*,
@@ -2657,6 +2668,8 @@ pub const CAPI = struct {
         try jw.write(cursor_row orelse 0);
         try jw.objectField("column");
         try jw.write(cursor_column);
+        try jw.objectField("active_row");
+        try jw.write(cursor_active_row);
         try jw.objectField("visible");
         try jw.write(cursor_visible and cursor_row != null);
         try jw.objectField("location");

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -2099,6 +2099,12 @@ pub const CAPI = struct {
         scrollforward,
     };
 
+    const RenderGridCursorLocation = enum {
+        viewport,
+        above_viewport,
+        below_viewport,
+    };
+
     const RenderGridRow = struct {
         pin: terminal.PageList.Pin,
         region: RenderGridRowRegion,
@@ -2188,6 +2194,23 @@ pub const CAPI = struct {
         return a.node == b.node and a.y == b.y;
     }
 
+    fn renderGridCursorLocation(
+        cursor: terminal.PageList.Pin,
+        viewport_top: terminal.PageList.Pin,
+        viewport_bottom: terminal.PageList.Pin,
+    ) RenderGridCursorLocation {
+        if (cursor.isBetween(viewport_top, viewport_bottom)) return .viewport;
+        return if (cursor.before(viewport_top)) .above_viewport else .below_viewport;
+    }
+
+    fn renderGridCursorLocationName(location: RenderGridCursorLocation) []const u8 {
+        return switch (location) {
+            .viewport => "viewport",
+            .above_viewport => "above_viewport",
+            .below_viewport => "below_viewport",
+        };
+    }
+
     const RenderGridPageReader = struct {
         alloc: Allocator,
         node: ?*terminal.PageList.List.Node = null,
@@ -2267,6 +2290,37 @@ pub const CAPI = struct {
         try testing.expectEqual(@as(u32, 2), active_it.scrollback_rows);
         try testing.expectEqual(@as(u32, 3), active_it.viewport_rows);
         try testing.expectEqual(@as(u32, 0), active_it.scrollforward_rows);
+    }
+
+    test "render grid cursor location distinguishes viewport and history directions" {
+        const testing = std.testing;
+
+        var screen = try terminal.Screen.init(testing.allocator, .{
+            .cols = 5,
+            .rows = 3,
+            .max_scrollback = 1_000_000,
+        });
+        defer screen.deinit();
+        try screen.testWriteString("1\n2\n3\n4\n5\n6\n7\n8");
+
+        var viewport_top = screen.pages.getTopLeft(.viewport);
+        var viewport_bottom = screen.pages.getBottomRight(.viewport).?;
+        try testing.expectEqual(
+            RenderGridCursorLocation.viewport,
+            renderGridCursorLocation(screen.cursor.page_pin.*, viewport_top, viewport_bottom),
+        );
+
+        screen.scroll(.{ .delta_row = -2 });
+        viewport_top = screen.pages.getTopLeft(.viewport);
+        viewport_bottom = screen.pages.getBottomRight(.viewport).?;
+        try testing.expectEqual(
+            RenderGridCursorLocation.below_viewport,
+            renderGridCursorLocation(screen.cursor.page_pin.*, viewport_top, viewport_bottom),
+        );
+        try testing.expectEqual(
+            RenderGridCursorLocation.above_viewport,
+            renderGridCursorLocation(viewport_top.up(1).?, viewport_top, viewport_bottom),
+        );
     }
 
     test "render grid bidirectional rows preserve compressed page storage" {
@@ -2436,6 +2490,7 @@ pub const CAPI = struct {
         var cursor_row: ?u32 = null;
         var cursor_column: u32 = 0;
         var cursor_visible = false;
+        var cursor_location: RenderGridCursorLocation = .viewport;
         var cursor_blinking = false;
         var cursor_style: terminal.CursorStyle = .block;
         var columns: u32 = 0;
@@ -2464,6 +2519,11 @@ pub const CAPI = struct {
             rows = @intCast(s.pages.rows);
             cursor_column = @intCast(@min(s.cursor.x, s.pages.cols - 1));
             cursor_visible = t.modes.get(.cursor_visible);
+            cursor_location = renderGridCursorLocation(
+                s.cursor.page_pin.*,
+                s.pages.getTopLeft(.viewport),
+                s.pages.getBottomRight(.viewport).?,
+            );
             cursor_blinking = t.modes.get(.cursor_blinking);
             cursor_style = s.cursor.cursor_style;
             is_alternate = t.screens.active_key == .alternate;
@@ -2599,6 +2659,8 @@ pub const CAPI = struct {
         try jw.write(cursor_column);
         try jw.objectField("visible");
         try jw.write(cursor_visible and cursor_row != null);
+        try jw.objectField("location");
+        try jw.write(renderGridCursorLocationName(cursor_location));
         try jw.objectField("style");
         try jw.write(cursorStyleName(cursor_style));
         try jw.objectField("blinking");

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -2286,6 +2286,10 @@ pub const CAPI = struct {
         };
     }
 
+    fn renderGridCursorIsVisible(mode_visible: bool, viewport_row: ?u32) bool {
+        return mode_visible and viewport_row != null;
+    }
+
     fn renderGridActiveCursorRow(screen: *const terminal.Screen) u32 {
         return @intCast(@min(screen.cursor.y, screen.pages.rows - 1));
     }
@@ -2407,6 +2411,34 @@ pub const CAPI = struct {
             screen.cursorAbsolute(0, @intCast(row));
             try testing.expectEqual(@as(u32, @intCast(row)), renderGridActiveCursorRow(&screen));
         }
+    }
+
+    test "render grid preserves visible cursor mode outside viewport" {
+        try std.testing.expect(renderGridCursorIsVisible(true, null));
+        try std.testing.expect(!renderGridCursorIsVisible(false, null));
+    }
+
+    test "render grid C API preserves legacy and bounded signatures" {
+        const LegacyRenderGridFn = *const fn (
+            *Surface,
+            [*]const u8,
+            usize,
+            u64,
+            usize,
+        ) callconv(.c) String;
+        const BoundedRenderGridFn = *const fn (
+            *Surface,
+            [*]const u8,
+            usize,
+            u64,
+            usize,
+            usize,
+        ) callconv(.c) String;
+
+        const legacy: LegacyRenderGridFn = &ghostty_surface_render_grid_json;
+        const bounded: BoundedRenderGridFn = &ghostty_surface_render_grid_json_bounded;
+        _ = legacy;
+        _ = bounded;
     }
 
     test "render grid bidirectional rows preserve compressed page storage" {
@@ -2759,7 +2791,7 @@ pub const CAPI = struct {
         try jw.objectField("active_row");
         try jw.write(cursor_active_row);
         try jw.objectField("visible");
-        try jw.write(cursor_visible and cursor_row != null);
+        try jw.write(renderGridCursorIsVisible(cursor_visible, cursor_row));
         try jw.objectField("location");
         try jw.write(renderGridCursorLocationName(cursor_location));
         try jw.objectField("style");

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -3619,3 +3619,24 @@ pub const CAPI = struct {
         }
     };
 };
+
+test "legacy render grid row iterator excludes rows after viewport" {
+    const testing = std.testing;
+
+    var screen = try terminal.Screen.init(testing.allocator, .{
+        .cols = 5,
+        .rows = 3,
+        .max_scrollback = 1_000_000,
+    });
+    defer screen.deinit();
+    try screen.testWriteString("1\n2\n3\n4\n5\n6\n7\n8");
+    screen.scroll(.top);
+
+    var it = CAPI.RenderGridRowIterator.init(&screen.pages, 2, 0);
+    while (it.next()) |_| {}
+
+    try testing.expectEqual(@as(u32, 0), it.scrollback_rows);
+    try testing.expectEqual(@as(u32, 3), it.viewport_rows);
+    try testing.expectEqual(@as(u32, 0), it.scrollforward_rows);
+    try testing.expectEqual(@as(u32, 0), it.primary_active_rows);
+}

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -917,6 +917,24 @@ pub const Surface = struct {
         };
     }
 
+    pub fn scrollCallbackWithViewportRows(
+        self: *Surface,
+        xoff: f64,
+        yoff: f64,
+        viewport_rows: i32,
+        mods: input.ScrollMods,
+    ) void {
+        self.core_surface.scrollCallbackWithViewportRows(
+            xoff,
+            yoff,
+            viewport_rows,
+            mods,
+        ) catch |err| {
+            log.err("error in mode-aware scroll callback err={}", .{err});
+            return;
+        };
+    }
+
     pub fn cursorPosCallback(
         self: *Surface,
         x: f64,
@@ -2044,20 +2062,27 @@ pub const CAPI = struct {
         strikethrough: bool = false,
         overline: bool = false,
 
-        fn visualEql(self: RenderGridStyle, other: RenderGridStyle) bool {
-            return self.foreground.eql(other.foreground) and
-                self.background.eql(other.background) and
-                self.bold == other.bold and
-                self.faint == other.faint and
-                self.italic == other.italic and
-                self.underline == other.underline and
-                self.blink == other.blink and
-                self.inverse == other.inverse and
-                self.invisible == other.invisible and
-                self.strikethrough == other.strikethrough and
-                self.overline == other.overline;
+        fn visualKey(self: RenderGridStyle) u64 {
+            var key: u64 = self.foreground.r;
+            key |= @as(u64, self.foreground.g) << 8;
+            key |= @as(u64, self.foreground.b) << 16;
+            key |= @as(u64, self.background.r) << 24;
+            key |= @as(u64, self.background.g) << 32;
+            key |= @as(u64, self.background.b) << 40;
+            key |= @as(u64, @intFromBool(self.bold)) << 48;
+            key |= @as(u64, @intFromBool(self.faint)) << 49;
+            key |= @as(u64, @intFromBool(self.italic)) << 50;
+            key |= @as(u64, @intFromBool(self.underline)) << 51;
+            key |= @as(u64, @intFromBool(self.blink)) << 52;
+            key |= @as(u64, @intFromBool(self.inverse)) << 53;
+            key |= @as(u64, @intFromBool(self.invisible)) << 54;
+            key |= @as(u64, @intFromBool(self.strikethrough)) << 55;
+            key |= @as(u64, @intFromBool(self.overline)) << 56;
+            return key;
         }
     };
+
+    const RenderGridStyleIndex = std.AutoHashMapUnmanaged(u64, u32);
 
     const RenderGridSpan = struct {
         row: u32,
@@ -2506,16 +2531,19 @@ pub const CAPI = struct {
     }
 
     fn renderGridStyleID(
+        alloc: Allocator,
         styles: *std.ArrayListUnmanaged(RenderGridStyle),
+        style_index: *RenderGridStyleIndex,
         style: RenderGridStyle,
     ) !u32 {
-        for (styles.items) |existing| {
-            if (existing.visualEql(style)) return existing.id;
-        }
+        const key = style.visualKey();
+        if (style_index.get(key)) |id| return id;
 
         var next = style;
         next.id = @intCast(styles.items.len);
-        try styles.append(global.alloc, next);
+        try styles.append(alloc, next);
+        errdefer _ = styles.pop();
+        try style_index.put(alloc, key, next.id);
         return next.id;
     }
 
@@ -2642,6 +2670,8 @@ pub const CAPI = struct {
 
         var styles: std.ArrayListUnmanaged(RenderGridStyle) = .empty;
         defer styles.deinit(alloc);
+        var style_index: RenderGridStyleIndex = .empty;
+        defer style_index.deinit(alloc);
         var spans: std.ArrayListUnmanaged(RenderGridSpan) = .empty;
         defer {
             for (spans.items) |span| alloc.free(span.text);
@@ -2733,6 +2763,7 @@ pub const CAPI = struct {
                 .background = background,
             };
             try styles.append(alloc, default_style);
+            try style_index.put(alloc, default_style.visualKey(), default_style.id);
 
             var vp_builder = RenderGridSpanBuilder.init(alloc, &spans);
             defer vp_builder.deinit();
@@ -2789,7 +2820,12 @@ pub const CAPI = struct {
                         bold_color,
                     );
                     const has_text = cell.hasText();
-                    const style_id = try renderGridStyleID(&styles, style);
+                    const style_id = try renderGridStyleID(
+                        alloc,
+                        &styles,
+                        &style_index,
+                        style,
+                    );
                     const is_default_blank = !has_text and style_id == 0;
                     if (is_default_blank) {
                         try builder.close();
@@ -3278,6 +3314,24 @@ pub const CAPI = struct {
         surface.scrollCallback(
             x,
             y,
+            @bitCast(@as(u8, @truncate(@as(c_uint, @bitCast(scroll_mods))))),
+        );
+    }
+
+    /// Scroll with an exact normal-screen viewport delta while preserving the
+    /// supplied wheel delta for alternate-screen and mouse-reporting modes.
+    /// Positive viewport rows scroll upward, matching the y wheel convention.
+    export fn ghostty_surface_mouse_scroll_with_viewport_rows(
+        surface: *Surface,
+        x: f64,
+        y: f64,
+        viewport_rows: i32,
+        scroll_mods: c_int,
+    ) void {
+        surface.scrollCallbackWithViewportRows(
+            x,
+            y,
+            viewport_rows,
             @bitCast(@as(u8, @truncate(@as(c_uint, @bitCast(scroll_mods))))),
         );
     }

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -2287,7 +2287,8 @@ pub const CAPI = struct {
     }
 
     fn renderGridCursorIsVisible(mode_visible: bool, viewport_row: ?u32) bool {
-        return mode_visible and viewport_row != null;
+        _ = viewport_row;
+        return mode_visible;
     }
 
     fn renderGridActiveCursorRow(screen: *const terminal.Screen) u32 {
@@ -2947,13 +2948,7 @@ pub const CAPI = struct {
         return .fromSlice(try buf.toOwnedSlice());
     }
 
-    /// Export the Ghostty grid as cmux mobile render-grid JSON: the visible
-    /// viewport plus full restore state (active screen, DEC/ANSI modes, dynamic
-    /// colors, cursor), up to `scrollback_lines` rows before the viewport, and
-    /// up to `scrollforward_lines` newer rows after it.
-    /// This reads the terminal page grid directly instead of consuming renderer
-    /// dirty state, so it does not interfere with desktop drawing.
-    export fn ghostty_surface_render_grid_json(
+    fn renderGridJson(
         surface: *Surface,
         surface_id_ptr: [*]const u8,
         surface_id_len: usize,
@@ -2971,6 +2966,46 @@ pub const CAPI = struct {
             log.warn("error exporting render grid err={}", .{err});
             return .empty;
         };
+    }
+
+    /// Legacy render-grid export. Keep this five-argument signature stable for
+    /// existing embedders; newer rows are available through the bounded export.
+    export fn ghostty_surface_render_grid_json(
+        surface: *Surface,
+        surface_id_ptr: [*]const u8,
+        surface_id_len: usize,
+        state_seq: u64,
+        scrollback_lines: usize,
+    ) String {
+        return renderGridJson(
+            surface,
+            surface_id_ptr,
+            surface_id_len,
+            state_seq,
+            scrollback_lines,
+            0,
+        );
+    }
+
+    /// Export the Ghostty grid as cmux mobile render-grid JSON: the visible
+    /// viewport plus full restore state, bounded older rows, and bounded newer
+    /// rows. Direct page-grid reads do not consume desktop renderer dirty state.
+    export fn ghostty_surface_render_grid_json_bounded(
+        surface: *Surface,
+        surface_id_ptr: [*]const u8,
+        surface_id_len: usize,
+        state_seq: u64,
+        scrollback_lines: usize,
+        scrollforward_lines: usize,
+    ) String {
+        return renderGridJson(
+            surface,
+            surface_id_ptr,
+            surface_id_len,
+            state_seq,
+            scrollback_lines,
+            scrollforward_lines,
+        );
     }
 
     /// Returns the PID of the foreground process for the surface PTY.

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -2097,6 +2097,7 @@ pub const CAPI = struct {
         scrollback,
         viewport,
         scrollforward,
+        primary_active,
     };
 
     const RenderGridCursorLocation = enum {
@@ -2113,12 +2114,14 @@ pub const CAPI = struct {
 
     const RenderGridRowIterator = struct {
         rows: terminal.PageList.RowIterator,
+        primary_active_rows_it: ?terminal.PageList.RowIterator,
         viewport_top: terminal.PageList.Pin,
         viewport_bottom: terminal.PageList.Pin,
         region: RenderGridRowRegion,
         scrollback_rows: u32 = 0,
         viewport_rows: u32 = 0,
         scrollforward_rows: u32 = 0,
+        primary_active_rows: u32 = 0,
 
         fn init(
             pages: *const terminal.PageList,
@@ -2140,6 +2143,7 @@ pub const CAPI = struct {
 
             return .{
                 .rows = start.rowIterator(.right_down, end),
+                .primary_active_rows_it = pages.activeRowsAfter(end),
                 .viewport_top = viewport_top,
                 .viewport_bottom = viewport_bottom,
                 .region = if (sameRenderGridRow(start, viewport_top))
@@ -2150,7 +2154,9 @@ pub const CAPI = struct {
         }
 
         fn next(self: *RenderGridRowIterator) ?RenderGridRow {
-            const pin = self.rows.next() orelse return null;
+            const bounded_pin = self.rows.next();
+            const pin = bounded_pin orelse self.nextPrimaryActive() orelse return null;
+            if (bounded_pin == null) self.region = .primary_active;
             if (self.region == .scrollback and
                 sameRenderGridRow(pin, self.viewport_top))
             {
@@ -2171,6 +2177,10 @@ pub const CAPI = struct {
                     defer self.scrollforward_rows += 1;
                     break :row self.scrollforward_rows;
                 },
+                .primary_active => row: {
+                    defer self.primary_active_rows += 1;
+                    break :row self.primary_active_rows;
+                },
             };
 
             if (region == .viewport and
@@ -2184,6 +2194,11 @@ pub const CAPI = struct {
                 .region = region,
                 .output_row = output_row,
             };
+        }
+
+        fn nextPrimaryActive(self: *RenderGridRowIterator) ?terminal.PageList.Pin {
+            if (self.primary_active_rows_it) |*rows| return rows.next();
+            return null;
         }
     };
 
@@ -2287,6 +2302,7 @@ pub const CAPI = struct {
         try testing.expectEqual(@as(u32, 0), top_it.scrollback_rows);
         try testing.expectEqual(@as(u32, 3), top_it.viewport_rows);
         try testing.expectEqual(@as(u32, 2), top_it.scrollforward_rows);
+        try testing.expectEqual(@as(u32, 3), top_it.primary_active_rows);
 
         screen.scroll(.active);
         var active_it = RenderGridRowIterator.init(&screen.pages, 2, 2);
@@ -2294,6 +2310,7 @@ pub const CAPI = struct {
         try testing.expectEqual(@as(u32, 2), active_it.scrollback_rows);
         try testing.expectEqual(@as(u32, 3), active_it.viewport_rows);
         try testing.expectEqual(@as(u32, 0), active_it.scrollforward_rows);
+        try testing.expectEqual(@as(u32, 0), active_it.primary_active_rows);
     }
 
     test "render grid cursor location distinguishes viewport and history directions" {
@@ -2493,6 +2510,11 @@ pub const CAPI = struct {
             for (scrollforward_spans.items) |span| alloc.free(span.text);
             scrollforward_spans.deinit(alloc);
         }
+        var primary_active_spans: std.ArrayListUnmanaged(RenderGridSpan) = .empty;
+        defer {
+            for (primary_active_spans.items) |span| alloc.free(span.text);
+            primary_active_spans.deinit(alloc);
+        }
         var modes_out: std.ArrayListUnmanaged(RenderGridMode) = .empty;
         defer modes_out.deinit(alloc);
 
@@ -2511,6 +2533,7 @@ pub const CAPI = struct {
         var cursor_color_override: ?terminal.color.RGB = null;
         var scrollback_rows: u32 = 0;
         var scrollforward_rows: u32 = 0;
+        var primary_active_rows: u32 = 0;
 
         {
             core_surface.renderer_state.mutex.lock();
@@ -2570,6 +2593,8 @@ pub const CAPI = struct {
             defer sb_builder.deinit();
             var sf_builder = RenderGridSpanBuilder.init(alloc, &scrollforward_spans);
             defer sf_builder.deinit();
+            var active_builder = RenderGridSpanBuilder.init(alloc, &primary_active_spans);
+            defer active_builder.deinit();
 
             // Traverse the bounded history window, viewport, and bounded newer
             // window in one pass. This keeps both prefetch directions capped by
@@ -2587,6 +2612,7 @@ pub const CAPI = struct {
                     .scrollback => &sb_builder,
                     .viewport => &vp_builder,
                     .scrollforward => &sf_builder,
+                    .primary_active => &active_builder,
                 };
 
                 if (render_row.region == .viewport and cursor_row == null and
@@ -2640,8 +2666,10 @@ pub const CAPI = struct {
             try vp_builder.close();
             try sb_builder.close();
             try sf_builder.close();
+            try active_builder.close();
             scrollback_rows = row_it.scrollback_rows;
             scrollforward_rows = row_it.scrollforward_rows;
+            primary_active_rows = row_it.primary_active_rows;
         }
 
         var buf: std.Io.Writer.Allocating = .init(alloc);
@@ -2787,6 +2815,27 @@ pub const CAPI = struct {
         try jw.objectField("scrollforward_spans");
         try jw.beginArray();
         for (scrollforward_spans.items) |span| {
+            try jw.beginObject();
+            try jw.objectField("row");
+            try jw.write(span.row);
+            try jw.objectField("column");
+            try jw.write(span.column);
+            try jw.objectField("style_id");
+            try jw.write(span.style_id);
+            try jw.objectField("cell_width");
+            try jw.write(span.cell_width);
+            try jw.objectField("text");
+            try jw.write(span.text);
+            try jw.endObject();
+        }
+        try jw.endArray();
+
+        try jw.objectField("primary_active_rows");
+        try jw.write(primary_active_rows);
+
+        try jw.objectField("primary_active_spans");
+        try jw.beginArray();
+        for (primary_active_spans.items) |span| {
             try jw.beginObject();
             try jw.objectField("row");
             try jw.write(span.row);

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -3163,6 +3163,8 @@ pub const CAPI = struct {
         scrollback_lines: usize,
         newer_rows: RenderGridNewerRowsPolicy,
     ) String {
+        // Snapshot the requested geometry, not the terminal's previous grid.
+        surface.core_surface.applyPendingResizeIfNeeded();
         return buildRenderGridJson(
             surface,
             surface_id_ptr[0..surface_id_len],

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -2172,6 +2172,11 @@ pub const CAPI = struct {
         output_row: u32,
     };
 
+    const RenderGridNewerRowsPolicy = union(enum) {
+        none,
+        bounded: usize,
+    };
+
     const RenderGridRowIterator = struct {
         rows: terminal.PageList.RowIterator,
         primary_active_rows_it: ?terminal.PageList.RowIterator,
@@ -2186,7 +2191,7 @@ pub const CAPI = struct {
         fn init(
             pages: *const terminal.PageList,
             scrollback_lines: usize,
-            scrollforward_lines: usize,
+            newer_rows: RenderGridNewerRowsPolicy,
         ) RenderGridRowIterator {
             const viewport_top = pages.getTopLeft(.viewport);
             const viewport_bottom = pages.getBottomRight(.viewport) orelse viewport_top;
@@ -2196,14 +2201,20 @@ pub const CAPI = struct {
                 viewport_top
             else
                 (viewport_top.up(scrollback_lines) orelse screen_top);
-            const end = if (scrollforward_lines == 0)
-                viewport_bottom
-            else
-                (viewport_bottom.down(scrollforward_lines) orelse screen_bottom);
+            const end = switch (newer_rows) {
+                .none => viewport_bottom,
+                .bounded => |lines| if (lines == 0)
+                    viewport_bottom
+                else
+                    (viewport_bottom.down(lines) orelse screen_bottom),
+            };
 
             return .{
                 .rows = start.rowIterator(.right_down, end),
-                .primary_active_rows_it = pages.activeRowsAfter(end),
+                .primary_active_rows_it = switch (newer_rows) {
+                    .none => null,
+                    .bounded => pages.activeRowsAfter(end),
+                },
                 .viewport_top = viewport_top,
                 .viewport_bottom = viewport_bottom,
                 .region = if (sameRenderGridRow(start, viewport_top))
@@ -2343,7 +2354,7 @@ pub const CAPI = struct {
         const expected_output_rows = [_]u32{ 0, 1, 0, 1, 2, 0, 1 };
         const expected_codepoints = [_]u21{ '2', '3', '4', '5', '6', '7', '8' };
 
-        var it = RenderGridRowIterator.init(&screen.pages, 2, 2);
+        var it = RenderGridRowIterator.init(&screen.pages, 2, .{ .bounded = 2 });
         var page_reader: RenderGridPageReader = .{ .alloc = testing.allocator };
         defer page_reader.deinit();
         var index: usize = 0;
@@ -2362,7 +2373,7 @@ pub const CAPI = struct {
         try testing.expectEqual(@as(u32, 2), it.scrollforward_rows);
 
         screen.scroll(.top);
-        var top_it = RenderGridRowIterator.init(&screen.pages, 2, 2);
+        var top_it = RenderGridRowIterator.init(&screen.pages, 2, .{ .bounded = 2 });
         while (top_it.next()) |_| {}
         try testing.expectEqual(@as(u32, 0), top_it.scrollback_rows);
         try testing.expectEqual(@as(u32, 3), top_it.viewport_rows);
@@ -2370,7 +2381,7 @@ pub const CAPI = struct {
         try testing.expectEqual(@as(u32, 3), top_it.primary_active_rows);
 
         screen.scroll(.active);
-        var active_it = RenderGridRowIterator.init(&screen.pages, 2, 2);
+        var active_it = RenderGridRowIterator.init(&screen.pages, 2, .{ .bounded = 2 });
         while (active_it.next()) |_| {}
         try testing.expectEqual(@as(u32, 2), active_it.scrollback_rows);
         try testing.expectEqual(@as(u32, 3), active_it.viewport_rows);
@@ -2461,7 +2472,7 @@ pub const CAPI = struct {
         try testing.expect(before.compressed_pages > 0);
 
         var compressed_rows: usize = 0;
-        var it = RenderGridRowIterator.init(&screen.pages, 300, 300);
+        var it = RenderGridRowIterator.init(&screen.pages, 300, .{ .bounded = 300 });
         {
             var page_reader: RenderGridPageReader = .{ .alloc = testing.allocator };
             defer page_reader.deinit();
@@ -2580,7 +2591,7 @@ pub const CAPI = struct {
         surface_id: []const u8,
         state_seq: u64,
         scrollback_lines: usize,
-        scrollforward_lines: usize,
+        newer_rows: RenderGridNewerRowsPolicy,
     ) !String {
         const alloc = global.alloc;
         const core_surface = &surface.core_surface;
@@ -2695,7 +2706,7 @@ pub const CAPI = struct {
             var row_it = RenderGridRowIterator.init(
                 &s.pages,
                 scrollback_lines,
-                scrollforward_lines,
+                newer_rows,
             );
             var page_reader: RenderGridPageReader = .{ .alloc = alloc };
             defer page_reader.deinit();
@@ -2954,14 +2965,14 @@ pub const CAPI = struct {
         surface_id_len: usize,
         state_seq: u64,
         scrollback_lines: usize,
-        scrollforward_lines: usize,
+        newer_rows: RenderGridNewerRowsPolicy,
     ) String {
         return buildRenderGridJson(
             surface,
             surface_id_ptr[0..surface_id_len],
             state_seq,
             scrollback_lines,
-            scrollforward_lines,
+            newer_rows,
         ) catch |err| {
             log.warn("error exporting render grid err={}", .{err});
             return .empty;
@@ -2983,7 +2994,7 @@ pub const CAPI = struct {
             surface_id_len,
             state_seq,
             scrollback_lines,
-            0,
+            .none,
         );
     }
 
@@ -3004,7 +3015,7 @@ pub const CAPI = struct {
             surface_id_len,
             state_seq,
             scrollback_lines,
-            scrollforward_lines,
+            .{ .bounded = scrollforward_lines },
         );
     }
 
@@ -3632,7 +3643,7 @@ test "legacy render grid row iterator excludes rows after viewport" {
     try screen.testWriteString("1\n2\n3\n4\n5\n6\n7\n8");
     screen.scroll(.top);
 
-    var it = CAPI.RenderGridRowIterator.init(&screen.pages, 2, 0);
+    var it = CAPI.RenderGridRowIterator.init(&screen.pages, 2, .none);
     while (it.next()) |_| {}
 
     try testing.expectEqual(@as(u32, 0), it.scrollback_rows);

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -2111,8 +2111,11 @@ pub const CAPI = struct {
     }
 
     const RenderGridSpanBuilder = struct {
+        const maximum_total_spans = 100_000;
+
         alloc: Allocator,
         spans: *std.ArrayListUnmanaged(RenderGridSpan),
+        total_spans: *usize,
         text: std.Io.Writer.Allocating,
         active: bool = false,
         row: u32 = 0,
@@ -2123,10 +2126,12 @@ pub const CAPI = struct {
         fn init(
             alloc: Allocator,
             spans: *std.ArrayListUnmanaged(RenderGridSpan),
+            total_spans: *usize,
         ) RenderGridSpanBuilder {
             return .{
                 .alloc = alloc,
                 .spans = spans,
+                .total_spans = total_spans,
                 .text = .init(alloc),
             };
         }
@@ -2163,6 +2168,9 @@ pub const CAPI = struct {
 
         fn close(self: *RenderGridSpanBuilder) !void {
             if (!self.active) return;
+            if (self.total_spans.* >= maximum_total_spans) {
+                return error.RenderGridSpanLimitExceeded;
+            }
             const text = try self.text.toOwnedSlice();
             errdefer self.alloc.free(text);
             try self.spans.append(self.alloc, .{
@@ -2172,6 +2180,7 @@ pub const CAPI = struct {
                 .cell_width = self.cell_width,
                 .text = text,
             });
+            self.total_spans.* += 1;
             self.text = .init(self.alloc);
             self.active = false;
             self.cell_width = 0;
@@ -2581,6 +2590,26 @@ pub const CAPI = struct {
         try testing.expectEqual(@as(usize, 4096), styles.items.len);
     }
 
+    test "render grid span builder rejects frames above the retained span limit" {
+        const testing = std.testing;
+        var spans: std.ArrayListUnmanaged(RenderGridSpan) = .empty;
+        defer spans.deinit(testing.allocator);
+        var total_spans: usize = RenderGridSpanBuilder.maximum_total_spans;
+        var builder = RenderGridSpanBuilder.init(
+            testing.allocator,
+            &spans,
+            &total_spans,
+        );
+        defer builder.deinit();
+
+        try builder.ensure(0, 0, 0);
+        try builder.text.writer.writeAll("x");
+        builder.appendCellWidth(1);
+
+        try testing.expectError(error.RenderGridSpanLimitExceeded, builder.close());
+        try testing.expectEqual(@as(usize, 0), spans.items.len);
+    }
+
     fn resolvedRenderGridStyle(
         p: *const terminal.Page,
         cell: *const terminal.Cell,
@@ -2711,6 +2740,7 @@ pub const CAPI = struct {
         var scrollback_rows: u32 = 0;
         var scrollforward_rows: u32 = 0;
         var primary_active_rows: u32 = 0;
+        var total_spans: usize = 0;
 
         {
             core_surface.renderer_state.mutex.lock();
@@ -2765,13 +2795,13 @@ pub const CAPI = struct {
             try styles.append(alloc, default_style);
             try style_index.put(alloc, default_style.visualKey(), default_style.id);
 
-            var vp_builder = RenderGridSpanBuilder.init(alloc, &spans);
+            var vp_builder = RenderGridSpanBuilder.init(alloc, &spans, &total_spans);
             defer vp_builder.deinit();
-            var sb_builder = RenderGridSpanBuilder.init(alloc, &scrollback_spans);
+            var sb_builder = RenderGridSpanBuilder.init(alloc, &scrollback_spans, &total_spans);
             defer sb_builder.deinit();
-            var sf_builder = RenderGridSpanBuilder.init(alloc, &scrollforward_spans);
+            var sf_builder = RenderGridSpanBuilder.init(alloc, &scrollforward_spans, &total_spans);
             defer sf_builder.deinit();
-            var active_builder = RenderGridSpanBuilder.init(alloc, &primary_active_spans);
+            var active_builder = RenderGridSpanBuilder.init(alloc, &primary_active_spans, &total_spans);
             defer active_builder.deinit();
 
             // Traverse the bounded history window, viewport, and bounded newer
@@ -2855,9 +2885,11 @@ pub const CAPI = struct {
             primary_active_rows = row_it.primary_active_rows;
         }
 
-        var buf: std.Io.Writer.Allocating = .init(alloc);
-        errdefer buf.deinit();
-        var jw: std.json.Stringify = .{ .writer = &buf.writer };
+        const maximum_json_bytes = 6 * 1024 * 1024;
+        const json_buffer = try alloc.alloc(u8, maximum_json_bytes);
+        defer alloc.free(json_buffer);
+        var writer: std.Io.Writer = .fixed(json_buffer);
+        var jw: std.json.Stringify = .{ .writer = &writer };
         try jw.beginObject();
 
         try jw.objectField("format");
@@ -3035,7 +3067,7 @@ pub const CAPI = struct {
         try jw.endArray();
 
         try jw.endObject();
-        return .fromSlice(try buf.toOwnedSlice());
+        return .fromSlice(try alloc.dupe(u8, writer.buffered()));
     }
 
     fn renderGridJson(

--- a/src/terminal/PageList.zig
+++ b/src/terminal/PageList.zig
@@ -5825,6 +5825,26 @@ pub fn getBottomRight(self: *const PageList, tag: point.Tag) ?Pin {
     };
 }
 
+/// Returns the portion of the active screen strictly after `end`, capped to
+/// the active screen's row count. When `end` is still in history this returns
+/// the full active screen; when it overlaps the active screen this returns only
+/// the missing suffix.
+pub fn activeRowsAfter(self: *const PageList, end: Pin) ?RowIterator {
+    var active_top = self.getTopLeft(.active);
+    active_top.x = 0;
+    var active_bottom = self.getBottomRight(.active).?;
+    active_bottom.x = 0;
+    var end_row = end;
+    end_row.x = 0;
+
+    if (!end_row.before(active_bottom)) return null;
+    const start = if (end_row.before(active_top))
+        active_top
+    else
+        end_row.down(1) orelse return null;
+    return start.rowIterator(.right_down, active_bottom);
+}
+
 /// The total rows in the screen. This is the actual row count currently
 /// and not a capacity or maximum.
 ///

--- a/src/terminal/PageList.zig
+++ b/src/terminal/PageList.zig
@@ -7976,6 +7976,28 @@ test "PageList scroll top" {
     }, s.scrollbar());
 }
 
+test "PageList active rows after bounded historical end" {
+    const testing = std.testing;
+
+    var s = try init(testing.allocator, 5, 3, null);
+    defer s.deinit();
+    try s.growRows(9);
+    s.scroll(.top);
+
+    const viewport_bottom = s.getBottomRight(.viewport).?;
+    const bounded_end = viewport_bottom.down(2).?;
+    var it = s.activeRowsAfter(bounded_end).?;
+    const active_top = s.getTopLeft(.active);
+    const active_bottom = s.getBottomRight(.active).?;
+    var count: usize = 0;
+    while (it.next()) |row| : (count += 1) {
+        try testing.expect(row.isBetween(active_top, active_bottom));
+    }
+    try testing.expectEqual(s.rows, count);
+
+    try testing.expect(s.activeRowsAfter(active_bottom) == null);
+}
+
 test "PageList scroll delta row back" {
     const testing = std.testing;
     const alloc = testing.allocator;


### PR DESCRIPTION
Adds an independent bounded rows-after-viewport window to the embedded render-grid export. The producer traverses one bounded range, preserves compressed pages, and leaves existing scrollback fields unchanged.

Verification:
- `zig build test -Dtest-filter="render grid" -Demit-macos-app=false`
- `zig build -Demit-macos-app=false`
- universal ReleaseFast GhosttyKit build with the symbol present in all slices

Parent: https://github.com/manaflow-ai/cmux/pull/7304

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/107"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786330505&installation_id=133855650&pr_number=107&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F107&signature=538db653c35ccc7b9f9185bc724222d6da7ace8b88eb214da7c3593a6265e4c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a bounded “rows after viewport” window to render‑grid JSON and a mode‑aware exact row scroll API for mobile. Exports now settle any pending resize first to reflect the current geometry.

- **New Features**
  - Adds `scrollforward_rows`/`scrollforward_spans` after the viewport; emits `primary_active_rows`/`primary_active_spans` when the forward window stops before the active screen (capped to one viewport).
  - Cursor JSON adds `location` (`viewport`, `above_viewport`, `below_viewport`) and `active_row`; `visible` now reflects cursor mode even when off‑screen.
  - New APIs: `ghostty_surface_render_grid_json_bounded(...)` and `ghostty_surface_mouse_scroll_with_viewport_rows(...)`; newer rows are excluded from the legacy entrypoint.
  - Exports are strictly bounded: caller row caps are honored, with a retained span limit and a JSON size cap to avoid oversized frames. Preserves compressed pages.

- **Migration**
  - `ghostty_surface_render_grid_json(...)` is unchanged and excludes rows after the viewport. Use `ghostty_surface_render_grid_json_bounded(surface, surface_id, len, state_seq, scrollback_lines, scrollforward_lines)` to include newer rows; pass `0` to omit.
  - For precise mobile scrolling, use `ghostty_surface_mouse_scroll_with_viewport_rows(surface, x, y, rows, mods)`; positive `rows` scroll upward.
  - Older JSON consumers can ignore `scrollforward_*`, `primary_active_*`, `cursor.location`, and `cursor.active_row`. Free returned strings with `ghostty_string_free`.

<sup>Written for commit 4f4f3857054dd995dbb9ab093c1c74f622eb10e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/107?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new bounded terminal grid JSON export that includes both before- and after-viewport row ranges.
  * Added screen-tail VT export with caller-controlled row/byte limits.
* **Documentation**
  * Clarified the rendered grid JSON frame structure, scrollback ordering, and viewport boundary semantics (including legacy “before” behavior).
* **Bug Fixes**
  * Improved cursor serialization to consistently report visibility and location class (viewport/above/below).
* **Tests**
  * Added coverage for bounded row traversal, iterator ordering/output-row mapping, cursor classification/visibility, and active-region bounds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->