### PR TITLE
Fix wrapped URL matching across semantic soft wraps

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -4792,7 +4792,7 @@ fn linkAtScreenPin(
 ) !?Link {
     if (links.len == 0) return null;
 
-    const line = screen.selectLine(.{
+    const semantic_line = screen.selectLine(.{
         .pin = mouse_pin,
         .whitespace = null,
         // Respect semantic prompt boundaries so link/path matching doesn't
@@ -4800,13 +4800,37 @@ fn linkAtScreenPin(
         .semantic_prompt_boundary = true,
     }) orelse return null;
 
-    var strmap: terminal.StringMap = undefined;
+    var semantic_map: terminal.StringMap = undefined;
     alloc.free(try screen.selectionString(alloc, .{
-        .sel = line,
+        .sel = semantic_line,
         .trim = false,
-        .map = &strmap,
+        .map = &semantic_map,
     }));
-    defer strmap.deinit(alloc);
+    defer semantic_map.deinit(alloc);
+
+    // Semantic prompt markers normally keep prompt/path text from merging.
+    // A marker emitted while the cursor has a pending wrap can, however,
+    // divide one explicit URL exactly at the visual row boundary. In that
+    // case, also search the complete soft-wrapped logical line. We only accept
+    // explicit-scheme matches from this wider scope so path/custom matching
+    // retains its semantic-boundary behavior.
+    var logical_map: ?terminal.StringMap = null;
+    defer if (logical_map) |map| map.deinit(alloc);
+    if (selectionTouchesSoftWrapBoundary(semantic_line)) {
+        if (screen.selectLine(.{
+            .pin = mouse_pin,
+            .whitespace = null,
+            .semantic_prompt_boundary = false,
+        })) |logical_line| {
+            var map: terminal.StringMap = undefined;
+            alloc.free(try screen.selectionString(alloc, .{
+                .sel = logical_line,
+                .trim = false,
+                .map = &map,
+            }));
+            logical_map = map;
+        }
+    }
 
     for (links) |link| {
         // Skip highlight/mods check when mouse_mods is null (double-click mode)
@@ -4815,7 +4839,22 @@ fn linkAtScreenPin(
             .always_mods, .hover_mods => |v| if (!v.equal(mods)) continue,
         };
 
-        var it = strmap.searchIterator(link.regex);
+        if (logical_map) |map| {
+            var it = map.searchIterator(link.regex);
+            while (true) {
+                var match = (try it.next()) orelse break;
+                defer match.deinit();
+                const sel = match.selection();
+                if (!sel.contains(screen, mouse_pin)) continue;
+                if (!configpkg.url.hasSupportedSchemePrefix(match.value())) continue;
+                return .{
+                    .action = link.action,
+                    .selection = sel,
+                };
+            }
+        }
+
+        var it = semantic_map.searchIterator(link.regex);
         while (true) {
             var match = (try it.next()) orelse break;
             defer match.deinit();
@@ -4829,6 +4868,20 @@ fn linkAtScreenPin(
     }
 
     return null;
+}
+
+/// True when a semantic line selection stopped at a physical row edge that is
+/// part of a soft-wrapped logical line.
+fn selectionTouchesSoftWrapBoundary(selection: terminal.Selection) bool {
+    const start = selection.start();
+    if (start.x == 0) {
+        if (start.up(1)) |previous| {
+            if (previous.rowAndCell().row.wrap) return true;
+        }
+    }
+
+    const end = selection.end();
+    return end.x == end.node.cols() - 1 and end.rowAndCell().row.wrap;
 }
 
 /// This returns the mouse mods to consider for link highlighting or

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -360,6 +360,7 @@ const DerivedConfig = struct {
         regex: oni.Regex,
         action: input.Link.Action,
         highlight: input.Link.Highlight,
+        candidate_scope: input.Link.CandidateScope,
     };
 
     pub fn init(alloc_gpa: Allocator, config: *const configpkg.Config) !DerivedConfig {
@@ -378,6 +379,7 @@ const DerivedConfig = struct {
                     .regex = regex,
                     .action = link.action,
                     .highlight = link.highlight,
+                    .candidate_scope = link.candidate_scope,
                 });
             }
 
@@ -4792,45 +4794,13 @@ fn linkAtScreenPin(
 ) !?Link {
     if (links.len == 0) return null;
 
-    const semantic_line = screen.selectLine(.{
-        .pin = mouse_pin,
-        .whitespace = null,
-        // Respect semantic prompt boundaries so link/path matching doesn't
-        // merge shell prompt content with the text beside it.
-        .semantic_prompt_boundary = true,
-    }) orelse return null;
+    var semantic_map_initialized = false;
+    var semantic_map: ?terminal.StringMap = null;
+    defer if (semantic_map) |map| map.deinit(alloc);
 
-    var semantic_map: terminal.StringMap = undefined;
-    alloc.free(try screen.selectionString(alloc, .{
-        .sel = semantic_line,
-        .trim = false,
-        .map = &semantic_map,
-    }));
-    defer semantic_map.deinit(alloc);
-
-    // Semantic prompt markers normally keep prompt/path text from merging.
-    // A marker emitted while the cursor has a pending wrap can, however,
-    // divide one explicit URL exactly at the visual row boundary. In that
-    // case, also search the complete soft-wrapped logical line. We only accept
-    // explicit-scheme matches from this wider scope so path/custom matching
-    // retains its semantic-boundary behavior.
+    var logical_map_initialized = false;
     var logical_map: ?terminal.StringMap = null;
     defer if (logical_map) |map| map.deinit(alloc);
-    if (selectionTouchesSoftWrapBoundary(semantic_line)) {
-        if (screen.selectLine(.{
-            .pin = mouse_pin,
-            .whitespace = null,
-            .semantic_prompt_boundary = false,
-        })) |logical_line| {
-            var map: terminal.StringMap = undefined;
-            alloc.free(try screen.selectionString(alloc, .{
-                .sel = logical_line,
-                .trim = false,
-                .map = &map,
-            }));
-            logical_map = map;
-        }
-    }
 
     for (links) |link| {
         // Skip highlight/mods check when mouse_mods is null (double-click mode)
@@ -4839,22 +4809,33 @@ fn linkAtScreenPin(
             .always_mods, .hover_mods => |v| if (!v.equal(mods)) continue,
         };
 
-        if (logical_map) |map| {
-            var it = map.searchIterator(link.regex);
-            while (true) {
-                var match = (try it.next()) orelse break;
-                defer match.deinit();
-                const sel = match.selection();
-                if (!sel.contains(screen, mouse_pin)) continue;
-                if (!configpkg.url.hasSupportedSchemePrefix(match.value())) continue;
-                return .{
-                    .action = link.action,
-                    .selection = sel,
-                };
-            }
-        }
+        const candidate_map: terminal.StringMap = switch (link.candidate_scope) {
+            .semantic => candidate: {
+                if (!semantic_map_initialized) {
+                    semantic_map_initialized = true;
+                    if (screen.selectLine(.{
+                        .pin = mouse_pin,
+                        .whitespace = null,
+                        .semantic_prompt_boundary = true,
+                    })) |selection| {
+                        semantic_map = try linkCandidateMap(alloc, screen, selection);
+                    }
+                }
+                break :candidate semantic_map orelse continue;
+            },
 
-        var it = semantic_map.searchIterator(link.regex);
+            .bounded_logical => candidate: {
+                if (!logical_map_initialized) {
+                    logical_map_initialized = true;
+                    if (boundedLogicalLinkLine(mouse_pin)) |selection| {
+                        logical_map = try linkCandidateMap(alloc, screen, selection);
+                    }
+                }
+                break :candidate logical_map orelse continue;
+            },
+        };
+
+        var it = candidate_map.searchIterator(link.regex);
         while (true) {
             var match = (try it.next()) orelse break;
             defer match.deinit();
@@ -4870,18 +4851,61 @@ fn linkAtScreenPin(
     return null;
 }
 
-/// True when a semantic line selection stopped at a physical row edge that is
-/// part of a soft-wrapped logical line.
-fn selectionTouchesSoftWrapBoundary(selection: terminal.Selection) bool {
-    const start = selection.start();
-    if (start.x == 0) {
-        if (start.up(1)) |previous| {
-            if (previous.rowAndCell().row.wrap) return true;
-        }
+fn linkCandidateMap(
+    alloc: Allocator,
+    screen: *terminal.Screen,
+    selection: terminal.Selection,
+) !terminal.StringMap {
+    var map: terminal.StringMap = undefined;
+    alloc.free(try screen.selectionString(alloc, .{
+        .sel = selection,
+        .trim = false,
+        .map = &map,
+    }));
+    return map;
+}
+
+const max_logical_link_candidate_cells = 8 * 1024;
+const max_logical_link_candidate_rows = 256;
+
+/// Returns the complete soft-wrapped logical line containing `pin`, provided
+/// it fits the renderer's fixed work budget. Oversized lines return null rather
+/// than a partial selection so a truncated URL can never be opened.
+fn boundedLogicalLinkLine(pin: terminal.Pin) ?terminal.Selection {
+    const initial_cols: usize = pin.node.cols();
+    if (initial_cols == 0 or initial_cols > max_logical_link_candidate_cells) return null;
+
+    var rows: usize = 1;
+    var remaining_cells = max_logical_link_candidate_cells - initial_cols;
+    var start = pin;
+    start.x = 0;
+    while (start.up(1)) |previous| {
+        if (!previous.rowAndCell().row.wrap) break;
+        if (rows == max_logical_link_candidate_rows) return null;
+
+        const previous_cols: usize = previous.node.cols();
+        if (previous_cols == 0 or previous_cols > remaining_cells) return null;
+        remaining_cells -= previous_cols;
+        start = previous;
+        start.x = 0;
+        rows += 1;
     }
 
-    const end = selection.end();
-    return end.x == end.node.cols() - 1 and end.rowAndCell().row.wrap;
+    var end = pin;
+    end.x = @intCast(initial_cols - 1);
+    while (end.rowAndCell().row.wrap) {
+        if (rows == max_logical_link_candidate_rows) return null;
+
+        const next = end.down(1) orelse return null;
+        const next_cols: usize = next.node.cols();
+        if (next_cols == 0 or next_cols > remaining_cells) return null;
+        remaining_cells -= next_cols;
+        end = next;
+        end.x = @intCast(next_cols - 1);
+        rows += 1;
+    }
+
+    return .init(start, end, false);
 }
 
 /// This returns the mouse mods to consider for link highlighting or
@@ -6715,4 +6739,76 @@ test "Surface: URL link selection spans semantic change at soft wrap" {
         defer alloc.free(selected);
         try testing.expectEqualStrings(value, selected);
     }
+}
+
+test "Surface: path link selection retains semantic soft-wrap boundary" {
+    if (comptime !@import("terminal_options").oniguruma) return error.SkipZigTest;
+
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const value = "/Users/example/Documents/project/src/file.swift";
+
+    try oni.testing.ensureInit();
+    var config = try configpkg.Config.default(alloc);
+    defer config.deinit();
+    var derived = try DerivedConfig.init(alloc, &config);
+    defer derived.deinit();
+
+    var screen = try terminal.Screen.init(alloc, .{
+        .cols = 32,
+        .rows = 3,
+        .max_scrollback = 0,
+    });
+    defer screen.deinit();
+
+    screen.cursorSetSemanticContent(.output);
+    try screen.testWriteString(value[0..32]);
+    screen.cursorSetSemanticContent(.{ .input = .clear_explicit });
+    try screen.testWriteString(value[32..]);
+
+    for ([_]terminal.point.Coordinate{
+        .{ .x = 10, .y = 0 },
+        .{ .x = 8, .y = 1 },
+    }, 0..) |point, index| {
+        const click_pin = screen.pages.pin(.{ .active = point }).?;
+        const link = (try linkAtScreenPin(
+            alloc,
+            &screen,
+            derived.links,
+            click_pin,
+            null,
+        )) orelse return error.TestExpectedEqual;
+        var selection = link.selection;
+        defer selection.deinit(&screen);
+
+        const selected = try screen.selectionString(alloc, .{
+            .sel = selection,
+            .trim = false,
+        });
+        defer alloc.free(selected);
+        const expected = if (index == 0) value[0..32] else value[32..];
+        try testing.expectEqualStrings(expected, selected);
+    }
+}
+
+test "Surface: oversized soft-wrapped URL candidate is rejected" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const cols = 256;
+    const cell_count = max_logical_link_candidate_cells + 1;
+
+    var screen = try terminal.Screen.init(alloc, .{
+        .cols = cols,
+        .rows = (cell_count + cols - 1) / cols,
+        .max_scrollback = 0,
+    });
+    defer screen.deinit();
+
+    const text = try alloc.alloc(u8, cell_count);
+    defer alloc.free(text);
+    @memset(text, 'a');
+    try screen.testWriteString(text);
+
+    const pin = screen.pages.pin(.{ .active = .{ .x = 0, .y = 0 } }).?;
+    try testing.expect(boundedLogicalLinkLine(pin) == null);
 }

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -4771,9 +4771,27 @@ fn linkAtPin(
     mouse_pin: terminal.Pin,
     mouse_mods: ?input.Mods,
 ) !?Link {
-    if (self.config.links.len == 0) return null;
+    return linkAtScreenPin(
+        self.alloc,
+        self.renderer_state.terminal.screens.active,
+        self.config.links,
+        mouse_pin,
+        mouse_mods,
+    );
+}
 
-    const screen: *terminal.Screen = self.renderer_state.terminal.screens.active;
+/// Detects a configured link at a terminal pin without requiring a full
+/// Surface. Keeping the grid matcher here gives link hover, click, and copy
+/// actions one shared selection path and a focused behavioral test seam.
+fn linkAtScreenPin(
+    alloc: Allocator,
+    screen: *terminal.Screen,
+    links: []const DerivedConfig.Link,
+    mouse_pin: terminal.Pin,
+    mouse_mods: ?input.Mods,
+) !?Link {
+    if (links.len == 0) return null;
+
     const line = screen.selectLine(.{
         .pin = mouse_pin,
         .whitespace = null,
@@ -4783,14 +4801,14 @@ fn linkAtPin(
     }) orelse return null;
 
     var strmap: terminal.StringMap = undefined;
-    self.alloc.free(try screen.selectionString(self.alloc, .{
+    alloc.free(try screen.selectionString(alloc, .{
         .sel = line,
         .trim = false,
         .map = &strmap,
     }));
-    defer strmap.deinit(self.alloc);
+    defer strmap.deinit(alloc);
 
-    for (self.config.links) |link| {
+    for (links) |link| {
         // Skip highlight/mods check when mouse_mods is null (double-click mode)
         if (mouse_mods) |mods| switch (link.highlight) {
             .always, .hover => {},
@@ -6594,4 +6612,54 @@ test "Surface: mouseLinkRefreshAllowedState honors ctrl/super under mouse report
     // Mouse reporting on, ctrl/super plus a non-shift modifier: not an exact
     // link-activation chord, so the event is reported to the app.
     try std.testing.expect(!mouseLinkRefreshAllowedState(true, false, input.ctrlOrSuper(.{ .alt = true })));
+}
+
+test "Surface: URL link selection spans semantic change at soft wrap" {
+    if (comptime !@import("terminal_options").oniguruma) return error.SkipZigTest;
+
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const value = "https://github.com/manaflow-ai/cmux/issues/8059#issuecomment-0123456789012345678901234567890";
+
+    try oni.testing.ensureInit();
+    var config = try configpkg.Config.default(alloc);
+    defer config.deinit();
+    var derived = try DerivedConfig.init(alloc, &config);
+    defer derived.deinit();
+
+    var screen = try terminal.Screen.init(alloc, .{
+        .cols = 32,
+        .rows = 5,
+        .max_scrollback = 0,
+    });
+    defer screen.deinit();
+
+    screen.cursorSetSemanticContent(.output);
+    try screen.testWriteString(value[0..32]);
+    screen.cursorSetSemanticContent(.{ .input = .clear_explicit });
+    try screen.testWriteString(value[32..]);
+    try testing.expect(screen.pages.getCell(.{ .active = .{} }).?.row.wrap);
+
+    for ([_]terminal.point.Coordinate{
+        .{ .x = 10, .y = 0 },
+        .{ .x = 10, .y = 1 },
+    }) |point| {
+        const click_pin = screen.pages.pin(.{ .active = point }).?;
+        const link = (try linkAtScreenPin(
+            alloc,
+            &screen,
+            derived.links,
+            click_pin,
+            null,
+        )) orelse return error.TestExpectedEqual;
+        var selection = link.selection;
+        defer selection.deinit(&screen);
+
+        const selected = try screen.selectionString(alloc, .{
+            .sel = selection,
+            .trim = false,
+        });
+        defer alloc.free(selected);
+        try testing.expectEqualStrings(value, selected);
+    }
 }

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -3950,6 +3950,33 @@ test "Config: default URL and path links use owned candidate scopes" {
     );
 }
 
+test "Config: disabling URL links is idempotent and preserves custom matchers" {
+    const testing = std.testing;
+    var config = try Config.default(testing.allocator);
+    defer config.deinit();
+
+    try config.link.links.append(config.arenaAlloc(), .{
+        .regex = "custom",
+        .action = .{ .open = {} },
+        .highlight = .hover,
+    });
+    config.@"link-url" = false;
+
+    try config.finalize();
+    try testing.expectEqual(@as(usize, 1), config.link.links.items.len);
+    try testing.expectEqualStrings("custom", config.link.links.items[0].regex);
+
+    try config.finalize();
+    try testing.expectEqual(@as(usize, 1), config.link.links.items.len);
+    try testing.expectEqualStrings("custom", config.link.links.items[0].regex);
+
+    var config_clone = try config.clone(testing.allocator);
+    defer config_clone.deinit();
+    try config_clone.finalize();
+    try testing.expectEqual(@as(usize, 1), config_clone.link.links.items.len);
+    try testing.expectEqualStrings("custom", config_clone.link.links.items[0].regex);
+}
+
 /// Load configuration from an iterator that yields values that look like
 /// command-line arguments, i.e. `--key=value`.
 pub fn loadIter(

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -3931,6 +3931,7 @@ pub fn default(alloc_gpa: Allocator) Allocator.Error!Config {
         .action = .{ .open = {} },
         .highlight = .{ .hover_mods = inputpkg.ctrlOrSuper(.{}) },
     });
+    result.link.default_matchers_present = true;
 
     return result;
 }
@@ -4788,8 +4789,8 @@ pub fn finalize(self: *Config) !void {
     if (self.@"window-width" > 0) self.@"window-width" = @max(10, self.@"window-width");
     if (self.@"window-height" > 0) self.@"window-height" = @max(4, self.@"window-height");
 
-    // If URLs are disabled, cut off the built-in URL and path matchers.
-    if (!self.@"link-url") self.link.links.items = self.link.links.items[default_link_matcher_count..];
+    // If URLs are disabled, remove the built-in URL and path matchers.
+    if (!self.@"link-url") self.link.removeDefaultMatchers();
 
     // We warn when the quit-after-last-window-closed-delay is set to a very
     // short value because it can cause Ghostty to quit before the first
@@ -8624,6 +8625,15 @@ pub const RepeatableLink = struct {
     const Self = @This();
 
     links: std.ArrayListUnmanaged(inputpkg.Link) = .{},
+    default_matchers_present: bool = false,
+
+    fn removeDefaultMatchers(self: *Self) void {
+        if (!self.default_matchers_present) return;
+
+        assert(self.links.items.len >= default_link_matcher_count);
+        self.links.items = self.links.items[default_link_matcher_count..];
+        self.default_matchers_present = false;
+    }
 
     pub fn parseCLI(self: *Self, alloc: Allocator, input_: ?[]const u8) !void {
         _ = self;
@@ -8649,11 +8659,16 @@ pub const RepeatableLink = struct {
             list.appendAssumeCapacity(copy);
         }
 
-        return .{ .links = list };
+        return .{
+            .links = list,
+            .default_matchers_present = self.default_matchers_present,
+        };
     }
 
     /// Compare if two of our value are requal. Required by Config.
     pub fn equal(self: Self, other: Self) bool {
+        if (self.default_matchers_present != other.default_matchers_present) return false;
+
         const itemsA = self.links.items;
         const itemsB = other.links.items;
         if (itemsA.len != itemsB.len) return false;

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -3903,6 +3903,8 @@ pub fn load(alloc_gpa: Allocator) !Config {
     return result;
 }
 
+const default_link_matcher_count = 2;
+
 pub fn default(alloc_gpa: Allocator) Allocator.Error!Config {
     // Build up our basic config
     var result: Config = .{
@@ -3919,12 +3921,33 @@ pub fn default(alloc_gpa: Allocator) Allocator.Error!Config {
 
     // Add our default link for URL detection
     try result.link.links.append(alloc, .{
-        .regex = url.regex,
+        .regex = url.scheme_regex,
+        .action = .{ .open = {} },
+        .highlight = .{ .hover_mods = inputpkg.ctrlOrSuper(.{}) },
+        .candidate_scope = .bounded_logical,
+    });
+    try result.link.links.append(alloc, .{
+        .regex = url.path_regex,
         .action = .{ .open = {} },
         .highlight = .{ .hover_mods = inputpkg.ctrlOrSuper(.{}) },
     });
 
     return result;
+}
+
+test "Config: default URL and path links use owned candidate scopes" {
+    var config = try Config.default(std.testing.allocator);
+    defer config.deinit();
+
+    try std.testing.expectEqual(default_link_matcher_count, config.link.links.items.len);
+    try std.testing.expectEqual(
+        inputpkg.Link.CandidateScope.bounded_logical,
+        config.link.links.items[0].candidate_scope,
+    );
+    try std.testing.expectEqual(
+        inputpkg.Link.CandidateScope.semantic,
+        config.link.links.items[1].candidate_scope,
+    );
 }
 
 /// Load configuration from an iterator that yields values that look like
@@ -4738,9 +4761,8 @@ pub fn finalize(self: *Config) !void {
     if (self.@"window-width" > 0) self.@"window-width" = @max(10, self.@"window-width");
     if (self.@"window-height" > 0) self.@"window-height" = @max(4, self.@"window-height");
 
-    // If URLs are disabled, cut off the first link. The first link is
-    // always the URL matcher.
-    if (!self.@"link-url") self.link.links.items = self.link.links.items[1..];
+    // If URLs are disabled, cut off the built-in URL and path matchers.
+    if (!self.@"link-url") self.link.links.items = self.link.links.items[default_link_matcher_count..];
 
     // We warn when the quit-after-last-window-closed-delay is set to a very
     // short value because it can cause Ghostty to quit before the first

--- a/src/config/url.zig
+++ b/src/config/url.zig
@@ -28,6 +28,31 @@ const url_schemes =
     \\https?://|mailto:|ftp://|file:|ssh:|git://|ssh://|tel:|magnet:|ipfs://|ipns://|gemini://|gopher://|news:
 ;
 
+/// Returns true when the value begins with one of the schemes recognized by
+/// the default URL matcher. Link extraction uses this to distinguish explicit
+/// URLs from the path branches that share `regex`.
+pub fn hasSupportedSchemePrefix(value: []const u8) bool {
+    inline for (.{
+        "http://",
+        "https://",
+        "mailto:",
+        "ftp://",
+        "file:",
+        "ssh:",
+        "git://",
+        "tel:",
+        "magnet:",
+        "ipfs://",
+        "ipns://",
+        "gemini://",
+        "gopher://",
+        "news:",
+    }) |prefix| {
+        if (std.mem.startsWith(u8, value, prefix)) return true;
+    }
+    return false;
+}
+
 const ipv6_url_pattern =
     \\(?:\[[:0-9a-fA-F]+(?:[:0-9a-fA-F]*)+\](?::[0-9]+)?)
 ;
@@ -680,4 +705,12 @@ test "url regex" {
             return error.TestUnexpectedResult;
         } else |_| {}
     }
+}
+
+test "supported URL scheme prefixes" {
+    try std.testing.expect(hasSupportedSchemePrefix("https://example.com"));
+    try std.testing.expect(hasSupportedSchemePrefix("mailto:test@example.com"));
+    try std.testing.expect(hasSupportedSchemePrefix("ssh://example.com"));
+    try std.testing.expect(!hasSupportedSchemePrefix("example.com/path"));
+    try std.testing.expect(!hasSupportedSchemePrefix("src/config/url.zig"));
 }

--- a/src/config/url.zig
+++ b/src/config/url.zig
@@ -28,31 +28,6 @@ const url_schemes =
     \\https?://|mailto:|ftp://|file:|ssh:|git://|ssh://|tel:|magnet:|ipfs://|ipns://|gemini://|gopher://|news:
 ;
 
-/// Returns true when the value begins with one of the schemes recognized by
-/// the default URL matcher. Link extraction uses this to distinguish explicit
-/// URLs from the path branches that share `regex`.
-pub fn hasSupportedSchemePrefix(value: []const u8) bool {
-    inline for (.{
-        "http://",
-        "https://",
-        "mailto:",
-        "ftp://",
-        "file:",
-        "ssh:",
-        "git://",
-        "tel:",
-        "magnet:",
-        "ipfs://",
-        "ipns://",
-        "gemini://",
-        "gopher://",
-        "news:",
-    }) |prefix| {
-        if (std.mem.startsWith(u8, value, prefix)) return true;
-    }
-    return false;
-}
-
 const ipv6_url_pattern =
     \\(?:\[[:0-9a-fA-F]+(?:[:0-9a-fA-F]*)+\](?::[0-9]+)?)
 ;
@@ -251,12 +226,14 @@ const bare_relative_path_branch =
     no_trailing_colon ++
     trailing_spaces_at_eol;
 
-pub const regex =
-    scheme_url_branch ++
-    "|" ++
+pub const scheme_regex = scheme_url_branch;
+
+pub const path_regex =
     rooted_or_relative_path_branch ++
     "|" ++
     bare_relative_path_branch;
+
+pub const regex = scheme_regex ++ "|" ++ path_regex;
 
 test "url regex" {
     const testing = std.testing;
@@ -705,12 +682,4 @@ test "url regex" {
             return error.TestUnexpectedResult;
         } else |_| {}
     }
-}
-
-test "supported URL scheme prefixes" {
-    try std.testing.expect(hasSupportedSchemePrefix("https://example.com"));
-    try std.testing.expect(hasSupportedSchemePrefix("mailto:test@example.com"));
-    try std.testing.expect(hasSupportedSchemePrefix("ssh://example.com"));
-    try std.testing.expect(!hasSupportedSchemePrefix("example.com/path"));
-    try std.testing.expect(!hasSupportedSchemePrefix("src/config/url.zig"));
 }

--- a/src/input/Link.zig
+++ b/src/input/Link.zig
@@ -21,6 +21,21 @@ action: Action,
 /// when the link is clickable.
 highlight: Highlight,
 
+/// The terminal text region searched by this matcher.
+candidate_scope: CandidateScope = .semantic,
+
+pub const CandidateScope = enum {
+    /// Search only the semantic prompt region containing the clicked cell.
+    semantic,
+
+    /// Search the complete soft-wrapped logical line, subject to the
+    /// renderer's fixed candidate-size budget. This is only for lexical
+    /// matchers where printable soft-wrap continuity intentionally outranks
+    /// OSC 133 metadata, such as the built-in explicit-scheme URL matcher.
+    /// File paths and custom matchers remain semantic.
+    bounded_logical,
+};
+
 pub const Action = union(enum) {
     /// Open the full matched value using the default open program.
     /// For example, on macOS this is "open" and on Linux this is "xdg-open".
@@ -68,6 +83,7 @@ pub fn clone(self: *const Link, alloc: Allocator) Allocator.Error!Link {
         .regex = try alloc.dupe(u8, self.regex),
         .action = self.action,
         .highlight = self.highlight,
+        .candidate_scope = self.candidate_scope,
     };
 }
 
@@ -75,5 +91,15 @@ pub fn clone(self: *const Link, alloc: Allocator) Allocator.Error!Link {
 pub fn equal(self: *const Link, other: *const Link) bool {
     return std.meta.eql(self.action, other.action) and
         std.meta.eql(self.highlight, other.highlight) and
+        self.candidate_scope == other.candidate_scope and
         std.mem.eql(u8, self.regex, other.regex);
+}
+
+test "Link: candidate scope defaults to semantic" {
+    const link: Link = .{
+        .regex = "https?://",
+        .action = .{ .open = {} },
+        .highlight = .hover,
+    };
+    try std.testing.expectEqual(CandidateScope.semantic, link.candidate_scope);
 }

--- a/src/terminal/StringMap.zig
+++ b/src/terminal/StringMap.zig
@@ -102,6 +102,13 @@ pub const Match = struct {
         self.region.deinit();
     }
 
+    /// Returns the UTF-8 bytes covered by this match.
+    pub fn value(self: Match) []const u8 {
+        const start_idx: usize = @intCast(self.region.starts()[0]);
+        const end_idx: usize = @intCast(self.region.ends()[0]);
+        return self.map.string[self.offset + start_idx .. self.offset + end_idx];
+    }
+
     /// Returns the selection containing the full match.
     pub fn selection(self: Match) Selection {
         const start_idx: usize = @intCast(self.region.starts()[0]);
@@ -154,6 +161,8 @@ test "StringMap searchIterator" {
     {
         var match = (try it.next()).?;
         defer match.deinit();
+
+        try testing.expectEqualStrings("AB", match.value());
 
         const sel = match.selection();
         try testing.expectEqual(point.Point{ .screen = .{

--- a/src/terminal/StringMap.zig
+++ b/src/terminal/StringMap.zig
@@ -102,13 +102,6 @@ pub const Match = struct {
         self.region.deinit();
     }
 
-    /// Returns the UTF-8 bytes covered by this match.
-    pub fn value(self: Match) []const u8 {
-        const start_idx: usize = @intCast(self.region.starts()[0]);
-        const end_idx: usize = @intCast(self.region.ends()[0]);
-        return self.map.string[self.offset + start_idx .. self.offset + end_idx];
-    }
-
     /// Returns the selection containing the full match.
     pub fn selection(self: Match) Selection {
         const start_idx: usize = @intCast(self.region.starts()[0]);
@@ -161,8 +154,6 @@ test "StringMap searchIterator" {
     {
         var match = (try it.next()).?;
         defer match.deinit();
-
-        try testing.expectEqualStrings("AB", match.value());
 
         const sel = match.selection();
         try testing.expectEqual(point.Point{ .screen = .{


### PR DESCRIPTION
## Summary

- match explicit-scheme URLs across semantic soft wraps even when OSC 133 metadata splits the visual rows
- keep file-path and custom matchers scoped to semantic prompt regions
- bound logical-line candidate work to 8,192 cells and 256 rows
- keep hover, click, preview, and copy on the shared link-selection path

Fixes manaflow-ai/cmux#8096.

## Verification

- `zig build test -Dapp-runtime=none -Demit-macos-app=false -Demit-xcframework=false -Dtest-filter=link`
- 139 selected tests pass; one initial run later hit the existing terminal-search thread timeout/overflow flake, and the immediate rerun passed cleanly

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/118"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786679219&installation_id=133855650&pr_number=118&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F118&signature=2be2ef8ed5e676deffa1c788addf5e20033801d88e42c6905ec32ff90fdc81f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cmd/ctrl-click for `http(s)://` links so matches span semantic soft wraps, even when OSC 133 splits rows. Also makes `link-url=false` idempotently remove built-in URL/path matchers without touching custom matchers. Addresses manaflow-ai/cmux#8096.

- **Bug Fixes**
  - Detect explicit-scheme URLs across soft wraps and OSC 133 boundaries.
  - Keep file-path and custom matchers limited to the current semantic prompt region.
  - Use one shared selection path for hover, click, preview, and copy.
  - Finalization preserves custom matchers and is idempotent when `link-url=false`.

- **New Features**
  - Add per-matcher `candidate_scope`: URLs use `bounded_logical`; paths use `semantic` with a fixed budget (8,192 cells, 256 rows) to avoid partial opens.
  - Split defaults into `url.scheme_regex` (URLs) and `url.path_regex` (paths); `link-url=false` disables both.

<sup>Written for commit 30bd025657ccad483191191edb69977ee3e998e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/118?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved link detection across soft-wrapped lines.
  * Added support for matching links within bounded logical-line scopes.
  * URL and path links now use dedicated matching behavior.

* **Bug Fixes**
  * Prevented truncated or partial links from being opened when soft-wrapped candidates exceed safe limits.
  * Preserved link boundaries across wrapped lines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->