### PR TITLE
shell-integration: invoke resolved Ghostty CLI path

### DIFF
--- a/src/shell-integration/bash/ghostty.bash
+++ b/src/shell-integration/bash/ghostty.bash
@@ -118,13 +118,13 @@ fi
 #
 # Wrap `ssh` with `ghostty +ssh` and translate the shell-integration
 # feature flags into command options.
-if [[ "$GHOSTTY_SHELL_FEATURES" == *ssh-* ]]; then
+if [[ "$GHOSTTY_SHELL_FEATURES" == *ssh-* && -n "$GHOSTTY_BIN" ]]; then
   function ssh() {
     builtin local -a flags
     flags=()
     [[ "$GHOSTTY_SHELL_FEATURES" != *ssh-env* ]] && flags+=(--forward-env=false)
     [[ "$GHOSTTY_SHELL_FEATURES" != *ssh-terminfo* ]] && flags+=(--terminfo=false)
-    "$GHOSTTY_BIN_DIR/ghostty" +ssh "${flags[@]}" -- "$@"
+    "$GHOSTTY_BIN" +ssh "${flags[@]}" -- "$@"
   }
 fi
 

--- a/src/shell-integration/elvish/lib/ghostty-integration.elv
+++ b/src/shell-integration/elvish/lib/ghostty-integration.elv
@@ -81,7 +81,7 @@
   # Wrap `ssh` with `ghostty +ssh` and translate the shell-integration
   # feature flags into command options.
   fn ssh-integration {|@args|
-    var ghostty = $E:GHOSTTY_BIN_DIR/"ghostty"
+    var ghostty = $E:GHOSTTY_BIN
     var flags = []
     if (not (has-value $features ssh-env)) {
       set flags = (conj $flags --forward-env=false)
@@ -119,7 +119,7 @@
   if (and (has-value $features sudo) (not-eq "" $E:TERMINFO) (has-external sudo)) {
     edit:add-var sudo~ $sudo-with-terminfo~
   }
-  if (and (str:contains $E:GHOSTTY_SHELL_FEATURES ssh-) (has-external ssh)) {
+  if (and (str:contains $E:GHOSTTY_SHELL_FEATURES ssh-) (has-env GHOSTTY_BIN) (has-external ssh)) {
     edit:add-var ssh~ $ssh-integration~
   }
 

--- a/src/shell-integration/fish/vendor_conf.d/ghostty-shell-integration.fish
+++ b/src/shell-integration/fish/vendor_conf.d/ghostty-shell-integration.fish
@@ -124,13 +124,13 @@ function __ghostty_setup --on-event fish_prompt -d "Setup ghostty integration"
     # Wrap `ssh` with `ghostty +ssh` and translate the shell-integration
     # feature flags into command options.
     set -l features (string split ',' -- "$GHOSTTY_SHELL_FEATURES")
-    if contains ssh-env $features; or contains ssh-terminfo $features
+    if test -n "$GHOSTTY_BIN"; and contains ssh-env $features; or test -n "$GHOSTTY_BIN"; and contains ssh-terminfo $features
         function ssh --wraps=ssh --description "SSH wrapper with Ghostty integration"
             set -l features (string split ',' -- "$GHOSTTY_SHELL_FEATURES")
             set -l flags
             contains ssh-env $features; or set -a flags --forward-env=false
             contains ssh-terminfo $features; or set -a flags --terminfo=false
-            "$GHOSTTY_BIN_DIR/ghostty" +ssh $flags -- $argv
+            "$GHOSTTY_BIN" +ssh $flags -- $argv
         end
     end
 

--- a/src/shell-integration/nushell/vendor/autoload/ghostty.nu
+++ b/src/shell-integration/nushell/vendor/autoload/ghostty.nu
@@ -7,12 +7,12 @@ export module ghostty {
   # Wrap `ssh` with `ghostty +ssh` and translate the shell-integration
   # feature flags into command options.
   export def --wrapped ssh [...args] {
-    if not ((has_feature "ssh-env") or (has_feature "ssh-terminfo")) {
+    if not ((has_feature "ssh-env") or (has_feature "ssh-terminfo")) or ($env.GHOSTTY_BIN? | is-empty) {
       ^ssh ...$args
       return
     }
 
-    let ghostty = ($env.GHOSTTY_BIN_DIR? | default "") | path join "ghostty"
+    let ghostty = $env.GHOSTTY_BIN
     mut flags = []
     if not (has_feature "ssh-env") {
       $flags = ($flags ++ ["--forward-env=false"])

--- a/src/shell-integration/zsh/ghostty-integration
+++ b/src/shell-integration/zsh/ghostty-integration
@@ -314,12 +314,12 @@ _ghostty_deferred_init() {
     #
     # Wrap `ssh` with `ghostty +ssh` and translate the shell-integration
     # feature flags into command options.
-    if [[ "$GHOSTTY_SHELL_FEATURES" == *ssh-* ]]; then
+    if [[ "$GHOSTTY_SHELL_FEATURES" == *ssh-* ]] && [[ -n "$GHOSTTY_BIN" ]]; then
       function ssh() {
         local flags=()
         [[ "$GHOSTTY_SHELL_FEATURES" != *ssh-env* ]] && flags+=(--forward-env=false)
         [[ "$GHOSTTY_SHELL_FEATURES" != *ssh-terminfo* ]] && flags+=(--terminfo=false)
-        "$GHOSTTY_BIN_DIR/ghostty" +ssh $flags -- "$@"
+        "$GHOSTTY_BIN" +ssh $flags -- "$@"
       }
     fi
 

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -661,7 +661,10 @@ const Subprocess = struct {
             try env.put("COLORTERM", "truecolor");
         }
 
-        // Add our binary to the path if we can find it.
+        // Export the exact Ghostty CLI path and add its directory to PATH.
+        // Embedded runtimes may provide a helper that doesn't live beside the
+        // host executable, so shell integration must not reconstruct this path
+        // by appending a hardcoded executable name to selfExePath's directory.
         ghostty_path: {
             // Skip this for flatpak since host cannot reach them
             if ((comptime build_config.flatpak) and
@@ -675,13 +678,18 @@ const Subprocess = struct {
                 log.warn("failed to get ghostty exe path err={}", .{err});
                 break :ghostty_path;
             };
-            const exe_dir = std.fs.path.dirname(exe_bin_path) orelse break :ghostty_path;
-            log.debug("appending ghostty bin to path dir={s}", .{exe_dir});
+            const ghostty_bin = resolveGhosttyBin(&env, exe_bin_path) orelse {
+                log.warn("failed to resolve ghostty CLI path; CLI shell integration disabled", .{});
+                break :ghostty_path;
+            };
+            const bin_dir = std.fs.path.dirname(ghostty_bin) orelse break :ghostty_path;
+            log.debug("resolved ghostty CLI path={s}", .{ghostty_bin});
 
-            // We always set this so that if the shell overwrites the path
-            // scripts still have a way to find the Ghostty binary when
-            // running in Ghostty.
-            try env.put("GHOSTTY_BIN_DIR", exe_dir);
+            // Always export both forms so shell integration keeps an exact CLI
+            // path even if the shell later overwrites PATH. GHOSTTY_BIN_DIR is
+            // retained for the separate shell-integration `path` feature.
+            try env.put("GHOSTTY_BIN", ghostty_bin);
+            try env.put("GHOSTTY_BIN_DIR", bin_dir);
 
             // Append if we have a path. We want to append so that ghostty is
             // the last priority in the path. If we don't have a path set
@@ -690,15 +698,15 @@ const Subprocess = struct {
                 // Verify that our path doesn't already contain this entry
                 var it = std.mem.tokenizeScalar(u8, path, std.fs.path.delimiter);
                 while (it.next()) |entry| {
-                    if (std.mem.eql(u8, entry, exe_dir)) break :ghostty_path;
+                    if (std.mem.eql(u8, entry, bin_dir)) break :ghostty_path;
                 }
 
                 try env.put(
                     "PATH",
-                    try internal_os.appendEnv(alloc, path, exe_dir),
+                    try internal_os.appendEnv(alloc, path, bin_dir),
                 );
             } else {
-                try env.put("PATH", exe_dir);
+                try env.put("PATH", bin_dir);
             }
         }
 
@@ -1239,6 +1247,55 @@ const Subprocess = struct {
         return pty.getProcessInfo(info);
     }
 };
+
+/// Resolve the CLI executable used by shell integration. Native Ghostty owns
+/// its executable path; embedded hosts can supply a distinct helper path.
+fn resolveGhosttyBin(env: *const EnvMap, self_exe_path: []const u8) ?[]const u8 {
+    if (std.mem.eql(u8, std.fs.path.basename(self_exe_path), "ghostty")) {
+        return self_exe_path;
+    }
+
+    const embedded_bin = env.get("GHOSTTY_BIN") orelse return null;
+    return if (embedded_bin.len > 0) embedded_bin else null;
+}
+
+test "resolveGhosttyBin uses native Ghostty executable" {
+    var env = EnvMap.init(std.testing.allocator);
+    defer env.deinit();
+    try env.put("GHOSTTY_BIN", "/embedded/helper");
+
+    try std.testing.expectEqualStrings(
+        "/Applications/Ghostty.app/Contents/MacOS/ghostty",
+        resolveGhosttyBin(
+            &env,
+            "/Applications/Ghostty.app/Contents/MacOS/ghostty",
+        ).?,
+    );
+}
+
+test "resolveGhosttyBin uses embedded host helper" {
+    var env = EnvMap.init(std.testing.allocator);
+    defer env.deinit();
+    try env.put("GHOSTTY_BIN", "/Applications/cmux.app/Contents/Resources/bin/ghostty");
+
+    try std.testing.expectEqualStrings(
+        "/Applications/cmux.app/Contents/Resources/bin/ghostty",
+        resolveGhosttyBin(
+            &env,
+            "/Applications/cmux.app/Contents/MacOS/cmux",
+        ).?,
+    );
+}
+
+test "resolveGhosttyBin disables CLI integration without embedded helper" {
+    var env = EnvMap.init(std.testing.allocator);
+    defer env.deinit();
+
+    try std.testing.expect(resolveGhosttyBin(
+        &env,
+        "/Applications/host.app/Contents/MacOS/host",
+    ) == null);
+}
 
 /// The read thread works with a companion gather thread to form a two-stage
 /// pipeline that moves pty output into the terminal:


### PR DESCRIPTION
## Summary

- export an exact `GHOSTTY_BIN` executable path for shell integration
- let embedded hosts provide a CLI helper outside the GUI executable directory
- make zsh, bash, fish, nushell, and elvish SSH wrappers invoke the resolved path
- skip installing a broken SSH wrapper when an embedded host has no helper

This fixes manaflow-ai/cmux#8093, where embedded Ghostty derived `/Applications/cmux.app/Contents/MacOS/ghostty` from the cmux GUI executable even though the CLI helper lives in `Contents/Resources/bin`.

## Verification

- zsh, bash, and fish syntax checks
- cmux behavioral zsh/bash wrapper regression
- focused Zig resolver tests added (cold full test graph deferred to parent CI)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/115"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786663812&installation_id=133855650&pr_number=115&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F115&signature=1a7a438a0f861576e047e02745aa6b2eee1c5367c9977bd009bb3e255c78d181"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Export and use the exact Ghostty CLI path for shell integration so SSH wrappers call the correct binary, including when Ghostty runs inside an embedded host app. Prevents wrong-path derivation and disables the SSH wrapper when no helper is available.

- **Bug Fixes**
  - Export `GHOSTTY_BIN` (exact CLI path) and keep `GHOSTTY_BIN_DIR`; append its directory to `PATH`.
  - Update zsh/bash/fish/nushell/elvish SSH wrappers to invoke `GHOSTTY_BIN` and only install when it’s set.
  - Add a resolver and tests to choose the native `ghostty` or an embedded helper, fixing incorrect paths in hosts like cmux.

<sup>Written for commit b4b6d69c82033e16137266a04b364dc53d16c350. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/115?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved SSH integration across supported shells by reliably locating and launching Ghostty.
  * Added support for embedded runtime environments when enabling Ghostty’s SSH features.

* **Bug Fixes**
  * SSH commands now fall back to the system SSH client when Ghostty’s executable is unavailable.
  * Improved executable path and environment handling for shell integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->