### PR TITLE
Preserve absolute terminal scroll identity for embedders

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -698,6 +698,8 @@ typedef struct {
   const char* pwd;
   // Valid only for the duration of the action callback.
   const ghostty_action_scrollbar_s* scrollbar;
+  // Monotonic identity for the absolute scrollbar row space.
+  uint64_t scrollbar_revision;
 } ghostty_action_pwd_s;
 
 // terminal.MouseShape
@@ -971,6 +973,7 @@ typedef enum {
   GHOSTTY_ACTION_READONLY,
   GHOSTTY_ACTION_COPY_TITLE_TO_CLIPBOARD,
   GHOSTTY_ACTION_SELECTION_CHANGED,
+  GHOSTTY_ACTION_SCROLLBAR_REVISION,
 } ghostty_action_tag_e;
 
 typedef union {
@@ -1012,6 +1015,7 @@ typedef union {
   ghostty_action_search_total_s search_total;
   ghostty_action_search_selected_s search_selected;
   ghostty_action_readonly_e readonly;
+  uint64_t scrollbar_revision;
 } ghostty_action_u;
 
 typedef struct {

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -686,9 +686,17 @@ typedef enum {
   GHOSTTY_PROMPT_TITLE_TAB,
 } ghostty_action_prompt_title_e;
 
+// terminal.Scrollbar
+typedef struct {
+  uint64_t total;
+  uint64_t offset;
+  uint64_t len;
+} ghostty_action_scrollbar_s;
+
 // apprt.action.Pwd.C
 typedef struct {
   const char* pwd;
+  ghostty_action_scrollbar_s scrollbar;
 } ghostty_action_pwd_s;
 
 // terminal.MouseShape
@@ -893,13 +901,6 @@ typedef enum {
   GHOSTTY_TMUX_WINDOWS_CHANGED,
   GHOSTTY_TMUX_PANE_OUTPUT,
 } ghostty_tmux_event_e;
-
-// terminal.Scrollbar
-typedef struct {
-  uint64_t total;
-  uint64_t offset;
-  uint64_t len;
-} ghostty_action_scrollbar_s;
 
 // apprt.Action.Key
 typedef enum {
@@ -1225,9 +1226,6 @@ GHOSTTY_API bool ghostty_surface_select_screen_rows(ghostty_surface_t,
 GHOSTTY_API bool ghostty_surface_selection_screen_rows(ghostty_surface_t,
                                                        uint32_t*,
                                                        uint32_t*);
-// cmux fork: copy the terminal core's authoritative scrollbar snapshot.
-GHOSTTY_API bool ghostty_surface_scrollbar(ghostty_surface_t,
-                                           ghostty_action_scrollbar_s*);
 GHOSTTY_API bool ghostty_surface_read_selection(ghostty_surface_t, ghostty_text_s*);
 GHOSTTY_API bool ghostty_surface_read_text(ghostty_surface_t,
                                               ghostty_selection_s,

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -500,6 +500,15 @@ typedef struct {
   uint32_t cell_height_px;
 } ghostty_surface_size_s;
 
+// cmux fork: authoritative scrollbar snapshot independent of renderer
+// publication. Delete when upstream exports equivalent row-space identity.
+typedef struct {
+  uint64_t total;
+  uint64_t offset;
+  uint64_t len;
+  uint64_t row_space_revision;
+} ghostty_surface_scrollbar_s;
+
 // Config types
 
 // config.Path
@@ -692,11 +701,6 @@ typedef struct {
   uint64_t offset;
   uint64_t len;
 } ghostty_action_scrollbar_s;
-
-// apprt.action.ScrollbarRevision
-typedef struct {
-  uint64_t value;
-} ghostty_action_scrollbar_revision_s;
 
 // apprt.action.Pwd.C
 typedef struct {
@@ -978,7 +982,6 @@ typedef enum {
   GHOSTTY_ACTION_READONLY,
   GHOSTTY_ACTION_COPY_TITLE_TO_CLIPBOARD,
   GHOSTTY_ACTION_SELECTION_CHANGED,
-  GHOSTTY_ACTION_SCROLLBAR_REVISION,
 } ghostty_action_tag_e;
 
 typedef union {
@@ -1020,7 +1023,6 @@ typedef union {
   ghostty_action_search_total_s search_total;
   ghostty_action_search_selected_s search_selected;
   ghostty_action_readonly_e readonly;
-  ghostty_action_scrollbar_revision_s scrollbar_revision;
 } ghostty_action_u;
 
 typedef struct {
@@ -1157,6 +1159,8 @@ GHOSTTY_API void ghostty_surface_set_focus(ghostty_surface_t, bool);
 GHOSTTY_API void ghostty_surface_set_occlusion(ghostty_surface_t, bool);
 GHOSTTY_API void ghostty_surface_set_size(ghostty_surface_t, uint32_t, uint32_t);
 GHOSTTY_API ghostty_surface_size_s ghostty_surface_size(ghostty_surface_t);
+GHOSTTY_API bool ghostty_surface_scrollbar(ghostty_surface_t,
+                                          ghostty_surface_scrollbar_s*);
 GHOSTTY_API uint64_t ghostty_surface_foreground_pid(ghostty_surface_t);
 GHOSTTY_API ghostty_string_s ghostty_surface_tty_name(ghostty_surface_t);
 // cmux fork: export the Ghostty grid as a compact render-grid JSON frame for

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1225,6 +1225,9 @@ GHOSTTY_API bool ghostty_surface_select_screen_rows(ghostty_surface_t,
 GHOSTTY_API bool ghostty_surface_selection_screen_rows(ghostty_surface_t,
                                                        uint32_t*,
                                                        uint32_t*);
+// cmux fork: copy the terminal core's authoritative scrollbar snapshot.
+GHOSTTY_API bool ghostty_surface_scrollbar(ghostty_surface_t,
+                                           ghostty_action_scrollbar_s*);
 GHOSTTY_API bool ghostty_surface_read_selection(ghostty_surface_t, ghostty_text_s*);
 GHOSTTY_API bool ghostty_surface_read_text(ghostty_surface_t,
                                               ghostty_selection_s,

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1161,6 +1161,13 @@ GHOSTTY_API void ghostty_surface_set_size(ghostty_surface_t, uint32_t, uint32_t)
 GHOSTTY_API ghostty_surface_size_s ghostty_surface_size(ghostty_surface_t);
 GHOSTTY_API bool ghostty_surface_scrollbar(ghostty_surface_t,
                                           ghostty_surface_scrollbar_s*);
+// Atomically validates the row-space identity and scrolls to an absolute row.
+// Returns false without scrolling when the identity no longer matches.
+GHOSTTY_API bool ghostty_surface_scroll_to_row_if_revision(
+    ghostty_surface_t,
+    uint64_t,
+    uint64_t,
+    ghostty_surface_scrollbar_s*);
 GHOSTTY_API uint64_t ghostty_surface_foreground_pid(ghostty_surface_t);
 GHOSTTY_API ghostty_string_s ghostty_surface_tty_name(ghostty_surface_t);
 // cmux fork: export the Ghostty grid as a compact render-grid JSON frame for

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -696,7 +696,8 @@ typedef struct {
 // apprt.action.Pwd.C
 typedef struct {
   const char* pwd;
-  ghostty_action_scrollbar_s scrollbar;
+  // Valid only for the duration of the action callback.
+  const ghostty_action_scrollbar_s* scrollbar;
 } ghostty_action_pwd_s;
 
 // terminal.MouseShape

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -693,6 +693,11 @@ typedef struct {
   uint64_t len;
 } ghostty_action_scrollbar_s;
 
+// apprt.action.ScrollbarRevision
+typedef struct {
+  uint64_t value;
+} ghostty_action_scrollbar_revision_s;
+
 // apprt.action.Pwd.C
 typedef struct {
   const char* pwd;
@@ -1015,7 +1020,7 @@ typedef union {
   ghostty_action_search_total_s search_total;
   ghostty_action_search_selected_s search_selected;
   ghostty_action_readonly_e readonly;
-  uint64_t scrollbar_revision;
+  ghostty_action_scrollbar_revision_s scrollbar_revision;
 } ghostty_action_u;
 
 typedef struct {

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -1110,11 +1110,12 @@ pub fn handleMessage(self: *Surface, msg: Message) !void {
             // We always allocate for this because we need to null-terminate.
             const str = try self.alloc.dupeZ(u8, w.pwd.slice());
             defer self.alloc.free(str);
+            const scrollbar = w.scrollbar.cval();
 
             _ = try self.rt_app.performAction(
                 .{ .surface = self },
                 .pwd,
-                .{ .pwd = str, .scrollbar = w.scrollbar },
+                .{ .pwd = str, .scrollbar = &scrollbar },
             );
         },
 

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -1118,7 +1118,11 @@ pub fn handleMessage(self: *Surface, msg: Message) !void {
                 .{
                     .pwd = str,
                     .scrollbar = &scrollbar,
-                    .scrollbar_revision = self.rowSpaceIdentity(w.scrollbar.row_space_revision),
+                    .scrollbar_revision = self.rowSpaceIdentity(
+                        w.screen_key,
+                        w.screen_generation,
+                        w.scrollbar.row_space_revision,
+                    ),
                 },
             );
         },
@@ -1767,9 +1771,41 @@ fn updateScrollbar(self: *Surface, scrollbar: terminal.Scrollbar) void {
 
 /// Opaque identity for an absolute row space within this surface incarnation.
 /// The random surface id prevents a recreated runtime's local revision counter
-/// from aliasing a notification captured by its predecessor.
-pub fn rowSpaceIdentity(self: *const Surface, revision: u64) u64 {
-    return std.hash.Wyhash.hash(self.id, std.mem.asBytes(&revision));
+/// from aliasing a notification captured by its predecessor. The screen key
+/// and generation distinguish primary, alternate, and recreated alternate
+/// buffers whose PageList revision counters may otherwise match.
+pub fn rowSpaceIdentity(
+    self: *const Surface,
+    screen_key: terminal.ScreenSet.Key,
+    screen_generation: usize,
+    revision: u64,
+) u64 {
+    return hashRowSpaceIdentity(self.id, screen_key, screen_generation, revision);
+}
+
+fn hashRowSpaceIdentity(
+    surface_id: u64,
+    screen_key: terminal.ScreenSet.Key,
+    screen_generation: usize,
+    revision: u64,
+) u64 {
+    var hash = std.hash.Wyhash.init(surface_id);
+    const key: u8 = switch (screen_key) {
+        .primary => 0,
+        .alternate => 1,
+    };
+    hash.update(std.mem.asBytes(&key));
+    hash.update(std.mem.asBytes(&screen_generation));
+    hash.update(std.mem.asBytes(&revision));
+    return hash.final();
+}
+
+test "row space identity includes screen key and generation" {
+    const primary = hashRowSpaceIdentity(1, .primary, 0, 7);
+    try std.testing.expect(primary != hashRowSpaceIdentity(1, .alternate, 0, 7));
+    try std.testing.expect(primary != hashRowSpaceIdentity(1, .primary, 1, 7));
+    try std.testing.expect(primary != hashRowSpaceIdentity(2, .primary, 0, 7));
+    try std.testing.expect(primary != hashRowSpaceIdentity(1, .primary, 0, 8));
 }
 
 /// This should be called anytime `config_conditional_state` changes

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -1105,16 +1105,16 @@ pub fn handleMessage(self: *Surface, msg: Message) !void {
         },
 
         .pwd_change => |w| {
-            defer w.deinit();
+            defer w.pwd.deinit();
 
             // We always allocate for this because we need to null-terminate.
-            const str = try self.alloc.dupeZ(u8, w.slice());
+            const str = try self.alloc.dupeZ(u8, w.pwd.slice());
             defer self.alloc.free(str);
 
             _ = try self.rt_app.performAction(
                 .{ .surface = self },
                 .pwd,
-                .{ .pwd = str },
+                .{ .pwd = str, .scrollbar = w.scrollbar },
             );
         },
 

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -1763,13 +1763,6 @@ fn updateScrollbar(self: *Surface, scrollbar: terminal.Scrollbar) void {
     ) catch |err| {
         log.warn("failed to notify app of scrollbar change err={}", .{err});
     };
-    _ = self.rt_app.performAction(
-        .{ .surface = self },
-        .scrollbar_revision,
-        .{ .value = scrollbar.row_space_revision },
-    ) catch |err| {
-        log.warn("failed to notify app of scrollbar revision err={}", .{err});
-    };
 }
 
 /// This should be called anytime `config_conditional_state` changes

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -1783,6 +1783,52 @@ pub fn rowSpaceIdentity(
     return hashRowSpaceIdentity(self.id, screen_key, screen_generation, revision);
 }
 
+pub const AbsoluteScrollSnapshot = struct {
+    total: u64,
+    offset: u64,
+    len: u64,
+    row_space_revision: u64,
+};
+
+/// Scroll to an absolute row only while the caller's row-space identity is
+/// still current. Validation, mutation, and the returned geometry share the
+/// renderer-state lock so destructive output cannot race the operation.
+pub fn scrollToRowIfRevision(
+    self: *Surface,
+    row: usize,
+    expected_row_space_revision: u64,
+) !?AbsoluteScrollSnapshot {
+    const snapshot: AbsoluteScrollSnapshot = snapshot: {
+        self.renderer_state.lockDemand();
+        defer self.renderer_state.unlockDemand();
+
+        const screens = &self.renderer_state.terminal.screens;
+        const screen_key = screens.active_key;
+        var scrollbar = screens.active.pages.scrollbar();
+        const revision = self.rowSpaceIdentity(
+            screen_key,
+            screens.generation(screen_key),
+            scrollbar.row_space_revision,
+        );
+        if (revision != expected_row_space_revision) return null;
+
+        screens.active.scroll(.{ .row = row });
+        scrollbar = screens.active.pages.scrollbar();
+        break :snapshot .{
+            .total = @intCast(scrollbar.total),
+            .offset = @intCast(scrollbar.offset),
+            .len = @intCast(scrollbar.len),
+            .row_space_revision = self.rowSpaceIdentity(
+                screen_key,
+                screens.generation(screen_key),
+                scrollbar.row_space_revision,
+            ),
+        };
+    };
+    try self.queueRender();
+    return snapshot;
+}
+
 fn hashRowSpaceIdentity(
     surface_id: u64,
     screen_key: terminal.ScreenSet.Key,

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -1118,9 +1118,7 @@ pub fn handleMessage(self: *Surface, msg: Message) !void {
                 .{
                     .pwd = str,
                     .scrollbar = &scrollbar,
-                    .scrollbar_revision = .{
-                        .value = w.scrollbar.row_space_revision,
-                    },
+                    .scrollbar_revision = w.scrollbar.row_space_revision,
                 },
             );
         },
@@ -1768,7 +1766,7 @@ fn updateScrollbar(self: *Surface, scrollbar: terminal.Scrollbar) void {
     _ = self.rt_app.performAction(
         .{ .surface = self },
         .scrollbar_revision,
-        scrollbar.row_space_revision,
+        .{ .value = scrollbar.row_space_revision },
     ) catch |err| {
         log.warn("failed to notify app of scrollbar revision err={}", .{err});
     };

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -1115,7 +1115,11 @@ pub fn handleMessage(self: *Surface, msg: Message) !void {
             _ = try self.rt_app.performAction(
                 .{ .surface = self },
                 .pwd,
-                .{ .pwd = str, .scrollbar = &scrollbar },
+                .{
+                    .pwd = str,
+                    .scrollbar = &scrollbar,
+                    .scrollbar_revision = w.scrollbar.row_space_revision,
+                },
             );
         },
 
@@ -1758,6 +1762,13 @@ fn updateScrollbar(self: *Surface, scrollbar: terminal.Scrollbar) void {
         scrollbar,
     ) catch |err| {
         log.warn("failed to notify app of scrollbar change err={}", .{err});
+    };
+    _ = self.rt_app.performAction(
+        .{ .surface = self },
+        .scrollbar_revision,
+        scrollbar.row_space_revision,
+    ) catch |err| {
+        log.warn("failed to notify app of scrollbar revision err={}", .{err});
     };
 }
 

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -1118,7 +1118,9 @@ pub fn handleMessage(self: *Surface, msg: Message) !void {
                 .{
                     .pwd = str,
                     .scrollbar = &scrollbar,
-                    .scrollbar_revision = w.scrollbar.row_space_revision,
+                    .scrollbar_revision = .{
+                        .value = w.scrollbar.row_space_revision,
+                    },
                 },
             );
         },

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -1118,7 +1118,7 @@ pub fn handleMessage(self: *Surface, msg: Message) !void {
                 .{
                     .pwd = str,
                     .scrollbar = &scrollbar,
-                    .scrollbar_revision = w.scrollbar.row_space_revision,
+                    .scrollbar_revision = self.rowSpaceIdentity(w.scrollbar.row_space_revision),
                 },
             );
         },
@@ -1763,6 +1763,13 @@ fn updateScrollbar(self: *Surface, scrollbar: terminal.Scrollbar) void {
     ) catch |err| {
         log.warn("failed to notify app of scrollbar change err={}", .{err});
     };
+}
+
+/// Opaque identity for an absolute row space within this surface incarnation.
+/// The random surface id prevents a recreated runtime's local revision counter
+/// from aliasing a notification captured by its predecessor.
+pub fn rowSpaceIdentity(self: *const Surface, revision: u64) u64 {
+    return std.hash.Wyhash.hash(self.id, std.mem.asBytes(&revision));
 }
 
 /// This should be called anytime `config_conditional_state` changes

--- a/src/apprt/action.zig
+++ b/src/apprt/action.zig
@@ -348,9 +348,6 @@ pub const Action = union(Key) {
     /// through the normal surface APIs. This carries no payload.
     selection_changed,
 
-    /// Monotonic identity for the scrollbar's absolute row space.
-    scrollbar_revision: ScrollbarRevision,
-
     /// Sync with: ghostty_action_tag_e
     pub const Key = enum(c_int) {
         quit,
@@ -419,7 +416,6 @@ pub const Action = union(Key) {
         readonly,
         copy_title_to_clipboard,
         selection_changed,
-        scrollbar_revision,
 
         test "ghostty.h Action.Key" {
             try lib.checkGhosttyHEnum(Key, "GHOSTTY_ACTION_");
@@ -433,10 +429,6 @@ pub const Action = union(Key) {
             try std.testing.expectEqual(
                 @as(c_int, 65),
                 @intFromEnum(Key.selection_changed),
-            );
-            try std.testing.expectEqual(
-                @as(c_int, 66),
-                @intFromEnum(Key.scrollbar_revision),
             );
         }
     };
@@ -714,11 +706,6 @@ pub const InitialSize = extern struct {
 pub const CellSize = extern struct {
     width: u32,
     height: u32,
-};
-
-/// Monotonic identity for the scrollbar's absolute row space.
-pub const ScrollbarRevision = extern struct {
-    value: u64,
 };
 
 pub const SetTitle = struct {

--- a/src/apprt/action.zig
+++ b/src/apprt/action.zig
@@ -349,7 +349,7 @@ pub const Action = union(Key) {
     selection_changed,
 
     /// Monotonic identity for the scrollbar's absolute row space.
-    scrollbar_revision: u64,
+    scrollbar_revision: ScrollbarRevision,
 
     /// Sync with: ghostty_action_tag_e
     pub const Key = enum(c_int) {
@@ -714,6 +714,11 @@ pub const InitialSize = extern struct {
 pub const CellSize = extern struct {
     width: u32,
     height: u32,
+};
+
+/// Monotonic identity for the scrollbar's absolute row space.
+pub const ScrollbarRevision = extern struct {
+    value: u64,
 };
 
 pub const SetTitle = struct {

--- a/src/apprt/action.zig
+++ b/src/apprt/action.zig
@@ -180,9 +180,6 @@ pub const Action = union(Key) {
     /// The scrollbar is updating.
     scrollbar: terminal.Scrollbar,
 
-    /// Monotonic identity for the scrollbar's absolute row space.
-    scrollbar_revision: u64,
-
     /// The target should be re-rendered. This usually has a specific
     /// surface target but if the app is targeted then all active
     /// surfaces should be redrawn.
@@ -350,6 +347,9 @@ pub const Action = union(Key) {
     /// the terminal mutex held, so the apprt may read the current selection
     /// through the normal surface APIs. This carries no payload.
     selection_changed,
+
+    /// Monotonic identity for the scrollbar's absolute row space.
+    scrollbar_revision: u64,
 
     /// Sync with: ghostty_action_tag_e
     pub const Key = enum(c_int) {

--- a/src/apprt/action.zig
+++ b/src/apprt/action.zig
@@ -734,15 +734,19 @@ pub const SetTitle = struct {
 
 pub const Pwd = struct {
     pwd: [:0]const u8,
+    /// Scrollbar state at the exact terminal-stream position of this OSC 7.
+    scrollbar: terminal.Scrollbar,
 
     // Sync with: ghostty_action_set_pwd_s
     pub const C = extern struct {
         pwd: [*:0]const u8,
+        scrollbar: terminal.Scrollbar.C,
     };
 
     pub fn cval(self: Pwd) C {
         return .{
             .pwd = self.pwd.ptr,
+            .scrollbar = self.scrollbar.cval(),
         };
     }
 

--- a/src/apprt/action.zig
+++ b/src/apprt/action.zig
@@ -180,6 +180,9 @@ pub const Action = union(Key) {
     /// The scrollbar is updating.
     scrollbar: terminal.Scrollbar,
 
+    /// Monotonic identity for the scrollbar's absolute row space.
+    scrollbar_revision: u64,
+
     /// The target should be re-rendered. This usually has a specific
     /// surface target but if the app is targeted then all active
     /// surfaces should be redrawn.
@@ -416,6 +419,7 @@ pub const Action = union(Key) {
         readonly,
         copy_title_to_clipboard,
         selection_changed,
+        scrollbar_revision,
 
         test "ghostty.h Action.Key" {
             try lib.checkGhosttyHEnum(Key, "GHOSTTY_ACTION_");
@@ -429,6 +433,10 @@ pub const Action = union(Key) {
             try std.testing.expectEqual(
                 @as(c_int, 65),
                 @intFromEnum(Key.selection_changed),
+            );
+            try std.testing.expectEqual(
+                @as(c_int, 66),
+                @intFromEnum(Key.scrollbar_revision),
             );
         }
     };
@@ -736,17 +744,21 @@ pub const Pwd = struct {
     pwd: [:0]const u8,
     /// Scrollbar state at the exact terminal-stream position of this OSC 7.
     scrollbar: *const terminal.Scrollbar.C,
+    /// Absolute row-space identity at the same terminal-stream position.
+    scrollbar_revision: u64,
 
     // Sync with: ghostty_action_set_pwd_s
     pub const C = extern struct {
         pwd: [*:0]const u8,
         scrollbar: *const terminal.Scrollbar.C,
+        scrollbar_revision: u64,
     };
 
     pub fn cval(self: Pwd) C {
         return .{
             .pwd = self.pwd.ptr,
             .scrollbar = self.scrollbar,
+            .scrollbar_revision = self.scrollbar_revision,
         };
     }
 

--- a/src/apprt/action.zig
+++ b/src/apprt/action.zig
@@ -735,18 +735,18 @@ pub const SetTitle = struct {
 pub const Pwd = struct {
     pwd: [:0]const u8,
     /// Scrollbar state at the exact terminal-stream position of this OSC 7.
-    scrollbar: terminal.Scrollbar,
+    scrollbar: *const terminal.Scrollbar.C,
 
     // Sync with: ghostty_action_set_pwd_s
     pub const C = extern struct {
         pwd: [*:0]const u8,
-        scrollbar: terminal.Scrollbar.C,
+        scrollbar: *const terminal.Scrollbar.C,
     };
 
     pub fn cval(self: Pwd) C {
         return .{
             .pwd = self.pwd.ptr,
-            .scrollbar = self.scrollbar.cval(),
+            .scrollbar = self.scrollbar,
         };
     }
 

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1992,7 +1992,7 @@ pub const CAPI = struct {
             .total = @intCast(scrollbar.total),
             .offset = @intCast(scrollbar.offset),
             .len = @intCast(scrollbar.len),
-            .row_space_revision = scrollbar.row_space_revision,
+            .row_space_revision = core_surface.rowSpaceIdentity(scrollbar.row_space_revision),
         };
         return true;
     }

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1987,12 +1987,18 @@ pub const CAPI = struct {
         core_surface.renderer_state.lockDemand();
         defer core_surface.renderer_state.unlockDemand();
 
-        const scrollbar = core_surface.renderer_state.terminal.screens.active.pages.scrollbar();
+        const screens = &core_surface.renderer_state.terminal.screens;
+        const screen_key = screens.active_key;
+        const scrollbar = screens.active.pages.scrollbar();
         result.* = .{
             .total = @intCast(scrollbar.total),
             .offset = @intCast(scrollbar.offset),
             .len = @intCast(scrollbar.len),
-            .row_space_revision = core_surface.rowSpaceIdentity(scrollbar.row_space_revision),
+            .row_space_revision = core_surface.rowSpaceIdentity(
+                screen_key,
+                screens.generation(screen_key),
+                scrollbar.row_space_revision,
+            ),
         };
         return true;
     }

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -2003,6 +2003,28 @@ pub const CAPI = struct {
         return true;
     }
 
+    /// Atomically validate an absolute row-space identity and scroll within it.
+    export fn ghostty_surface_scroll_to_row_if_revision(
+        surface: *Surface,
+        row: u64,
+        expected_row_space_revision: u64,
+        result: *SurfaceScrollbar,
+    ) bool {
+        const target_row = std.math.cast(usize, row) orelse return false;
+        const maybe_snapshot = surface.core_surface.scrollToRowIfRevision(
+            target_row,
+            expected_row_space_revision,
+        ) catch return false;
+        const snapshot = maybe_snapshot orelse return false;
+        result.* = .{
+            .total = snapshot.total,
+            .offset = snapshot.offset,
+            .len = snapshot.len,
+            .row_space_revision = snapshot.row_space_revision,
+        };
+        return true;
+    }
+
     const RenderGridStyle = struct {
         id: u32,
         foreground: terminal.color.RGB,

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1727,19 +1727,6 @@ pub const CAPI = struct {
         return surface.core_surface.selectionScreenRows(top_y, bottom_y);
     }
 
-    /// Copy the terminal core's authoritative scrollbar state (cmux-specific).
-    export fn ghostty_surface_scrollbar(
-        surface: *Surface,
-        result: *terminal.Scrollbar.C,
-    ) bool {
-        const core_surface = &surface.core_surface;
-        core_surface.renderer_state.lockDemand();
-        defer core_surface.renderer_state.unlockDemand();
-
-        result.* = core_surface.renderer_state.terminal.screens.active.pages.scrollbar().cval();
-        return true;
-    }
-
     /// Same as ghostty_surface_read_text but reads from the user selection,
     /// if any.
     export fn ghostty_surface_read_selection(

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1727,6 +1727,19 @@ pub const CAPI = struct {
         return surface.core_surface.selectionScreenRows(top_y, bottom_y);
     }
 
+    /// Copy the terminal core's authoritative scrollbar state (cmux-specific).
+    export fn ghostty_surface_scrollbar(
+        surface: *Surface,
+        result: *terminal.Scrollbar.C,
+    ) bool {
+        const core_surface = &surface.core_surface;
+        core_surface.renderer_state.lockDemand();
+        defer core_surface.renderer_state.unlockDemand();
+
+        result.* = core_surface.renderer_state.terminal.screens.active.pages.scrollbar().cval();
+        return true;
+    }
+
     /// Same as ghostty_surface_read_text but reads from the user selection,
     /// if any.
     export fn ghostty_surface_read_selection(

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1984,8 +1984,8 @@ pub const CAPI = struct {
         result: *SurfaceScrollbar,
     ) bool {
         const core_surface = &surface.core_surface;
-        core_surface.renderer_state.mutex.lock();
-        defer core_surface.renderer_state.mutex.unlock();
+        core_surface.renderer_state.lockDemand();
+        defer core_surface.renderer_state.unlockDemand();
 
         const scrollbar = core_surface.renderer_state.terminal.screens.active.pages.scrollbar();
         result.* = .{

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1358,6 +1358,13 @@ pub const CAPI = struct {
         cell_height_px: u32,
     };
 
+    const SurfaceScrollbar = extern struct {
+        total: u64,
+        offset: u64,
+        len: u64,
+        row_space_revision: u64,
+    };
+
     // ghostty_clipboard_content_s
     const ClipboardContent = extern struct {
         mime: [*:0]const u8,
@@ -1968,6 +1975,26 @@ pub const CAPI = struct {
             .cell_width_px = surface.core_surface.size.cell.width,
             .cell_height_px = surface.core_surface.size.cell.height,
         };
+    }
+
+    /// Read current scrollbar geometry and its absolute row-space identity
+    /// directly from the terminal, independent of renderer publication.
+    export fn ghostty_surface_scrollbar(
+        surface: *Surface,
+        result: *SurfaceScrollbar,
+    ) bool {
+        const core_surface = &surface.core_surface;
+        core_surface.renderer_state.mutex.lock();
+        defer core_surface.renderer_state.mutex.unlock();
+
+        const scrollbar = core_surface.renderer_state.terminal.screens.active.pages.scrollbar();
+        result.* = .{
+            .total = @intCast(scrollbar.total),
+            .offset = @intCast(scrollbar.offset),
+            .len = @intCast(scrollbar.len),
+            .row_space_revision = scrollbar.row_space_revision,
+        };
+        return true;
     }
 
     const RenderGridStyle = struct {

--- a/src/apprt/gtk/class/application.zig
+++ b/src/apprt/gtk/class/application.zig
@@ -747,8 +747,6 @@ pub const Application = extern struct {
             .selection_changed => {},
 
             .scrollbar => Action.scrollbar(target, value),
-            .scrollbar_revision => {},
-
             .set_title => Action.setTitle(target, value),
             .set_tab_title => return Action.setTabTitle(target, value),
 

--- a/src/apprt/gtk/class/application.zig
+++ b/src/apprt/gtk/class/application.zig
@@ -747,6 +747,7 @@ pub const Application = extern struct {
             .selection_changed => {},
 
             .scrollbar => Action.scrollbar(target, value),
+            .scrollbar_revision => {},
 
             .set_title => Action.setTitle(target, value),
             .set_tab_title => return Action.setTabTitle(target, value),

--- a/src/apprt/surface.zig
+++ b/src/apprt/surface.zig
@@ -89,6 +89,8 @@ pub const Message = union(enum) {
     pwd_change: struct {
         pwd: WriteReq,
         scrollbar: terminal.Scrollbar,
+        screen_key: terminal.ScreenSet.Key,
+        screen_generation: usize,
     },
 
     /// The terminal encountered a bell character.

--- a/src/apprt/surface.zig
+++ b/src/apprt/surface.zig
@@ -84,7 +84,12 @@ pub const Message = union(enum) {
     selection_scroll_tick: bool,
 
     /// The terminal has reported a change in the working directory.
-    pwd_change: WriteReq,
+    /// The scrollbar is captured by the terminal stream at the same point as
+    /// the OSC 7 report, before any later PTY output can mutate the viewport.
+    pwd_change: struct {
+        pwd: WriteReq,
+        scrollbar: terminal.Scrollbar,
+    },
 
     /// The terminal encountered a bell character.
     ring_bell,

--- a/src/terminal/PageList.zig
+++ b/src/terminal/PageList.zig
@@ -407,6 +407,10 @@ min_max_size: usize,
 /// specifically for scrollbar information so we can have the total size.
 total_rows: usize,
 
+/// Monotonic identity for the absolute scrollbar row space. This changes
+/// whenever retained rows can move to different absolute offsets.
+row_space_revision: u64 = 0,
+
 /// The list of tracked pins. These are kept up to date automatically.
 tracked_pins: PinSet,
 
@@ -912,6 +916,7 @@ pub fn deinit(self: *PageList) void {
 /// memory to fit the active area.
 pub fn reset(self: *PageList) void {
     defer self.assertIntegrity();
+    self.row_space_revision +%= 1;
 
     // Reset discards all scrollback, so there is nothing left to compress.
     self.page_compression.reset();
@@ -1156,6 +1161,7 @@ pub fn clone(
         .cols = self.cols,
         .rows = self.rows,
         .total_rows = total_rows,
+        .row_space_revision = self.row_space_revision,
         .tracked_pins = tracked_pins,
         .viewport = .{ .active = {} },
         .viewport_pin = viewport_pin,
@@ -1214,6 +1220,10 @@ pub const Resize = struct {
 /// TODO: docs
 pub fn resize(self: *PageList, opts: Resize) Allocator.Error!void {
     defer self.assertIntegrity();
+
+    if (opts.cols) |cols| {
+        if (cols != self.cols) self.row_space_revision +%= 1;
+    }
 
     // Resizing forces all nodes to be decompressed today so we need to
     // reschedule compression.
@@ -3272,11 +3282,16 @@ pub const Scrollbar = struct {
     /// The length of the visible area. This is including the offset row.
     len: usize,
 
+    /// Identity of the current absolute row space. Embedded runtimes receive
+    /// this separately so the legacy C scrollbar payload stays ABI-stable.
+    row_space_revision: u64 = 0,
+
     /// A zero-sized scrollable region.
     pub const zero: Scrollbar = .{
         .total = 0,
         .offset = 0,
         .len = 0,
+        .row_space_revision = 0,
     };
 
     // Sync with: ghostty_action_scrollbar_s
@@ -3298,7 +3313,8 @@ pub const Scrollbar = struct {
     pub fn eql(self: Scrollbar, other: Scrollbar) bool {
         return self.total == other.total and
             self.offset == other.offset and
-            self.len == other.len;
+            self.len == other.len and
+            self.row_space_revision == other.row_space_revision;
     }
 };
 
@@ -3319,12 +3335,14 @@ pub fn scrollbar(self: *PageList) Scrollbar {
         .total = self.rows,
         .offset = 0,
         .len = self.rows,
+        .row_space_revision = self.row_space_revision,
     };
 
     return .{
         .total = self.total_rows,
         .offset = self.viewportRowOffset(),
         .len = self.rows, // Length is always rows
+        .row_space_revision = self.row_space_revision,
     };
 }
 
@@ -3481,6 +3499,8 @@ pub fn grow(self: *PageList) Allocator.Error!?*List.Node {
             self.total_rows += first.rows();
             break :prune;
         }
+
+        self.row_space_revision +%= 1;
 
         // If we have a pin viewport cache then we need to update it.
         if (self.viewport == .pin) viewport: {
@@ -4664,6 +4684,7 @@ fn eraseRows(
     }
 
     // Update our total row count
+    if (erased > 0) self.row_space_revision +%= 1;
     self.total_rows -= erased;
 
     // If we deleted active, we need to regrow because one of our invariants
@@ -8977,6 +8998,7 @@ test "PageList grow prune scrollback" {
     const new = (try s.grow()).?;
     try testing.expect(s.pages.last.? == new);
     try testing.expectEqual(s.page_size, old_page_size);
+    try testing.expect(s.scrollbar().row_space_revision > scrollbar_before.row_space_revision);
 
     // Our first should now be page2 and our last should be page1
     try testing.expectEqual(page2_node, s.pages.first.?);

--- a/src/terminal/PageList.zig
+++ b/src/terminal/PageList.zig
@@ -2406,6 +2406,7 @@ fn resizeWithoutReflow(self: *PageList, opts: Resize) Allocator.Error!void {
                 const trimmed = self.trimTrailingBlankRows(self.rows - rows);
 
                 // Account for our trimmed rows in the total row cache
+                if (trimmed > 0) self.row_space_revision +%= 1;
                 self.total_rows -= trimmed;
 
                 // If we didn't trim enough, just modify our row count and this
@@ -12193,10 +12194,13 @@ test "PageList resize (no reflow) less rows trims blank lines" {
         try testing.expectEqual(@as(u21, 'A'), get.cell.content.codepoint);
     }
 
+    const row_space_revision = s.scrollbar().row_space_revision;
+
     // Resize
     try s.resize(.{ .rows = 2, .reflow = false });
     try testing.expectEqual(@as(usize, 2), s.rows);
     try testing.expectEqual(@as(usize, 2), s.totalRows());
+    try testing.expect(s.scrollbar().row_space_revision > row_space_revision);
 
     // Our cursor should not move since we trimmed
     try testing.expectEqual(point.Point{ .active = .{

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -1226,7 +1226,7 @@ pub const StreamHandler = struct {
             }
 
             // Report the change.
-            self.surfaceMessageWriter(.{ .pwd_change = .{ .stable = "" } });
+            self.surfaceMessageWriter(pwdChangeMessage(self.terminal, .{ .stable = "" }));
             return;
         }
 
@@ -1294,7 +1294,7 @@ pub const StreamHandler = struct {
         // Report it to the surface. If creating our write request fails
         // then we just ignore it.
         if (apprt.surface.Message.WriteReq.init(self.alloc, path)) |req| {
-            self.surfaceMessageWriter(.{ .pwd_change = req });
+            self.surfaceMessageWriter(pwdChangeMessage(self.terminal, req));
         } else |err| {
             log.warn("error notifying surface of pwd change err={}", .{err});
         }
@@ -1655,6 +1655,16 @@ pub const StreamHandler = struct {
     }
 };
 
+fn pwdChangeMessage(
+    term: *terminal.Terminal,
+    pwd: apprt.surface.Message.WriteReq,
+) apprt.surface.Message {
+    return .{ .pwd_change = .{
+        .pwd = pwd,
+        .scrollbar = term.screens.active.pages.scrollbar(),
+    } };
+}
+
 /// Serialize tmux Viewer window topology to JSON for embedded runtimes.
 fn serializeTmuxWindows(
     alloc: Allocator,
@@ -1719,4 +1729,24 @@ test "tmux control pane output payload keeps bounded suffix" {
     try std.testing.expectEqual(@as(u8, 'a'), capped[0]);
     try std.testing.expectEqual(@as(u8, '!'), capped[capped.len - 1]);
     try std.testing.expect(!std.mem.containsAtLeast(u8, capped, 1, "xyz"));
+}
+
+test "pwd change keeps scrollbar from OSC stream position" {
+    const alloc = std.testing.allocator;
+    var term = try terminal.Terminal.init(alloc, .{
+        .cols = 5,
+        .rows = 2,
+        .max_scrollback = 10_000,
+    });
+    defer term.deinit(alloc);
+
+    const marker = pwdChangeMessage(&term, .{ .stable = "/marker" });
+    const marker_scrollbar = marker.pwd_change.scrollbar;
+
+    var stream = term.vtStream();
+    stream.nextSlice("one\r\ntwo\r\nthree\r\nfour");
+
+    try std.testing.expect(!marker_scrollbar.eql(term.screens.active.pages.scrollbar()));
+    try std.testing.expectEqual(@as(usize, 2), marker_scrollbar.total);
+    try std.testing.expectEqual(@as(usize, 0), marker_scrollbar.offset);
 }

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -1662,6 +1662,8 @@ fn pwdChangeMessage(
     return .{ .pwd_change = .{
         .pwd = pwd,
         .scrollbar = term.screens.active.pages.scrollbar(),
+        .screen_key = term.screens.active_key,
+        .screen_generation = term.screens.generation(term.screens.active_key),
     } };
 }
 
@@ -1749,4 +1751,6 @@ test "pwd change keeps scrollbar from OSC stream position" {
     try std.testing.expect(!marker_scrollbar.eql(term.screens.active.pages.scrollbar()));
     try std.testing.expectEqual(@as(usize, 2), marker_scrollbar.total);
     try std.testing.expectEqual(@as(usize, 0), marker_scrollbar.offset);
+    try std.testing.expectEqual(.primary, marker.pwd_change.screen_key);
+    try std.testing.expectEqual(@as(usize, 0), marker.pwd_change.screen_generation);
 }


### PR DESCRIPTION
Adds an authoritative embedded scrollbar snapshot with an opaque row-space identity.

Tracks destructive row-space changes, screen generations, and surface incarnations. Captures the identity with PWD actions and adds an atomic compare-and-scroll API so cmux notification navigation cannot race terminal output.

Tested: `/opt/homebrew/Cellar/zig@0.15/0.15.2/bin/zig build test -Dtest-filter="row space identity"`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/111"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786571971&installation_id=133855650&pr_number=111&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F111&signature=f6b356e84eadfd810cb8a443981eafb49cfb2f2183a236a91051055ddb67dbdb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an authoritative scrollbar snapshot and an opaque row-space identity so embedders can restore absolute scroll positions reliably. Adds an atomic compare-and-scroll API to prevent cmux notification navigation from racing terminal output.

- **New Features**
  - New C API and struct: `ghostty_surface_scrollbar_s`, `ghostty_surface_scrollbar(...)`, `ghostty_surface_scroll_to_row_if_revision(...)`.
  - `Pwd` action now includes `scrollbar` (callback-lifetime pointer) and `scrollbar_revision` for absolute identity.
  - Tracks `row_space_revision` in the terminal and increments it on destructive changes (resize, grow/prune, erase, reset).
  - Identity includes surface id, screen key (primary/alternate), and generation; validation and scrolling occur under the renderer-state lock.

- **Migration**
  - Capture `row_space_revision` via `ghostty_surface_scrollbar(...)` or from `Pwd.scrollbar_revision`, then call `ghostty_surface_scroll_to_row_if_revision(surface, row, revision, &out)`; handle a false return without scrolling.
  - Do not retain `Pwd.scrollbar` beyond the callback; copy needed values into your own storage.

<sup>Written for commit eb500e9f45c8b6ffa6043350ec1488a42d195406. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/111?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added scrollbar information APIs for retrieving total rows, current position, viewport length, and row-space identity.
  - Added identity-validated absolute-row scrolling for reliable navigation after terminal content changes.
  - Working-directory notifications now include associated scrollback position and terminal-screen context.

- **Bug Fixes**
  - Improved scrollbar consistency across resizing, scrollback pruning, resets, and row deletion.
  - Correctly handles selection changes in the GTK application flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->