### PR TITLE
Add external Metal presenter ABI

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -66,6 +66,7 @@ typedef enum {
   GHOSTTY_PLATFORM_INVALID,
   GHOSTTY_PLATFORM_MACOS,
   GHOSTTY_PLATFORM_IOS,
+  GHOSTTY_PLATFORM_METAL_EXTERNAL,
 } ghostty_platform_e;
 
 typedef enum {
@@ -453,9 +454,29 @@ typedef struct {
   void* uiview;
 } ghostty_platform_ios_s;
 
+/**
+ * Called after Metal finishes rendering a frame into an IOSurface.
+ *
+ * This callback runs on a Metal command-buffer completion thread and must be
+ * thread-safe and non-blocking. `iosurface` is a borrowed IOSurfaceRef that is
+ * valid only for the duration of the callback. The embedder must retain it or
+ * create its transport handle before returning if it needs a longer lifetime.
+ * `width_px` and `height_px` are the IOSurface dimensions in pixels.
+ */
+typedef void (*ghostty_metal_external_present_cb)(void* userdata,
+                                                  void* iosurface,
+                                                  uint32_t width_px,
+                                                  uint32_t height_px);
+
+typedef struct {
+  void* userdata;
+  ghostty_metal_external_present_cb present;
+} ghostty_platform_metal_external_s;
+
 typedef union {
   ghostty_platform_macos_s macos;
   ghostty_platform_ios_s ios;
+  ghostty_platform_metal_external_s metal_external;
 } ghostty_platform_u;
 
 typedef enum {
@@ -472,6 +493,9 @@ typedef enum {
 } ghostty_surface_io_mode_e;
 
 typedef void (*ghostty_io_write_cb)(void*, const char*, uintptr_t);
+typedef void (*ghostty_pty_tee_cb)(void* userdata,
+                                  const char* bytes,
+                                  uintptr_t len);
 
 // Content-free renderer activity events emitted only when a surface installs
 // ghostty_renderer_event_cb. Begin/end pairs run on the renderer thread.
@@ -504,6 +528,10 @@ typedef struct {
   ghostty_io_write_cb io_write_cb;
   void* io_write_userdata;
   ghostty_renderer_event_cb renderer_event_cb;
+  // Optional initial tee installed before the IO thread starts. This prevents
+  // embedders from missing startup bytes while racing the post-create setter.
+  ghostty_pty_tee_cb pty_tee_cb;
+  void* pty_tee_userdata;
 } ghostty_surface_config_s;
 
 typedef struct {
@@ -1247,7 +1275,6 @@ GHOSTTY_API void ghostty_surface_process_output(ghostty_surface_t, const char*, 
 // broadcast raw bytes to a paired iPhone. Set cb=NULL to clear. Callback
 // runs on the IO read thread; embedder owns cross-thread hand-off. Upstream
 // candidate.
-typedef void (*ghostty_pty_tee_cb)(void* userdata, const char* bytes, uintptr_t len);
 GHOSTTY_API void ghostty_surface_set_pty_tee_cb(ghostty_surface_t,
                                                 ghostty_pty_tee_cb,
                                                 void* userdata);

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1152,6 +1152,10 @@ GHOSTTY_API void ghostty_string_free(ghostty_string_s);
 GHOSTTY_API ghostty_config_t ghostty_config_new();
 GHOSTTY_API void ghostty_config_free(ghostty_config_t);
 GHOSTTY_API ghostty_config_t ghostty_config_clone(ghostty_config_t);
+// Serialize the effective configuration as valid Ghostty config-file syntax.
+// The returned bytes include all public values and must be released with
+// ghostty_string_free.
+GHOSTTY_API ghostty_string_s ghostty_config_serialize(ghostty_config_t);
 GHOSTTY_API void ghostty_config_load_cli_args(ghostty_config_t);
 GHOSTTY_API void ghostty_config_load_file(ghostty_config_t, const char*);
 GHOSTTY_API void ghostty_config_load_string(ghostty_config_t, const char*, uintptr_t, const char*);
@@ -1343,6 +1347,16 @@ GHOSTTY_API bool ghostty_surface_read_screen_tail_vt(ghostty_surface_t,
                                                      uintptr_t,
                                                      uintptr_t,
                                                      ghostty_text_s*);
+// Atomically capture the same VT tail plus the modulo-uint64 position of the
+// next PTY-output byte. The position advances only after output has been
+// applied to the terminal, so bytes at or after it can be replayed following a
+// worker restart. The sequence wraps on uint64 overflow.
+GHOSTTY_API bool ghostty_surface_read_screen_tail_vt_with_output_sequence(
+    ghostty_surface_t,
+    uintptr_t,
+    uintptr_t,
+    ghostty_text_s*,
+    uint64_t* next_sequence);
 GHOSTTY_API void ghostty_surface_free_text(ghostty_surface_t, ghostty_text_s*);
 
 #ifdef __APPLE__

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -732,6 +732,14 @@ pub fn init(
             .renderer_wakeup = render_thread.wakeup,
             .renderer_mailbox = render_thread.mailbox,
             .surface_mailbox = .{ .surface = self, .app = app_mailbox },
+            .pty_tee_cb = if (comptime @hasDecl(apprt.runtime.Surface, "ptyTeeCallback"))
+                rt_surface.ptyTeeCallback()
+            else
+                null,
+            .pty_tee_userdata = if (comptime @hasDecl(apprt.runtime.Surface, "ptyTeeUserdata"))
+                rt_surface.ptyTeeUserdata()
+            else
+                null,
         });
     }
     // Outside the block, IO has now taken ownership of our temporary state

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -2027,6 +2027,40 @@ pub const CAPI = struct {
         surface.core_surface.renderer_state.mutex.lock();
         defer surface.core_surface.renderer_state.mutex.unlock();
 
+        return readScreenTailVTLocked(surface, max_rows, max_bytes, result);
+    }
+
+    /// Atomically capture a VT tail and the modulo-u64 position immediately
+    /// after every PTY-output byte represented by that terminal snapshot.
+    export fn ghostty_surface_read_screen_tail_vt_with_output_sequence(
+        surface: *Surface,
+        max_rows: usize,
+        max_bytes: usize,
+        result: *Text,
+        next_sequence: *u64,
+    ) bool {
+        surface.core_surface.renderer_state.mutex.lock();
+        defer surface.core_surface.renderer_state.mutex.unlock();
+
+        const snapshot_succeeded = readScreenTailVTLocked(
+            surface,
+            max_rows,
+            max_bytes,
+            result,
+        );
+        return publishOutputSnapshotSequenceLocked(
+            snapshot_succeeded,
+            surface.core_surface.io.processed_output_bytes,
+            next_sequence,
+        );
+    }
+
+    fn readScreenTailVTLocked(
+        surface: *Surface,
+        max_rows: usize,
+        max_bytes: usize,
+        result: *Text,
+    ) bool {
         if (max_rows == 0 or max_bytes == 0) return false;
         const core_surface = &surface.core_surface;
         const opts: terminal.formatter.Options = .{
@@ -2065,6 +2099,16 @@ pub const CAPI = struct {
             .text = owned.ptr,
             .text_len = owned.len,
         };
+        return true;
+    }
+
+    fn publishOutputSnapshotSequenceLocked(
+        snapshot_succeeded: bool,
+        processed_output_bytes: u64,
+        next_sequence: *u64,
+    ) bool {
+        if (!snapshot_succeeded) return false;
+        next_sequence.* = processed_output_bytes;
         return true;
     }
 
@@ -3679,6 +3723,23 @@ pub const CAPI = struct {
         }
     };
 };
+
+test "output sequence publishes only with successful VT tail snapshot" {
+    var next_sequence: u64 = 99;
+    try std.testing.expect(!CAPI.publishOutputSnapshotSequenceLocked(
+        false,
+        42,
+        &next_sequence,
+    ));
+    try std.testing.expectEqual(@as(u64, 99), next_sequence);
+
+    try std.testing.expect(CAPI.publishOutputSnapshotSequenceLocked(
+        true,
+        42,
+        &next_sequence,
+    ));
+    try std.testing.expectEqual(@as(u64, 42), next_sequence);
+}
 
 test "render grid preserves terminal color semantics" {
     const default_color = CAPI.renderGridColorSemantics(.none);

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -360,6 +360,7 @@ pub const App = struct {
 pub const Platform = union(PlatformTag) {
     macos: MacOS,
     ios: IOS,
+    metal_external: MetalExternal,
 
     // If our build target for libghostty is not darwin then we do
     // not include macos support at all.
@@ -373,6 +374,24 @@ pub const Platform = union(PlatformTag) {
         uiview: objc.Object,
     } else void;
 
+    /// An embedder-owned presenter for Metal IOSurfaces. This platform never
+    /// accesses an NSView, UIView, or CALayer. The callback runs on a Metal
+    /// command-buffer completion thread after the GPU finishes the frame.
+    pub const MetalExternal = if (builtin.target.os.tag.isDarwin()) struct {
+        userdata: ?*anyopaque,
+
+        /// `iosurface` is borrowed and valid only for the callback duration.
+        /// Retain it or create its transport handle before returning if the
+        /// embedder needs to extend its lifetime. The callback must be
+        /// thread-safe and must not block the renderer thread.
+        present: *const fn (
+            userdata: ?*anyopaque,
+            iosurface: *anyopaque,
+            width_px: u32,
+            height_px: u32,
+        ) callconv(.c) void,
+    } else void;
+
     // The C ABI compatible version of this union. The tag is expected
     // to be stored elsewhere.
     pub const C = extern union {
@@ -382,6 +401,16 @@ pub const Platform = union(PlatformTag) {
 
         ios: extern struct {
             uiview: ?*anyopaque,
+        },
+
+        metal_external: extern struct {
+            userdata: ?*anyopaque,
+            present: ?*const fn (
+                userdata: ?*anyopaque,
+                iosurface: *anyopaque,
+                width_px: u32,
+                height_px: u32,
+            ) callconv(.c) void,
         },
     };
 
@@ -402,6 +431,15 @@ pub const Platform = union(PlatformTag) {
                     break :ios error.UIViewMustBeSet);
                 break :ios .{ .ios = .{ .uiview = uiview } };
             } else error.UnsupportedPlatform,
+
+            .metal_external => if (MetalExternal != void) metal_external: {
+                const config = c_platform.metal_external;
+                break :metal_external .{ .metal_external = .{
+                    .userdata = config.userdata,
+                    .present = config.present orelse
+                        return error.MetalExternalPresentMustBeSet,
+                } };
+            } else error.UnsupportedPlatform,
         };
     }
 };
@@ -412,7 +450,45 @@ pub const PlatformTag = enum(c_int) {
 
     macos = 1,
     ios = 2,
+    metal_external = 3,
 };
+
+test "embedded metal external platform validates presentation callback" {
+    if (Platform.MetalExternal == void) return error.SkipZigTest;
+
+    var c_platform: Platform.C = undefined;
+    c_platform.metal_external = .{
+        .userdata = null,
+        .present = null,
+    };
+    try std.testing.expectError(
+        error.MetalExternalPresentMustBeSet,
+        Platform.init(@intFromEnum(PlatformTag.metal_external), c_platform),
+    );
+
+    const Callback = struct {
+        fn present(
+            _: ?*anyopaque,
+            _: *anyopaque,
+            _: u32,
+            _: u32,
+        ) callconv(.c) void {}
+    };
+    c_platform.metal_external.present = &Callback.present;
+
+    const platform = try Platform.init(
+        @intFromEnum(PlatformTag.metal_external),
+        c_platform,
+    );
+    try std.testing.expectEqual(
+        PlatformTag.metal_external,
+        std.meta.activeTag(platform),
+    );
+    try std.testing.expectEqual(
+        @as(c_int, 3),
+        @intFromEnum(PlatformTag.metal_external),
+    );
+}
 
 pub const EnvVar = extern struct {
     /// The name of the environment variable.
@@ -430,6 +506,7 @@ pub const IoMode = enum(c_int) {
 };
 
 pub const IoWriteCallback = *const fn (?*anyopaque, [*]const u8, usize) callconv(.c) void;
+pub const PtyTeeCallback = *const fn (?*anyopaque, [*]const u8, usize) callconv(.c) void;
 pub const RendererEventCallback = renderer.InstrumentationCallback;
 
 pub const Surface = struct {
@@ -445,6 +522,8 @@ pub const Surface = struct {
     io_mode: IoMode = .exec,
     io_write_cb: ?IoWriteCallback = null,
     io_write_userdata: ?*anyopaque = null,
+    pty_tee_cb: ?PtyTeeCallback = null,
+    pty_tee_userdata: ?*anyopaque = null,
     renderer_event_cb: ?RendererEventCallback = null,
     scrollback_limit_bytes: usize = 0,
 
@@ -506,6 +585,14 @@ pub const Surface = struct {
         /// Optional content-free renderer activity callback. This receives the
         /// surface `userdata` and runs synchronously on the renderer thread.
         renderer_event_cb: ?RendererEventCallback = null,
+
+        /// Optional tee for every PTY-output byte slice before parsing. Unlike
+        /// the post-create setter, this is installed before the IO thread can
+        /// emit startup bytes.
+        pty_tee_cb: ?PtyTeeCallback = null,
+
+        /// Userdata passed to pty_tee_cb.
+        pty_tee_userdata: ?*anyopaque = null,
     };
 
     pub fn init(
@@ -529,6 +616,8 @@ pub const Surface = struct {
             .io_mode = opts.io_mode,
             .io_write_cb = opts.io_write_cb,
             .io_write_userdata = opts.io_write_userdata,
+            .pty_tee_cb = opts.pty_tee_cb,
+            .pty_tee_userdata = opts.pty_tee_userdata,
             .renderer_event_cb = opts.renderer_event_cb,
             .scrollback_limit_bytes = scrollback_limit_bytes,
         };
@@ -661,10 +750,20 @@ pub const Surface = struct {
     }
 
     test "embedded surface scrollback cap inherits when unset" {
-        try std.testing.expectEqual(@as(usize, 120), @sizeOf(Options));
+        try std.testing.expectEqual(@as(usize, 144), @sizeOf(Options));
         try std.testing.expectEqual(
             @as(usize, 50_000_000),
             effectiveScrollbackLimit(50_000_000, 0),
+        );
+    }
+
+    test "embedded surface options include initial PTY tee" {
+        const options: Options = .{};
+        try std.testing.expect(options.pty_tee_cb == null);
+        try std.testing.expect(options.pty_tee_userdata == null);
+        try std.testing.expect(
+            @offsetOf(Options, "pty_tee_cb") <
+                @offsetOf(Options, "pty_tee_userdata"),
         );
     }
 
@@ -764,6 +863,14 @@ pub const Surface = struct {
 
     pub fn ioWriteUserdata(self: *const Surface) ?*anyopaque {
         return self.io_write_userdata;
+    }
+
+    pub fn ptyTeeCallback(self: *const Surface) ?PtyTeeCallback {
+        return self.pty_tee_cb;
+    }
+
+    pub fn ptyTeeUserdata(self: *const Surface) ?*anyopaque {
+        return self.pty_tee_userdata;
     }
 
     pub fn rendererInstrumentation(self: *const Surface) renderer.Instrumentation {

--- a/src/config/CApi.zig
+++ b/src/config/CApi.zig
@@ -5,6 +5,7 @@ const state = &@import("../global.zig").state;
 const String = @import("../main_c.zig").String;
 
 const Config = @import("Config.zig");
+const FileFormatter = @import("formatter_file.zig").FileFormatter;
 const c_get = @import("c_get.zig");
 const edit = @import("edit.zig");
 const Key = @import("key.zig").Key;
@@ -48,6 +49,36 @@ export fn ghostty_config_clone(self: *Config) ?*Config {
     };
 
     return result;
+}
+
+/// Serialize every public effective configuration value using Ghostty's
+/// config-file formatter. The returned allocation is owned by the caller and
+/// is released by ghostty_string_free.
+export fn ghostty_config_serialize(self: *const Config) String {
+    const serialized = serializeConfig(state.alloc, self) catch |err| {
+        log.err("error serializing config err={}", .{err});
+        return .empty;
+    };
+    return .fromSlice(serialized);
+}
+
+fn serializeConfig(alloc: std.mem.Allocator, self: *const Config) ![]u8 {
+    var output: std.Io.Writer.Allocating = .init(alloc);
+    defer output.deinit();
+
+    // Config.default preloads command-palette entries, while parsing that key
+    // appends. Clear it before the all-values formatter emits the effective
+    // entries so loading this snapshot into a fresh config is lossless.
+    try output.writer.writeAll("command-palette-entry = clear\n");
+
+    const formatter: FileFormatter = .{
+        .alloc = alloc,
+        .config = self,
+        .docs = false,
+        .changed = false,
+    };
+    try formatter.format(&output.writer);
+    return try output.toOwnedSlice();
 }
 
 /// Load the configuration from the CLI args.
@@ -174,6 +205,39 @@ test "ghostty_config_get: bool" {
     const key = "maximize";
     try testing.expect(ghostty_config_get(&cfg, &out, key, key.len));
     try testing.expect(out);
+}
+
+test "ghostty_config_serialize round trips effective values" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var source = try Config.default(alloc);
+    defer source.deinit();
+    source.@"font-size" = 23.5;
+    source.@"window-theme" = .dark;
+    source.@"cursor-opacity" = 0.375;
+
+    const serialized = try serializeConfig(alloc, &source);
+    defer alloc.free(serialized);
+    try testing.expect(std.mem.indexOf(u8, serialized, "font-size = 23.5") != null);
+    try testing.expect(std.mem.indexOf(u8, serialized, "window-theme = dark") != null);
+
+    var restored = try Config.default(alloc);
+    defer restored.deinit();
+    try restored.loadString(
+        alloc,
+        serialized,
+        "/tmp/ghostty-effective-config",
+    );
+    try restored.finalize();
+
+    try testing.expectEqual(source.@"font-size", restored.@"font-size");
+    try testing.expectEqual(source.@"window-theme", restored.@"window-theme");
+    try testing.expectEqual(source.@"cursor-opacity", restored.@"cursor-opacity");
+    try testing.expect(source.@"command-palette-entry".equal(
+        restored.@"command-palette-entry",
+    ));
+    try testing.expectEqual(@as(usize, 0), restored._diagnostics.items().len);
 }
 
 test "ghostty_config_get: enum" {

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -1324,6 +1324,18 @@ pub const Action = union(enum) {
         return Error.InvalidAction;
     }
 
+    /// Bridge the generic config struct parser to the action grammar. This is
+    /// required for command-palette entries whose action parameters contain
+    /// commas, such as `write_screen_file:copy,vt`.
+    pub fn parseCLI(
+        self: *Action,
+        alloc: Allocator,
+        input: ?[]const u8,
+    ) !void {
+        const parsed = try parse(input orelse return Error.InvalidFormat);
+        self.* = try parsed.clone(alloc);
+    }
+
     /// The scope of an action. The scope is the context in which an action
     /// must be executed.
     pub const Scope = enum {

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -38,7 +38,97 @@ pub const swap_chain_count = 3;
 
 const log = std.log.scoped(.metal);
 
-layer: IOSurfaceLayer,
+const ExternalPresenter = struct {
+    surface: *apprt.Surface,
+    userdata: ?*anyopaque,
+    present_callback: *const fn (
+        userdata: ?*anyopaque,
+        iosurface: *anyopaque,
+        width_px: u32,
+        height_px: u32,
+    ) callconv(.c) void,
+};
+
+const Presenter = union(enum) {
+    layer: IOSurfaceLayer,
+    external: ExternalPresenter,
+
+    fn init(opts: rendererpkg.Options) !Presenter {
+        switch (opts.rt_surface.platform) {
+            .metal_external => |config| return .{ .external = .{
+                .surface = opts.rt_surface,
+                .userdata = config.userdata,
+                .present_callback = config.present,
+            } },
+            .macos, .ios => {},
+        }
+
+        const ViewInfo = struct {
+            view: objc.Object,
+            scale_factor: f64,
+        };
+
+        const info: ViewInfo = .{
+            .scale_factor = @floatCast(opts.rt_surface.content_scale.x),
+            .view = switch (opts.rt_surface.platform) {
+                .macos => |value| value.nsview,
+                .ios => |value| value.uiview,
+                .metal_external => unreachable,
+            },
+        };
+
+        // Create an IOSurfaceLayer which we can assign to the view to make
+        // it in to a "layer-hosting view", so that we can manually control
+        // the layer contents.
+        var layer = try IOSurfaceLayer.init();
+        errdefer layer.release();
+
+        // Add our layer to the view.
+        //
+        // On macOS we do this by making the view "layer-hosting"
+        // by assigning it to the view's `layer` property BEFORE
+        // setting `wantsLayer` to `true`.
+        //
+        // On iOS, views are always layer-backed, and `layer`
+        // is readonly, so instead we add it as a sublayer.
+        switch (comptime builtin.os.tag) {
+            .macos => {
+                info.view.setProperty("layer", layer.layer.value);
+                info.view.setProperty("wantsLayer", true);
+            },
+
+            .ios => {
+                const view_layer = objc.Object.fromId(info.view.getProperty(?*anyopaque, "layer"));
+                view_layer.msgSend(void, objc.sel("addSublayer:"), .{layer.layer.value});
+            },
+
+            else => @compileError("unsupported target for Metal"),
+        }
+
+        // Ensure that if our layer is oversized it
+        // does not overflow the bounds of the view.
+        info.view.setProperty("clipsToBounds", true);
+
+        // Ensure that our layer has a content scale set to
+        // match the scale factor of the window. This avoids
+        // magnification issues leading to blurry rendering.
+        layer.layer.setProperty("contentsScale", info.scale_factor);
+
+        // This makes it so that our display callback will actually be called.
+        layer.layer.setProperty("needsDisplayOnBoundsChange", true);
+
+        return .{ .layer = layer };
+    }
+
+    fn deinit(self: *Presenter) void {
+        switch (self.*) {
+            .layer => |*layer| layer.release(),
+            .external => {},
+        }
+    }
+};
+
+presenter: Presenter,
 
 /// MTLDevice
 device: objc.Object,
@@ -87,66 +177,17 @@ pub fn init(alloc: Allocator, opts: rendererpkg.Options) !Metal {
         .{ default_storage_mode, max_texture_size },
     );
 
-    const ViewInfo = struct {
-        view: objc.Object,
-        scaleFactor: f64,
-    };
-
-    // Get the metadata about our underlying view that we'll be rendering to.
-    const info: ViewInfo = switch (apprt.runtime) {
-        apprt.embedded => .{
-            .scaleFactor = @floatCast(opts.rt_surface.content_scale.x),
-            .view = switch (opts.rt_surface.platform) {
-                .macos => |v| v.nsview,
-                .ios => |v| v.uiview,
-            },
-        },
-
+    const presenter = switch (apprt.runtime) {
+        apprt.embedded => try Presenter.init(opts),
         else => @compileError("unsupported apprt for metal"),
     };
-
-    // Create an IOSurfaceLayer which we can assign to the view to make
-    // it in to a "layer-hosting view", so that we can manually control
-    // the layer contents.
-    var layer = try IOSurfaceLayer.init();
-    errdefer layer.release();
-
-    // Add our layer to the view.
-    //
-    // On macOS we do this by making the view "layer-hosting"
-    // by assigning it to the view's `layer` property BEFORE
-    // setting `wantsLayer` to `true`.
-    //
-    // On iOS, views are always layer-backed, and `layer`
-    // is readonly, so instead we add it as a sublayer.
-    switch (comptime builtin.os.tag) {
-        .macos => {
-            info.view.setProperty("layer", layer.layer.value);
-            info.view.setProperty("wantsLayer", true);
-        },
-
-        .ios => {
-            const view_layer = objc.Object.fromId(info.view.getProperty(?*anyopaque, "layer"));
-            view_layer.msgSend(void, objc.sel("addSublayer:"), .{layer.layer.value});
-        },
-
-        else => @compileError("unsupported target for Metal"),
+    errdefer {
+        var value = presenter;
+        value.deinit();
     }
 
-    // Ensure that if our layer is oversized it
-    // does not overflow the bounds of the view.
-    info.view.setProperty("clipsToBounds", true);
-
-    // Ensure that our layer has a content scale set to
-    // match the scale factor of the window. This avoids
-    // magnification issues leading to blurry rendering.
-    layer.layer.setProperty("contentsScale", info.scaleFactor);
-
-    // This makes it so that our display callback will actually be called.
-    layer.layer.setProperty("needsDisplayOnBoundsChange", true);
-
     return .{
-        .layer = layer,
+        .presenter = presenter,
         .device = device,
         .queue = queue,
         .blending = opts.config.blending,
@@ -158,14 +199,18 @@ pub fn init(alloc: Allocator, opts: rendererpkg.Options) !Metal {
 pub fn deinit(self: *Metal) void {
     self.queue.release();
     self.device.release();
-    self.layer.release();
+    self.presenter.deinit();
 }
 
 pub fn prepareDeinit(self: *Metal) void {
     switch (comptime builtin.os.tag) {
         .ios => {
+            const layer = switch (self.presenter) {
+                .layer => |*value| value,
+                .external => return,
+            };
             const renderer: *align(1) Renderer = @fieldParentPtr("api", self);
-            self.layer.detachFromHostIfDisplayCallbackOwned(
+            layer.detachFromHostIfDisplayCallbackOwned(
                 @ptrCast(&displayCallback),
                 @ptrCast(renderer),
             );
@@ -176,8 +221,14 @@ pub fn prepareDeinit(self: *Metal) void {
 }
 
 pub fn loopEnter(self: *Metal) void {
+    const layer = switch (self.presenter) {
+        .layer => |*value| value,
+        // The external presenter is driven by Ghostty's existing renderer
+        // loop. It deliberately installs no AppKit display callback.
+        .external => return,
+    };
     const renderer: *align(1) Renderer = @fieldParentPtr("api", self);
-    self.layer.setDisplayCallback(
+    layer.setDisplayCallback(
         @ptrCast(&displayCallback),
         @ptrCast(renderer),
     );
@@ -228,21 +279,30 @@ pub fn initShaders(
 
 /// Get the current size of the runtime surface.
 pub fn surfaceSize(self: *const Metal) !struct { width: u32, height: u32 } {
-    const bounds = self.layer.layer.getProperty(graphics.Rect, "bounds");
-    const scale = self.layer.layer.getProperty(f64, "contentsScale");
+    const size: struct { width: u32, height: u32 } = switch (self.presenter) {
+        .layer => |layer| layer_size: {
+            const bounds = layer.layer.getProperty(graphics.Rect, "bounds");
+            const scale = layer.layer.getProperty(f64, "contentsScale");
+            break :layer_size .{
+                .width = @intFromFloat(bounds.size.width * scale),
+                .height = @intFromFloat(bounds.size.height * scale),
+            };
+        },
+        .external => |external| external_size: {
+            const value = try external.surface.getSize();
+            break :external_size .{
+                .width = value.width,
+                .height = value.height,
+            };
+        },
+    };
 
     // We need to clamp our runtime surface size to the maximum
     // possible texture size since we can't create a screen buffer (texture)
     // larger than that.
     return .{
-        .width = @min(
-            @as(u32, @intFromFloat(bounds.size.width * scale)),
-            self.max_texture_size,
-        ),
-        .height = @min(
-            @as(u32, @intFromFloat(bounds.size.height * scale)),
-            self.max_texture_size,
-        ),
+        .width = @min(size.width, self.max_texture_size),
+        .height = @min(size.height, self.max_texture_size),
     };
 }
 
@@ -265,10 +325,20 @@ pub fn initTarget(self: *const Metal, width: usize, height: usize) !Target {
 
 /// Present the provided target.
 pub inline fn present(self: *Metal, target: Target, sync: bool) !void {
-    if (sync) {
-        self.layer.setSurfaceSync(target.surface);
-    } else {
-        try self.layer.setSurface(target.surface);
+    switch (self.presenter) {
+        .layer => |*layer| {
+            if (sync) {
+                layer.setSurfaceSync(target.surface);
+            } else {
+                try layer.setSurface(target.surface);
+            }
+        },
+        .external => |external| external.present_callback(
+            external.userdata,
+            @ptrCast(target.surface),
+            @intCast(target.width),
+            @intCast(target.height),
+        ),
     }
 }
 

--- a/src/termio/Options.zig
+++ b/src/termio/Options.zig
@@ -39,3 +39,9 @@ renderer_mailbox: *renderer.Thread.Mailbox,
 
 /// The mailbox for sending the surface messages.
 surface_mailbox: apprt.surface.Mailbox,
+
+/// Optional PTY-output tee installed before the IO thread starts.
+pty_tee_cb: ?termio.Termio.PtyTeeCallback = null,
+
+/// Userdata passed to pty_tee_cb.
+pty_tee_userdata: ?*anyopaque = null,

--- a/src/termio/Termio.zig
+++ b/src/termio/Termio.zig
@@ -24,6 +24,12 @@ const ProcessInfo = @import("../pty.zig").ProcessInfo;
 
 const log = std.log.scoped(.io_exec);
 
+pub const PtyTeeCallback = *const fn (
+    ?*anyopaque,
+    [*]const u8,
+    usize,
+) callconv(.c) void;
+
 /// Mutex state argument for queueMessage.
 pub const MutexState = enum { locked, unlocked };
 
@@ -70,9 +76,9 @@ manual_linefeed_mode: std.atomic.Value(bool) = .{ .raw = false },
 /// this to broadcast raw bytes to a paired iPhone so the phone can feed
 /// the same bytes through its own libghostty surface, producing an
 /// identical grid by construction. Both fields are read on the IO read
-/// thread; install once from `apprt.embedded` after surface create and
-/// leave alone for the surface's lifetime.
-pty_tee_cb: ?*const fn (?*anyopaque, [*]const u8, usize) callconv(.c) void = null,
+/// thread. The embedded runtime installs initial values before starting that
+/// thread; the compatibility setter may replace them after surface creation.
+pty_tee_cb: ?PtyTeeCallback = null,
 pty_tee_userdata: ?*anyopaque = null,
 
 /// The stream parser. This parses the stream of escape codes and so on
@@ -322,6 +328,8 @@ pub fn init(self: *Termio, alloc: Allocator, opts: termio.Options) !void {
         .size = opts.size,
         .backend = backend,
         .mailbox = opts.mailbox,
+        .pty_tee_cb = opts.pty_tee_cb,
+        .pty_tee_userdata = opts.pty_tee_userdata,
         .terminal_stream = .initAlloc(alloc, handler),
         .thread_enter_state = thread_enter_state,
     };

--- a/src/termio/Termio.zig
+++ b/src/termio/Termio.zig
@@ -81,6 +81,11 @@ manual_linefeed_mode: std.atomic.Value(bool) = .{ .raw = false },
 pty_tee_cb: ?PtyTeeCallback = null,
 pty_tee_userdata: ?*anyopaque = null,
 
+/// Number of PTY-output bytes fully applied to terminal state. This is read
+/// and updated only while renderer_state.mutex is held. Addition wraps so the
+/// value remains a stable modulo-u64 stream position across long sessions.
+processed_output_bytes: u64 = 0,
+
 /// The stream parser. This parses the stream of escape codes and so on
 /// from the child process and calls callbacks in the stream handler.
 terminal_stream: StreamHandler.Stream,
@@ -804,7 +809,15 @@ pub fn processOutput(self: *Termio, buf: []const u8) void {
     // the lock to grab our read data.
     self.renderer_state.mutex.lock();
     defer self.renderer_state.mutex.unlock();
-    self.processOutputLocked(buf);
+    processOutputAndAdvanceLocked(self, buf);
+}
+
+/// Apply output and publish its byte position as one renderer-mutex critical
+/// section. Keeping the sequence update after the parser is the recovery
+/// contract: observers never see bytes as processed before terminal state does.
+fn processOutputAndAdvanceLocked(context: anytype, buf: []const u8) void {
+    context.processOutputLocked(buf);
+    context.processed_output_bytes +%= @intCast(buf.len);
 }
 
 /// Process output from readdata but the lock is already held.
@@ -857,6 +870,31 @@ fn processOutputLocked(self: *Termio, buf: []const u8) void {
         self.terminal_stream.handler.termio_messaged = false;
         self.mailbox.notify();
     }
+}
+
+test "processed output sequence advances after output is applied" {
+    const FakeTermio = struct {
+        processed_output_bytes: u64,
+        sequence_during_apply: u64 = 0,
+        applied_bytes: usize = 0,
+
+        fn processOutputLocked(self: *@This(), buf: []const u8) void {
+            self.sequence_during_apply = self.processed_output_bytes;
+            self.applied_bytes = buf.len;
+        }
+    };
+
+    var fake: FakeTermio = .{
+        .processed_output_bytes = std.math.maxInt(u64) - 1,
+    };
+    processOutputAndAdvanceLocked(&fake, "abc");
+
+    try std.testing.expectEqual(
+        std.math.maxInt(u64) - 1,
+        fake.sequence_during_apply,
+    );
+    try std.testing.expectEqual(@as(usize, 3), fake.applied_bytes);
+    try std.testing.expectEqual(@as(u64, 1), fake.processed_output_bytes);
 }
 
 /// Sends a DSR response for the current color scheme to the pty.


### PR DESCRIPTION
## Summary

- add a Metal external-presenter platform mode that renders without owning a window or drawable
- expose completed frames after GPU work finishes
- allow PTY output teeing before Ghostty starts I/O
- serialize configuration and atomically snapshot bounded VT recovery state

## Verification

- Ghostty ReleaseFast build and tests pass
- exercised through cmux's real out-of-process render-worker integration test

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/122"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786861247&installation_id=133855650&pr_number=122&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F122&signature=fb081a63d9cdd2a931251941de5f6562c2465ac9f1931eeac83e32186a60951d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Metal external-presenter mode that renders to IOSurfaces without owning a window and delivers completed frames via a callback. Also adds config serialization and an atomic VT+output-sequence snapshot for reliable out-of-process worker recovery, plus an initial PTY tee to avoid losing startup bytes.

- **New Features**
  - New platform `GHOSTTY_PLATFORM_METAL_EXTERNAL` with `ghostty_platform_metal_external_s` and `ghostty_metal_external_present_cb` for IOSurface presentation after GPU completion.
  - Metal renderer supports an external presenter (no `NSView`/`UIView`); size comes from the runtime surface; present path invokes the embedder callback.
  - Initial PTY tee at surface creation via `ghostty_surface_config_s` (`pty_tee_cb`, `pty_tee_userdata`); setter still supported.
  - Serialize effective config with `ghostty_config_serialize` (returns config-file syntax).
  - Atomically snapshot VT tail with output position using `ghostty_surface_read_screen_tail_vt_with_output_sequence`; sequence advances only after bytes are applied and wraps on `u64`.

- **Bug Fixes**
  - Command-palette actions with commas parse correctly via `Binding.Action.parseCLI` (e.g. `write_screen_file:copy,vt`).

<sup>Written for commit 0f400d0f5c12c5be4534f3397af999eca6a3411d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/122?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added external Metal rendering support for macOS and iOS embedding.
  * Added optional PTY output capture callbacks for embedders.
  * Added configuration serialization to Ghostty config-file format.
  * Added terminal screen-tail reading with output-sequence tracking.
  * Added command-line parsing support for binding actions.

* **Improvements**
  * Improved rendering presentation flexibility and external surface sizing.
  * Ensured output sequence tracking advances only after terminal updates complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->