### PR TITLE
font/shaper: preserve authoritative sprite runs

### DIFF
--- a/src/font/shaper/coretext.zig
+++ b/src/font/shaper/coretext.zig
@@ -2750,6 +2750,46 @@ test "shape high plane sprite font codepoint" {
     try testing.expectEqual(null, try it.next(alloc));
 }
 
+test "run iterator preserves sprite font inside text" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var testdata = try testShaper(alloc);
+    defer testdata.deinit();
+
+    var t = try terminal.Terminal.init(alloc, .{ .cols = 10, .rows = 3 });
+    defer t.deinit(alloc);
+
+    var s = t.vtStream();
+    defer s.deinit();
+    s.nextSlice("│ A │");
+
+    var state: terminal.RenderState = .empty;
+    defer state.deinit(alloc);
+    try state.update(alloc, &t);
+
+    var it = testdata.shaper.runIterator(.{
+        .grid = testdata.grid,
+        .cells = state.row_data.get(0).cells.slice(),
+    });
+
+    const left_border = (try it.next(alloc)).?;
+    try testing.expectEqual(@as(u16, 0), left_border.offset);
+    try testing.expectEqual(@as(u16, 1), left_border.cells);
+    try testing.expect(left_border.font_index.special() != null);
+
+    const text = (try it.next(alloc)).?;
+    try testing.expectEqual(@as(u16, 1), text.offset);
+    try testing.expectEqual(@as(u16, 3), text.cells);
+    try testing.expectEqual(@as(?font.Collection.Index.Special, null), text.font_index.special());
+
+    const right_border = (try it.next(alloc)).?;
+    try testing.expectEqual(@as(u16, 4), right_border.offset);
+    try testing.expectEqual(@as(u16, 1), right_border.cells);
+    try testing.expect(right_border.font_index.special() != null);
+    try testing.expectEqual(@as(?font.shape.TextRun, null), try it.next(alloc));
+}
+
 test "shape LTR neutral RTL splits and sets direction" {
     const testing = std.testing;
     const alloc = testing.allocator;

--- a/src/font/shaper/run.zig
+++ b/src/font/shaper/run.zig
@@ -210,11 +210,12 @@ pub const RunIterator = struct {
                 // UNLESS the codepoint is neutral (space, punctuation) and
                 // the current run's font also supports it.
                 if (font_info.idx != current_font) {
-                    const cp = cell.codepoint();
-                    const is_neutral_in_current_font = cp != 0 and
-                        codepointIsRtl(cp) == null and
-                        self.opts.grid.hasCodepoint(current_font, cp, presentation);
-                    if (!is_neutral_in_current_font) break;
+                    if (!self.canCoalesceIntoCurrentFont(
+                        font_info,
+                        current_font,
+                        cell.codepoint(),
+                        presentation,
+                    )) break;
                 }
             }
 
@@ -265,11 +266,12 @@ pub const RunIterator = struct {
                 );
 
                 if (font_info.idx != current_font) {
-                    const cp = cell.codepoint();
-                    const is_neutral_in_current_font = cp != 0 and
-                        codepointIsRtl(cp) == null and
-                        self.opts.grid.hasCodepoint(current_font, cp, presentation);
-                    if (!is_neutral_in_current_font) continue;
+                    if (!self.canCoalesceIntoCurrentFont(
+                        font_info,
+                        current_font,
+                        cell.codepoint(),
+                        presentation,
+                    )) continue;
                 }
 
                 // If we're a fallback character and that fallback is in the
@@ -455,6 +457,24 @@ pub const RunIterator = struct {
         idx: font.Collection.Index,
         fallback: ?u32 = null,
     };
+
+    /// Returns true when a bidi-neutral codepoint may use the surrounding
+    /// run's font instead of the font selected by the resolver.
+    fn canCoalesceIntoCurrentFont(
+        self: *RunIterator,
+        font_info: FontInfo,
+        current_font: font.Collection.Index,
+        cp: u32,
+        presentation: ?font.Presentation,
+    ) bool {
+        // Special fonts bypass normal shaping and render their own glyphs.
+        // Their resolver result is authoritative even when a text font also
+        // happens to contain the same neutral codepoint.
+        return font_info.idx.special() == null and
+            cp != 0 and
+            codepointIsRtl(cp) == null and
+            self.opts.grid.hasCodepoint(current_font, cp, presentation);
+    }
 
     /// Resolve which font to use for a cell, falling back to the replacement
     /// character or space if the cell's glyph is unavailable.


### PR DESCRIPTION
## Summary

- keep special sprite-font resolutions in their own shaping runs
- share the neutral-font coalescing predicate between boundary detection and run construction
- add a regression for a sprite box-drawing glyph surrounded by normal text

## Root cause

The bidi run iterator coalesces neutral characters into the surrounding font when that font contains the codepoint. Box-drawing characters are neutral, so a resolved sprite glyph inside a text row was silently handed to CoreText and rasterized from the text font. Special fonts bypass normal shaping and their resolver result must remain authoritative.

## Testing

- `zig build test -Dtest-filter="run iterator preserves sprite font inside text"`
- `zig build test -Dtest-filter="shape LTR neutral RTL splits and sets direction"`
- `zig build test -Dtest-filter="shape high plane sprite font codepoint"`

The first test fails on the test-only commit `a6ca2cca0` and passes with the fix commit `20d11e519`.

Parent issue: https://github.com/manaflow-ai/cmux/issues/8167

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/120"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786746910&installation_id=133855650&pr_number=120&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F120&signature=6572b380287d1ea85b97a12639b74d31be8c8ce4f7d60d9a6df6314ff2869369"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep sprite-font glyphs (e.g., box-drawing) in their own shaping runs so borders render with the correct thickness and aren’t rasterized by text fonts. Addresses #8167 (table border thickness).

- **Bug Fixes**
  - Prevent coalescing neutral codepoints into the surrounding font when the resolver selects a special sprite font; the sprite run remains authoritative.
  - Centralize the neutral-font coalescing check and use it for both run boundary detection and run construction.
  - Add a regression test to ensure a box-drawing glyph between text keeps the sprite font.

<sup>Written for commit 20d11e5199519127f7a54f2a193188f0e415820e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/120?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text shaping for mixed regular and sprite-font content.
  * Ensured special glyphs retain their correct font treatment without incorrectly merging with surrounding text.
* **Tests**
  * Added coverage verifying correct font runs for borders, spaces, and standard text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->