### PR TITLE
cmux: add bounded VT screen tail export

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1238,6 +1238,17 @@ GHOSTTY_API bool ghostty_surface_read_screen_clipboard_text(ghostty_surface_t,
                                                             uint32_t,
                                                             uintptr_t,
                                                             ghostty_text_s*);
+// cmux fork: format at most max_rows of the most recent screen/history rows as
+// VT into a fixed max_bytes scratch buffer. If that suffix does not fit, the
+// selected row count is progressively reduced until it does; a single row that
+// exceeds max_bytes fails. The returned bytes preserve Ghostty's rendered cell
+// styles (including conceal), wide characters, graphemes, and compressed
+// history without exposing raw PTY control sequences. The exact-sized result
+// is owned by the surface and must be released with ghostty_surface_free_text.
+GHOSTTY_API bool ghostty_surface_read_screen_tail_vt(ghostty_surface_t,
+                                                     uintptr_t,
+                                                     uintptr_t,
+                                                     ghostty_text_s*);
 GHOSTTY_API void ghostty_surface_free_text(ghostty_surface_t, ghostty_text_s*);
 
 #ifdef __APPLE__

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1793,6 +1793,58 @@ pub const CAPI = struct {
         return readClipboardTextLocked(surface, core_sel, max_bytes, result);
     }
 
+    /// cmux fork: read a byte-bounded VT reconstruction of the most recent
+    /// physical screen/history rows without flattening Ghostty's cell model.
+    export fn ghostty_surface_read_screen_tail_vt(
+        surface: *Surface,
+        max_rows: usize,
+        max_bytes: usize,
+        result: *Text,
+    ) bool {
+        surface.core_surface.renderer_state.mutex.lock();
+        defer surface.core_surface.renderer_state.mutex.unlock();
+
+        if (max_rows == 0 or max_bytes == 0) return false;
+        const core_surface = &surface.core_surface;
+        const opts: terminal.formatter.Options = .{
+            .emit = .vt,
+            .unwrap = false,
+            .trim = false,
+            .background = core_surface.io.terminal.colors.background.get(),
+            .foreground = core_surface.io.terminal.colors.foreground.get(),
+            .palette = &core_surface.io.terminal.colors.palette.current,
+        };
+        const formatter: terminal.formatter.ScreenFormatter = .init(
+            core_surface.io.terminal.screens.active,
+            opts,
+        );
+
+        const scratch = global.alloc.alloc(u8, max_bytes) catch |err| {
+            log.warn("error allocating bounded screen tail buffer err={}", .{err});
+            return false;
+        };
+        defer global.alloc.free(scratch);
+
+        const formatted = formatter.formatTailBounded(scratch, max_rows) catch |err| {
+            log.warn("error formatting bounded screen tail err={}", .{err});
+            return false;
+        };
+        const owned = global.alloc.dupeZ(u8, formatted) catch |err| {
+            log.warn("error allocating bounded screen tail result err={}", .{err});
+            return false;
+        };
+
+        result.* = .{
+            .tl_px_x = -1,
+            .tl_px_y = -1,
+            .offset_start = 0,
+            .offset_len = 0,
+            .text = owned.ptr,
+            .text_len = owned.len,
+        };
+        return true;
+    }
+
     fn readTextLocked(
         surface: *Surface,
         core_sel: terminal.Selection,

--- a/src/terminal/formatter.zig
+++ b/src/terminal/formatter.zig
@@ -531,6 +531,49 @@ pub const ScreenFormatter = struct {
         };
     }
 
