### PR TITLE
shell-integration: preserve fish SSH feature variants

### DIFF
--- a/src/shell-integration/fish/vendor_conf.d/ghostty-shell-integration.fish
+++ b/src/shell-integration/fish/vendor_conf.d/ghostty-shell-integration.fish
@@ -124,13 +124,15 @@ function __ghostty_setup --on-event fish_prompt -d "Setup ghostty integration"
     # Wrap `ssh` with `ghostty +ssh` and translate the shell-integration
     # feature flags into command options.
     set -l features (string split ',' -- "$GHOSTTY_SHELL_FEATURES")
-    if test -n "$GHOSTTY_BIN"; and contains ssh-env $features; or test -n "$GHOSTTY_BIN"; and contains ssh-terminfo $features
-        function ssh --wraps=ssh --description "SSH wrapper with Ghostty integration"
-            set -l features (string split ',' -- "$GHOSTTY_SHELL_FEATURES")
-            set -l flags
-            contains ssh-env $features; or set -a flags --forward-env=false
-            contains ssh-terminfo $features; or set -a flags --terminfo=false
-            "$GHOSTTY_BIN" +ssh $flags -- $argv
+    if test -n "$GHOSTTY_BIN"
+        if contains ssh-env $features; or contains ssh-terminfo $features
+            function ssh --wraps=ssh --description "SSH wrapper with Ghostty integration"
+                set -l features (string split ',' -- "$GHOSTTY_SHELL_FEATURES")
+                set -l flags
+                contains ssh-env $features; or set -a flags --forward-env=false
+                contains ssh-terminfo $features; or set -a flags --terminfo=false
+                "$GHOSTTY_BIN" +ssh $flags -- $argv
+            end
         end
     end
 


### PR DESCRIPTION
Fix the fish-shell condition added by #115 so `ssh-env` by itself still installs the Ghostty SSH wrapper.

Fish evaluates semicolon-chained `and`/`or` commands left-to-right. Repeating the `GHOSTTY_BIN` guard in a single condition therefore made the final `ssh-terminfo` check override a successful `ssh-env` check. Nest the feature disjunction below the executable guard so each feature works independently.

Focused proof in manaflow-ai/cmux#8109 sources the real fish integration and verifies `ssh-env`, `ssh-terminfo`, and both feature flags against a host-provided executable path. The test failed with exit 97 (`fish SSH wrapper was not installed`) before this change and passes after it.

Validation:
- `python3 tests/test_issue_8093_ghostty_ssh_binary_path.py` (from cmux checkout)
- `fish --no-config --no-execute src/shell-integration/fish/vendor_conf.d/ghostty-shell-integration.fish`
- zsh/bash integration syntax checks

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/117"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786668039&installation_id=133855650&pr_number=117&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F117&signature=0319d81c688a6519e816814fe2d0c486b359737e52d138d667005a9780d107c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the fish SSH wrapper so `ssh-env` and `ssh-terminfo` work independently. The wrapper now installs when either feature is enabled, aligning with issue 8093’s feature precedence.

- **Bug Fixes**
  - Nest feature checks under a single `test -n "$GHOSTTY_BIN"` guard to avoid fish’s left-to-right `and/or` precedence overriding `ssh-env`.
  - Preserve per-feature behavior: missing `ssh-env` adds `--forward-env=false`; missing `ssh-terminfo` adds `--terminfo=false`.

<sup>Written for commit 84555c31378cc51f9bbec4de54be4541f7247bb1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/117?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

