### PR TITLE
Signal completed renderer frames to embedded hosts

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -480,6 +480,7 @@ typedef enum {
   GHOSTTY_RENDERER_EVENT_UPDATE_FRAME_END = 1,
   GHOSTTY_RENDERER_EVENT_DRAW_FRAME_BEGIN = 2,
   GHOSTTY_RENDERER_EVENT_DRAW_FRAME_END = 3,
+  GHOSTTY_RENDERER_EVENT_FRAME_COMPLETED = 4,
 } ghostty_renderer_event_e;
 
 // The userdata is ghostty_surface_config_s.userdata. The callback must be

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -573,6 +573,11 @@ pub fn init(
         .mailbox = &app.mailbox,
         .redraw_retry_requested = &app.redraw_retry_requested,
     };
+    const renderer_instrumentation: rendererpkg.Instrumentation =
+        if (comptime @hasDecl(apprt.runtime.Surface, "rendererInstrumentation"))
+            rt_surface.rendererInstrumentation()
+        else
+            .{};
     var renderer_impl = try Renderer.init(alloc, .{
         .config = try .init(alloc, config),
         .font_grid = font_grid,
@@ -580,6 +585,7 @@ pub fn init(
         .surface_mailbox = .{ .surface = self, .app = app_mailbox },
         .rt_surface = rt_surface,
         .thread = &self.renderer_thread,
+        .instrumentation = renderer_instrumentation,
     });
     errdefer renderer_impl.deinit();
 
@@ -589,11 +595,6 @@ pub fn init(
     errdefer alloc.destroy(mutex);
 
     // Create the renderer thread
-    const renderer_instrumentation: rendererpkg.Instrumentation =
-        if (comptime @hasDecl(apprt.runtime.Surface, "rendererInstrumentation"))
-            rt_surface.rendererInstrumentation()
-        else
-            .{};
     var render_thread = try rendererpkg.Thread.init(
         alloc,
         config,

--- a/src/renderer/Options.zig
+++ b/src/renderer/Options.zig
@@ -22,3 +22,7 @@ rt_surface: *apprt.Surface,
 
 /// The renderer thread.
 thread: *renderer.Thread,
+
+/// Optional embedded-host lifecycle instrumentation. The renderer retains a
+/// copy because GPU completion callbacks run after draw submission returns.
+instrumentation: renderer.Instrumentation = .{},

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -238,6 +238,11 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
         /// Health of the most recently completed frame.
         health: std.atomic.Value(Health) = .{ .raw = .healthy },
 
+        /// Embedded-host renderer lifecycle notifications. This is copied from
+        /// the surface's renderer-thread instrumentation so GPU completion can
+        /// be reported from the backend callback.
+        instrumentation: renderer.Instrumentation = .{},
+
         /// Our swap chain (multiple buffering)
         swap_chain: SwapChain,
 
@@ -866,6 +871,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 .api = api,
                 .swap_chain = swap_chain,
                 .display_link = display_link,
+                .instrumentation = options.instrumentation,
             };
 
             try result.initShaders();
@@ -1849,6 +1855,11 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             self: *Self,
             health: Health,
         ) void {
+            // The backend invokes this only after its command buffer completed
+            // and a healthy target was presented. Keep this distinct from
+            // draw_frame_end, which records CPU submission completion.
+            if (health == .healthy) self.instrumentation.emit(.frame_completed);
+
             // If our health value hasn't changed, then we do nothing. We don't
             // do a cmpxchg here because strict atomicity isn't important.
             if (self.health.load(.seq_cst) != health) {

--- a/src/renderer/instrumentation.zig
+++ b/src/renderer/instrumentation.zig
@@ -5,6 +5,10 @@ pub const Event = enum(c_int) {
     update_frame_end = 1,
     draw_frame_begin = 2,
     draw_frame_end = 3,
+    /// The graphics backend has finished writing and presenting the frame.
+    /// Embedded compositors use this to publish a cross-process surface
+    /// without blocking the renderer thread on GPU completion.
+    frame_completed = 4,
 };
 
 pub const Callback = *const fn (


### PR DESCRIPTION
Adds an append-only renderer instrumentation event after a healthy GPU frame completes and is presented. Embedded compositors can publish cross-process IOSurfaces without blocking the renderer thread or racing Metal writes.\n\nVerification: `zig build test -Dapp-runtime=none -Demit-macos-app=false -Demit-xcframework=false -Dtest-filter="renderer instrumentation"`; universal ReleaseFast GhosttyKit build with `-Demit-macos-app=false`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/121"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786858288&installation_id=133855650&pr_number=121&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F121&signature=bf20f121ec4f2f88dd1c7651faf13b0a8d785776245c13c6e1e901b4f17f8d1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Signals a new renderer event when a GPU frame is completed and presented, so embedded hosts can publish IOSurfaces safely without blocking or racing Metal writes. Adds `.frame_completed` to the C/zig instrumentation and wires it through the renderer.

- **New Features**
  - Added `GHOSTTY_RENDERER_EVENT_FRAME_COMPLETED` / `.frame_completed`, emitted only after a healthy frame is presented.
  - Plumbed optional instrumentation into `Renderer.Options` and the backend to fire from GPU completion callbacks.
  - Kept `draw_frame_end` semantics unchanged (CPU submission completion).

- **Migration**
  - Embedders can listen for `GHOSTTY_RENDERER_EVENT_FRAME_COMPLETED` to publish cross-process surfaces post-presentation.
  - No action needed if you don’t use instrumentation; defaults remain no-op.

<sup>Written for commit 827c20f7979b19b2138f24f03c926a7e0bf2e9f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/121?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a renderer lifecycle event indicating when a frame has completed writing and presentation.
  * Exposed frame-completion notifications for embedded and compositor integrations.
  * Added renderer instrumentation configuration to support GPU completion callbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->