+    /// Format a bounded suffix of the physical screen rows into `buffer`.
+    ///
+    /// The first attempt includes at most `max_rows` ending at the bottom of
+    /// history/current screen. If the fixed writer fills, the row suffix is
+    /// halved until it fits. This keeps allocation bounded by the caller while
+    /// preserving complete VT formatter output rather than truncating bytes in
+    /// the middle of an escape sequence or UTF-8 codepoint.
+    pub fn formatTailBounded(
+        self: ScreenFormatter,
+        buffer: []u8,
+        max_rows: usize,
+    ) (std.Io.Writer.Error || Allocator.Error)![]const u8 {
+        if (buffer.len == 0 or max_rows == 0) return buffer[0..0];
+
+        const pages = &self.screen.pages;
+        var bottom_right = pages.getBottomRight(.screen) orelse return buffer[0..0];
+        bottom_right.x = bottom_right.node.cols() - 1;
+
+        var row_count = max_rows;
+        switch (bottom_right.upOverflow(max_rows - 1)) {
+            .offset => {},
+            .overflow => |overflow| row_count -= overflow.remaining,
+        }
+        while (true) {
+            var top_left = bottom_right.up(row_count - 1) orelse pages.getTopLeft(.screen);
+            top_left.x = 0;
+
+            var formatter = self;
+            formatter.content = .{ .selection = Selection.init(top_left, bottom_right, false) };
+
+            var writer = std.Io.Writer.fixed(buffer);
+            formatter.format(&writer) catch |err| switch (err) {
+                error.WriteFailed => {
+                    if (row_count == 1) return error.WriteFailed;
+                    row_count = @max(1, row_count / 2);
+                    continue;
+                },
+                else => |other| return other,
+            };
+            return writer.buffered();
+        }
+    }
+
     pub fn format(
         self: ScreenFormatter,
         writer: *std.Io.Writer,
@@ -4767,6 +4810,62 @@ test "Screen vt with style" {
     for (0..output.len) |i| {
         try testing.expectEqual(node, pin_map.items[i].node);
     }
+}
+
+test "Screen VT bounded tail shrinks to a complete row suffix" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var t = try Terminal.init(alloc, .{
+        .cols = 16,
+        .rows = 2,
+    });
+    defer t.deinit(alloc);
+
+    var stream = t.vtStream();
+    defer stream.deinit();
+    stream.nextSlice("oldest\r\nmiddle\r\nlatest");
+
+    var buffer: [8]u8 = undefined;
+    const formatter: ScreenFormatter = .init(t.screens.active, .vt);
+    const output = try formatter.formatTailBounded(&buffer, 3000);
+
+    try testing.expectEqualStrings("latest", output);
+    try testing.expect(output.len <= buffer.len);
+}
+
+test "Screen VT bounded tail preserves conceal wide and grapheme cells" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var t = try Terminal.init(alloc, .{
+        .cols = 20,
+        .rows = 2,
+    });
+    defer t.deinit(alloc);
+
+    var stream = t.vtStream();
+    defer stream.deinit();
+    stream.nextSlice("\r\n\x1b[8msecret\x1b[0m界e\u{301}");
+
+    var buffer: [256]u8 = undefined;
+    const formatter: ScreenFormatter = .init(t.screens.active, .vt);
+    const output = try formatter.formatTailBounded(&buffer, 1);
+
+    try testing.expectEqual(@as(usize, 1), std.mem.count(u8, output, "界"));
+    try testing.expectEqual(@as(usize, 1), std.mem.count(u8, output, "e\u{301}"));
+
+    var replay = try Terminal.init(alloc, .{
+        .cols = 20,
+        .rows = 2,
+    });
+    defer replay.deinit(alloc);
+    var replay_stream = replay.vtStream();
+    defer replay_stream.deinit();
+    replay_stream.nextSlice(output);
+
+    const concealed = replay.screens.active.pages.pin(.{ .active = .{ .x = 0, .y = 0 } }).?;
+    try testing.expect(concealed.style(concealed.rowAndCell().cell).flags.invisible);
 }
 
 test "Screen vt with hyperlink" {


### PR DESCRIPTION
Adds a cmux fork API that formats the newest terminal history rows as VT within caller-provided row and byte limits. The formatter derives the suffix inside Ghostty, preserves conceal/wide/grapheme semantics, and reduces the row suffix only when the fixed buffer overflows.\n\nRequired by manaflow-ai/cmux#7911.\n\nValidation:\n- zig build test -Dapp-runtime=none -Demit-macos-app=false -Demit-xcframework=false -Dtest-filter='Screen VT bounded tail'\n- zig build -Demit-xcframework=true -Dxcframework-target=universal -Doptimize=ReleaseFast\n- zig fmt --check src/apprt/embedded.zig src/terminal/formatter.zig

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/108"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786409913&installation_id=133855650&pr_number=108&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F108&signature=bd41b311a4fff5b8f1dabda43139a75a9432170f258731db8e284c4cfec59502"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a bounded VT export for the newest screen/history rows, letting callers get a size-limited VT snapshot that preserves Ghostty’s render semantics. Enables bounded scrollback tail for cmux (issue 7911).

- **New Features**
  - `ghostty_surface_read_screen_tail_vt(surface, max_rows, max_bytes, out)` emits VT for the most recent rows into a fixed buffer; shrinks the row suffix until it fits; fails if one row alone exceeds `max_bytes`. Result is owned by the surface; free with `ghostty_surface_free_text`.
  - Adds `ScreenFormatter.formatTailBounded` to format a complete row suffix without cutting escape sequences or UTF‑8, preserving conceal, wide characters, graphemes, and compressed history semantics.

<sup>Written for commit 5ae712a89479f16d47d9a75e1a802a22415a3033. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/108?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an embedding API for retrieving the most recent terminal screen and scrollback content as formatted VT text.
  - Callers can limit results by both row count and output size; the returned content automatically fits within the requested byte limit.
  - Output preserves terminal formatting, including colors, concealment, wide characters, and grapheme behavior.
  - Added support for releasing returned text through the existing text cleanup API.
- **Tests**
  - Added coverage for size-limited output and formatting preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->