### PR TITLE
Export authoritative terminal grids for embedded clients

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -119,6 +119,13 @@ typedef enum {
   GHOSTTY_COLOR_SCHEME_DARK = 1,
 } ghostty_color_scheme_e;
 
+// cmux fork: outcome of a visual render-grid snapshot request.
+typedef enum {
+  GHOSTTY_RENDER_GRID_SUCCESS = 0,
+  GHOSTTY_RENDER_GRID_RETRYABLE_NOT_QUIESCENT = 1,
+  GHOSTTY_RENDER_GRID_FAILURE = 2,
+} ghostty_render_grid_status_e;
+
 // This is a packed struct (see src/input/mouse.zig) but the C standard
 // afaik doesn't let us reliably define packed structs so we build it up
 // from scratch.
@@ -1187,8 +1194,6 @@ GHOSTTY_API void ghostty_surface_set_focus(ghostty_surface_t, bool);
 GHOSTTY_API void ghostty_surface_set_occlusion(ghostty_surface_t, bool);
 GHOSTTY_API void ghostty_surface_set_size(ghostty_surface_t, uint32_t, uint32_t);
 GHOSTTY_API ghostty_surface_size_s ghostty_surface_size(ghostty_surface_t);
-// Parser-applied PTY byte coverage, read under the terminal-state lock.
-GHOSTTY_API uint64_t ghostty_surface_output_sequence(ghostty_surface_t);
 GHOSTTY_API bool ghostty_surface_scrollbar(ghostty_surface_t,
                                           ghostty_surface_scrollbar_s*);
 // Atomically validates the row-space identity and scrolls to an absolute row.
@@ -1203,13 +1208,18 @@ GHOSTTY_API ghostty_string_s ghostty_surface_tty_name(ghostty_surface_t);
 // cmux fork: export the Ghostty grid as a compact render-grid JSON frame for
 // mobile mirrors: the visible viewport plus full restore state (active screen,
 // DEC/ANSI modes, dynamic colors, cursor) and up to the given number of
