### PR TITLE
Expose live font adjustment ownership

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1138,6 +1138,8 @@ GHOSTTY_API bool ghostty_surface_needs_confirm_quit(ghostty_surface_t);
 GHOSTTY_API bool ghostty_surface_process_exited(ghostty_surface_t);
 // Returns the app-thread-owned live font size in points without reading renderer state.
 GHOSTTY_API float ghostty_surface_font_size(ghostty_surface_t);
+// Returns whether the live font size has explicit surface-local ownership.
+GHOSTTY_API bool ghostty_surface_font_size_adjusted(ghostty_surface_t);
 GHOSTTY_API void ghostty_surface_refresh(ghostty_surface_t);
 GHOSTTY_API void ghostty_surface_draw(ghostty_surface_t);
 // cmux fork: delete when upstream exposes a synchronous render tick for

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1680,6 +1680,11 @@ pub const CAPI = struct {
         return surface.core_surface.font_size.points;
     }
 
+    /// Returns whether the live font size has explicit surface-local ownership.
+    export fn ghostty_surface_font_size_adjusted(surface: *Surface) bool {
+        return surface.core_surface.font_size_adjusted;
+    }
+
     /// Returns true if the surface has a selection.
     export fn ghostty_surface_has_selection(surface: *Surface) bool {
         return surface.core_surface.hasSelection();


### PR DESCRIPTION
Adds a read-only C API for Ghostty’s app-thread-owned `font_size_adjusted` state alongside `ghostty_surface_font_size`. cmux uses the explicit ownership bit to preserve manual zoom across mobile viewport configuration reloads even when the live point size equals the configured value.\n\nVerification:\n- `zig fmt --check src/apprt/embedded.zig`\n- `zig build -Demit-macos-app=false -Demit-xcframework=false`\n\nRelated cmux work: https://github.com/manaflow-ai/cmux/pull/7904

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/113"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786606759&installation_id=133855650&pr_number=113&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F113&signature=87cc8cd861109dee3c1091f6f1934d4b0097a98eaa6ec81c76cff8b98c39b951"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose a read-only C API, `ghostty_surface_font_size_adjusted`, that tells if a surface’s live font size is explicitly adjusted. This complements `ghostty_surface_font_size` and lets `cmux` preserve manual zoom across viewport reloads even when the live size equals the configured value.

<sup>Written for commit 3349567f66e559f72c089d45a8ca2a68d047fbdd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/113?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a public API to report whether a surface’s font size has been explicitly adjusted locally or inherited.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->