### PR TITLE
embedded: export effective surface theme in render grid

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1216,8 +1216,15 @@ GHOSTTY_API ghostty_string_s ghostty_surface_render_grid_json(ghostty_surface_t,
                                                                  const char*,
                                                                  uintptr_t,
                                                                  uint64_t,
-                                                                 uintptr_t,
-                                                                 bool);
+                                                                 uintptr_t);
+// Versioned form that also exports the effective and raw config themes.
+GHOSTTY_API ghostty_string_s ghostty_surface_render_grid_json_with_theme(
+    ghostty_surface_t,
+    const char*,
+    uintptr_t,
+    uint64_t,
+    uintptr_t,
+    bool);
 GHOSTTY_API void ghostty_surface_set_color_scheme(ghostty_surface_t,
                                                      ghostty_color_scheme_e);
 GHOSTTY_API ghostty_input_mods_e ghostty_surface_key_translation_mods(ghostty_surface_t,

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1157,7 +1157,8 @@ GHOSTTY_API ghostty_string_s ghostty_surface_render_grid_json(ghostty_surface_t,
                                                                  const char*,
                                                                  uintptr_t,
                                                                  uint64_t,
-                                                                 uintptr_t);
+                                                                 uintptr_t,
+                                                                 bool);
 GHOSTTY_API void ghostty_surface_set_color_scheme(ghostty_surface_t,
                                                      ghostty_color_scheme_e);
 GHOSTTY_API ghostty_input_mods_e ghostty_surface_key_translation_mods(ghostty_surface_t,

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1134,6 +1134,15 @@ GHOSTTY_API void* ghostty_surface_userdata(ghostty_surface_t);
 GHOSTTY_API ghostty_app_t ghostty_surface_app(ghostty_surface_t);
 GHOSTTY_API ghostty_surface_config_s ghostty_surface_inherited_config(ghostty_surface_t, ghostty_surface_context_e);
 GHOSTTY_API void ghostty_surface_update_config(ghostty_surface_t, ghostty_config_t);
+
+/**
+ * Update only terminal color defaults used by OSC resets.
+ *
+ * Manual-IO embedders must serialize this with
+ * ghostty_surface_process_output. This avoids the font and renderer work of a
+ * full surface config update.
+ */
+GHOSTTY_API void ghostty_surface_update_theme_config(ghostty_surface_t, ghostty_config_t);
 GHOSTTY_API bool ghostty_surface_needs_confirm_quit(ghostty_surface_t);
 GHOSTTY_API bool ghostty_surface_process_exited(ghostty_surface_t);
 GHOSTTY_API void ghostty_surface_refresh(ghostty_surface_t);

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -2274,6 +2274,7 @@ pub const CAPI = struct {
         var theme_selection_background: terminal.color.RGB = undefined;
         var theme_selection_foreground: terminal.color.RGB = undefined;
         var theme_palette: [256]terminal.color.RGB = undefined;
+        var config_palette: [256]terminal.color.RGB = undefined;
         var theme_cursor_color_semantic: ?configpkg.Config.TerminalColor = null;
         var theme_cursor_text_semantic: ?configpkg.Config.TerminalColor = null;
         var theme_selection_background_semantic: ?configpkg.Config.TerminalColor = null;
@@ -2331,6 +2332,7 @@ pub const CAPI = struct {
                     background,
                 );
                 @memcpy(&theme_palette, palette[0..theme_palette.len]);
+                @memcpy(&config_palette, t.colors.palette.original[0..config_palette.len]);
                 if (cursor_color_override == null) theme_cursor_color_semantic = config_cursor_color;
                 theme_cursor_text_semantic = config_cursor_text;
                 theme_selection_background_semantic = config_selection_background;
@@ -2537,6 +2539,72 @@ pub const CAPI = struct {
         try jw.write(if (is_alternate) "alternate" else "primary");
 
         if (include_theme) {
+            try jw.objectField("terminal_config_theme");
+            try jw.beginObject();
+            try jw.objectField("background");
+            try writeRenderGridColor(&jw, config_background);
+            try jw.objectField("foreground");
+            try writeRenderGridColor(&jw, config_foreground);
+            try jw.objectField("cursor");
+            try writeRenderGridColor(
+                &jw,
+                resolveRenderGridThemeColor(
+                    config_cursor_color,
+                    config_foreground,
+                    config_background,
+                    config_foreground,
+                ),
+            );
+            try writeRenderGridSemanticColor(&jw, "cursorColorSemantic", config_cursor_color);
+            if (config_cursor_text) |cursor_text| {
+                try jw.objectField("cursorText");
+                try writeRenderGridColor(
+                    &jw,
+                    resolveRenderGridThemeColor(
+                        cursor_text,
+                        config_foreground,
+                        config_background,
+                        config_background,
+                    ),
+                );
+            }
+            try writeRenderGridSemanticColor(&jw, "cursorTextSemantic", config_cursor_text);
+            try jw.objectField("selectionBackground");
+            try writeRenderGridColor(
+                &jw,
+                resolveRenderGridThemeColor(
+                    config_selection_background,
+                    config_foreground,
+                    config_background,
+                    config_foreground,
+                ),
+            );
+            try writeRenderGridSemanticColor(
+                &jw,
+                "selectionBackgroundSemantic",
+                config_selection_background,
+            );
+            try jw.objectField("selectionForeground");
+            try writeRenderGridColor(
+                &jw,
+                resolveRenderGridThemeColor(
+                    config_selection_foreground,
+                    config_foreground,
+                    config_background,
+                    config_background,
+                ),
+            );
+            try writeRenderGridSemanticColor(
+                &jw,
+                "selectionForegroundSemantic",
+                config_selection_foreground,
+            );
+            try jw.objectField("palette");
+            try jw.beginArray();
+            for (config_palette) |color| try writeRenderGridColor(&jw, color);
+            try jw.endArray();
+            try jw.endObject();
+
             try jw.objectField("terminal_theme");
             try jw.beginObject();
             try jw.objectField("background");

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -2183,15 +2183,65 @@ pub const CAPI = struct {
         };
     }
 
+    fn resolveRenderGridThemeColor(
+        value: ?configpkg.Config.TerminalColor,
+        foreground: terminal.color.RGB,
+        background: terminal.color.RGB,
+        fallback: terminal.color.RGB,
+    ) terminal.color.RGB {
+        const configured = value orelse return fallback;
+        return switch (configured) {
+            .color => |color| color.toTerminalRGB(),
+            .@"cell-foreground" => foreground,
+            .@"cell-background" => background,
+        };
+    }
+
+    fn writeRenderGridSemanticColor(
+        jw: *std.json.Stringify,
+        field: []const u8,
+        value: ?configpkg.Config.TerminalColor,
+    ) !void {
+        const configured = value orelse return;
+        const semantic = switch (configured) {
+            .color => return,
+            .@"cell-foreground" => "cell-foreground",
+            .@"cell-background" => "cell-background",
+        };
+        try jw.objectField(field);
+        try jw.write(semantic);
+    }
+
     fn buildRenderGridJson(
         surface: *Surface,
         surface_id: []const u8,
         state_seq: u64,
         scrollback_lines: usize,
+        include_theme: bool,
     ) !String {
         const alloc = global.alloc;
         const core_surface = &surface.core_surface;
-        const bold_color = core_surface.renderer.config.bold_color;
+        var config_background: terminal.color.RGB = undefined;
+        var config_foreground: terminal.color.RGB = undefined;
+        var config_cursor_color: ?configpkg.Config.TerminalColor = null;
+        var config_cursor_text: ?configpkg.Config.TerminalColor = null;
+        var config_selection_background: ?configpkg.Config.TerminalColor = null;
+        var config_selection_foreground: ?configpkg.Config.TerminalColor = null;
+        var bold_color: ?terminal.Style.BoldColor = null;
+        {
+            core_surface.renderer.draw_mutex.lock();
+            defer core_surface.renderer.draw_mutex.unlock();
+            const config = &core_surface.renderer.config;
+            config_background = config.background;
+            config_foreground = config.foreground;
+            if (include_theme) {
+                config_cursor_color = config.cursor_color;
+                config_cursor_text = config.cursor_text;
+                config_selection_background = config.selection_background;
+                config_selection_foreground = config.selection_foreground;
+            }
+            bold_color = config.bold_color;
+        }
 
         var styles: std.ArrayListUnmanaged(RenderGridStyle) = .empty;
         defer styles.deinit(alloc);
@@ -2219,6 +2269,17 @@ pub const CAPI = struct {
         var fg_override: ?terminal.color.RGB = null;
         var bg_override: ?terminal.color.RGB = null;
         var cursor_color_override: ?terminal.color.RGB = null;
+        var theme_background: terminal.color.RGB = undefined;
+        var theme_foreground: terminal.color.RGB = undefined;
+        var theme_cursor: terminal.color.RGB = undefined;
+        var theme_cursor_text: ?terminal.color.RGB = null;
+        var theme_selection_background: terminal.color.RGB = undefined;
+        var theme_selection_foreground: terminal.color.RGB = undefined;
+        var theme_palette: [256]terminal.color.RGB = undefined;
+        var theme_cursor_color_semantic: ?configpkg.Config.TerminalColor = null;
+        var theme_cursor_text_semantic: ?configpkg.Config.TerminalColor = null;
+        var theme_selection_background_semantic: ?configpkg.Config.TerminalColor = null;
+        var theme_selection_foreground_semantic: ?configpkg.Config.TerminalColor = null;
         var scrollback_rows: u32 = 0;
 
         {
@@ -2228,8 +2289,8 @@ pub const CAPI = struct {
             const t: *terminal.Terminal = core_surface.renderer_state.terminal;
             const s: *terminal.Screen = t.screens.active;
             const palette = &t.colors.palette.current;
-            var background = t.colors.background.get() orelse core_surface.renderer.config.background;
-            var foreground = t.colors.foreground.get() orelse core_surface.renderer.config.foreground;
+            var background = t.colors.background.get() orelse config_background;
+            var foreground = t.colors.foreground.get() orelse config_foreground;
             if (t.modes.get(.reverse_colors)) {
                 std.mem.swap(terminal.color.RGB, &background, &foreground);
             }
@@ -2244,6 +2305,41 @@ pub const CAPI = struct {
             fg_override = t.colors.foreground.override;
             bg_override = t.colors.background.override;
             cursor_color_override = t.colors.cursor.override;
+            if (include_theme) {
+                theme_background = background;
+                theme_foreground = foreground;
+                theme_cursor = t.colors.cursor.get() orelse resolveRenderGridThemeColor(
+                    config_cursor_color,
+                    foreground,
+                    background,
+                    foreground,
+                );
+                if (config_cursor_text) |cursor_text| {
+                    theme_cursor_text = resolveRenderGridThemeColor(
+                        cursor_text,
+                        foreground,
+                        background,
+                        background,
+                    );
+                }
+                theme_selection_background = resolveRenderGridThemeColor(
+                    config_selection_background,
+                    foreground,
+                    background,
+                    foreground,
+                );
+                theme_selection_foreground = resolveRenderGridThemeColor(
+                    config_selection_foreground,
+                    foreground,
+                    background,
+                    background,
+                );
+                @memcpy(&theme_palette, palette[0..theme_palette.len]);
+                if (cursor_color_override == null) theme_cursor_color_semantic = config_cursor_color;
+                theme_cursor_text_semantic = config_cursor_text;
+                theme_selection_background_semantic = config_selection_background;
+                theme_selection_foreground_semantic = config_selection_foreground;
+            }
 
             // Capture every non-default-handled DEC/ANSI mode so the client can
             // restore mouse tracking, bracketed paste, application keys, origin,
@@ -2444,6 +2540,42 @@ pub const CAPI = struct {
         try jw.objectField("active_screen");
         try jw.write(if (is_alternate) "alternate" else "primary");
 
+        if (include_theme) {
+            try jw.objectField("terminal_theme");
+            try jw.beginObject();
+            try jw.objectField("background");
+            try writeRenderGridColor(&jw, theme_background);
+            try jw.objectField("foreground");
+            try writeRenderGridColor(&jw, theme_foreground);
+            try jw.objectField("cursor");
+            try writeRenderGridColor(&jw, theme_cursor);
+            try writeRenderGridSemanticColor(&jw, "cursorColorSemantic", theme_cursor_color_semantic);
+            if (theme_cursor_text) |cursor_text| {
+                try jw.objectField("cursorText");
+                try writeRenderGridColor(&jw, cursor_text);
+            }
+            try writeRenderGridSemanticColor(&jw, "cursorTextSemantic", theme_cursor_text_semantic);
+            try jw.objectField("selectionBackground");
+            try writeRenderGridColor(&jw, theme_selection_background);
+            try writeRenderGridSemanticColor(
+                &jw,
+                "selectionBackgroundSemantic",
+                theme_selection_background_semantic,
+            );
+            try jw.objectField("selectionForeground");
+            try writeRenderGridColor(&jw, theme_selection_foreground);
+            try writeRenderGridSemanticColor(
+                &jw,
+                "selectionForegroundSemantic",
+                theme_selection_foreground_semantic,
+            );
+            try jw.objectField("palette");
+            try jw.beginArray();
+            for (theme_palette) |color| try writeRenderGridColor(&jw, color);
+            try jw.endArray();
+            try jw.endObject();
+        }
+
         if (fg_override) |c| {
             try jw.objectField("terminal_foreground");
             try writeRenderGridColor(&jw, c);
@@ -2507,12 +2639,14 @@ pub const CAPI = struct {
         surface_id_len: usize,
         state_seq: u64,
         scrollback_lines: usize,
+        include_theme: bool,
     ) String {
         return buildRenderGridJson(
             surface,
             surface_id_ptr[0..surface_id_len],
             state_seq,
             scrollback_lines,
+            include_theme,
         ) catch |err| {
             log.warn("error exporting render grid err={}", .{err});
             return .empty;

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1681,6 +1681,7 @@ pub const CAPI = struct {
         };
         defer derived.deinit();
         surface.core_surface.io.changeColorConfig(&derived);
+        surface.core_surface.renderer.changeColorConfig(config);
     }
 
     /// Returns true if the surface needs to confirm quitting.

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -2266,11 +2266,9 @@ pub const CAPI = struct {
         var columns: u32 = 0;
         var rows: u32 = 0;
         var is_alternate = false;
-        var fg_override: ?terminal.color.RGB = null;
-        var bg_override: ?terminal.color.RGB = null;
         var cursor_color_override: ?terminal.color.RGB = null;
-        var theme_background: terminal.color.RGB = undefined;
-        var theme_foreground: terminal.color.RGB = undefined;
+        var effective_background: terminal.color.RGB = undefined;
+        var effective_foreground: terminal.color.RGB = undefined;
         var theme_cursor: terminal.color.RGB = undefined;
         var theme_cursor_text: ?terminal.color.RGB = null;
         var theme_selection_background: terminal.color.RGB = undefined;
@@ -2302,12 +2300,10 @@ pub const CAPI = struct {
             cursor_blinking = t.modes.get(.cursor_blinking);
             cursor_style = s.cursor.cursor_style;
             is_alternate = t.screens.active_key == .alternate;
-            fg_override = t.colors.foreground.override;
-            bg_override = t.colors.background.override;
+            effective_background = background;
+            effective_foreground = foreground;
             cursor_color_override = t.colors.cursor.override;
             if (include_theme) {
-                theme_background = background;
-                theme_foreground = foreground;
                 theme_cursor = t.colors.cursor.get() orelse resolveRenderGridThemeColor(
                     config_cursor_color,
                     foreground,
@@ -2544,9 +2540,9 @@ pub const CAPI = struct {
             try jw.objectField("terminal_theme");
             try jw.beginObject();
             try jw.objectField("background");
-            try writeRenderGridColor(&jw, theme_background);
+            try writeRenderGridColor(&jw, effective_background);
             try jw.objectField("foreground");
-            try writeRenderGridColor(&jw, theme_foreground);
+            try writeRenderGridColor(&jw, effective_foreground);
             try jw.objectField("cursor");
             try writeRenderGridColor(&jw, theme_cursor);
             try writeRenderGridSemanticColor(&jw, "cursorColorSemantic", theme_cursor_color_semantic);
@@ -2576,14 +2572,13 @@ pub const CAPI = struct {
             try jw.endObject();
         }
 
-        if (fg_override) |c| {
-            try jw.objectField("terminal_foreground");
-            try writeRenderGridColor(&jw, c);
-        }
-        if (bg_override) |c| {
-            try jw.objectField("terminal_background");
-            try writeRenderGridColor(&jw, c);
-        }
+        // Always export the small effective default colors. These include OSC
+        // overrides and DECSCNM reverse-video, so clients can keep chrome in sync
+        // without requesting the full 256-color terminal_theme on every tick.
+        try jw.objectField("terminal_foreground");
+        try writeRenderGridColor(&jw, effective_foreground);
+        try jw.objectField("terminal_background");
+        try writeRenderGridColor(&jw, effective_background);
         if (cursor_color_override) |c| {
             try jw.objectField("terminal_cursor_color");
             try writeRenderGridColor(&jw, c);

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -16,6 +16,7 @@ const internal_os = @import("../os/main.zig");
 const renderer = @import("../renderer.zig");
 const terminal = @import("../terminal/main.zig");
 const terminal_style = @import("../terminal/style.zig");
+const termio = @import("../termio.zig");
 const CoreApp = @import("../App.zig");
 const CoreInspector = @import("../inspector/main.zig").Inspector;
 const CoreSurface = @import("../Surface.zig");

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1665,6 +1665,23 @@ pub const CAPI = struct {
         };
     }
 
+    /// Update only the terminal color defaults used by OSC reset sequences.
+    /// Manual-IO embedders must serialize this with process_output.
+    export fn ghostty_surface_update_theme_config(
+        surface: *Surface,
+        config: *const Config,
+    ) void {
+        var derived = termio.Termio.DerivedConfig.init(
+            surface.core_surface.alloc,
+            config,
+        ) catch |err| {
+            log.err("error deriving theme config err={}", .{err});
+            return;
+        };
+        defer derived.deinit();
+        surface.core_surface.io.changeColorConfig(&derived);
+    }
+
     /// Returns true if the surface needs to confirm quitting.
     export fn ghostty_surface_needs_confirm_quit(surface: *Surface) bool {
         return surface.core_surface.needsConfirmQuit();

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1989,10 +1989,25 @@ pub const CAPI = struct {
         };
     }
 
+    const RenderGridColorSource = enum {
+        default_color,
+        palette,
+        rgb,
+    };
+
+    const RenderGridColorSemantics = struct {
+        source: RenderGridColorSource,
+        palette_index: ?u8 = null,
+    };
+
     const RenderGridStyle = struct {
         id: u32,
         foreground: terminal.color.RGB,
         background: terminal.color.RGB,
+        foreground_source: RenderGridColorSource,
+        foreground_palette_index: ?u8 = null,
+        background_source: RenderGridColorSource,
+        background_palette_index: ?u8 = null,
         bold: bool = false,
         faint: bool = false,
         italic: bool = false,
@@ -2006,6 +2021,10 @@ pub const CAPI = struct {
         fn visualEql(self: RenderGridStyle, other: RenderGridStyle) bool {
             return self.foreground.eql(other.foreground) and
                 self.background.eql(other.background) and
+                self.foreground_source == other.foreground_source and
+                self.foreground_palette_index == other.foreground_palette_index and
+                self.background_source == other.background_source and
+                self.background_palette_index == other.background_palette_index and
                 self.bold == other.bold and
                 self.faint == other.faint and
                 self.italic == other.italic and
@@ -2138,6 +2157,15 @@ pub const CAPI = struct {
             .{}
         else
             p.styles.get(p.memory, cell.style_id).*;
+        const foreground_semantics = renderGridColorSemantics(style.fg_color);
+        const background_semantics: RenderGridColorSemantics = switch (cell.content_tag) {
+            .bg_color_palette => .{
+                .source = .palette,
+                .palette_index = cell.content.color_palette,
+            },
+            .bg_color_rgb => .{ .source = .rgb },
+            else => renderGridColorSemantics(style.bg_color),
+        };
         return .{
             .id = 0,
             .foreground = style.fg(.{
@@ -2146,6 +2174,10 @@ pub const CAPI = struct {
                 .bold = bold_color,
             }),
             .background = style.bg(cell, palette) orelse background,
+            .foreground_source = foreground_semantics.source,
+            .foreground_palette_index = foreground_semantics.palette_index,
+            .background_source = background_semantics.source,
+            .background_palette_index = background_semantics.palette_index,
             .bold = style.flags.bold,
             .faint = style.flags.faint,
             .italic = style.flags.italic,
@@ -2155,6 +2187,22 @@ pub const CAPI = struct {
             .invisible = style.flags.invisible,
             .strikethrough = style.flags.strikethrough,
             .overline = style.flags.overline,
+        };
+    }
+
+    fn renderGridColorSemantics(color: terminal.Style.Color) RenderGridColorSemantics {
+        return switch (color) {
+            .none => .{ .source = .default_color },
+            .palette => |index| .{ .source = .palette, .palette_index = index },
+            .rgb => .{ .source = .rgb },
+        };
+    }
+
+    fn renderGridColorSourceName(source: RenderGridColorSource) []const u8 {
+        return switch (source) {
+            .default_color => "default",
+            .palette => "palette",
+            .rgb => "rgb",
         };
     }
 
@@ -2377,6 +2425,8 @@ pub const CAPI = struct {
                 .id = 0,
                 .foreground = foreground,
                 .background = background,
+                .foreground_source = .default_color,
+                .background_source = .default_color,
             };
             try styles.append(alloc, default_style);
 
@@ -2514,6 +2564,18 @@ pub const CAPI = struct {
             try writeRenderGridColor(&jw, style.foreground);
             try jw.objectField("background");
             try writeRenderGridColor(&jw, style.background);
+            try jw.objectField("foreground_source");
+            try jw.write(renderGridColorSourceName(style.foreground_source));
+            if (style.foreground_palette_index) |index| {
+                try jw.objectField("foreground_palette_index");
+                try jw.write(index);
+            }
+            try jw.objectField("background_source");
+            try jw.write(renderGridColorSourceName(style.background_source));
+            if (style.background_palette_index) |index| {
+                try jw.objectField("background_palette_index");
+                try jw.write(index);
+            }
             try jw.objectField("bold");
             try jw.write(style.bold);
             try jw.objectField("faint");
@@ -3346,3 +3408,17 @@ pub const CAPI = struct {
         }
     };
 };
+
+test "render grid preserves terminal color semantics" {
+    const default_color = CAPI.renderGridColorSemantics(.none);
+    try std.testing.expectEqual(CAPI.RenderGridColorSource.default_color, default_color.source);
+    try std.testing.expectEqual(@as(?u8, null), default_color.palette_index);
+
+    const palette = CAPI.renderGridColorSemantics(.{ .palette = 42 });
+    try std.testing.expectEqual(CAPI.RenderGridColorSource.palette, palette.source);
+    try std.testing.expectEqual(@as(?u8, 42), palette.palette_index);
+
+    const rgb = CAPI.renderGridColorSemantics(.{ .rgb = .{ .r = 1, .g = 2, .b = 3 } });
+    try std.testing.expectEqual(CAPI.RenderGridColorSource.rgb, rgb.source);
+    try std.testing.expectEqual(@as(?u8, null), rgb.palette_index);
+}

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -2928,6 +2928,25 @@ pub const CAPI = struct {
         surface_id_len: usize,
         state_seq: u64,
         scrollback_lines: usize,
+    ) String {
+        return buildRenderGridJson(
+            surface,
+            surface_id_ptr[0..surface_id_len],
+            state_seq,
+            scrollback_lines,
+            false,
+        ) catch |err| {
+            log.warn("error exporting render grid err={}", .{err});
+            return .empty;
+        };
+    }
+
+    export fn ghostty_surface_render_grid_json_with_theme(
+        surface: *Surface,
+        surface_id_ptr: [*]const u8,
+        surface_id_len: usize,
+        state_seq: u64,
+        scrollback_lines: usize,
         include_theme: bool,
     ) String {
         return buildRenderGridJson(

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -2027,6 +2027,21 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             }
         }
 
+        /// Update only renderer colors for a manual-IO theme change.
+        pub fn changeColorConfig(self: *Self, config: *const configpkg.Config) void {
+            self.draw_mutex.lock();
+            defer self.draw_mutex.unlock();
+
+            self.config.cursor_color = config.@"cursor-color";
+            self.config.cursor_text = config.@"cursor-text";
+            self.config.background = config.background.toTerminalRGB();
+            self.config.foreground = config.foreground.toTerminalRGB();
+            self.config.selection_background = config.@"selection-background";
+            self.config.selection_foreground = config.@"selection-foreground";
+            self.config.bold_color = if (config.@"bold-color") |color| color.toTerminal() else null;
+            self.markDirty();
+        }
+
         /// Resize the screen.
         pub fn setScreenSize(
             self: *Self,

--- a/src/termio/Termio.zig
+++ b/src/termio/Termio.zig
@@ -558,6 +558,25 @@ pub fn changeConfig(self: *Termio, td: *ThreadData, config: *DerivedConfig) !voi
     self.terminal.setKittyGraphicsLoadingLimits(.all);
 }
 
+/// Update only the terminal color defaults used by OSC resets.
+///
+/// Manual-IO embedders call this on the same serial executor as processOutput.
+/// Unlike a full surface config reload, this does not touch the font grid or
+/// enqueue a blocking renderer-mailbox config message.
+pub fn changeColorConfig(self: *Termio, config: *const DerivedConfig) void {
+    self.renderer_state.mutex.lock();
+    defer self.renderer_state.mutex.unlock();
+
+    self.terminal.colors.palette.changeDefault(config.palette);
+    self.terminal.colors.background.default = config.background.toTerminalRGB();
+    self.terminal.colors.foreground.default = config.foreground.toTerminalRGB();
+    self.terminal.colors.cursor.default = cursor: {
+        const color = config.cursor_color orelse break :cursor null;
+        break :cursor color.toTerminalRGB() orelse break :cursor null;
+    };
+    self.terminal.flags.dirty.palette = true;
+}
+
 /// Resize the terminal.
 pub fn resize(
     self: *Termio,


### PR DESCRIPTION
Adds the complete renderer-effective terminal theme to full mobile render-grid snapshots. The snapshot includes all 256 palette entries, preserves cell-relative cursor/selection semantics, and copies renderer config under its draw mutex before reading terminal state. Live events, replay, and scroll prefetch therefore share one per-surface theme artifact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to include terminal theme details in render-grid JSON exports.
  * When enabled, exports include resolved theme colors (foreground/background), cursor color (and cursor text when configured), selection colors, semantic indicator fields, and the active 256-color palette.
  * Render-grid JSON always includes effective `terminal_foreground` and `terminal_background`.
* **API Changes**
  * Extended `ghostty_surface_render_grid_json` with a `bool include_theme` parameter.
  * Added `ghostty_surface_update_theme_config` to update terminal color defaults used by OSC resets for embedders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->