-// scrollback history rows. Its state sequence is captured atomically with
-// parser-applied terminal state. The returned string must be freed with
-// ghostty_string_free.
+// scrollback history rows. This is visual state only: it does not serialize
+// parser continuation state and cannot seed later raw-byte replay. The JSON's
+// state sequence is a visual ordering watermark captured with the grid. A
+// retryable-not-quiescent result returns an empty string and must be retried
+// after the current escape/UTF-8/synchronized-output unit completes. The
+// returned non-empty string must be freed with ghostty_string_free.
 GHOSTTY_API ghostty_string_s ghostty_surface_render_grid_json(ghostty_surface_t,
-                                                                 const char*,
-                                                                 uintptr_t,
-                                                                 uintptr_t);
+                                                              const char*,
+                                                              uintptr_t,
+                                                              uintptr_t,
+                                                              uint64_t*,
+                                                              ghostty_render_grid_status_e*);
 GHOSTTY_API void ghostty_surface_set_color_scheme(ghostty_surface_t,
                                                      ghostty_color_scheme_e);
 GHOSTTY_API ghostty_input_mods_e ghostty_surface_key_translation_mods(ghostty_surface_t,
@@ -1228,9 +1238,10 @@ GHOSTTY_API void ghostty_surface_preedit(ghostty_surface_t, const char*, uintptr
 GHOSTTY_API void ghostty_surface_process_output(ghostty_surface_t, const char*, uintptr_t);
 
 // cmux fork: PTY tee callback. Fires after every byte slice has reached the VT
-// parser and includes that chunk's parser-applied start sequence. Render-grid
-// snapshots capture the corresponding end sequence under the same terminal
-// lock. Set cb=NULL to clear. The callback runs on the IO read thread.
+// parser and includes that chunk's start sequence for raw-stream ordering.
+// Render-grid state_seq uses the same counter only as an advisory visual
+// watermark, never as raw continuation coverage. Set cb=NULL to clear. The
+// callback runs on the IO read thread.
 typedef void (*ghostty_pty_tee_cb)(void* userdata,
                                   const char* bytes,
                                   uintptr_t len,
@@ -1238,6 +1249,11 @@ typedef void (*ghostty_pty_tee_cb)(void* userdata,
 GHOSTTY_API void ghostty_surface_set_pty_tee_cb(ghostty_surface_t,
                                                 ghostty_pty_tee_cb,
                                                 void* userdata);
+// Clear the PTY tee only if expected_userdata still owns it. Returns after any
+// matching in-flight callback completes. Returns false without changing a
+// callback installed by a newer owner.
+GHOSTTY_API bool ghostty_surface_clear_pty_tee_cb_if_userdata(ghostty_surface_t,
+                                                              void* expected_userdata);
 
 GHOSTTY_API bool ghostty_surface_mouse_captured(ghostty_surface_t);
 GHOSTTY_API bool ghostty_surface_mouse_button(ghostty_surface_t,

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1159,6 +1159,8 @@ GHOSTTY_API void ghostty_surface_set_focus(ghostty_surface_t, bool);
 GHOSTTY_API void ghostty_surface_set_occlusion(ghostty_surface_t, bool);
 GHOSTTY_API void ghostty_surface_set_size(ghostty_surface_t, uint32_t, uint32_t);
 GHOSTTY_API ghostty_surface_size_s ghostty_surface_size(ghostty_surface_t);
+// Parser-applied PTY byte coverage, read under the terminal-state lock.
+GHOSTTY_API uint64_t ghostty_surface_output_sequence(ghostty_surface_t);
 GHOSTTY_API bool ghostty_surface_scrollbar(ghostty_surface_t,
                                           ghostty_surface_scrollbar_s*);
 // Atomically validates the row-space identity and scrolls to an absolute row.
@@ -1173,12 +1175,12 @@ GHOSTTY_API ghostty_string_s ghostty_surface_tty_name(ghostty_surface_t);
 // cmux fork: export the Ghostty grid as a compact render-grid JSON frame for
 // mobile mirrors: the visible viewport plus full restore state (active screen,
 // DEC/ANSI modes, dynamic colors, cursor) and up to the given number of
-// scrollback history rows. The returned string must be freed with
+// scrollback history rows. Its state sequence is captured atomically with
+// parser-applied terminal state. The returned string must be freed with
 // ghostty_string_free.
 GHOSTTY_API ghostty_string_s ghostty_surface_render_grid_json(ghostty_surface_t,
                                                                  const char*,
                                                                  uintptr_t,
-                                                                 uint64_t,
                                                                  uintptr_t);
 GHOSTTY_API void ghostty_surface_set_color_scheme(ghostty_surface_t,
                                                      ghostty_color_scheme_e);
@@ -1197,12 +1199,14 @@ GHOSTTY_API void ghostty_surface_preedit(ghostty_surface_t, const char*, uintptr
 // C bridge when upstream exports an equivalent surface output API.
 GHOSTTY_API void ghostty_surface_process_output(ghostty_surface_t, const char*, uintptr_t);
 
-// cmux fork: PTY tee callback. Fires for every byte slice the read thread
-// produces before the VT parser sees it. Used by the Mac sync server to
-// broadcast raw bytes to a paired iPhone. Set cb=NULL to clear. Callback
-// runs on the IO read thread; embedder owns cross-thread hand-off. Upstream
-// candidate.
-typedef void (*ghostty_pty_tee_cb)(void* userdata, const char* bytes, uintptr_t len);
+// cmux fork: PTY tee callback. Fires after every byte slice has reached the VT
+// parser and includes that chunk's parser-applied start sequence. Render-grid
+// snapshots capture the corresponding end sequence under the same terminal
+// lock. Set cb=NULL to clear. The callback runs on the IO read thread.
+typedef void (*ghostty_pty_tee_cb)(void* userdata,
+                                  const char* bytes,
+                                  uintptr_t len,
+                                  uint64_t start_seq);
 GHOSTTY_API void ghostty_surface_set_pty_tee_cb(ghostty_surface_t,
                                                 ghostty_pty_tee_cb,
                                                 void* userdata);

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1290,6 +1290,8 @@ typedef void (*ghostty_pty_tee_cb)(void* userdata,
                                   const char* bytes,
                                   uintptr_t len,
                                   uint64_t start_seq);
+// A non-NULL callback requires non-NULL userdata. Invalid registrations clear
+// the callback instead of installing a conditionally unowned lease.
 GHOSTTY_API void ghostty_surface_set_pty_tee_cb(ghostty_surface_t,
                                                 ghostty_pty_tee_cb,
                                                 void* userdata);

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1218,6 +1218,9 @@ GHOSTTY_API void ghostty_surface_set_focus(ghostty_surface_t, bool);
 GHOSTTY_API void ghostty_surface_set_occlusion(ghostty_surface_t, bool);
 GHOSTTY_API void ghostty_surface_set_size(ghostty_surface_t, uint32_t, uint32_t);
 GHOSTTY_API ghostty_surface_size_s ghostty_surface_size(ghostty_surface_t);
+// Returns the synchronized raw PTY-output sequence after any in-flight
+// publication finishes, so embedders can detect replay-admission gaps.
+GHOSTTY_API uint64_t ghostty_surface_pty_output_sequence(ghostty_surface_t);
 GHOSTTY_API bool ghostty_surface_scrollbar(ghostty_surface_t,
                                           ghostty_surface_scrollbar_s*);
 // Atomically validates the row-space identity and scrolls to an absolute row.

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -126,6 +126,13 @@ typedef enum {
   GHOSTTY_RENDER_GRID_FAILURE = 2,
 } ghostty_render_grid_status_e;
 
+// cmux fork: exact outcome for an embedder-supplied render ticket.
+typedef enum {
+  GHOSTTY_RENDER_PRESENTATION_PRESENTED = 0,
+  GHOSTTY_RENDER_PRESENTATION_WRONG_SIZE_DISCARDED = 1,
+  GHOSTTY_RENDER_PRESENTATION_BACKEND_FAILED = 2,
+} ghostty_render_presentation_status_e;
+
 // This is a packed struct (see src/input/mouse.zig) but the C standard
 // afaik doesn't let us reliably define packed structs so we build it up
 // from scratch.
@@ -494,6 +501,13 @@ typedef enum {
 typedef void (*ghostty_renderer_event_cb)(void* userdata,
                                          ghostty_renderer_event_e event);
 
+// Called exactly at the terminal frame's host-layer presentation boundary.
+// The userdata is ghostty_surface_config_s.userdata.
+typedef void (*ghostty_render_presentation_cb)(
+    void* userdata,
+    uint64_t ticket,
+    ghostty_render_presentation_status_e status);
+
 typedef struct {
   ghostty_platform_e platform_tag;
   ghostty_platform_u platform;
@@ -511,6 +525,7 @@ typedef struct {
   ghostty_io_write_cb io_write_cb;
   void* io_write_userdata;
   ghostty_renderer_event_cb renderer_event_cb;
+  ghostty_render_presentation_cb render_presentation_cb;
 } ghostty_surface_config_s;
 
 typedef struct {
@@ -1189,6 +1204,10 @@ GHOSTTY_API void ghostty_surface_draw(ghostty_surface_t);
 // cmux fork: delete when upstream exposes a synchronous render tick for
 // embedders that drive rendering from a platform display callback.
 GHOSTTY_API void ghostty_surface_render_now(ghostty_surface_t);
+// Renders the current terminal state and reports the exact ticket through
+// render_presentation_cb after layer presentation or terminal failure.
+GHOSTTY_API void ghostty_surface_render_now_with_ticket(ghostty_surface_t,
+                                                        uint64_t ticket);
 GHOSTTY_API void ghostty_surface_set_content_scale(ghostty_surface_t, double, double);
 GHOSTTY_API void ghostty_surface_set_focus(ghostty_surface_t, bool);
 GHOSTTY_API void ghostty_surface_set_occlusion(ghostty_surface_t, bool);

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1208,6 +1208,11 @@ GHOSTTY_API void ghostty_surface_render_now(ghostty_surface_t);
 // render_presentation_cb after layer presentation or terminal failure.
 GHOSTTY_API void ghostty_surface_render_now_with_ticket(ghostty_surface_t,
                                                         uint64_t ticket);
+// Synchronously rejects this ticket and every older queued presentation before
+// any of them can mutate the host layer. Existing layer contents are retained.
+GHOSTTY_API void ghostty_surface_invalidate_render_presentation_through(
+    ghostty_surface_t,
+    uint64_t ticket);
 GHOSTTY_API void ghostty_surface_set_content_scale(ghostty_surface_t, double, double);
 GHOSTTY_API void ghostty_surface_set_focus(ghostty_surface_t, bool);
 GHOSTTY_API void ghostty_surface_set_occlusion(ghostty_surface_t, bool);

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -501,8 +501,10 @@ typedef enum {
 typedef void (*ghostty_renderer_event_cb)(void* userdata,
                                          ghostty_renderer_event_e event);
 
-// Called exactly at the terminal frame's host-layer presentation boundary.
-// The userdata is ghostty_surface_config_s.userdata.
+// Reports the final disposition for an exact render ticket. PRESENTED is
+// emitted after host-layer assignment. WRONG_SIZE_DISCARDED and BACKEND_FAILED
+// mean no frame was presented. The userdata is
+// ghostty_surface_config_s.userdata.
 typedef void (*ghostty_render_presentation_cb)(
     void* userdata,
     uint64_t ticket,
@@ -1213,8 +1215,8 @@ GHOSTTY_API void ghostty_surface_draw(ghostty_surface_t);
 // cmux fork: delete when upstream exposes a synchronous render tick for
 // embedders that drive rendering from a platform display callback.
 GHOSTTY_API void ghostty_surface_render_now(ghostty_surface_t);
-// Renders the current terminal state and reports the exact ticket through
-// render_presentation_cb after layer presentation or terminal failure.
+// Renders the current terminal state and reports the ticket's final disposition
+// through render_presentation_cb. Only PRESENTED reached the host layer.
 GHOSTTY_API void ghostty_surface_render_now_with_ticket(ghostty_surface_t,
                                                         uint64_t ticket);
 // Synchronously rejects this ticket and every older queued presentation before

--- a/src/apprt.zig
+++ b/src/apprt.zig
@@ -11,6 +11,7 @@
 const build_config = @import("build_config.zig");
 
 const structs = @import("apprt/structs.zig");
+const render_grid_json = @import("apprt/render_grid_json.zig");
 
 pub const action = @import("apprt/action.zig");
 pub const ipc = @import("apprt/ipc.zig");
@@ -54,6 +55,7 @@ pub const Surface = runtime.Surface;
 test {
     _ = Runtime;
     _ = runtime;
+    _ = render_grid_json;
     _ = action;
     _ = structs;
 }

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -3330,8 +3330,9 @@ pub const CAPI = struct {
     /// safety for any cross-thread hand-off; the typical pattern is a
     /// non-blocking memcpy into a ring buffer + an async wakeup.
     ///
-    /// userdata is opaque to libghostty; the embedder owns its lifetime
-    /// (usually tied to the surface).
+    /// userdata is opaque to libghostty; a non-null callback requires non-null
+    /// userdata, and the embedder owns its lifetime (usually tied to the
+    /// surface).
     ///
     /// cmux fork: the Mac sync server uses this to broadcast raw PTY
     /// bytes to paired iPhones so the phone can feed identical bytes
@@ -3339,7 +3340,7 @@ pub const CAPI = struct {
     /// matching grid. Upstream candidate.
     export fn ghostty_surface_set_pty_tee_cb(
         surface: *Surface,
-        cb: ?*const fn (?*anyopaque, [*]const u8, usize, u64) callconv(.c) void,
+        cb: ?*const fn (*anyopaque, [*]const u8, usize, u64) callconv(.c) void,
         userdata: ?*anyopaque,
     ) void {
         surface.core_surface.io.setPtyTeeCallback(cb, userdata);

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -435,6 +435,8 @@ pub const RenderGridStatus = enum(c_int) {
     failure = 2,
 };
 
+pub const RenderPresentationStatus = renderer.RenderPresentationStatus;
+
 test "ghostty.h render presentation status" {
     try renderer.lib.checkGhosttyHEnum(
         RenderPresentationStatus,
@@ -460,6 +462,7 @@ fn retryableRenderGridResult(out_status: *RenderGridStatus) String {
 
 pub const IoWriteCallback = *const fn (?*anyopaque, [*]const u8, usize) callconv(.c) void;
 pub const RendererEventCallback = renderer.InstrumentationCallback;
+pub const RenderPresentationCallback = renderer.RenderPresentationCallback;
 
 pub const Surface = struct {
     app: *App,
@@ -475,6 +478,7 @@ pub const Surface = struct {
     io_write_cb: ?IoWriteCallback = null,
     io_write_userdata: ?*anyopaque = null,
     renderer_event_cb: ?RendererEventCallback = null,
+    render_presentation_cb: ?RenderPresentationCallback = null,
     scrollback_limit_bytes: usize = 0,
 
     /// The current title of the surface. The embedded apprt saves this so
@@ -535,6 +539,9 @@ pub const Surface = struct {
         /// Optional content-free renderer activity callback. This receives the
         /// surface `userdata` and runs synchronously on the renderer thread.
         renderer_event_cb: ?RendererEventCallback = null,
+
+        /// Completion for exact tickets supplied to render_now_with_ticket.
+        render_presentation_cb: ?RenderPresentationCallback = null,
     };
 
     pub fn init(
@@ -559,6 +566,7 @@ pub const Surface = struct {
             .io_write_cb = opts.io_write_cb,
             .io_write_userdata = opts.io_write_userdata,
             .renderer_event_cb = opts.renderer_event_cb,
+            .render_presentation_cb = opts.render_presentation_cb,
             .scrollback_limit_bytes = scrollback_limit_bytes,
         };
 
@@ -690,7 +698,7 @@ pub const Surface = struct {
     }
 
     test "embedded surface scrollback cap inherits when unset" {
-        try std.testing.expectEqual(@as(usize, 120), @sizeOf(Options));
+        try std.testing.expectEqual(@as(usize, 128), @sizeOf(Options));
         try std.testing.expectEqual(
             @as(usize, 50_000_000),
             effectiveScrollbackLimit(50_000_000, 0),
@@ -927,6 +935,11 @@ pub const Surface = struct {
         self.core_surface.renderer_thread.renderNow();
     }
 
+    pub fn renderNowWithTicket(self: *Surface, ticket: u64) void {
+        self.core_surface.applyPendingResizeIfNeeded();
+        self.core_surface.renderer_thread.renderNowWithTicket(ticket);
+    }
+
     pub fn updateContentScale(self: *Surface, x: f64, y: f64) void {
         // We are an embedded API so the caller can send us all sorts of
         // garbage. We want to make sure that the float values are valid
@@ -1112,6 +1125,7 @@ pub const Surface = struct {
             .io_write_cb = self.io_write_cb,
             .io_write_userdata = self.io_write_userdata,
             .renderer_event_cb = self.renderer_event_cb,
+            .render_presentation_cb = self.render_presentation_cb,
         };
     }
 
@@ -2076,6 +2090,13 @@ pub const CAPI = struct {
     /// Perform a full render cycle synchronously from the calling thread.
     export fn ghostty_surface_render_now(surface: *Surface) void {
         surface.renderNow();
+    }
+
+    export fn ghostty_surface_render_now_with_ticket(
+        surface: *Surface,
+        ticket: u64,
+    ) void {
+        surface.renderNowWithTicket(ticket);
     }
 
     /// Update the size of a surface. This will trigger resize notifications

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -2129,6 +2129,13 @@ pub const CAPI = struct {
         };
     }
 
+    /// Return the synchronized raw PTY-output sequence after any in-flight
+    /// publication finishes. This keeps provisional embedder demand active
+    /// until the matching callback has observed it.
+    export fn ghostty_surface_pty_output_sequence(surface: *Surface) u64 {
+        return surface.core_surface.io.ptyOutputSequence();
+    }
+
     /// Read current scrollbar geometry and its absolute row-space identity
     /// directly from the terminal, independent of renderer publication.
     export fn ghostty_surface_scrollbar(

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -428,6 +428,29 @@ pub const IoMode = enum(c_int) {
     manual = 1,
 };
 
+// cmux fork: typed result for visual render-grid snapshot requests.
+pub const RenderGridStatus = enum(c_int) {
+    success = 0,
+    retryable_not_quiescent = 1,
+    failure = 2,
+};
+
+fn renderGridGateStatus(
+    pty_output_in_progress: bool,
+    parser_quiescent: bool,
+    synchronized_output: bool,
+) ?RenderGridStatus {
+    if (pty_output_in_progress or !parser_quiescent or synchronized_output) {
+        return .retryable_not_quiescent;
+    }
+    return null;
+}
+
+fn retryableRenderGridResult(out_status: *RenderGridStatus) String {
+    out_status.* = .retryable_not_quiescent;
+    return .empty;
+}
+
 pub const IoWriteCallback = *const fn (?*anyopaque, [*]const u8, usize) callconv(.c) void;
 pub const RendererEventCallback = renderer.InstrumentationCallback;
 
@@ -2067,14 +2090,6 @@ pub const CAPI = struct {
         };
     }
 
-    /// Return the exact PTY prefix already applied by the VT parser.
-    export fn ghostty_surface_output_sequence(surface: *Surface) u64 {
-        const core_surface = &surface.core_surface;
-        core_surface.renderer_state.lockDemand();
-        defer core_surface.renderer_state.unlockDemand();
-        return core_surface.io.pty_output_seq;
-    }
-
     /// Read current scrollbar geometry and its absolute row-space identity
     /// directly from the terminal, independent of renderer publication.
     export fn ghostty_surface_scrollbar(
@@ -2136,7 +2151,6 @@ pub const CAPI = struct {
         invisible: bool = false,
         strikethrough: bool = false,
         overline: bool = false,
-        foreground_opacity: f64 = 1,
 
         fn visualEql(self: RenderGridStyle, other: RenderGridStyle) bool {
             return self.foreground.eql(other.foreground) and
@@ -2149,8 +2163,7 @@ pub const CAPI = struct {
                 self.inverse == other.inverse and
                 self.invisible == other.invisible and
                 self.strikethrough == other.strikethrough and
-                self.overline == other.overline and
-                self.foreground_opacity == other.foreground_opacity;
+                self.overline == other.overline;
         }
     };
 
@@ -2262,6 +2275,29 @@ pub const CAPI = struct {
         return next.id;
     }
 
+    /// Blend one opaque terminal color over another with renderer-compatible
+    /// 8-bit alpha rounding. Render-grid replay can express the result through
+    /// ordinary VT colors without depending on matching host opacity config.
+    fn blendRenderGridColor(
+        foreground: terminal.color.RGB,
+        background: terminal.color.RGB,
+        alpha: u8,
+    ) terminal.color.RGB {
+        if (alpha == 255) return foreground;
+        if (alpha == 0) return background;
+
+        const inverse_alpha: u32 = 255 - @as(u32, alpha);
+        const a: u32 = alpha;
+        return .{
+            .r = @intCast((@as(u32, foreground.r) * a +
+                @as(u32, background.r) * inverse_alpha + 127) / 255),
+            .g = @intCast((@as(u32, foreground.g) * a +
+                @as(u32, background.g) * inverse_alpha + 127) / 255),
+            .b = @intCast((@as(u32, foreground.b) * a +
+                @as(u32, background.b) * inverse_alpha + 127) / 255),
+        };
+    }
+
     fn resolvedRenderGridStyle(
         p: *const terminal.Page,
         cell: *const terminal.Cell,
@@ -2269,13 +2305,13 @@ pub const CAPI = struct {
         background: terminal.color.RGB,
         palette: *const terminal.color.Palette,
         bold_color: ?terminal.Style.BoldColor,
-        faint_opacity: f64,
+        faint_opacity: u8,
     ) RenderGridStyle {
         const style: terminal.Style = if (cell.style_id == terminal_style.default_id)
             .{}
         else
             p.styles.get(p.memory, cell.style_id).*;
-        return .{
+        var result: RenderGridStyle = .{
             .id = 0,
             .foreground = style.fg(.{
                 .default = foreground,
@@ -2284,7 +2320,9 @@ pub const CAPI = struct {
             }),
             .background = style.bg(cell, palette) orelse background,
             .bold = style.flags.bold,
-            .faint = style.flags.faint,
+            // Faint is resolved into an opaque color below so a differently
+            // configured mobile renderer cannot dim the snapshot twice.
+            .faint = false,
             .italic = style.flags.italic,
             .underline = style.flags.underline != .none,
             .blink = style.flags.blink,
@@ -2292,8 +2330,23 @@ pub const CAPI = struct {
             .invisible = style.flags.invisible,
             .strikethrough = style.flags.strikethrough,
             .overline = style.flags.overline,
-            .foreground_opacity = if (style.flags.faint) faint_opacity else 1,
         };
+        if (style.flags.faint) {
+            if (style.flags.inverse) {
+                result.background = blendRenderGridColor(
+                    result.background,
+                    result.foreground,
+                    faint_opacity,
+                );
+            } else {
+                result.foreground = blendRenderGridColor(
+                    result.foreground,
+                    result.background,
+                    faint_opacity,
+                );
+            }
+        }
+        return result;
     }
 
     fn appendRenderGridCellText(
@@ -2325,7 +2378,7 @@ pub const CAPI = struct {
         background: terminal.color.RGB,
         palette: *const terminal.color.Palette,
         bold_color: ?terminal.Style.BoldColor,
-        faint_opacity: f64,
+        faint_opacity: u8,
         preserved_node: *?*terminal.PageList.List.Node,
         preserved_page: *?terminal.PageList.List.Node.PreservedPage,
     ) !void {
@@ -2405,6 +2458,7 @@ pub const CAPI = struct {
         surface: *Surface,
         surface_id: []const u8,
         scrollback_lines: usize,
+        out_state_seq: *u64,
     ) !String {
         const alloc = global.alloc;
         const core_surface = &surface.core_surface;
@@ -2430,23 +2484,28 @@ pub const CAPI = struct {
         var cursor_visible = false;
         var cursor_blinking = false;
         var cursor_style: terminal.CursorStyle = .block;
-        var cursor_cell_width: u32 = 1;
-        var cursor_opacity: f64 = 1;
         var columns: u32 = 0;
         var rows: u32 = 0;
         var is_alternate = false;
         var fg_override: ?terminal.color.RGB = null;
         var bg_override: ?terminal.color.RGB = null;
         var cursor_color_override: ?terminal.color.RGB = null;
-        var cursor_text_color: terminal.color.RGB = .{ .r = 0, .g = 0, .b = 0 };
         var scrollback_rows: u32 = 0;
         var state_seq: u64 = 0;
 
         {
-            core_surface.renderer_state.mutex.lock();
-            defer core_surface.renderer_state.mutex.unlock();
+            core_surface.renderer_state.lockDemand();
+            defer core_surface.renderer_state.unlockDemand();
 
             const t: *terminal.Terminal = core_surface.renderer_state.terminal;
+            out_state_seq.* = core_surface.io.pty_output_seq;
+            if (renderGridGateStatus(
+                core_surface.io.pty_output_in_progress,
+                core_surface.io.terminal_stream.isQuiescent(),
+                t.modes.get(.synchronized_output),
+            ) != null) {
+                return error.RenderGridNotQuiescent;
+            }
             const s: *terminal.Screen = t.screens.active;
             const palette = &t.colors.palette.current;
             var background = t.colors.background.get() orelse core_surface.renderer.config.background;
@@ -2460,85 +2519,67 @@ pub const CAPI = struct {
             rows = @intCast(s.pages.rows);
             cursor_column = @intCast(@min(s.cursor.x, s.pages.cols - 1));
             switch (s.cursor.page_cell.wide) {
-                .wide => cursor_cell_width = 2,
-                .spacer_tail => {
-                    cursor_column -|= 1;
-                    cursor_cell_width = 2;
-                },
-                .narrow, .spacer_head => cursor_cell_width = 1,
+                .spacer_tail => cursor_column -|= 1,
+                .wide, .narrow, .spacer_head => {},
             }
-            cursor_opacity = if (core_surface.focused)
-                @ceil(core_surface.renderer.config.cursor_opacity * 255.0) / 255.0
-            else
-                1;
             cursor_visible = t.modes.get(.cursor_visible);
-            cursor_blinking = t.modes.get(.cursor_blinking);
-            cursor_style = s.cursor.cursor_style;
+            cursor_blinking = if (core_surface.focused)
+                t.modes.get(.cursor_blinking)
+            else
+                false;
+            cursor_style = if (core_surface.focused)
+                s.cursor.cursor_style
+            else
+                .block_hollow;
             is_alternate = t.screens.active_key == .alternate;
             fg_override = t.colors.foreground.override;
             bg_override = t.colors.background.override;
-            cursor_color_override = cursor_color: {
+            const cursor_cell_style = s.cursor.style;
+            const cursor_cell_foreground = cursor_cell_style.fg(.{
+                .default = foreground,
+                .palette = palette,
+                .bold = bold_color,
+            });
+            const cursor_cell_background_uninverted = cursor_cell_style.bg(
+                s.cursor.page_cell,
+                palette,
+            ) orelse background;
+            const cursor_cell_background = if (cursor_cell_style.flags.inverse)
+                cursor_cell_foreground
+            else
+                cursor_cell_background_uninverted;
+            const raw_cursor_color = cursor_color: {
                 if (t.colors.cursor.get()) |value| break :cursor_color value;
                 if (core_surface.renderer.config.cursor_color) |value| switch (value) {
                     .color => |color| break :cursor_color color.toTerminalRGB(),
                     inline .@"cell-foreground", .@"cell-background" => |_, tag| {
-                        const cursor_cell_style = s.cursor.style;
-                        const cell_foreground = cursor_cell_style.fg(.{
-                            .default = foreground,
-                            .palette = palette,
-                            .bold = bold_color,
-                        });
-                        const cell_background = cursor_cell_style.bg(
-                            s.cursor.page_cell,
-                            palette,
-                        ) orelse background;
                         break :cursor_color switch (tag) {
                             .color => unreachable,
                             .@"cell-foreground" => if (cursor_cell_style.flags.inverse)
-                                cell_background
+                                cursor_cell_background_uninverted
                             else
-                                cell_foreground,
+                                cursor_cell_foreground,
                             .@"cell-background" => if (cursor_cell_style.flags.inverse)
-                                cell_foreground
+                                cursor_cell_foreground
                             else
-                                cell_background,
+                                cursor_cell_background_uninverted,
                         };
                     },
                 };
                 break :cursor_color foreground;
             };
-            cursor_text_color = cursor_text: {
-                const cursor_cell_style = s.cursor.style;
-                const cell_foreground = cursor_cell_style.fg(.{
-                    .default = foreground,
-                    .palette = palette,
-                    .bold = bold_color,
-                });
-                const cell_background = cursor_cell_style.bg(
-                    s.cursor.page_cell,
-                    palette,
-                ) orelse background;
-                if (core_surface.renderer.config.cursor_text) |value| switch (value) {
-                    .color => |color| break :cursor_text color.toTerminalRGB(),
-                    inline .@"cell-foreground", .@"cell-background" => |_, tag| {
-                        break :cursor_text switch (tag) {
-                            .color => unreachable,
-                            .@"cell-foreground" => if (cursor_cell_style.flags.inverse)
-                                cell_background
-                            else
-                                cell_foreground,
-                            .@"cell-background" => if (cursor_cell_style.flags.inverse)
-                                cell_foreground
-                            else
-                                cell_background,
-                        };
-                    },
-                };
-                break :cursor_text background;
-            };
-            // This sequence is advanced only after each VT chunk has been
-            // parsed, under this same renderer-state mutex. The snapshot and
-            // its coverage stamp therefore describe one atomic terminal state.
+            const cursor_alpha: u8 = if (core_surface.focused)
+                @intFromFloat(@ceil(255.0 * core_surface.renderer.config.cursor_opacity))
+            else
+                255;
+            cursor_color_override = blendRenderGridColor(
+                raw_cursor_color,
+                cursor_cell_background,
+                cursor_alpha,
+            );
+            // Advisory visual ordering only. This counter is captured with the
+            // grid, but the grid does not serialize enough terminal state to
+            // define a raw-byte continuation boundary.
             state_seq = core_surface.io.pty_output_seq;
             // Capture every non-default-handled DEC/ANSI mode so the client can
             // restore mouse tracking, bracketed paste, application keys, origin,
@@ -2561,10 +2602,7 @@ pub const CAPI = struct {
                 .background = background,
             };
             try styles.append(alloc, default_style);
-            const faint_opacity = @as(
-                f64,
-                @floatFromInt(core_surface.renderer.config.faint_opacity),
-            ) / 255.0;
+            const faint_opacity = core_surface.renderer.config.faint_opacity;
 
             var vp_builder = RenderGridSpanBuilder.init(alloc, &spans);
             defer vp_builder.deinit();
@@ -2655,10 +2693,6 @@ pub const CAPI = struct {
         try jw.write(cursorStyleName(cursor_style));
         try jw.objectField("blinking");
         try jw.write(cursor_blinking);
-        try jw.objectField("cell_width");
-        try jw.write(cursor_cell_width);
-        try jw.objectField("opacity");
-        try jw.write(cursor_opacity);
         try jw.endObject();
 
         try jw.objectField("styles");
@@ -2689,8 +2723,6 @@ pub const CAPI = struct {
             try jw.write(style.strikethrough);
             try jw.objectField("overline");
             try jw.write(style.overline);
-            try jw.objectField("foreground_opacity");
-            try jw.write(style.foreground_opacity);
             try jw.endObject();
         }
         try jw.endArray();
@@ -2728,8 +2760,6 @@ pub const CAPI = struct {
             try jw.objectField("terminal_cursor_color");
             try writeRenderGridColor(&jw, c);
         }
-        try jw.objectField("terminal_cursor_text_color");
-        try writeRenderGridColor(&jw, cursor_text_color);
 
         try jw.objectField("modes");
         try jw.beginArray();
@@ -2780,15 +2810,25 @@ pub const CAPI = struct {
         surface_id_ptr: [*]const u8,
         surface_id_len: usize,
         scrollback_lines: usize,
+        out_state_seq: *u64,
+        out_status: *RenderGridStatus,
     ) String {
-        return buildRenderGridJson(
+        out_state_seq.* = 0;
+        out_status.* = .failure;
+        const result = buildRenderGridJson(
             surface,
             surface_id_ptr[0..surface_id_len],
             scrollback_lines,
+            out_state_seq,
         ) catch |err| {
+            if (err == error.RenderGridNotQuiescent) {
+                return retryableRenderGridResult(out_status);
+            }
             log.warn("error exporting render grid err={}", .{err});
             return .empty;
         };
+        out_status.* = .success;
+        return result;
     }
 
     /// Returns the PID of the foreground process for the surface PTY.
@@ -2955,8 +2995,18 @@ pub const CAPI = struct {
         cb: ?*const fn (?*anyopaque, [*]const u8, usize, u64) callconv(.c) void,
         userdata: ?*anyopaque,
     ) void {
-        surface.core_surface.io.pty_tee_cb = cb;
-        surface.core_surface.io.pty_tee_userdata = userdata;
+        surface.core_surface.io.setPtyTeeCallback(cb, userdata);
+    }
+
+    /// Clear a PTY tee only if `expected_userdata` still owns the installed
+    /// callback. This is a lifetime fence for stale surface wrappers: it waits
+    /// for a matching in-flight callback, while refusing to clear a callback
+    /// already replaced by a newer owner.
+    export fn ghostty_surface_clear_pty_tee_cb_if_userdata(
+        surface: *Surface,
+        expected_userdata: *anyopaque,
+    ) bool {
+        return surface.core_surface.io.clearPtyTeeCallbackIfUserdata(expected_userdata);
     }
 
     /// Returns true if the surface currently has mouse capturing

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -3403,3 +3403,37 @@ pub const CAPI = struct {
         }
     };
 };
+
+test "render grid gate returns retryable empty result while output is in progress" {
+    const gate = renderGridGateStatus(true, true, false);
+    try std.testing.expectEqual(RenderGridStatus.retryable_not_quiescent, gate.?);
+
+    var status: RenderGridStatus = .failure;
+    const result = retryableRenderGridResult(&status);
+    try std.testing.expectEqual(RenderGridStatus.retryable_not_quiescent, status);
+    try std.testing.expect(result.ptr == null);
+    try std.testing.expectEqual(@as(usize, 0), result.len);
+}
+
+test "render grid gate returns retryable empty result during synchronized output" {
+    const gate = renderGridGateStatus(false, true, true);
+    try std.testing.expectEqual(RenderGridStatus.retryable_not_quiescent, gate.?);
+
+    var status: RenderGridStatus = .failure;
+    const result = retryableRenderGridResult(&status);
+    try std.testing.expectEqual(RenderGridStatus.retryable_not_quiescent, status);
+    try std.testing.expect(result.ptr == null);
+    try std.testing.expectEqual(@as(usize, 0), result.len);
+}
+
+test "render grid color blend resolves opacity into replayable RGB" {
+    const black: terminal.color.RGB = .{ .r = 0, .g = 0, .b = 0 };
+    const white: terminal.color.RGB = .{ .r = 255, .g = 255, .b = 255 };
+    try std.testing.expect(CAPI.blendRenderGridColor(black, white, 0).eql(white));
+    try std.testing.expect(CAPI.blendRenderGridColor(black, white, 255).eql(black));
+    try std.testing.expect(CAPI.blendRenderGridColor(black, white, 128).eql(.{
+        .r = 127,
+        .g = 127,
+        .b = 127,
+    }));
+}

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -431,11 +431,7 @@ pub const IoMode = enum(c_int) {
 };
 
 // cmux fork: typed result for visual render-grid snapshot requests.
-pub const RenderGridStatus = enum(c_int) {
-    success = 0,
-    retryable_not_quiescent = 1,
-    failure = 2,
-};
+pub const RenderGridStatus = render_grid_json.Status;
 
 pub const RenderPresentationStatus = renderer.RenderPresentationStatus;
 

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -2719,7 +2719,7 @@ pub const CAPI = struct {
             is_alternate = t.screens.active_key == .alternate;
             effective_background = background;
             effective_foreground = foreground;
-            const cursor_cell_style = s.cursor.style;
+            const cursor_cell_style = render_grid_json.cursorCellStyle(s.cursor);
             const cursor_cell_foreground = cursor_cell_style.fg(.{
                 .default = foreground,
                 .palette = palette,

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -940,6 +940,10 @@ pub const Surface = struct {
         self.core_surface.renderer_thread.renderNowWithTicket(ticket);
     }
 
+    pub fn invalidateRenderPresentationThrough(self: *Surface, ticket: u64) void {
+        self.core_surface.renderer_thread.invalidatePresentationThrough(ticket);
+    }
+
     pub fn updateContentScale(self: *Surface, x: f64, y: f64) void {
         // We are an embedded API so the caller can send us all sorts of
         // garbage. We want to make sure that the float values are valid
@@ -2097,6 +2101,13 @@ pub const CAPI = struct {
         ticket: u64,
     ) void {
         surface.renderNowWithTicket(ticket);
+    }
+
+    export fn ghostty_surface_invalidate_render_presentation_through(
+        surface: *Surface,
+        ticket: u64,
+    ) void {
+        surface.invalidateRenderPresentationThrough(ticket);
     }
 
     /// Update the size of a surface. This will trigger resize notifications

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -2614,7 +2614,7 @@ pub const CAPI = struct {
         var config_selection_background: ?configpkg.Config.TerminalColor = null;
         var config_selection_foreground: ?configpkg.Config.TerminalColor = null;
         var bold_color: ?terminal.Style.BoldColor = null;
-        var cursor_opacity: f64 = 1;
+        var config_cursor_opacity: f64 = 1;
         var faint_opacity: u8 = 255;
         {
             core_surface.renderer.draw_mutex.lock();
@@ -2622,14 +2622,14 @@ pub const CAPI = struct {
             const config = &core_surface.renderer.config;
             config_background = config.background;
             config_foreground = config.foreground;
+            config_cursor_color = config.cursor_color;
+            config_cursor_text = config.cursor_text;
             if (include_theme) {
-                config_cursor_color = config.cursor_color;
-                config_cursor_text = config.cursor_text;
                 config_selection_background = config.selection_background;
                 config_selection_foreground = config.selection_foreground;
             }
             bold_color = config.bold_color;
-            cursor_opacity = config.cursor_opacity;
+            config_cursor_opacity = config.cursor_opacity;
             faint_opacity = config.faint_opacity;
         }
 
@@ -2653,9 +2653,9 @@ pub const CAPI = struct {
         var cursor_visible = false;
         var cursor_blinking = false;
         var cursor_style: terminal.CursorStyle = .block;
-        const cursor_cell_width: u32 = 1;
-        const cursor_opacity_out: f64 = 1;
-        const cursor_text_color: terminal.color.RGB = .{ .r = 0, .g = 0, .b = 0 };
+        var cursor_cell_width: u32 = 1;
+        var cursor_opacity: f64 = 1;
+        var cursor_text_color: terminal.color.RGB = .{ .r = 0, .g = 0, .b = 0 };
         var columns: u32 = 0;
         var rows: u32 = 0;
         var is_alternate = false;
@@ -2700,9 +2700,17 @@ pub const CAPI = struct {
             rows = @intCast(s.pages.rows);
             cursor_column = @intCast(@min(s.cursor.x, s.pages.cols - 1));
             switch (s.cursor.page_cell.wide) {
-                .spacer_tail => cursor_column -|= 1,
-                .wide, .narrow, .spacer_head => {},
+                .wide => cursor_cell_width = 2,
+                .spacer_tail => {
+                    cursor_column -|= 1;
+                    cursor_cell_width = 2;
+                },
+                .narrow, .spacer_head => cursor_cell_width = 1,
             }
+            cursor_opacity = if (core_surface.focused)
+                @ceil(config_cursor_opacity * 255.0) / 255.0
+            else
+                1;
             cursor_visible = t.modes.get(.cursor_visible);
             cursor_blinking = if (core_surface.focused)
                 t.modes.get(.cursor_blinking)
@@ -2725,10 +2733,6 @@ pub const CAPI = struct {
                 s.cursor.page_cell,
                 palette,
             ) orelse background;
-            const cursor_cell_background = if (cursor_cell_style.flags.inverse)
-                cursor_cell_foreground
-            else
-                cursor_cell_background_uninverted;
             const raw_cursor_color = cursor_color: {
                 if (t.colors.cursor.get()) |value| break :cursor_color value;
                 if (config_cursor_color) |value| switch (value) {
@@ -2749,15 +2753,26 @@ pub const CAPI = struct {
                 };
                 break :cursor_color foreground;
             };
-            const cursor_alpha: u8 = if (core_surface.focused)
-                @intFromFloat(@ceil(255.0 * cursor_opacity))
-            else
-                255;
-            cursor_color_override = blendRenderGridColor(
-                raw_cursor_color,
-                cursor_cell_background,
-                cursor_alpha,
-            );
+            cursor_color_override = raw_cursor_color;
+            cursor_text_color = cursor_text: {
+                if (config_cursor_text) |value| switch (value) {
+                    .color => |color| break :cursor_text color.toTerminalRGB(),
+                    inline .@"cell-foreground", .@"cell-background" => |_, tag| {
+                        break :cursor_text switch (tag) {
+                            .color => unreachable,
+                            .@"cell-foreground" => if (cursor_cell_style.flags.inverse)
+                                cursor_cell_background_uninverted
+                            else
+                                cursor_cell_foreground,
+                            .@"cell-background" => if (cursor_cell_style.flags.inverse)
+                                cursor_cell_foreground
+                            else
+                                cursor_cell_background_uninverted,
+                        };
+                    },
+                };
+                break :cursor_text background;
+            };
             // Advisory visual ordering only. This counter is captured with the
             // grid, but the grid does not serialize enough terminal state to
             // define a raw-byte continuation boundary.
@@ -2904,7 +2919,7 @@ pub const CAPI = struct {
             .style = cursorStyleName(cursor_style),
             .blinking = cursor_blinking,
             .cell_width = cursor_cell_width,
-            .opacity = cursor_opacity_out,
+            .opacity = cursor_opacity,
         });
 
         try jw.objectField("styles");

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -17,6 +17,7 @@ const renderer = @import("../renderer.zig");
 const terminal = @import("../terminal/main.zig");
 const terminal_style = @import("../terminal/style.zig");
 const termio = @import("../termio.zig");
+const render_grid_json = @import("render_grid_json.zig");
 const CoreApp = @import("../App.zig");
 const CoreInspector = @import("../inspector/main.zig").Inspector;
 const CoreSurface = @import("../Surface.zig");
@@ -2652,6 +2653,9 @@ pub const CAPI = struct {
         var cursor_visible = false;
         var cursor_blinking = false;
         var cursor_style: terminal.CursorStyle = .block;
+        const cursor_cell_width: u32 = 1;
+        const cursor_opacity_out: f64 = 1;
+        const cursor_text_color: terminal.color.RGB = .{ .r = 0, .g = 0, .b = 0 };
         var columns: u32 = 0;
         var rows: u32 = 0;
         var is_alternate = false;
@@ -2893,18 +2897,15 @@ pub const CAPI = struct {
         try jw.write(true);
 
         try jw.objectField("cursor");
-        try jw.beginObject();
-        try jw.objectField("row");
-        try jw.write(cursor_row orelse 0);
-        try jw.objectField("column");
-        try jw.write(cursor_column);
-        try jw.objectField("visible");
-        try jw.write(cursor_visible and cursor_row != null);
-        try jw.objectField("style");
-        try jw.write(cursorStyleName(cursor_style));
-        try jw.objectField("blinking");
-        try jw.write(cursor_blinking);
-        try jw.endObject();
+        try render_grid_json.writeCursor(&jw, .{
+            .row = cursor_row orelse 0,
+            .column = cursor_column,
+            .visible = cursor_visible and cursor_row != null,
+            .style = cursorStyleName(cursor_style),
+            .blinking = cursor_blinking,
+            .cell_width = cursor_cell_width,
+            .opacity = cursor_opacity_out,
+        });
 
         try jw.objectField("styles");
         try jw.beginArray();
@@ -3084,6 +3085,11 @@ pub const CAPI = struct {
             try jw.objectField("terminal_cursor_color");
             try writeRenderGridColor(&jw, c);
         }
+        try render_grid_json.writeCursorTextColor(&jw, .{
+            cursor_text_color.r,
+            cursor_text_color.g,
+            cursor_text_color.b,
+        });
 
         try jw.objectField("modes");
         try jw.beginArray();

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1977,6 +1977,14 @@ pub const CAPI = struct {
         };
     }
 
+    /// Return the exact PTY prefix already applied by the VT parser.
+    export fn ghostty_surface_output_sequence(surface: *Surface) u64 {
+        const core_surface = &surface.core_surface;
+        core_surface.renderer_state.lockDemand();
+        defer core_surface.renderer_state.unlockDemand();
+        return core_surface.io.pty_output_seq;
+    }
+
     /// Read current scrollbar geometry and its absolute row-space identity
     /// directly from the terminal, independent of renderer publication.
     export fn ghostty_surface_scrollbar(
@@ -2038,6 +2046,7 @@ pub const CAPI = struct {
         invisible: bool = false,
         strikethrough: bool = false,
         overline: bool = false,
+        foreground_opacity: f64 = 1,
 
         fn visualEql(self: RenderGridStyle, other: RenderGridStyle) bool {
             return self.foreground.eql(other.foreground) and
@@ -2050,7 +2059,8 @@ pub const CAPI = struct {
                 self.inverse == other.inverse and
                 self.invisible == other.invisible and
                 self.strikethrough == other.strikethrough and
-                self.overline == other.overline;
+                self.overline == other.overline and
+                self.foreground_opacity == other.foreground_opacity;
         }
     };
 
@@ -2169,6 +2179,7 @@ pub const CAPI = struct {
         background: terminal.color.RGB,
         palette: *const terminal.color.Palette,
         bold_color: ?terminal.Style.BoldColor,
+        faint_opacity: f64,
     ) RenderGridStyle {
         const style: terminal.Style = if (cell.style_id == terminal_style.default_id)
             .{}
@@ -2191,6 +2202,7 @@ pub const CAPI = struct {
             .invisible = style.flags.invisible,
             .strikethrough = style.flags.strikethrough,
             .overline = style.flags.overline,
+            .foreground_opacity = if (style.flags.faint) faint_opacity else 1,
         };
     }
 
@@ -2211,6 +2223,67 @@ pub const CAPI = struct {
 
     fn renderGridCellNeedsOwnSpan(cell: *const terminal.Cell) bool {
         return cell.gridWidth() != 1 or cell.hasGrapheme();
+    }
+
+    fn appendRenderGridRow(
+        alloc: Allocator,
+        builder: *RenderGridSpanBuilder,
+        row_pin: terminal.Pin,
+        out_row: u32,
+        styles: *std.ArrayListUnmanaged(RenderGridStyle),
+        foreground: terminal.color.RGB,
+        background: terminal.color.RGB,
+        palette: *const terminal.color.Palette,
+        bold_color: ?terminal.Style.BoldColor,
+        faint_opacity: f64,
+        preserved_node: *?*terminal.PageList.List.Node,
+        preserved_page: *?terminal.PageList.List.Node.PreservedPage,
+    ) !void {
+        // Render-grid snapshots must not make compressed scrollback resident
+        // again. Decode each compressed node once and reuse it for its rows.
+        if (preserved_node.* != row_pin.node) {
+            const next_page = try row_pin.node.pagePreservingState(alloc);
+            if (preserved_page.*) |*page_| page_.deinit();
+            preserved_page.* = next_page;
+            preserved_node.* = row_pin.node;
+        }
+        const p = if (preserved_page.*) |*page_| page_.page() else unreachable;
+        const page_rac = p.getRowAndCell(row_pin.x, row_pin.y);
+        const page_cells: []const terminal.Cell = p.getCells(page_rac.row);
+        for (page_cells, 0..) |*cell, x| {
+            if (cell.wide == .spacer_tail) continue;
+
+            const style = resolvedRenderGridStyle(
+                p,
+                cell,
+                foreground,
+                background,
+                palette,
+                bold_color,
+                faint_opacity,
+            );
+            const has_text = cell.hasText();
+            const style_id = try renderGridStyleID(styles, style);
+            const is_default_blank = !has_text and style_id == 0;
+            if (is_default_blank) {
+                try builder.close();
+                continue;
+            }
+
+            const owns_span = has_text and renderGridCellNeedsOwnSpan(cell);
+            if (owns_span) try builder.close();
+            try builder.ensure(out_row, @intCast(x), style_id);
+            if (has_text) {
+                try appendRenderGridCellText(builder, p, cell);
+                builder.appendCellWidth(@intCast(cell.gridWidth()));
+            } else {
+                try builder.text.writer.writeByte(' ');
+                builder.appendCellWidth(1);
+            }
+            if (owns_span) try builder.close();
+        }
+        try builder.close();
+        return;
     }
 
     fn writeRenderGridColor(
@@ -2241,7 +2314,6 @@ pub const CAPI = struct {
     fn buildRenderGridJson(
         surface: *Surface,
         surface_id: []const u8,
-        state_seq: u64,
         scrollback_lines: usize,
     ) !String {
         const alloc = global.alloc;
@@ -2268,13 +2340,17 @@ pub const CAPI = struct {
         var cursor_visible = false;
         var cursor_blinking = false;
         var cursor_style: terminal.CursorStyle = .block;
+        var cursor_cell_width: u32 = 1;
+        var cursor_opacity: f64 = 1;
         var columns: u32 = 0;
         var rows: u32 = 0;
         var is_alternate = false;
         var fg_override: ?terminal.color.RGB = null;
         var bg_override: ?terminal.color.RGB = null;
         var cursor_color_override: ?terminal.color.RGB = null;
+        var cursor_text_color: terminal.color.RGB = .{ .r = 0, .g = 0, .b = 0 };
         var scrollback_rows: u32 = 0;
+        var state_seq: u64 = 0;
 
         {
             core_surface.renderer_state.mutex.lock();
@@ -2285,21 +2361,95 @@ pub const CAPI = struct {
             const palette = &t.colors.palette.current;
             var background = t.colors.background.get() orelse core_surface.renderer.config.background;
             var foreground = t.colors.foreground.get() orelse core_surface.renderer.config.foreground;
-            if (t.modes.get(.reverse_colors)) {
+            const reverse_colors = t.modes.get(.reverse_colors);
+            if (reverse_colors) {
                 std.mem.swap(terminal.color.RGB, &background, &foreground);
             }
 
             columns = @intCast(s.pages.cols);
             rows = @intCast(s.pages.rows);
             cursor_column = @intCast(@min(s.cursor.x, s.pages.cols - 1));
+            switch (s.cursor.page_cell.wide) {
+                .wide => cursor_cell_width = 2,
+                .spacer_tail => {
+                    cursor_column -|= 1;
+                    cursor_cell_width = 2;
+                },
+                .narrow, .spacer_head => cursor_cell_width = 1,
+            }
+            cursor_opacity = if (core_surface.focused)
+                @ceil(core_surface.renderer.config.cursor_opacity * 255.0) / 255.0
+            else
+                1;
             cursor_visible = t.modes.get(.cursor_visible);
             cursor_blinking = t.modes.get(.cursor_blinking);
             cursor_style = s.cursor.cursor_style;
             is_alternate = t.screens.active_key == .alternate;
             fg_override = t.colors.foreground.override;
             bg_override = t.colors.background.override;
-            cursor_color_override = t.colors.cursor.override;
-
+            cursor_color_override = cursor_color: {
+                if (t.colors.cursor.get()) |value| break :cursor_color value;
+                if (core_surface.renderer.config.cursor_color) |value| switch (value) {
+                    .color => |color| break :cursor_color color.toTerminalRGB(),
+                    inline .@"cell-foreground", .@"cell-background" => |_, tag| {
+                        const cursor_cell_style = s.cursor.style;
+                        const cell_foreground = cursor_cell_style.fg(.{
+                            .default = foreground,
+                            .palette = palette,
+                            .bold = bold_color,
+                        });
+                        const cell_background = cursor_cell_style.bg(
+                            s.cursor.page_cell,
+                            palette,
+                        ) orelse background;
+                        break :cursor_color switch (tag) {
+                            .color => unreachable,
+                            .@"cell-foreground" => if (cursor_cell_style.flags.inverse)
+                                cell_background
+                            else
+                                cell_foreground,
+                            .@"cell-background" => if (cursor_cell_style.flags.inverse)
+                                cell_foreground
+                            else
+                                cell_background,
+                        };
+                    },
+                };
+                break :cursor_color foreground;
+            };
+            cursor_text_color = cursor_text: {
+                const cursor_cell_style = s.cursor.style;
+                const cell_foreground = cursor_cell_style.fg(.{
+                    .default = foreground,
+                    .palette = palette,
+                    .bold = bold_color,
+                });
+                const cell_background = cursor_cell_style.bg(
+                    s.cursor.page_cell,
+                    palette,
+                ) orelse background;
+                if (core_surface.renderer.config.cursor_text) |value| switch (value) {
+                    .color => |color| break :cursor_text color.toTerminalRGB(),
+                    inline .@"cell-foreground", .@"cell-background" => |_, tag| {
+                        break :cursor_text switch (tag) {
+                            .color => unreachable,
+                            .@"cell-foreground" => if (cursor_cell_style.flags.inverse)
+                                cell_background
+                            else
+                                cell_foreground,
+                            .@"cell-background" => if (cursor_cell_style.flags.inverse)
+                                cell_foreground
+                            else
+                                cell_background,
+                        };
+                    },
+                };
+                break :cursor_text background;
+            };
+            // This sequence is advanced only after each VT chunk has been
+            // parsed, under this same renderer-state mutex. The snapshot and
+            // its coverage stamp therefore describe one atomic terminal state.
+            state_seq = core_surface.io.pty_output_seq;
             // Capture every non-default-handled DEC/ANSI mode so the client can
             // restore mouse tracking, bracketed paste, application keys, origin,
             // autowrap, etc. exactly.
@@ -2321,12 +2471,15 @@ pub const CAPI = struct {
                 .background = background,
             };
             try styles.append(alloc, default_style);
+            const faint_opacity = @as(
+                f64,
+                @floatFromInt(core_surface.renderer.config.faint_opacity),
+            ) / 255.0;
 
             var vp_builder = RenderGridSpanBuilder.init(alloc, &spans);
             defer vp_builder.deinit();
             var sb_builder = RenderGridSpanBuilder.init(alloc, &scrollback_spans);
             defer sb_builder.deinit();
-
             // Iterate the (bounded) scrollback above the viewport plus the
             // viewport itself in one pass. The alternate screen has no
             // scrollback, so `up` clamps to the viewport top and no scrollback
@@ -2357,52 +2510,20 @@ pub const CAPI = struct {
                     cursor_row = vp_y;
                 }
 
-                // Render-grid snapshots must not make compressed scrollback
-                // resident again. Decode each compressed node once into a
-                // temporary page and reuse it for every row from that node.
-                if (preserved_node != row_pin.node) {
-                    const next_page = try row_pin.node.pagePreservingState(alloc);
-                    if (preserved_page) |*page_| page_.deinit();
-                    preserved_page = next_page;
-                    preserved_node = row_pin.node;
-                }
-                const p = if (preserved_page) |*page_| page_.page() else unreachable;
-                const page_rac = p.getRowAndCell(row_pin.x, row_pin.y);
-                const page_cells: []const terminal.Cell = p.getCells(page_rac.row);
-                for (page_cells, 0..) |*cell, x| {
-                    if (cell.wide == .spacer_tail) {
-                        continue;
-                    }
-
-                    const style = resolvedRenderGridStyle(
-                        p,
-                        cell,
-                        foreground,
-                        background,
-                        palette,
-                        bold_color,
-                    );
-                    const has_text = cell.hasText();
-                    const style_id = try renderGridStyleID(&styles, style);
-                    const is_default_blank = !has_text and style_id == 0;
-                    if (is_default_blank) {
-                        try builder.close();
-                        continue;
-                    }
-
-                    const owns_span = has_text and renderGridCellNeedsOwnSpan(cell);
-                    if (owns_span) try builder.close();
-                    try builder.ensure(out_row, @intCast(x), style_id);
-                    if (has_text) {
-                        try appendRenderGridCellText(builder, p, cell);
-                        builder.appendCellWidth(@intCast(cell.gridWidth()));
-                    } else {
-                        try builder.text.writer.writeByte(' ');
-                        builder.appendCellWidth(1);
-                    }
-                    if (owns_span) try builder.close();
-                }
-                try builder.close();
+                try appendRenderGridRow(
+                    alloc,
+                    builder,
+                    row_pin,
+                    out_row,
+                    &styles,
+                    foreground,
+                    background,
+                    palette,
+                    bold_color,
+                    faint_opacity,
+                    &preserved_node,
+                    &preserved_page,
+                );
                 if (in_viewport) {
                     vp_y += 1;
                 } else {
@@ -2444,6 +2565,10 @@ pub const CAPI = struct {
         try jw.write(cursorStyleName(cursor_style));
         try jw.objectField("blinking");
         try jw.write(cursor_blinking);
+        try jw.objectField("cell_width");
+        try jw.write(cursor_cell_width);
+        try jw.objectField("opacity");
+        try jw.write(cursor_opacity);
         try jw.endObject();
 
         try jw.objectField("styles");
@@ -2474,6 +2599,8 @@ pub const CAPI = struct {
             try jw.write(style.strikethrough);
             try jw.objectField("overline");
             try jw.write(style.overline);
+            try jw.objectField("foreground_opacity");
+            try jw.write(style.foreground_opacity);
             try jw.endObject();
         }
         try jw.endArray();
@@ -2511,6 +2638,8 @@ pub const CAPI = struct {
             try jw.objectField("terminal_cursor_color");
             try writeRenderGridColor(&jw, c);
         }
+        try jw.objectField("terminal_cursor_text_color");
+        try writeRenderGridColor(&jw, cursor_text_color);
 
         try jw.objectField("modes");
         try jw.beginArray();
@@ -2560,13 +2689,11 @@ pub const CAPI = struct {
         surface: *Surface,
         surface_id_ptr: [*]const u8,
         surface_id_len: usize,
-        state_seq: u64,
         scrollback_lines: usize,
     ) String {
         return buildRenderGridJson(
             surface,
             surface_id_ptr[0..surface_id_len],
-            state_seq,
             scrollback_lines,
         ) catch |err| {
             log.warn("error exporting render grid err={}", .{err});
@@ -2717,8 +2844,9 @@ pub const CAPI = struct {
         surface.core_surface.io.processOutput(ptr[0..len]);
     }
 
-    /// Install a callback that fires on every PTY-output byte slice
-    /// before the VT parser sees it. Pass `cb = null` to clear.
+    /// Install a callback that fires after every PTY-output byte slice has
+    /// reached the VT parser. Pass `cb = null` to clear. The callback receives
+    /// the parser-applied chunk's start sequence.
     ///
     /// The callback runs on the IO read thread (or whoever calls
     /// `ghostty_surface_process_output`). The embedder owns thread
@@ -2734,7 +2862,7 @@ pub const CAPI = struct {
     /// matching grid. Upstream candidate.
     export fn ghostty_surface_set_pty_tee_cb(
         surface: *Surface,
-        cb: ?*const fn (?*anyopaque, [*]const u8, usize) callconv(.c) void,
+        cb: ?*const fn (?*anyopaque, [*]const u8, usize, u64) callconv(.c) void,
         userdata: ?*anyopaque,
     ) void {
         surface.core_surface.io.pty_tee_cb = cb;

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -435,6 +435,13 @@ pub const RenderGridStatus = enum(c_int) {
     failure = 2,
 };
 
+test "ghostty.h render presentation status" {
+    try renderer.lib.checkGhosttyHEnum(
+        RenderPresentationStatus,
+        "GHOSTTY_RENDER_PRESENTATION_",
+    );
+}
+
 fn renderGridGateStatus(
     pty_output_in_progress: bool,
     parser_quiescent: bool,

--- a/src/apprt/render_grid_json.zig
+++ b/src/apprt/render_grid_json.zig
@@ -1,0 +1,65 @@
+const std = @import("std");
+
+pub const Cursor = struct {
+    row: u32,
+    column: u32,
+    visible: bool,
+    style: []const u8,
+    blinking: bool,
+    cell_width: u32,
+    opacity: f64,
+};
+
+pub fn writeCursor(jw: *std.json.Stringify, cursor: Cursor) !void {
+    try jw.beginObject();
+    try jw.objectField("row");
+    try jw.write(cursor.row);
+    try jw.objectField("column");
+    try jw.write(cursor.column);
+    try jw.objectField("visible");
+    try jw.write(cursor.visible);
+    try jw.objectField("style");
+    try jw.write(cursor.style);
+    try jw.objectField("blinking");
+    try jw.write(cursor.blinking);
+    try jw.endObject();
+}
+
+pub fn writeCursorTextColor(jw: *std.json.Stringify, color: [3]u8) !void {
+    _ = jw;
+    _ = color;
+}
+
+fn fixtureJson(cursor: Cursor, cursor_text_color: [3]u8) ![]u8 {
+    var buf: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    errdefer buf.deinit();
+    var jw: std.json.Stringify = .{ .writer = &buf.writer };
+    try jw.beginObject();
+    try jw.objectField("cursor");
+    try writeCursor(&jw, cursor);
+    try writeCursorTextColor(&jw, cursor_text_color);
+    try jw.endObject();
+    return try buf.toOwnedSlice();
+}
+
+test "render grid cursor JSON includes width opacity and text color" {
+    const json = try fixtureJson(
+        .{
+            .row = 2,
+            .column = 3,
+            .visible = true,
+            .style = "block",
+            .blinking = false,
+            .cell_width = 2,
+            .opacity = 0.5,
+        },
+        .{ 17, 34, 51 },
+    );
+    defer std.testing.allocator.free(json);
+
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"cell_width\":2") != null);
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"opacity\":0.5") != null);
+    try std.testing.expect(
+        std.mem.indexOf(u8, json, "\"terminal_cursor_text_color\":\"#112233\"") != null,
+    );
+}

--- a/src/apprt/render_grid_json.zig
+++ b/src/apprt/render_grid_json.zig
@@ -22,12 +22,26 @@ pub fn writeCursor(jw: *std.json.Stringify, cursor: Cursor) !void {
     try jw.write(cursor.style);
     try jw.objectField("blinking");
     try jw.write(cursor.blinking);
+    try jw.objectField("cell_width");
+    try jw.write(cursor.cell_width);
+    try jw.objectField("opacity");
+    try jw.write(cursor.opacity);
     try jw.endObject();
 }
 
 pub fn writeCursorTextColor(jw: *std.json.Stringify, color: [3]u8) !void {
-    _ = jw;
-    _ = color;
+    const digits = "0123456789ABCDEF";
+    var value: [7]u8 = undefined;
+    value[0] = '#';
+    value[1] = digits[color[0] >> 4];
+    value[2] = digits[color[0] & 0x0F];
+    value[3] = digits[color[1] >> 4];
+    value[4] = digits[color[1] & 0x0F];
+    value[5] = digits[color[2] >> 4];
+    value[6] = digits[color[2] & 0x0F];
+
+    try jw.objectField("terminal_cursor_text_color");
+    try jw.write(value[0..]);
 }
 
 fn fixtureJson(cursor: Cursor, cursor_text_color: [3]u8) ![]u8 {

--- a/src/apprt/render_grid_json.zig
+++ b/src/apprt/render_grid_json.zig
@@ -52,7 +52,7 @@ pub fn writeCursorTextColor(jw: *std.json.Stringify, color: [3]u8) !void {
 }
 
 pub fn cursorCellStyle(cursor: anytype) @TypeOf(cursor.style) {
-    return cursor.style;
+    return cursor.page_pin.style(cursor.page_cell);
 }
 
 fn fixtureJson(cursor: Cursor, cursor_text_color: [3]u8) ![]u8 {

--- a/src/apprt/render_grid_json.zig
+++ b/src/apprt/render_grid_json.zig
@@ -51,6 +51,10 @@ pub fn writeCursorTextColor(jw: *std.json.Stringify, color: [3]u8) !void {
     try jw.write(value[0..]);
 }
 
+pub fn cursorCellStyle(cursor: anytype) @TypeOf(cursor.style) {
+    return cursor.style;
+}
+
 fn fixtureJson(cursor: Cursor, cursor_text_color: [3]u8) ![]u8 {
     var buf: std.Io.Writer.Allocating = .init(std.testing.allocator);
     errdefer buf.deinit();
@@ -87,4 +91,22 @@ test "render grid cursor JSON includes width opacity and text color" {
 
 test "ghostty.h render grid status" {
     try lib.checkGhosttyHEnum(Status, "GHOSTTY_RENDER_GRID_");
+}
+
+test "render grid cursor colors use stored cell style" {
+    const Style = enum { active_pen, stored_cell };
+    const Cell = struct {};
+    const Pin = struct {
+        fn style(_: @This(), _: *const Cell) Style {
+            return .stored_cell;
+        }
+    };
+    const cell: Cell = .{};
+    const cursor = .{
+        .style = Style.active_pen,
+        .page_pin = Pin{},
+        .page_cell = &cell,
+    };
+
+    try std.testing.expectEqual(Style.stored_cell, cursorCellStyle(cursor));
 }

--- a/src/apprt/render_grid_json.zig
+++ b/src/apprt/render_grid_json.zig
@@ -1,4 +1,11 @@
 const std = @import("std");
+const lib = @import("../lib/main.zig");
+
+pub const Status = enum(c_int) {
+    success = 0,
+    retryable_not_quiescent = 1,
+    failure = 2,
+};
 
 pub const Cursor = struct {
     row: u32,
@@ -76,4 +83,8 @@ test "render grid cursor JSON includes width opacity and text color" {
     try std.testing.expect(
         std.mem.indexOf(u8, json, "\"terminal_cursor_text_color\":\"#112233\"") != null,
     );
+}
+
+test "ghostty.h render grid status" {
+    try lib.checkGhosttyHEnum(Status, "GHOSTTY_RENDER_GRID_");
 }

--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -11,6 +11,7 @@ const build_config = @import("build_config.zig");
 
 const cursor = @import("renderer/cursor.zig");
 const instrumentation = @import("renderer/instrumentation.zig");
+const presentation = @import("renderer/presentation.zig");
 const message = @import("renderer/message.zig");
 const size = @import("renderer/size.zig");
 pub const shadertoy = @import("renderer/shadertoy.zig");
@@ -27,6 +28,8 @@ pub const CursorStyle = cursor.Style;
 pub const Instrumentation = instrumentation.Instrumentation;
 pub const InstrumentationCallback = instrumentation.Callback;
 pub const InstrumentationEvent = instrumentation.Event;
+pub const RenderPresentationStatus = presentation.Status;
+pub const RenderPresentationCallback = presentation.Callback;
 pub const Message = message.Message;
 pub const Size = size.Size;
 pub const Coordinate = size.Coordinate;
@@ -63,6 +66,7 @@ test {
 
     _ = cursor;
     _ = instrumentation;
+    _ = presentation;
     _ = message;
     _ = shadertoy;
     _ = size;

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -164,18 +164,17 @@ pub fn deinit(self: *Metal) void {
     self.layer.release();
 }
 
-pub fn prepareDeinit(self: *Metal) void {
-    switch (comptime builtin.os.tag) {
-        .ios => {
-            const renderer: *align(1) Renderer = @fieldParentPtr("api", self);
-            self.layer.detachFromHostIfDisplayCallbackOwned(
-                @ptrCast(&displayCallback),
-                @ptrCast(renderer),
-            );
-        },
+fn prepareDeinitClearsLayerCallbacks(os_tag: std.Target.Os.Tag) bool {
+    return os_tag == .ios;
+}
 
-        else => {},
-    }
+pub fn prepareDeinit(self: *Metal) void {
+    if (!prepareDeinitClearsLayerCallbacks(comptime builtin.os.tag)) return;
+    const renderer: *align(1) Renderer = @fieldParentPtr("api", self);
+    self.layer.detachFromHostIfDisplayCallbackOwned(
+        @ptrCast(&displayCallback),
+        @ptrCast(renderer),
+    );
 }
 
 pub fn loopEnter(self: *Metal) void {
@@ -504,4 +503,9 @@ fn queryMaxTextureSize(device: objc.Object) u32 {
     )) return 16384;
 
     return 8192;
+}
+
+test "Metal prepareDeinit clears callbacks on macOS" {
+    try std.testing.expect(prepareDeinitClearsLayerCallbacks(.macos));
+    try std.testing.expect(prepareDeinitClearsLayerCallbacks(.ios));
 }

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -295,6 +295,10 @@ pub fn beginPresentation(self: *Metal, ticket: u64) void {
     self.layer.beginPresentation(ticket);
 }
 
+pub fn invalidatePresentationThrough(self: *Metal, ticket: u64) void {
+    self.layer.invalidatePresentationThrough(ticket);
+}
+
 /// Present the last presented target again. (noop for Metal)
 pub inline fn presentLastTarget(self: *Metal) !void {
     _ = self;

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -165,7 +165,10 @@ pub fn deinit(self: *Metal) void {
 }
 
 fn prepareDeinitClearsLayerCallbacks(os_tag: std.Target.Os.Tag) bool {
-    return os_tag == .ios;
+    return switch (os_tag) {
+        .macos, .ios => true,
+        else => false,
+    };
 }
 
 pub fn prepareDeinit(self: *Metal) void {

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -108,7 +108,10 @@ pub fn init(alloc: Allocator, opts: rendererpkg.Options) !Metal {
     // Create an IOSurfaceLayer which we can assign to the view to make
     // it in to a "layer-hosting view", so that we can manually control
     // the layer contents.
-    var layer = try IOSurfaceLayer.init();
+    var layer = try IOSurfaceLayer.init(
+        opts.rt_surface.render_presentation_cb,
+        opts.rt_surface.userdata,
+    );
     errdefer layer.release();
 
     // Add our layer to the view.
@@ -264,12 +267,32 @@ pub fn initTarget(self: *const Metal, width: usize, height: usize) !Target {
 }
 
 /// Present the provided target.
-pub inline fn present(self: *Metal, target: Target, sync: bool) !void {
-    if (sync) {
+pub inline fn present(
+    self: *Metal,
+    target: Target,
+    sync: bool,
+    presentation_ticket: ?u64,
+) !void {
+    // Ticketed presentation must pass through the main-queue size gate where
+    // the exact visible outcome is known. The unticketed synchronous macOS
+    // path retains its existing direct assignment.
+    if (sync and presentation_ticket == null) {
         self.layer.setSurfaceSync(target.surface);
     } else {
-        try self.layer.setSurface(target.surface);
+        try self.layer.setSurface(target.surface, presentation_ticket);
     }
+}
+
+pub fn completePresentation(
+    self: *Metal,
+    ticket: u64,
+    status: rendererpkg.RenderPresentationStatus,
+) void {
+    self.layer.completePresentation(ticket, status);
+}
+
+pub fn beginPresentation(self: *Metal, ticket: u64) void {
+    self.layer.beginPresentation(ticket);
 }
 
 /// Present the last presented target again. (noop for Metal)
@@ -417,8 +440,16 @@ pub inline fn beginFrame(
     renderer: *Renderer,
     /// The target is presented via the provided renderer's API when completed.
     target: *Target,
+    presentation_ticket: ?u64,
 ) !Frame {
-    return try Frame.begin(.{ .queue = self.queue }, renderer, target);
+    return try Frame.begin(
+        .{
+            .queue = self.queue,
+            .presentation_ticket = presentation_ticket,
+        },
+        renderer,
+        target,
+    );
 }
 
 fn chooseDevice() error{NoMetalDevice}!objc.Object {

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -346,6 +346,11 @@ pub fn beginPresentation(self: *OpenGL, ticket: u64) void {
     _ = ticket;
 }
 
+pub fn invalidatePresentationThrough(self: *OpenGL, ticket: u64) void {
+    _ = self;
+    _ = ticket;
+}
+
 /// Present the last presented target again.
 pub fn presentLastTarget(self: *OpenGL) !void {
     if (self.last_target) |target| try self.present(target);

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -330,6 +330,22 @@ pub fn present(self: *OpenGL, target: Target) !void {
     self.last_target = target;
 }
 
+/// Exact presentation tickets are currently an embedded Metal-only contract.
+pub fn completePresentation(
+    self: *OpenGL,
+    ticket: u64,
+    status: rendererpkg.RenderPresentationStatus,
+) void {
+    _ = self;
+    _ = ticket;
+    _ = status;
+}
+
+pub fn beginPresentation(self: *OpenGL, ticket: u64) void {
+    _ = self;
+    _ = ticket;
+}
+
 /// Present the last presented target again.
 pub fn presentLastTarget(self: *OpenGL) !void {
     if (self.last_target) |target| try self.present(target);
@@ -455,7 +471,9 @@ pub inline fn beginFrame(
     renderer: *Renderer,
     /// The target is presented via the provided renderer's API when completed.
     target: *Target,
+    presentation_ticket: ?u64,
 ) !Frame {
     _ = self;
+    _ = presentation_ticket;
     return try Frame.begin(.{}, renderer, target);
 }

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -445,6 +445,13 @@ pub fn renderNowWithTicket(self: *Thread, ticket: u64) void {
     self.renderNowWithOptionalTicket(ticket);
 }
 
+/// Install a synchronous host-layer floor for queued presentation work. This
+/// is called by embedders at lifecycle boundaries while renderer work may still
+/// have main-queue begin/set-surface callbacks pending.
+pub fn invalidatePresentationThrough(self: *Thread, ticket: u64) void {
+    self.renderer.api.invalidatePresentationThrough(ticket);
+}
+
 fn renderNowWithOptionalTicket(self: *Thread, ticket: ?u64) void {
     if (ticket) |value| self.renderer.api.beginPresentation(value);
     self.enterExternalDrainMode();

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -438,6 +438,15 @@ pub fn deinit(self: *Thread) void {
 /// cmux fork: iOS drives frames from a platform display callback. Delete this
 /// when upstream exposes a synchronous embedder render tick.
 pub fn renderNow(self: *Thread) void {
+    self.renderNowWithOptionalTicket(null);
+}
+
+pub fn renderNowWithTicket(self: *Thread, ticket: u64) void {
+    self.renderNowWithOptionalTicket(ticket);
+}
+
+fn renderNowWithOptionalTicket(self: *Thread, ticket: ?u64) void {
+    if (ticket) |value| self.renderer.api.beginPresentation(value);
     self.enterExternalDrainMode();
     _ = self.drainMailbox() catch |err| fallback: {
         log.err("renderNow: error draining mailbox err={}", .{err});
@@ -448,10 +457,20 @@ pub fn renderNow(self: *Thread) void {
 
     self.updateFrame(self.effectiveCursorBlinkVisible()) catch |err| {
         log.warn("renderNow: error updating frame err={}", .{err});
+        if (ticket) |value| self.renderer.api.completePresentation(
+            value,
+            .backend_failed,
+        );
         return;
     };
 
-    _ = self.drawFrame(true);
+    const result = self.drawFrameWithPresentationTicket(true, ticket);
+    if (result != .submitted) {
+        if (ticket) |value| self.renderer.api.completePresentation(
+            value,
+            .backend_failed,
+        );
+    }
 }
 
 /// Drain the renderer mailbox once, applying every queued message.
@@ -895,6 +914,14 @@ fn renderWakeFrame(self: *Thread) void {
 /// Trigger a draw. This will not update frame data or anything, it will
 /// just trigger a draw/paint.
 fn drawFrame(self: *Thread, now: bool) DrawFrameResult {
+    return self.drawFrameWithPresentationTicket(now, null);
+}
+
+fn drawFrameWithPresentationTicket(
+    self: *Thread,
+    now: bool,
+    presentation_ticket: ?u64,
+) DrawFrameResult {
     // If we're invisible, we do not draw.
     //
     // cmux iOS fork: skip this early-return on iOS. The iOS embedder owns
@@ -933,7 +960,10 @@ fn drawFrame(self: *Thread, now: bool) DrawFrameResult {
         self.instrumentation.emit(.draw_frame_begin);
         defer self.instrumentation.emit(.draw_frame_end);
 
-        self.renderer.drawFrame(false) catch |err| {
+        self.renderer.drawFrameWithPresentationTicket(
+            false,
+            presentation_ticket,
+        ) catch |err| {
             switch (err) {
                 // cmux iOS fork: a bounded frame-state acquire timed out under GPU
                 // backpressure; the frame is SKIPPED and the display link

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -1541,6 +1541,16 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             self: *Self,
             sync: bool,
         ) !void {
+            return self.drawFrameWithPresentationTicket(sync, null);
+        }
+
+        /// Draw one frame carrying an exact embedder ticket to the graphics
+        /// presentation boundary. A null ticket preserves the normal path.
+        pub fn drawFrameWithPresentationTicket(
+            self: *Self,
+            sync: bool,
+            presentation_ticket: ?u64,
+        ) !void {
             // const start = std.time.Instant.now() catch unreachable;
             // const start_micro = std.time.microTimestamp();
             // defer {
@@ -1576,7 +1586,13 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
 
             // If either of our surface dimensions is zero
             // then drawing is absurd, so we just return.
-            if (surface_size.width == 0 or surface_size.height == 0) return;
+            if (surface_size.width == 0 or surface_size.height == 0) {
+                if (presentation_ticket) |ticket| self.api.completePresentation(
+                    ticket,
+                    .backend_failed,
+                );
+                return;
+            }
 
             const size_changed =
                 self.size.screen.width != surface_size.width or
@@ -1697,7 +1713,11 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             }
 
             // Get a frame context from the graphics API.
-            var frame_ctx = try self.api.beginFrame(self, &frame.target);
+            var frame_ctx = try self.api.beginFrame(
+                self,
+                &frame.target,
+                presentation_ticket,
+            );
             defer frame_ctx.complete(sync);
 
             {

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -64,6 +64,17 @@ const DrawDamageCommit = struct {
     }
 };
 
+fn frameNeedsRedraw(
+    size_changed: bool,
+    cells_rebuilt: bool,
+    has_animations: bool,
+    sync: bool,
+    has_presentation_ticket: bool,
+) bool {
+    _ = has_presentation_ticket;
+    return size_changed or cells_rebuilt or has_animations or sync;
+}
+
 fn advanceShaperCellIndexToX(
     run_offset: usize,
     shaped_cells: []const font.shape.Cell,
@@ -1600,11 +1611,13 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
 
             // Conditions under which we need to draw the frame, otherwise we
             // don't need to since the previous frame should be identical.
-            const needs_redraw =
-                size_changed or
-                self.cells_rebuilt or
-                self.hasAnimations() or
-                sync;
+            const needs_redraw = frameNeedsRedraw(
+                size_changed,
+                self.cells_rebuilt,
+                self.hasAnimations(),
+                sync,
+                presentation_ticket != null,
+            );
 
             if (!needs_redraw) {
                 // We still need to present the last target again, because the
@@ -3580,4 +3593,14 @@ test "prepared frame damage remains retryable until draw commit" {
         damage.commit();
     }
     try std.testing.expect(!cells_rebuilt);
+}
+
+test "presentation ticket forces a frame without ordinary redraw damage" {
+    try std.testing.expect(frameNeedsRedraw(
+        false,
+        false,
+        false,
+        false,
+        true,
+    ));
 }

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -71,8 +71,11 @@ fn frameNeedsRedraw(
     sync: bool,
     has_presentation_ticket: bool,
 ) bool {
-    _ = has_presentation_ticket;
-    return size_changed or cells_rebuilt or has_animations or sync;
+    return size_changed or
+        cells_rebuilt or
+        has_animations or
+        sync or
+        has_presentation_ticket;
 }
 
 fn advanceShaperCellIndexToX(

--- a/src/renderer/metal/Frame.zig
+++ b/src/renderer/metal/Frame.zig
@@ -20,6 +20,7 @@ const log = std.log.scoped(.metal);
 pub const Options = struct {
     /// MTLCommandQueue
     queue: objc.Object,
+    presentation_ticket: ?u64,
 };
 
 /// MTLCommandBuffer
@@ -49,6 +50,8 @@ pub fn begin(
             .renderer = renderer,
             .target = target,
             .sync = false,
+            .presentation_ticket = opts.presentation_ticket orelse 0,
+            .has_presentation_ticket = opts.presentation_ticket != null,
         },
         &bufferCompleted,
     );
@@ -61,6 +64,8 @@ const CompletionBlock = objc.Block(struct {
     renderer: *Renderer,
     target: *Target,
     sync: bool,
+    presentation_ticket: u64,
+    has_presentation_ticket: bool,
 }, .{
     objc.c.id, // MTLCommandBuffer
 }, void);
@@ -83,9 +88,24 @@ fn bufferCompleted(
         block.renderer.api.present(
             block.target.*,
             block.sync,
+            if (block.has_presentation_ticket)
+                block.presentation_ticket
+            else
+                null,
         ) catch |err| {
             log.err("Failed to present render target: err={}", .{err});
+            if (block.has_presentation_ticket) {
+                block.renderer.api.completePresentation(
+                    block.presentation_ticket,
+                    .backend_failed,
+                );
+            }
         };
+    } else if (block.has_presentation_ticket) {
+        block.renderer.api.completePresentation(
+            block.presentation_ticket,
+            .backend_failed,
+        );
     }
 
     block.renderer.frameCompleted(health);

--- a/src/renderer/metal/IOSurfaceLayer.zig
+++ b/src/renderer/metal/IOSurfaceLayer.zig
@@ -6,6 +6,7 @@ const std = @import("std");
 const Allocator = std.mem.Allocator;
 const objc = @import("objc");
 const macos = @import("macos");
+const presentation = @import("../presentation.zig");
 
 const IOSurface = macos.iosurface.IOSurface;
 
@@ -18,7 +19,10 @@ var Subclass: ?objc.Class = null;
 /// The underlying CALayer
 layer: objc.Object,
 
-pub fn init() !IOSurfaceLayer {
+pub fn init(
+    presentation_cb: ?presentation.Callback,
+    presentation_ctx: ?*anyopaque,
+) !IOSurfaceLayer {
     // The layer returned by `[CALayer layer]` is autoreleased, which means
     // that at the end of the current autorelease pool it will be deallocated
     // if it isn't retained, so we retain it here manually an extra time.
@@ -35,6 +39,16 @@ pub fn init() !IOSurfaceLayer {
 
     layer.setInstanceVariable("display_cb", .{ .value = null });
     layer.setInstanceVariable("display_ctx", .{ .value = null });
+    layer.setInstanceVariable(
+        "presentation_cb",
+        objc.Object.fromId(@constCast(presentation_cb)),
+    );
+    layer.setInstanceVariable(
+        "presentation_ctx",
+        objc.Object.fromId(presentation_ctx),
+    );
+    layer.setInstanceVariable("presentation_active", .{ .value = null });
+    layer.setInstanceVariable("presentation_ticket", .{ .value = null });
 
     return .{ .layer = layer };
 }
@@ -73,7 +87,11 @@ pub fn detachFromHostIfDisplayCallbackOwned(
 /// Sets the layer's `contents` to the provided IOSurface.
 ///
 /// Makes sure to do so on the main thread to avoid visual artifacts.
-pub inline fn setSurface(self: *IOSurfaceLayer, surface: *IOSurface) !void {
+pub inline fn setSurface(
+    self: *IOSurfaceLayer,
+    surface: *IOSurface,
+    ticket: ?u64,
+) !void {
     // We retain the surface to make sure it's not GC'd
     // before we can set it as the contents of the layer.
     //
@@ -86,6 +104,8 @@ pub inline fn setSurface(self: *IOSurfaceLayer, surface: *IOSurface) !void {
     var block = SetSurfaceBlock.init(.{
         .layer = self.layer.value,
         .surface = surface,
+        .ticket = ticket orelse 0,
+        .has_ticket = ticket != null,
     }, &setSurfaceCallback);
 
     // We check if we're on the main thread and run the block directly if so.
@@ -111,9 +131,67 @@ pub inline fn setSurfaceSync(self: *IOSurfaceLayer, surface: *IOSurface) void {
     self.layer.setProperty("contents", surface);
 }
 
+/// Install the current ticket on the main queue before its frame is submitted.
+/// A later ticket supersedes an older in-flight frame, so stale presentation
+/// callbacks cannot complete the newer terminal delivery.
+pub fn beginPresentation(self: *IOSurfaceLayer, ticket: u64) void {
+    var block = PresentationBeginBlock.init(.{
+        .layer = self.layer.value,
+        .ticket = ticket,
+    }, &presentationBeginCallback);
+
+    const NSThread = objc.getClass("NSThread").?;
+    if (NSThread.msgSend(bool, "isMainThread", .{})) {
+        presentationBeginCallback(&block);
+    } else {
+        macos.dispatch.dispatch_async(
+            @ptrCast(macos.dispatch.queue.getMain()),
+            @ptrCast(&block),
+        );
+    }
+}
+
+/// Report a ticket that failed before an IOSurface reached the layer. The
+/// callback is always read and invoked on the main queue, where teardown also
+/// clears it, so a queued completion cannot outlive its embedder userdata.
+pub fn completePresentation(
+    self: *IOSurfaceLayer,
+    ticket: u64,
+    status: presentation.Status,
+) void {
+    var block = PresentationBlock.init(.{
+        .layer = self.layer.value,
+        .ticket = ticket,
+        .status = status,
+    }, &presentationCallback);
+
+    const NSThread = objc.getClass("NSThread").?;
+    if (NSThread.msgSend(bool, "isMainThread", .{})) {
+        presentationCallback(&block);
+    } else {
+        macos.dispatch.dispatch_async(
+            @ptrCast(macos.dispatch.queue.getMain()),
+            @ptrCast(&block),
+        );
+    }
+}
+
 const SetSurfaceBlock = objc.Block(struct {
     layer: objc.c.id,
     surface: *IOSurface,
+    ticket: u64,
+    has_ticket: bool,
+}, .{}, void);
+
+const PresentationBlock = objc.Block(struct {
+    layer: objc.c.id,
+    ticket: u64,
+    status: presentation.Status,
+}, .{}, void);
+
+const PresentationBeginBlock = objc.Block(struct {
+    layer: objc.c.id,
+    ticket: u64,
 }, .{}, void);
 
 const DetachFromHostBlock = objc.Block(struct {
@@ -136,19 +214,79 @@ fn setSurfaceCallback(
     // asynchronously drawn frames can sometimes finish just after
     // a synchronously drawn frame during a resize, and if we don't
     // discard the improperly sized surface it creates jank.
-    const bounds = layer.getProperty(macos.graphics.Rect, "bounds");
-    const scale = layer.getProperty(f64, "contentsScale");
-    const width: usize = @intFromFloat(bounds.size.width * scale);
-    const height: usize = @intFromFloat(bounds.size.height * scale);
-    if (width != surface.getWidth() or height != surface.getHeight()) {
+    const status = presentationStatusForLayerAndSurface(layer, surface);
+    if (status == .wrong_size_discarded) {
+        const bounds = layer.getProperty(macos.graphics.Rect, "bounds");
+        const scale = layer.getProperty(f64, "contentsScale");
         log.debug(
             "setSurfaceCallback(): surface is wrong size for layer, discarding. surface = {d}x{d}, layer = {d}x{d}",
-            .{ surface.getWidth(), surface.getHeight(), width, height },
+            .{
+                surface.getWidth(),
+                surface.getHeight(),
+                @as(usize, @intFromFloat(bounds.size.width * scale)),
+                @as(usize, @intFromFloat(bounds.size.height * scale)),
+            },
+        );
+        if (block.has_ticket) notifyPresentation(
+            layer,
+            block.ticket,
+            .wrong_size_discarded,
         );
         return;
     }
 
     layer.setProperty("contents", surface);
+    if (block.has_ticket) notifyPresentation(layer, block.ticket, .presented);
+}
+
+fn presentationCallback(
+    block: *const PresentationBlock.Context,
+) callconv(.c) void {
+    notifyPresentation(
+        objc.Object.fromId(block.layer),
+        block.ticket,
+        block.status,
+    );
+}
+
+fn presentationBeginCallback(
+    block: *const PresentationBeginBlock.Context,
+) callconv(.c) void {
+    const layer = objc.Object.fromId(block.layer);
+    layer.setInstanceVariable(
+        "presentation_ticket",
+        objc.Object.fromId(@as(?*anyopaque, @ptrFromInt(block.ticket))),
+    );
+    layer.setInstanceVariable(
+        "presentation_active",
+        objc.Object.fromId(@as(?*anyopaque, @ptrFromInt(1))),
+    );
+}
+
+fn notifyPresentation(
+    layer: objc.Object,
+    ticket: u64,
+    status: presentation.Status,
+) void {
+    const active = layer.getInstanceVariable("presentation_active").value != null;
+    const active_ticket = @intFromPtr(
+        layer.getInstanceVariable("presentation_ticket").value,
+    );
+    if (!active or active_ticket != ticket) return;
+
+    // Clear before invoking foreign code so reentrancy cannot complete twice.
+    layer.setInstanceVariable("presentation_active", .{ .value = null });
+    layer.setInstanceVariable("presentation_ticket", .{ .value = null });
+
+    const callback: ?presentation.Callback = @ptrFromInt(@intFromPtr(
+        layer.getInstanceVariable("presentation_cb").value,
+    ));
+    const cb = callback orelse return;
+    cb(
+        @ptrCast(layer.getInstanceVariable("presentation_ctx").value),
+        ticket,
+        status,
+    );
 }
 
 fn detachFromHostCallback(
@@ -166,6 +304,10 @@ fn detachFromHostCallback(
 
     layer.setInstanceVariable("display_cb", .{ .value = null });
     layer.setInstanceVariable("display_ctx", .{ .value = null });
+    layer.setInstanceVariable("presentation_cb", .{ .value = null });
+    layer.setInstanceVariable("presentation_ctx", .{ .value = null });
+    layer.setInstanceVariable("presentation_active", .{ .value = null });
+    layer.setInstanceVariable("presentation_ticket", .{ .value = null });
     layer.setProperty("contents", @as(?*anyopaque, null));
     layer.msgSend(void, objc.sel("removeFromSuperlayer"), .{});
 }
@@ -199,6 +341,10 @@ fn getSubclass() error{ObjCFailed}!objc.Class {
 
     if (!subclass.addIvar("display_cb")) return error.ObjCFailed;
     if (!subclass.addIvar("display_ctx")) return error.ObjCFailed;
+    if (!subclass.addIvar("presentation_cb")) return error.ObjCFailed;
+    if (!subclass.addIvar("presentation_ctx")) return error.ObjCFailed;
+    if (!subclass.addIvar("presentation_active")) return error.ObjCFailed;
+    if (!subclass.addIvar("presentation_ticket")) return error.ObjCFailed;
 
     subclass.replaceMethod("display", struct {
         fn display(target: objc.c.id, sel: objc.c.SEL) callconv(.c) void {
@@ -233,6 +379,64 @@ fn getSubclass() error{ObjCFailed}!objc.Class {
 
     return subclass;
 }
+
+const PixelSize = struct {
+    width: usize,
+    height: usize,
+};
+
+const PresentationStatus = presentation.Status;
+
+fn presentationStatusForSizes(
+    layer_size: PixelSize,
+    surface_size: PixelSize,
+) PresentationStatus {
+    if (layer_size.width != surface_size.width or
+        layer_size.height != surface_size.height)
+    {
+        return .wrong_size_discarded;
+    }
+    return .presented;
+}
+
+fn presentationStatusForLayerAndSurface(
+    layer: objc.Object,
+    surface: *IOSurface,
+) PresentationStatus {
+    const bounds = layer.getProperty(macos.graphics.Rect, "bounds");
+    const scale = layer.getProperty(f64, "contentsScale");
+    return presentationStatusForSizes(
+        .{
+            .width = @intFromFloat(bounds.size.width * scale),
+            .height = @intFromFloat(bounds.size.height * scale),
+        },
+        .{ .width = surface.getWidth(), .height = surface.getHeight() },
+    );
+}
+
+const PresentationTicketTracker = struct {
+    pending_ticket: ?u64 = null,
+    completed_ticket: ?u64 = null,
+    completed_status: ?PresentationStatus = null,
+
+    fn begin(self: *@This(), ticket: u64) bool {
+        if (self.pending_ticket == ticket) return false;
+        self.pending_ticket = ticket;
+        return true;
+    }
+
+    fn complete(
+        self: *@This(),
+        ticket: u64,
+        status: PresentationStatus,
+    ) bool {
+        if (self.pending_ticket != ticket) return false;
+        self.pending_ticket = null;
+        self.completed_ticket = ticket;
+        self.completed_status = status;
+        return true;
+    }
+};
 
 test "presentation ticket completes once with the exact terminal frame result" {
     var tracker = PresentationTicketTracker{};

--- a/src/renderer/metal/IOSurfaceLayer.zig
+++ b/src/renderer/metal/IOSurfaceLayer.zig
@@ -49,6 +49,7 @@ pub fn init(
     );
     layer.setInstanceVariable("presentation_active", .{ .value = null });
     layer.setInstanceVariable("presentation_ticket", .{ .value = null });
+    layer.setInstanceVariable("presentation_floor", .{ .value = null });
 
     return .{ .layer = layer };
 }
@@ -151,6 +152,29 @@ pub fn beginPresentation(self: *IOSurfaceLayer, ticket: u64) void {
     }
 }
 
+/// Synchronously invalidate a ticket and every older queued presentation on
+/// the main-layer owner. Existing contents stay visible until a newer ticket
+/// reaches `setSurfaceCallback`.
+pub fn invalidatePresentationThrough(
+    self: *IOSurfaceLayer,
+    ticket: u64,
+) void {
+    var block = PresentationInvalidationBlock.init(.{
+        .layer = self.layer.value,
+        .ticket = ticket,
+    }, &presentationInvalidationCallback);
+
+    const NSThread = objc.getClass("NSThread").?;
+    if (NSThread.msgSend(bool, "isMainThread", .{})) {
+        presentationInvalidationCallback(&block);
+    } else {
+        macos.dispatch.dispatch_sync(
+            @ptrCast(macos.dispatch.queue.getMain()),
+            @ptrCast(&block),
+        );
+    }
+}
+
 /// Report a ticket that failed before an IOSurface reached the layer. The
 /// callback is always read and invoked on the main queue, where teardown also
 /// clears it, so a queued completion cannot outlive its embedder userdata.
@@ -194,6 +218,11 @@ const PresentationBeginBlock = objc.Block(struct {
     ticket: u64,
 }, .{}, void);
 
+const PresentationInvalidationBlock = objc.Block(struct {
+    layer: objc.c.id,
+    ticket: u64,
+}, .{}, void);
+
 const DetachFromHostBlock = objc.Block(struct {
     layer: objc.c.id,
     display_cb: ?*anyopaque,
@@ -208,6 +237,13 @@ fn setSurfaceCallback(
 
     // See explanation of why we retain and release in `setSurface`.
     defer surface.release();
+
+    // Lifecycle invalidation must win before either the wrong-size callback or
+    // the contents assignment. Otherwise a queued pre-suspend frame can flash
+    // stale pixels after foreground resume even though Swift ignores its ACK.
+    if (block.has_ticket and !presentationTicketIsActive(layer, block.ticket)) {
+        return;
+    }
 
     // We check to see if the surface is the appropriate size for
     // the layer, if it's not then we discard it. This is because
@@ -253,6 +289,12 @@ fn presentationBeginCallback(
     block: *const PresentationBeginBlock.Context,
 ) callconv(.c) void {
     const layer = objc.Object.fromId(block.layer);
+    if (block.ticket <= presentationFloor(layer)) return;
+    const active = layer.getInstanceVariable("presentation_active").value != null;
+    const active_ticket = @intFromPtr(
+        layer.getInstanceVariable("presentation_ticket").value,
+    );
+    if (active and block.ticket <= active_ticket) return;
     layer.setInstanceVariable(
         "presentation_ticket",
         objc.Object.fromId(@as(?*anyopaque, @ptrFromInt(block.ticket))),
@@ -263,16 +305,44 @@ fn presentationBeginCallback(
     );
 }
 
+fn presentationInvalidationCallback(
+    block: *const PresentationInvalidationBlock.Context,
+) callconv(.c) void {
+    const layer = objc.Object.fromId(block.layer);
+    const floor = @max(presentationFloor(layer), block.ticket);
+    layer.setInstanceVariable(
+        "presentation_floor",
+        objc.Object.fromId(@as(?*anyopaque, @ptrFromInt(floor))),
+    );
+
+    const active_ticket = @intFromPtr(
+        layer.getInstanceVariable("presentation_ticket").value,
+    );
+    if (active_ticket <= floor) {
+        layer.setInstanceVariable("presentation_active", .{ .value = null });
+        layer.setInstanceVariable("presentation_ticket", .{ .value = null });
+    }
+}
+
+fn presentationFloor(layer: objc.Object) u64 {
+    return @intFromPtr(layer.getInstanceVariable("presentation_floor").value);
+}
+
+fn presentationTicketIsActive(layer: objc.Object, ticket: u64) bool {
+    if (ticket <= presentationFloor(layer)) return false;
+    const active = layer.getInstanceVariable("presentation_active").value != null;
+    const active_ticket = @intFromPtr(
+        layer.getInstanceVariable("presentation_ticket").value,
+    );
+    return active and active_ticket == ticket;
+}
+
 fn notifyPresentation(
     layer: objc.Object,
     ticket: u64,
     status: presentation.Status,
 ) void {
-    const active = layer.getInstanceVariable("presentation_active").value != null;
-    const active_ticket = @intFromPtr(
-        layer.getInstanceVariable("presentation_ticket").value,
-    );
-    if (!active or active_ticket != ticket) return;
+    if (!presentationTicketIsActive(layer, ticket)) return;
 
     // Clear before invoking foreign code so reentrancy cannot complete twice.
     layer.setInstanceVariable("presentation_active", .{ .value = null });
@@ -308,6 +378,7 @@ fn detachFromHostCallback(
     layer.setInstanceVariable("presentation_ctx", .{ .value = null });
     layer.setInstanceVariable("presentation_active", .{ .value = null });
     layer.setInstanceVariable("presentation_ticket", .{ .value = null });
+    layer.setInstanceVariable("presentation_floor", .{ .value = null });
     layer.setProperty("contents", @as(?*anyopaque, null));
     layer.msgSend(void, objc.sel("removeFromSuperlayer"), .{});
 }
@@ -345,6 +416,7 @@ fn getSubclass() error{ObjCFailed}!objc.Class {
     if (!subclass.addIvar("presentation_ctx")) return error.ObjCFailed;
     if (!subclass.addIvar("presentation_active")) return error.ObjCFailed;
     if (!subclass.addIvar("presentation_ticket")) return error.ObjCFailed;
+    if (!subclass.addIvar("presentation_floor")) return error.ObjCFailed;
 
     subclass.replaceMethod("display", struct {
         fn display(target: objc.c.id, sel: objc.c.SEL) callconv(.c) void {
@@ -415,14 +487,34 @@ fn presentationStatusForLayerAndSurface(
 }
 
 const PresentationTicketTracker = struct {
+    invalidation_floor: u64 = 0,
     pending_ticket: ?u64 = null,
+    contents_ticket: ?u64 = null,
     completed_ticket: ?u64 = null,
     completed_status: ?PresentationStatus = null,
+    callback_count: usize = 0,
 
     fn begin(self: *@This(), ticket: u64) bool {
-        if (self.pending_ticket == ticket) return false;
+        if (ticket <= self.invalidation_floor) return false;
+        if (self.pending_ticket) |pending| {
+            if (ticket <= pending) return false;
+        }
         self.pending_ticket = ticket;
         return true;
+    }
+
+    fn invalidateThrough(self: *@This(), ticket: u64) void {
+        self.invalidation_floor = @max(self.invalidation_floor, ticket);
+        if (self.pending_ticket) |pending| {
+            if (pending <= self.invalidation_floor) self.pending_ticket = null;
+        }
+    }
+
+    fn setSurface(self: *@This(), ticket: u64) bool {
+        if (ticket <= self.invalidation_floor or
+            self.pending_ticket != ticket) return false;
+        self.contents_ticket = ticket;
+        return self.complete(ticket, .presented);
     }
 
     fn complete(
@@ -430,10 +522,12 @@ const PresentationTicketTracker = struct {
         ticket: u64,
         status: PresentationStatus,
     ) bool {
-        if (self.pending_ticket != ticket) return false;
+        if (ticket <= self.invalidation_floor or
+            self.pending_ticket != ticket) return false;
         self.pending_ticket = null;
         self.completed_ticket = ticket;
         self.completed_status = status;
+        self.callback_count += 1;
         return true;
     }
 };
@@ -471,4 +565,28 @@ test "stale presentation cannot complete a newer ticket" {
     try std.testing.expect(!tracker.complete(7, .presented));
     try std.testing.expect(tracker.complete(8, .wrong_size_discarded));
     try std.testing.expectEqual(@as(?u64, 8), tracker.completed_ticket);
+}
+
+test "invalidation gates queued begin and surface mutation through exact ticket" {
+    var tracker = PresentationTicketTracker{ .contents_ticket = 40 };
+
+    try std.testing.expect(tracker.begin(41));
+    tracker.invalidateThrough(41);
+    try std.testing.expect(!tracker.begin(41));
+    try std.testing.expect(!tracker.setSurface(41));
+    try std.testing.expectEqual(@as(?u64, 40), tracker.contents_ticket);
+    try std.testing.expectEqual(@as(usize, 0), tracker.callback_count);
+
+    try std.testing.expect(tracker.begin(42));
+    try std.testing.expect(!tracker.begin(41));
+    try std.testing.expect(!tracker.setSurface(41));
+    try std.testing.expectEqual(@as(?u64, 40), tracker.contents_ticket);
+    try std.testing.expect(tracker.setSurface(42));
+    try std.testing.expectEqual(@as(?u64, 42), tracker.contents_ticket);
+    try std.testing.expectEqual(@as(usize, 1), tracker.callback_count);
+    try std.testing.expectEqual(@as(?u64, 42), tracker.completed_ticket);
+
+    // The floor survives successful presentation, so even a very late queued
+    // begin from before invalidation cannot reactivate ticket 41.
+    try std.testing.expect(!tracker.begin(41));
 }

--- a/src/renderer/metal/IOSurfaceLayer.zig
+++ b/src/renderer/metal/IOSurfaceLayer.zig
@@ -233,3 +233,38 @@ fn getSubclass() error{ObjCFailed}!objc.Class {
 
     return subclass;
 }
+
+test "presentation ticket completes once with the exact terminal frame result" {
+    var tracker = PresentationTicketTracker{};
+
+    try std.testing.expect(tracker.begin(41));
+    try std.testing.expect(!tracker.begin(41));
+    try std.testing.expectEqual(
+        PresentationStatus.wrong_size_discarded,
+        presentationStatusForSizes(
+            .{ .width = 100, .height = 60 },
+            .{ .width = 101, .height = 60 },
+        ),
+    );
+    try std.testing.expectEqual(
+        PresentationStatus.presented,
+        presentationStatusForSizes(
+            .{ .width = 100, .height = 60 },
+            .{ .width = 100, .height = 60 },
+        ),
+    );
+    try std.testing.expect(tracker.complete(41, .presented));
+    try std.testing.expect(!tracker.complete(41, .backend_failed));
+    try std.testing.expectEqual(@as(?u64, 41), tracker.completed_ticket);
+    try std.testing.expectEqual(PresentationStatus.presented, tracker.completed_status.?);
+}
+
+test "stale presentation cannot complete a newer ticket" {
+    var tracker = PresentationTicketTracker{};
+
+    try std.testing.expect(tracker.begin(7));
+    try std.testing.expect(tracker.begin(8));
+    try std.testing.expect(!tracker.complete(7, .presented));
+    try std.testing.expect(tracker.complete(8, .wrong_size_discarded));
+    try std.testing.expectEqual(@as(?u64, 8), tracker.completed_ticket);
+}

--- a/src/renderer/metal/IOSurfaceLayer.zig
+++ b/src/renderer/metal/IOSurfaceLayer.zig
@@ -590,3 +590,29 @@ test "invalidation gates queued begin and surface mutation through exact ticket"
     // begin from before invalidation cannot reactivate ticket 41.
     try std.testing.expect(!tracker.begin(41));
 }
+
+test "synchronous detach clears display and presentation callbacks" {
+    const Callbacks = struct {
+        fn display(_: ?*anyopaque) align(8) void {}
+
+        fn presentationCallback(
+            _: ?*anyopaque,
+            _: u64,
+            _: presentation.Status,
+        ) callconv(.c) void {}
+    };
+
+    var context: u8 = 0;
+    var layer = try IOSurfaceLayer.init(Callbacks.presentationCallback, &context);
+    defer layer.release();
+    layer.setDisplayCallback(@ptrCast(&Callbacks.display), &context);
+    layer.detachFromHostIfDisplayCallbackOwned(
+        @ptrCast(&Callbacks.display),
+        &context,
+    );
+
+    try std.testing.expect(layer.layer.getInstanceVariable("display_cb").value == null);
+    try std.testing.expect(layer.layer.getInstanceVariable("display_ctx").value == null);
+    try std.testing.expect(layer.layer.getInstanceVariable("presentation_cb").value == null);
+    try std.testing.expect(layer.layer.getInstanceVariable("presentation_ctx").value == null);
+}

--- a/src/renderer/presentation.zig
+++ b/src/renderer/presentation.zig
@@ -1,0 +1,16 @@
+//! Exact render-presentation completion reported to embedded runtimes.
+
+/// The terminal frame reached the host layer, was discarded because its
+/// geometry was stale, or could not reach the presentation boundary.
+pub const Status = enum(c_int) {
+    presented = 0,
+    wrong_size_discarded = 1,
+    backend_failed = 2,
+};
+
+/// Completion for a render ticket supplied by the embedder.
+pub const Callback = *const fn (
+    ?*anyopaque,
+    u64,
+    Status,
+) callconv(.c) void;

--- a/src/renderer/presentation.zig
+++ b/src/renderer/presentation.zig
@@ -1,14 +1,19 @@
 //! Exact render-presentation completion reported to embedded runtimes.
 
-/// The terminal frame reached the host layer, was discarded because its
-/// geometry was stale, or could not reach the presentation boundary.
+/// Final disposition for an exact render ticket. Only `presented` means the
+/// frame reached the host layer.
 pub const Status = enum(c_int) {
+    /// The host layer accepted the rendered frame.
     presented = 0,
+
+    /// Stale geometry caused the frame to be discarded before presentation.
     wrong_size_discarded = 1,
+
+    /// The renderer backend failed before presentation.
     backend_failed = 2,
 };
 
-/// Completion for a render ticket supplied by the embedder.
+/// Reports one final disposition for a render ticket supplied by the embedder.
 pub const Callback = *const fn (
     ?*anyopaque,
     u64,

--- a/src/terminal/PageList.zig
+++ b/src/terminal/PageList.zig
@@ -9106,11 +9106,10 @@ test "PageList eraseRows invalidates viewport offset cache" {
     const pin_y = page.capacity.rows;
     s.scroll(.{ .pin = s.pin(.{ .screen = .{ .y = pin_y } }).? });
     try testing.expect(s.viewport == .pin);
-    try testing.expectEqual(Scrollbar{
-        .total = s.total_rows,
-        .offset = pin_y,
-        .len = s.rows,
-    }, s.scrollbar());
+    const scrollbar_before = s.scrollbar();
+    try testing.expectEqual(s.total_rows, scrollbar_before.total);
+    try testing.expectEqual(pin_y, scrollbar_before.offset);
+    try testing.expectEqual(s.rows, scrollbar_before.len);
 
     // Erase some history rows BEFORE the viewport pin.
     // This removes rows from before our pin, which changes its absolute
@@ -9118,11 +9117,13 @@ test "PageList eraseRows invalidates viewport offset cache" {
     const rows_to_erase = page.capacity.rows / 2;
     s.eraseHistory(.{ .history = .{ .y = rows_to_erase - 1 } });
 
-    try testing.expectEqual(Scrollbar{
-        .total = s.total_rows,
-        .offset = pin_y - rows_to_erase,
-        .len = s.rows,
-    }, s.scrollbar());
+    const scrollbar_after = s.scrollbar();
+    try testing.expectEqual(s.total_rows, scrollbar_after.total);
+    try testing.expectEqual(pin_y - rows_to_erase, scrollbar_after.offset);
+    try testing.expectEqual(s.rows, scrollbar_after.len);
+    try testing.expect(
+        scrollbar_after.row_space_revision > scrollbar_before.row_space_revision,
+    );
 }
 
 test "PageList eraseRow invalidates viewport offset cache" {
@@ -13102,22 +13103,23 @@ test "PageList resize reflow invalidates viewport offset cache" {
     const pin_y = 10;
     s.scroll(.{ .pin = s.pin(.{ .screen = .{ .y = pin_y } }).? });
     try testing.expect(s.viewport == .pin);
-    try testing.expectEqual(Scrollbar{
-        .total = s.total_rows,
-        .offset = pin_y,
-        .len = s.rows,
-    }, s.scrollbar());
+    const scrollbar_before = s.scrollbar();
+    try testing.expectEqual(s.total_rows, scrollbar_before.total);
+    try testing.expectEqual(pin_y, scrollbar_before.offset);
+    try testing.expectEqual(s.rows, scrollbar_before.len);
 
     // Resize with reflow - unwrapping rows changes total_rows
     try s.resize(.{ .cols = 4, .reflow = true });
     try testing.expectEqual(@as(usize, 4), s.cols);
 
     // Verify scrollbar cache was invalidated during reflow
-    try testing.expectEqual(Scrollbar{
-        .total = s.total_rows,
-        .offset = 5,
-        .len = s.rows,
-    }, s.scrollbar());
+    const scrollbar_after = s.scrollbar();
+    try testing.expectEqual(s.total_rows, scrollbar_after.total);
+    try testing.expectEqual(@as(usize, 5), scrollbar_after.offset);
+    try testing.expectEqual(s.rows, scrollbar_after.len);
+    try testing.expect(
+        scrollbar_after.row_space_revision > scrollbar_before.row_space_revision,
+    );
 }
 
 test "PageList resize reflow more cols creates multiple pages" {

--- a/src/terminal/stream.zig
+++ b/src/terminal/stream.zig
@@ -495,6 +495,16 @@ pub fn Stream(comptime H: type) type {
             self.handler.deinit();
         }
 
+        /// Whether the parser is between complete terminal input units.
+        ///
+        /// A terminal grid can be rendered while this is false, but it cannot
+        /// be used as a visual synchronization boundary: later bytes may
+        /// complete an escape sequence or UTF-8 scalar whose visible effect
+        /// belongs to the already-consumed prefix.
+        pub fn isQuiescent(self: *const Self) bool {
+            return self.parser.state == .ground and self.utf8decoder.state == 0;
+        }
+
         /// Process a string of characters.
         pub inline fn nextSlice(self: *Self, input: []const u8) void {
             // Disable SIMD optimizations if build requests it or if our
@@ -2762,16 +2772,6 @@ test "simd: complete incomplete utf-8" {
     try testing.expectEqual(@as(u21, 0x800), s.handler.c.?);
 }
 
-test "stream: cursor right (CUF)" {
-    const H = struct {
-        amount: u16 = 0,
-
-        pub fn vt(
-            self: *@This(),
-            comptime action: Action.Tag,
-            value: Action.Value(action),
-        ) void {
-            switch (action) {
 test "stream: quiescence tracks split CSI" {
     const H = struct {
         pub fn vt(
@@ -2868,6 +2868,16 @@ test "stream: quiescence tracks split APC" {
     try testing.expect(s.isQuiescent());
 }
 
+test "stream: cursor right (CUF)" {
+    const H = struct {
+        amount: u16 = 0,
+
+        pub fn vt(
+            self: *@This(),
+            comptime action: Action.Tag,
+            value: Action.Value(action),
+        ) void {
+            switch (action) {
                 .cursor_right => self.amount = value.value,
                 else => {},
             }

--- a/src/terminal/stream.zig
+++ b/src/terminal/stream.zig
@@ -2772,6 +2772,102 @@ test "stream: cursor right (CUF)" {
             value: Action.Value(action),
         ) void {
             switch (action) {
+test "stream: quiescence tracks split CSI" {
+    const H = struct {
+        pub fn vt(
+            self: *@This(),
+            comptime action: Action.Tag,
+            value: Action.Value(action),
+        ) void {
+            _ = self;
+            _ = value;
+        }
+    };
+
+    var s: Stream(H) = .init(.{});
+    try testing.expect(s.isQuiescent());
+    s.nextSlice("\x1B[31");
+    try testing.expect(!s.isQuiescent());
+    s.next('m');
+    try testing.expect(s.isQuiescent());
+}
+
+test "stream: quiescence tracks split UTF-8" {
+    const H = struct {
+        pub fn vt(
+            self: *@This(),
+            comptime action: Action.Tag,
+            value: Action.Value(action),
+        ) void {
+            _ = self;
+            _ = value;
+        }
+    };
+
+    var s: Stream(H) = .init(.{});
+    s.nextSlice(&.{ 0xE2, 0x82 });
+    try testing.expect(!s.isQuiescent());
+    s.next(0xAC);
+    try testing.expect(s.isQuiescent());
+}
+
+test "stream: quiescence tracks split OSC" {
+    const H = struct {
+        pub fn vt(
+            self: *@This(),
+            comptime action: Action.Tag,
+            value: Action.Value(action),
+        ) void {
+            _ = self;
+            _ = value;
+        }
+    };
+
+    var s: Stream(H) = .init(.{});
+    s.nextSlice("\x1B]0;partial title");
+    try testing.expect(!s.isQuiescent());
+    s.next(0x07);
+    try testing.expect(s.isQuiescent());
+}
+
+test "stream: quiescence tracks split DCS" {
+    const H = struct {
+        pub fn vt(
+            self: *@This(),
+            comptime action: Action.Tag,
+            value: Action.Value(action),
+        ) void {
+            _ = self;
+            _ = value;
+        }
+    };
+
+    var s: Stream(H) = .init(.{});
+    s.nextSlice("\x1BPqpartial payload");
+    try testing.expect(!s.isQuiescent());
+    s.nextSlice("\x1B\\");
+    try testing.expect(s.isQuiescent());
+}
+
+test "stream: quiescence tracks split APC" {
+    const H = struct {
+        pub fn vt(
+            self: *@This(),
+            comptime action: Action.Tag,
+            value: Action.Value(action),
+        ) void {
+            _ = self;
+            _ = value;
+        }
+    };
+
+    var s: Stream(H) = .init(.{});
+    s.nextSlice("\x1B_partial payload");
+    try testing.expect(!s.isQuiescent());
+    s.nextSlice("\x1B\\");
+    try testing.expect(s.isQuiescent());
+}
+
                 .cursor_right => self.amount = value.value,
                 else => {},
             }

--- a/src/termio/Termio.zig
+++ b/src/termio/Termio.zig
@@ -24,6 +24,65 @@ const ProcessInfo = @import("../pty.zig").ProcessInfo;
 
 const log = std.log.scoped(.io_exec);
 
+const PtyTeeCallback = *const fn (
+    ?*anyopaque,
+    [*]const u8,
+    usize,
+    u64,
+) callconv(.c) void;
+
+/// Owns callback publication ordering and the userdata lifetime fence.
+const PtyOutputPublication = struct {
+    mutex: std.Thread.Mutex = .{},
+    callback: ?PtyTeeCallback = null,
+    userdata: ?*anyopaque = null,
+
+    fn begin(self: *PtyOutputPublication) void {
+        self.mutex.lock();
+    }
+
+    fn finish(
+        self: *PtyOutputPublication,
+        bytes: []const u8,
+        start_seq: u64,
+    ) void {
+        defer self.mutex.unlock();
+        if (self.callback) |callback| {
+            callback(self.userdata, bytes.ptr, bytes.len, start_seq);
+        }
+    }
+
+    fn set(
+        self: *PtyOutputPublication,
+        callback: ?PtyTeeCallback,
+        userdata: ?*anyopaque,
+    ) void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        self.callback = callback;
+        self.userdata = userdata;
+    }
+
+    /// Clear only the callback still owned by `expected_userdata`. Locking is
+    /// both the ownership comparison and the lifetime fence: an in-flight
+    /// callback holds this mutex until it returns, while a replacement setter
+    /// changes userdata under the same mutex.
+    fn clearIfUserdata(
+        self: *PtyOutputPublication,
+        expected_userdata: *anyopaque,
+    ) bool {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        const current_userdata = self.userdata orelse return false;
+        if (current_userdata != expected_userdata or self.callback == null) {
+            return false;
+        }
+        self.callback = null;
+        self.userdata = null;
+        return true;
+    }
+};
+
 /// Mutex state argument for queueMessage.
 pub const MutexState = enum { locked, unlocked };
 
@@ -65,17 +124,21 @@ mailbox: termio.Mailbox,
 /// Delete when upstream supports manual backend writes without this path.
 manual_linefeed_mode: std.atomic.Value(bool) = .{ .raw = false },
 
-/// cmux fork: parser-applied PTY byte coverage. This advances under the same
-/// renderer-state mutex as terminal mutation, so grid export can stamp one
-/// atomic state and the tee can identify the exact raw suffix after it.
+/// cmux fork: parser-applied PTY byte counter. Grid export uses this only as an
+/// advisory visual-order watermark. It is not raw continuation coverage because
+/// the grid does not serialize parser, pen, margin, or saved-screen state.
 pty_output_seq: u64 = 0,
 
-/// Optional tee callback that fires after each PTY-output slice is parsed.
-/// The final argument is the chunk's start sequence. Both fields are read on
-/// the IO read thread; install once from `apprt.embedded` after surface create
-/// and leave alone for the surface's lifetime.
-pty_tee_cb: ?*const fn (?*anyopaque, [*]const u8, usize, u64) callconv(.c) void = null,
-pty_tee_userdata: ?*anyopaque = null,
+/// Serializes PTY parse transactions through callback publication. The
+/// renderer-state mutex may be released temporarily by stream handlers while
+/// draining a full mailbox, so it cannot by itself order concurrent callers
+/// or protect the callback/userdata pair.
+pty_output_publication: PtyOutputPublication = .{},
+
+/// Protected by the renderer-state mutex. This remains true across temporary
+/// unlocks inside `processOutputLocked`, preventing a visual snapshot from
+/// treating an intermediate parser state as a stable synchronization point.
+pty_output_in_progress: bool = false,
 
 /// The stream parser. This parses the stream of escape codes and so on
 /// from the child process and calls callbacks in the stream handler.
@@ -767,21 +830,46 @@ pub fn focusGained(self: *Termio, td: *ThreadData, focused: bool) !void {
 /// call with pty data but it is also called by the read thread when using
 /// an exec subprocess.
 pub fn processOutput(self: *Termio, buf: []const u8) void {
-    // Parse and advance coverage as one renderer-state transaction. Exporters
-    // can never observe bytes without their sequence or a sequence for bytes
-    // that have not reached the VT parser yet.
+    // Keep parsing, sequence advancement, and callback publication in one
+    // total order even when manual embedders invoke this concurrently.
+    self.pty_output_publication.begin();
+
+    // Parse and advance the advisory visual watermark as one renderer-state
+    // transaction. Exporters cannot observe a watermark ahead of parser state.
     self.renderer_state.mutex.lock();
+    self.pty_output_in_progress = true;
     self.processOutputLocked(buf);
     const chunk_seq = self.pty_output_seq;
     self.pty_output_seq +%= @intCast(buf.len);
+    self.pty_output_in_progress = false;
     self.renderer_state.mutex.unlock();
+    self.renderer_state.yieldToDemand();
 
     // Publish only after parser-applied state and its sequence are visible.
     // The callback runs on the read thread; the embedder owns cross-thread
     // hand-off and must copy bytes before returning.
-    if (self.pty_tee_cb) |cb| {
-        cb(self.pty_tee_userdata, buf.ptr, buf.len, chunk_seq);
-    }
+    self.pty_output_publication.finish(buf, chunk_seq);
+}
+
+/// Atomically replace the PTY callback and its userdata. This waits for any
+/// callback already in progress, so clearing the callback is a lifetime fence
+/// for embedder-owned userdata.
+pub fn setPtyTeeCallback(
+    self: *Termio,
+    cb: ?PtyTeeCallback,
+    userdata: ?*anyopaque,
+) void {
+    self.pty_output_publication.set(cb, userdata);
+}
+
+/// Clear the installed callback only when its userdata still belongs to the
+/// expected embedder lease. Returns after any matching in-flight callback has
+/// completed. A stale lease cannot clear a newer replacement callback.
+pub fn clearPtyTeeCallbackIfUserdata(
+    self: *Termio,
+    expected_userdata: *anyopaque,
+) bool {
+    return self.pty_output_publication.clearIfUserdata(expected_userdata);
 }
 
 /// Process output from readdata but the lock is already held.

--- a/src/termio/Termio.zig
+++ b/src/termio/Termio.zig
@@ -895,3 +895,226 @@ pub const ThreadData = struct {
 pub fn getProcessInfo(self: *Termio, comptime info: ProcessInfo) ?ProcessInfo.Type(info) {
     return self.backend.getProcessInfo(info);
 }
+
+const PtyPublicationTestRecorder = struct {
+    bytes: [2]u8 = undefined,
+    sequences: [2]u64 = undefined,
+    count: usize = 0,
+
+    fn callback(
+        userdata: ?*anyopaque,
+        bytes: [*]const u8,
+        len: usize,
+        start_seq: u64,
+    ) callconv(.c) void {
+        const self: *@This() = @ptrCast(@alignCast(userdata.?));
+        std.debug.assert(len == 1);
+        std.debug.assert(self.count < self.bytes.len);
+        self.bytes[self.count] = bytes[0];
+        self.sequences[self.count] = start_seq;
+        self.count += 1;
+    }
+};
+
+test "pty publication preserves concurrent A B order" {
+    const Context = struct {
+        publication: *PtyOutputPublication,
+        byte: u8,
+        sequence: u64,
+        acquired: ?*std.Thread.ResetEvent = null,
+        attempted: ?*std.Thread.ResetEvent = null,
+        release: ?*std.Thread.ResetEvent = null,
+
+        fn run(self: *@This()) void {
+            if (self.attempted) |event| event.set();
+            self.publication.begin();
+            if (self.acquired) |event| event.set();
+            if (self.release) |event| event.wait();
+            self.publication.finish(&.{self.byte}, self.sequence);
+        }
+    };
+
+    var recorder: PtyPublicationTestRecorder = .{};
+    var publication: PtyOutputPublication = .{};
+    publication.set(PtyPublicationTestRecorder.callback, &recorder);
+
+    var a_acquired: std.Thread.ResetEvent = .{};
+    var release_a: std.Thread.ResetEvent = .{};
+    var a: Context = .{
+        .publication = &publication,
+        .byte = 'A',
+        .sequence = 10,
+        .acquired = &a_acquired,
+        .release = &release_a,
+    };
+    var a_thread = try std.Thread.spawn(.{}, Context.run, .{&a});
+    try a_acquired.timedWait(std.time.ns_per_s);
+
+    var b_attempted: std.Thread.ResetEvent = .{};
+    var b: Context = .{
+        .publication = &publication,
+        .byte = 'B',
+        .sequence = 11,
+        .attempted = &b_attempted,
+    };
+    var b_thread = try std.Thread.spawn(.{}, Context.run, .{&b});
+    try b_attempted.timedWait(std.time.ns_per_s);
+
+    release_a.set();
+    a_thread.join();
+    b_thread.join();
+
+    try std.testing.expectEqual(@as(usize, 2), recorder.count);
+    try std.testing.expectEqualSlices(u8, "AB", &recorder.bytes);
+    try std.testing.expectEqualSlices(u64, &.{ 10, 11 }, &recorder.sequences);
+}
+
+test "clearing pty callback waits for in flight publication" {
+    const BlockingCallback = struct {
+        entered: std.Thread.ResetEvent = .{},
+        release: std.Thread.ResetEvent = .{},
+
+        fn callback(
+            userdata: ?*anyopaque,
+            _: [*]const u8,
+            _: usize,
+            _: u64,
+        ) callconv(.c) void {
+            const self: *@This() = @ptrCast(@alignCast(userdata.?));
+            self.entered.set();
+            self.release.wait();
+        }
+    };
+    const PublishContext = struct {
+        publication: *PtyOutputPublication,
+
+        fn run(self: *@This()) void {
+            self.publication.begin();
+            self.publication.finish("x", 0);
+        }
+    };
+    const ClearContext = struct {
+        publication: *PtyOutputPublication,
+        attempted: *std.Thread.ResetEvent,
+        completed: *std.atomic.Value(bool),
+
+        fn run(self: *@This()) void {
+            self.attempted.set();
+            self.publication.set(null, null);
+            self.completed.store(true, .release);
+        }
+    };
+
+    var blocker: BlockingCallback = .{};
+    var publication: PtyOutputPublication = .{};
+    publication.set(BlockingCallback.callback, &blocker);
+
+    var publish: PublishContext = .{ .publication = &publication };
+    var publish_thread = try std.Thread.spawn(.{}, PublishContext.run, .{&publish});
+    try blocker.entered.timedWait(std.time.ns_per_s);
+
+    var clear_attempted: std.Thread.ResetEvent = .{};
+    var clear_completed: std.atomic.Value(bool) = .init(false);
+    var clear: ClearContext = .{
+        .publication = &publication,
+        .attempted = &clear_attempted,
+        .completed = &clear_completed,
+    };
+    var clear_thread = try std.Thread.spawn(.{}, ClearContext.run, .{&clear});
+    try clear_attempted.timedWait(std.time.ns_per_s);
+    try std.testing.expect(!clear_completed.load(.acquire));
+
+    blocker.release.set();
+    publish_thread.join();
+    clear_thread.join();
+    try std.testing.expect(clear_completed.load(.acquire));
+    try std.testing.expect(publication.callback == null);
+    try std.testing.expect(publication.userdata == null);
+}
+
+test "compare clearing pty callback waits for matching in flight publication" {
+    const BlockingCallback = struct {
+        entered: std.Thread.ResetEvent = .{},
+        release: std.Thread.ResetEvent = .{},
+
+        fn callback(
+            userdata: ?*anyopaque,
+            _: [*]const u8,
+            _: usize,
+            _: u64,
+        ) callconv(.c) void {
+            const self: *@This() = @ptrCast(@alignCast(userdata.?));
+            self.entered.set();
+            self.release.wait();
+        }
+    };
+    const PublishContext = struct {
+        publication: *PtyOutputPublication,
+
+        fn run(self: *@This()) void {
+            self.publication.begin();
+            self.publication.finish("x", 0);
+        }
+    };
+    const ClearContext = struct {
+        publication: *PtyOutputPublication,
+        expected_userdata: *anyopaque,
+        attempted: *std.Thread.ResetEvent,
+        completed: *std.atomic.Value(bool),
+        cleared: *std.atomic.Value(bool),
+
+        fn run(self: *@This()) void {
+            self.attempted.set();
+            const cleared = self.publication.clearIfUserdata(self.expected_userdata);
+            self.cleared.store(cleared, .release);
+            self.completed.store(true, .release);
+        }
+    };
+
+    var blocker: BlockingCallback = .{};
+    var publication: PtyOutputPublication = .{};
+    publication.set(BlockingCallback.callback, &blocker);
+
+    var publish: PublishContext = .{ .publication = &publication };
+    var publish_thread = try std.Thread.spawn(.{}, PublishContext.run, .{&publish});
+    try blocker.entered.timedWait(std.time.ns_per_s);
+
+    var clear_attempted: std.Thread.ResetEvent = .{};
+    var clear_completed: std.atomic.Value(bool) = .init(false);
+    var did_clear: std.atomic.Value(bool) = .init(false);
+    var clear: ClearContext = .{
+        .publication = &publication,
+        .expected_userdata = &blocker,
+        .attempted = &clear_attempted,
+        .completed = &clear_completed,
+        .cleared = &did_clear,
+    };
+    var clear_thread = try std.Thread.spawn(.{}, ClearContext.run, .{&clear});
+    try clear_attempted.timedWait(std.time.ns_per_s);
+    try std.testing.expect(!clear_completed.load(.acquire));
+
+    blocker.release.set();
+    publish_thread.join();
+    clear_thread.join();
+    try std.testing.expect(clear_completed.load(.acquire));
+    try std.testing.expect(did_clear.load(.acquire));
+    try std.testing.expect(publication.callback == null);
+    try std.testing.expect(publication.userdata == null);
+}
+
+test "stale userdata cannot clear replacement pty callback" {
+    var old_recorder: PtyPublicationTestRecorder = .{};
+    var replacement_recorder: PtyPublicationTestRecorder = .{};
+    var publication: PtyOutputPublication = .{};
+    publication.set(PtyPublicationTestRecorder.callback, &old_recorder);
+    publication.set(PtyPublicationTestRecorder.callback, &replacement_recorder);
+
+    try std.testing.expect(!publication.clearIfUserdata(&old_recorder));
+    try std.testing.expect(publication.callback != null);
+    try std.testing.expect(
+        publication.userdata.? == @as(*anyopaque, @ptrCast(&replacement_recorder)),
+    );
+    try std.testing.expect(publication.clearIfUserdata(&replacement_recorder));
+    try std.testing.expect(publication.callback == null);
+    try std.testing.expect(publication.userdata == null);
+}

--- a/src/termio/Termio.zig
+++ b/src/termio/Termio.zig
@@ -63,6 +63,18 @@ const PtyOutputPublication = struct {
         self.userdata = userdata;
     }
 
+    /// Read a sequence value only after every older parser/callback
+    /// publication has completed. Writers mutate the sequence while holding
+    /// this mutex from before parsing through callback return.
+    fn snapshotSequence(
+        self: *PtyOutputPublication,
+        sequence: *const u64,
+    ) u64 {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        return sequence.*;
+    }
+
     /// Clear only the callback still owned by `expected_userdata`. Locking is
     /// both the ownership comparison and the lifetime fence: an in-flight
     /// callback holds this mutex until it returns, while a replacement setter
@@ -872,6 +884,14 @@ pub fn clearPtyTeeCallbackIfUserdata(
     return self.pty_output_publication.clearIfUserdata(expected_userdata);
 }
 
+/// Return the raw PTY-output watermark after any in-flight publication has
+/// completed. This deliberately uses only the publication mutex: output takes
+/// publication before renderer state, while render-grid reads stay under the
+/// renderer-state mutex, so no reverse lock order is introduced.
+pub fn ptyOutputSequence(self: *Termio) u64 {
+    return self.pty_output_publication.snapshotSequence(&self.pty_output_seq);
+}
+
 /// Process output from readdata but the lock is already held.
 fn processOutputLocked(self: *Termio, buf: []const u8) void {
     // Schedule a render. We can call this first because we have the lock.
@@ -1118,6 +1138,80 @@ test "clearing pty callback waits for in flight publication" {
     try std.testing.expect(clear_completed.load(.acquire));
     try std.testing.expect(publication.callback == null);
     try std.testing.expect(publication.userdata == null);
+}
+
+test "pty sequence snapshot waits for callback publication" {
+    const BlockingCallback = struct {
+        entered: std.Thread.ResetEvent = .{},
+        release: std.Thread.ResetEvent = .{},
+
+        fn callback(
+            userdata: ?*anyopaque,
+            _: [*]const u8,
+            _: usize,
+            _: u64,
+        ) callconv(.c) void {
+            const self: *@This() = @ptrCast(@alignCast(userdata.?));
+            self.entered.set();
+            self.release.wait();
+        }
+    };
+    const PublishContext = struct {
+        publication: *PtyOutputPublication,
+        sequence: *u64,
+
+        fn run(self: *@This()) void {
+            self.publication.begin();
+            self.sequence.* = 5;
+            self.publication.finish("bytes", 0);
+        }
+    };
+    const SnapshotContext = struct {
+        publication: *PtyOutputPublication,
+        sequence: *const u64,
+        attempted: *std.Thread.ResetEvent,
+        completed: *std.atomic.Value(bool),
+        result: *std.atomic.Value(u64),
+
+        fn run(self: *@This()) void {
+            self.attempted.set();
+            const value = self.publication.snapshotSequence(self.sequence);
+            self.result.store(value, .release);
+            self.completed.store(true, .release);
+        }
+    };
+
+    var blocker: BlockingCallback = .{};
+    var publication: PtyOutputPublication = .{};
+    publication.set(BlockingCallback.callback, &blocker);
+
+    var sequence: u64 = 0;
+    var publish: PublishContext = .{
+        .publication = &publication,
+        .sequence = &sequence,
+    };
+    var publish_thread = try std.Thread.spawn(.{}, PublishContext.run, .{&publish});
+    try blocker.entered.timedWait(std.time.ns_per_s);
+
+    var snapshot_attempted: std.Thread.ResetEvent = .{};
+    var snapshot_completed: std.atomic.Value(bool) = .init(false);
+    var snapshot_result: std.atomic.Value(u64) = .init(0);
+    var snapshot: SnapshotContext = .{
+        .publication = &publication,
+        .sequence = &sequence,
+        .attempted = &snapshot_attempted,
+        .completed = &snapshot_completed,
+        .result = &snapshot_result,
+    };
+    var snapshot_thread = try std.Thread.spawn(.{}, SnapshotContext.run, .{&snapshot});
+    try snapshot_attempted.timedWait(std.time.ns_per_s);
+    try std.testing.expect(!snapshot_completed.load(.acquire));
+
+    blocker.release.set();
+    publish_thread.join();
+    snapshot_thread.join();
+    try std.testing.expect(snapshot_completed.load(.acquire));
+    try std.testing.expectEqual(@as(u64, 5), snapshot_result.load(.acquire));
 }
 
 test "compare clearing pty callback waits for matching in flight publication" {

--- a/src/termio/Termio.zig
+++ b/src/termio/Termio.zig
@@ -25,20 +25,36 @@ const ProcessInfo = @import("../pty.zig").ProcessInfo;
 const log = std.log.scoped(.io_exec);
 
 const PtyTeeCallback = *const fn (
-    ?*anyopaque,
+    *anyopaque,
     [*]const u8,
     usize,
     u64,
 ) callconv(.c) void;
 
-/// Owns callback publication ordering and the userdata lifetime fence.
+/// Owns parser/callback publication ordering and the userdata lifetime fence.
+/// A logical transaction is reentrant on its owning thread. The monitor mutex
+/// is released while parser and foreign callback code execute.
 const PtyOutputPublication = struct {
     mutex: std.Thread.Mutex = .{},
+    condition: std.Thread.Condition = .{},
+    owner: ?std.Thread.Id = null,
+    depth: usize = 0,
     callback: ?PtyTeeCallback = null,
     userdata: ?*anyopaque = null,
 
     fn begin(self: *PtyOutputPublication) void {
+        const current = std.Thread.getCurrentId();
         self.mutex.lock();
+        defer self.mutex.unlock();
+        while (self.owner) |owner| {
+            if (owner == current) {
+                self.depth += 1;
+                return;
+            }
+            self.condition.wait(&self.mutex);
+        }
+        self.owner = current;
+        self.depth = 1;
     }
 
     fn finish(
@@ -46,9 +62,26 @@ const PtyOutputPublication = struct {
         bytes: []const u8,
         start_seq: u64,
     ) void {
+        const current = std.Thread.getCurrentId();
+        self.mutex.lock();
+        std.debug.assert(self.owner == current);
+        std.debug.assert(self.depth > 0);
+        const callback = self.callback;
+        const userdata = self.userdata;
+        self.mutex.unlock();
+
+        // Foreign code must never run under our nonrecursive monitor mutex.
+        // The logical transaction remains owned by this thread, so concurrent
+        // publishers wait while callback-driven reentry can safely nest.
+        if (callback) |cb| cb(userdata.?, bytes.ptr, bytes.len, start_seq);
+
+        self.mutex.lock();
         defer self.mutex.unlock();
-        if (self.callback) |callback| {
-            callback(self.userdata, bytes.ptr, bytes.len, start_seq);
+        std.debug.assert(self.owner == current);
+        self.depth -= 1;
+        if (self.depth == 0) {
+            self.owner = null;
+            self.condition.broadcast();
         }
     }
 
@@ -57,34 +90,44 @@ const PtyOutputPublication = struct {
         callback: ?PtyTeeCallback,
         userdata: ?*anyopaque,
     ) void {
+        const current = std.Thread.getCurrentId();
         self.mutex.lock();
         defer self.mutex.unlock();
+        self.waitUntilIdleOrOwned(current);
+        if (callback != null and userdata == null) {
+            self.callback = null;
+            self.userdata = null;
+            return;
+        }
         self.callback = callback;
-        self.userdata = userdata;
+        self.userdata = if (callback == null) null else userdata;
     }
 
     /// Read a sequence value only after every older parser/callback
-    /// publication has completed. Writers mutate the sequence while holding
-    /// this mutex from before parsing through callback return.
+    /// publication has completed. Callback-thread reentry reads the sequence
+    /// already committed by its owning transaction without waiting on itself.
     fn snapshotSequence(
         self: *PtyOutputPublication,
         sequence: *const u64,
     ) u64 {
+        const current = std.Thread.getCurrentId();
         self.mutex.lock();
         defer self.mutex.unlock();
+        self.waitUntilIdleOrOwned(current);
         return sequence.*;
     }
 
-    /// Clear only the callback still owned by `expected_userdata`. Locking is
-    /// both the ownership comparison and the lifetime fence: an in-flight
-    /// callback holds this mutex until it returns, while a replacement setter
-    /// changes userdata under the same mutex.
+    /// Clear only the callback still owned by `expected_userdata`. The logical
+    /// transaction is the lifetime fence: other threads wait for an in-flight
+    /// callback, while its own thread may clear or replace itself reentrantly.
     fn clearIfUserdata(
         self: *PtyOutputPublication,
         expected_userdata: *anyopaque,
     ) bool {
+        const current = std.Thread.getCurrentId();
         self.mutex.lock();
         defer self.mutex.unlock();
+        self.waitUntilIdleOrOwned(current);
         const current_userdata = self.userdata orelse return false;
         if (current_userdata != expected_userdata or self.callback == null) {
             return false;
@@ -92,6 +135,16 @@ const PtyOutputPublication = struct {
         self.callback = null;
         self.userdata = null;
         return true;
+    }
+
+    fn waitUntilIdleOrOwned(
+        self: *PtyOutputPublication,
+        current: std.Thread.Id,
+    ) void {
+        while (self.owner) |owner| {
+            if (owner == current) return;
+            self.condition.wait(&self.mutex);
+        }
     }
 };
 
@@ -882,9 +935,10 @@ pub fn processOutput(self: *Termio, buf: []const u8) void {
     self.pty_output_publication.finish(buf, chunk_seq);
 }
 
-/// Atomically replace the PTY callback and its userdata. This waits for any
-/// callback already in progress, so clearing the callback is a lifetime fence
-/// for embedder-owned userdata.
+/// Atomically replace the PTY callback and its userdata. A non-null callback
+/// requires non-null userdata. Other threads wait for any callback already in
+/// progress, while callback-thread replacement is reentrant and takes effect
+/// before any nested publication.
 pub fn setPtyTeeCallback(
     self: *Termio,
     cb: ?PtyTeeCallback,
@@ -904,9 +958,8 @@ pub fn clearPtyTeeCallbackIfUserdata(
 }
 
 /// Return the raw PTY-output watermark after any in-flight publication has
-/// completed. This deliberately uses only the publication mutex: output takes
-/// publication before renderer state, while render-grid reads stay under the
-/// renderer-state mutex, so no reverse lock order is introduced.
+/// completed. Reentrant callback reads return the already-committed watermark
+/// without waiting on their own logical transaction.
 pub fn ptyOutputSequence(self: *Termio) u64 {
     return self.pty_output_publication.snapshotSequence(&self.pty_output_seq);
 }
@@ -1029,12 +1082,12 @@ const PtyPublicationTestRecorder = struct {
     count: usize = 0,
 
     fn callback(
-        userdata: ?*anyopaque,
+        userdata: *anyopaque,
         bytes: [*]const u8,
         len: usize,
         start_seq: u64,
     ) callconv(.c) void {
-        const self: *@This() = @ptrCast(@alignCast(userdata.?));
+        const self: *@This() = @ptrCast(@alignCast(userdata));
         std.debug.assert(len == 1);
         std.debug.assert(self.count < self.bytes.len);
         self.bytes[self.count] = bytes[0];
@@ -1102,12 +1155,12 @@ test "clearing pty callback waits for in flight publication" {
         release: std.Thread.ResetEvent = .{},
 
         fn callback(
-            userdata: ?*anyopaque,
+            userdata: *anyopaque,
             _: [*]const u8,
             _: usize,
             _: u64,
         ) callconv(.c) void {
-            const self: *@This() = @ptrCast(@alignCast(userdata.?));
+            const self: *@This() = @ptrCast(@alignCast(userdata));
             self.entered.set();
             self.release.wait();
         }
@@ -1165,12 +1218,12 @@ test "pty sequence snapshot waits for callback publication" {
         release: std.Thread.ResetEvent = .{},
 
         fn callback(
-            userdata: ?*anyopaque,
+            userdata: *anyopaque,
             _: [*]const u8,
             _: usize,
             _: u64,
         ) callconv(.c) void {
-            const self: *@This() = @ptrCast(@alignCast(userdata.?));
+            const self: *@This() = @ptrCast(@alignCast(userdata));
             self.entered.set();
             self.release.wait();
         }
@@ -1239,12 +1292,12 @@ test "compare clearing pty callback waits for matching in flight publication" {
         release: std.Thread.ResetEvent = .{},
 
         fn callback(
-            userdata: ?*anyopaque,
+            userdata: *anyopaque,
             _: [*]const u8,
             _: usize,
             _: u64,
         ) callconv(.c) void {
-            const self: *@This() = @ptrCast(@alignCast(userdata.?));
+            const self: *@This() = @ptrCast(@alignCast(userdata));
             self.entered.set();
             self.release.wait();
         }
@@ -1326,12 +1379,12 @@ test "pty callback runs without publication mutex held" {
         mutex_was_available: bool = false,
 
         fn callback(
-            userdata: ?*anyopaque,
+            userdata: *anyopaque,
             _: [*]const u8,
             _: usize,
             _: u64,
         ) callconv(.c) void {
-            const self: *@This() = @ptrCast(@alignCast(userdata.?));
+            const self: *@This() = @ptrCast(@alignCast(userdata));
             self.mutex_was_available = self.publication.mutex.tryLock();
             if (self.mutex_was_available) self.publication.mutex.unlock();
         }
@@ -1349,7 +1402,7 @@ test "pty callback runs without publication mutex held" {
 test "pty callback registration rejects null userdata" {
     const callback = struct {
         fn call(
-            _: ?*anyopaque,
+            _: *anyopaque,
             _: [*]const u8,
             _: usize,
             _: u64,
@@ -1360,4 +1413,88 @@ test "pty callback registration rejects null userdata" {
     publication.set(callback, null);
     try std.testing.expect(publication.callback == null);
     try std.testing.expect(publication.userdata == null);
+}
+
+test "pty callback may replace itself and publish reentrantly" {
+    const Replacement = struct {
+        byte: u8 = 0,
+        sequence: u64 = 0,
+
+        fn callback(
+            userdata: *anyopaque,
+            bytes: [*]const u8,
+            len: usize,
+            start_seq: u64,
+        ) callconv(.c) void {
+            const self: *@This() = @ptrCast(@alignCast(userdata));
+            std.debug.assert(len == 1);
+            self.byte = bytes[0];
+            self.sequence = start_seq;
+        }
+    };
+    const Initial = struct {
+        publication: *PtyOutputPublication,
+        replacement: *Replacement,
+        sequence: *const u64,
+        snapshot: u64 = 0,
+
+        fn callback(
+            userdata: *anyopaque,
+            _: [*]const u8,
+            _: usize,
+            _: u64,
+        ) callconv(.c) void {
+            const self: *@This() = @ptrCast(@alignCast(userdata));
+            self.snapshot = self.publication.snapshotSequence(self.sequence);
+            self.publication.set(Replacement.callback, self.replacement);
+            self.publication.begin();
+            self.publication.finish("B", 11);
+        }
+    };
+
+    var publication: PtyOutputPublication = .{};
+    var replacement: Replacement = .{};
+    var sequence: u64 = 12;
+    var initial: Initial = .{
+        .publication = &publication,
+        .replacement = &replacement,
+        .sequence = &sequence,
+    };
+    publication.set(Initial.callback, &initial);
+    publication.begin();
+    publication.finish("A", 10);
+
+    try std.testing.expectEqual(@as(u64, 12), initial.snapshot);
+    try std.testing.expectEqual(@as(u8, 'B'), replacement.byte);
+    try std.testing.expectEqual(@as(u64, 11), replacement.sequence);
+}
+
+test "pty callback may conditionally clear itself reentrantly" {
+    const Context = struct {
+        publication: *PtyOutputPublication,
+        cleared: bool = false,
+        callback_count: usize = 0,
+
+        fn callback(
+            userdata: *anyopaque,
+            _: [*]const u8,
+            _: usize,
+            _: u64,
+        ) callconv(.c) void {
+            const self: *@This() = @ptrCast(@alignCast(userdata));
+            self.callback_count += 1;
+            self.cleared = self.publication.clearIfUserdata(self);
+        }
+    };
+
+    var publication: PtyOutputPublication = .{};
+    var context: Context = .{ .publication = &publication };
+    publication.set(Context.callback, &context);
+    publication.begin();
+    publication.finish("A", 0);
+    publication.begin();
+    publication.finish("B", 1);
+
+    try std.testing.expect(context.cleared);
+    try std.testing.expectEqual(@as(usize, 1), context.callback_count);
 }

--- a/src/termio/Termio.zig
+++ b/src/termio/Termio.zig
@@ -65,14 +65,16 @@ mailbox: termio.Mailbox,
 /// Delete when upstream supports manual backend writes without this path.
 manual_linefeed_mode: std.atomic.Value(bool) = .{ .raw = false },
 
-/// cmux fork: optional tee callback that fires on every PTY-output byte
-/// before the VT parser sees it. Embedders (cmux's mac sync server) use
-/// this to broadcast raw bytes to a paired iPhone so the phone can feed
-/// the same bytes through its own libghostty surface, producing an
-/// identical grid by construction. Both fields are read on the IO read
-/// thread; install once from `apprt.embedded` after surface create and
-/// leave alone for the surface's lifetime.
-pty_tee_cb: ?*const fn (?*anyopaque, [*]const u8, usize) callconv(.c) void = null,
+/// cmux fork: parser-applied PTY byte coverage. This advances under the same
+/// renderer-state mutex as terminal mutation, so grid export can stamp one
+/// atomic state and the tee can identify the exact raw suffix after it.
+pty_output_seq: u64 = 0,
+
+/// Optional tee callback that fires after each PTY-output slice is parsed.
+/// The final argument is the chunk's start sequence. Both fields are read on
+/// the IO read thread; install once from `apprt.embedded` after surface create
+/// and leave alone for the surface's lifetime.
+pty_tee_cb: ?*const fn (?*anyopaque, [*]const u8, usize, u64) callconv(.c) void = null,
 pty_tee_userdata: ?*anyopaque = null,
 
 /// The stream parser. This parses the stream of escape codes and so on
@@ -765,19 +767,21 @@ pub fn focusGained(self: *Termio, td: *ThreadData, focused: bool) !void {
 /// call with pty data but it is also called by the read thread when using
 /// an exec subprocess.
 pub fn processOutput(self: *Termio, buf: []const u8) void {
-    // cmux fork: tee raw PTY bytes BEFORE locking the renderer mutex or
-    // touching terminal state. The tee callback is expected to be cheap
-    // (typically a memcpy into a ring buffer + a wakeup). It runs on the
-    // read thread; the embedder owns thread safety for any cross-thread
-    // hand-off. Tee fires for every byte the read thread produces,
-    // regardless of mode.
-    if (self.pty_tee_cb) |cb| cb(self.pty_tee_userdata, buf.ptr, buf.len);
-
-    // We are modifying terminal state from here on out and we need
-    // the lock to grab our read data.
+    // Parse and advance coverage as one renderer-state transaction. Exporters
+    // can never observe bytes without their sequence or a sequence for bytes
+    // that have not reached the VT parser yet.
     self.renderer_state.mutex.lock();
-    defer self.renderer_state.mutex.unlock();
     self.processOutputLocked(buf);
+    const chunk_seq = self.pty_output_seq;
+    self.pty_output_seq +%= @intCast(buf.len);
+    self.renderer_state.mutex.unlock();
+
+    // Publish only after parser-applied state and its sequence are visible.
+    // The callback runs on the read thread; the embedder owns cross-thread
+    // hand-off and must copy bytes before returning.
+    if (self.pty_tee_cb) |cb| {
+        cb(self.pty_tee_userdata, buf.ptr, buf.len, chunk_seq);
+    }
 }
 
 /// Process output from readdata but the lock is already held.

--- a/src/termio/Termio.zig
+++ b/src/termio/Termio.zig
@@ -1319,3 +1319,45 @@ test "stale userdata cannot clear replacement pty callback" {
     try std.testing.expect(publication.callback == null);
     try std.testing.expect(publication.userdata == null);
 }
+
+test "pty callback runs without publication mutex held" {
+    const Context = struct {
+        publication: *PtyOutputPublication,
+        mutex_was_available: bool = false,
+
+        fn callback(
+            userdata: ?*anyopaque,
+            _: [*]const u8,
+            _: usize,
+            _: u64,
+        ) callconv(.c) void {
+            const self: *@This() = @ptrCast(@alignCast(userdata.?));
+            self.mutex_was_available = self.publication.mutex.tryLock();
+            if (self.mutex_was_available) self.publication.mutex.unlock();
+        }
+    };
+
+    var publication: PtyOutputPublication = .{};
+    var context: Context = .{ .publication = &publication };
+    publication.set(Context.callback, &context);
+    publication.begin();
+    publication.finish("x", 0);
+
+    try std.testing.expect(context.mutex_was_available);
+}
+
+test "pty callback registration rejects null userdata" {
+    const callback = struct {
+        fn call(
+            _: ?*anyopaque,
+            _: [*]const u8,
+            _: usize,
+            _: u64,
+        ) callconv(.c) void {}
+    }.call;
+
+    var publication: PtyOutputPublication = .{};
+    publication.set(callback, null);
+    try std.testing.expect(publication.callback == null);
+    try std.testing.expect(publication.userdata == null);
+}


### PR DESCRIPTION
## Summary
- export a producer-owned terminal viewport grid through the embedded API
- snapshot cursor, colors, cell attributes, and parser/update sequences on the terminal owner thread
- keep the export visual-only so clients cannot mistake it for semantic terminal state

## Verification
- `zig build -Demit-macos-app=false`
- GhosttyKit artifact workflow: `29392177968` passed

Parent experiment for https://github.com/manaflow-ai/cmux/issues/7160.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/119"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786689073&installation_id=133855650&pr_number=119&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F119&signature=73cbbabbd0854e984efbf549e4a98af0f58bf049590d7e0c9c91dd5fdb009922"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exports an authoritative, visual-only terminal render grid with a visual state watermark and exact presentation tickets so embedded clients stay pixel- and frame-accurate.

- **New Features**
  - Atomic render‑grid JSON of viewport + bounded scrollback with an embedded `state_seq`; snapshot is gated and returns `retryable_not_quiescent` until output/parsing completes or synchronized‑output ends.
  - C API: added `ghostty_render_presentation_cb`; ticketed renders via `ghostty_surface_render_now_with_ticket`; `ghostty_surface_invalidate_render_presentation_through` to fence stale frames; tickets are forced through presentation even with no new damage; final statuses: `presented`, `wrong_size_discarded`, `backend_failed`.
  - JSON API update: `ghostty_surface_render_grid_json(surface_id, id_len, scrollback_lines, out_state_seq*, out_status*)`.
  - PTY tee fires post‑parse with `start_seq` for each chunk; publication is serialized and reentrant‑safe; accessor `ghostty_surface_pty_output_sequence` exposed for synchronized coordination.
  - Visual fidelity: cursor JSON includes style, blinking, cell width, and opacity; cursor color blends with its cell background and is resolved from the underlying cell style; unfocused cursor is hollow and non‑blinking; faint is resolved into RGB with correct reverse‑color handling.

- **Migration**
  - Set `render_presentation_cb` on `ghostty_surface_config_s` and use ticketed render on iOS; handle statuses `presented`, `wrong_size_discarded`, `backend_failed`; call invalidate to drop stale tickets.
  - Update tee callback to `(userdata, bytes, len, start_seq)`; optionally clear with `ghostty_surface_clear_pty_tee_cb_if_userdata`.
  - Stop passing a `state_seq` to `ghostty_surface_render_grid_json`; read `out_state_seq`/`out_status` and retry on `retryable_not_quiescent`, or use `ghostty_surface_pty_output_sequence` when needed.

<sup>Written for commit 51d20b27d668b36092f0fb6eeeac876d01d0ec0b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/119?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added ticket-based render presentation control and presentation completion reporting.
  - Exposed a synchronized “raw PTY output sequence” accessor for embedder-side coordination.
  - Added a parser-state quiescence check to define a clean synchronization boundary.

- **API Updates**
  - PTY tee callbacks now include a per-chunk parser start sequence.
  - Render-grid JSON export now provides an atomic state sequence watermark plus updated status/retry outputs.

- **Tests**
  - Added/extended unit coverage for render-grid gating, sequencing, callback ordering/clearing, and quiescence behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->