### PR TITLE
Support indented hard-wrapped links

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -356,6 +356,9 @@ pub fn build(b: *std.Build) !void {
         });
         if (config.emit_test_exe) b.installArtifact(test_exe);
         _ = try deps.add(test_exe);
+        if (config.target.result.os.tag.isDarwin()) {
+            test_exe.linkFramework("Metal");
+        }
 
         // Verify our internal libghostty header.
         const ghostty_h = b.addTranslateC(.{

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -472,6 +472,10 @@ typedef enum {
 } ghostty_surface_io_mode_e;
 
 typedef void (*ghostty_io_write_cb)(void*, const char*, uintptr_t);
+// cmux fork: completion for one explicitly tokened render. The callback runs
+// only after that command buffer completed and its IOSurface was assigned to
+// the renderer layer on the main thread.
+typedef void (*ghostty_render_presented_cb)(void*, uint64_t);
 
 // Content-free renderer activity events emitted only when a surface installs
 // ghostty_renderer_event_cb. Begin/end pairs run on the renderer thread.
@@ -504,6 +508,8 @@ typedef struct {
   ghostty_io_write_cb io_write_cb;
   void* io_write_userdata;
   ghostty_renderer_event_cb renderer_event_cb;
+  ghostty_render_presented_cb render_presented_cb;
+  void* render_presented_userdata;
 } ghostty_surface_config_s;
 
 typedef struct {
@@ -1182,6 +1188,11 @@ GHOSTTY_API void ghostty_surface_draw(ghostty_surface_t);
 // cmux fork: delete when upstream exposes a synchronous render tick for
 // embedders that drive rendering from a platform display callback.
 GHOSTTY_API void ghostty_surface_render_now(ghostty_surface_t);
+// cmux fork: submit a forced render associated with `token`. When successful,
+// the surface's render_presented_cb fires after the exact rendered IOSurface
+// reaches the renderer CALayer. A failed or size-discarded render has no callback.
+GHOSTTY_API void ghostty_surface_render_now_with_token(ghostty_surface_t,
+                                                       uint64_t token);
 GHOSTTY_API void ghostty_surface_set_content_scale(ghostty_surface_t, double, double);
 GHOSTTY_API void ghostty_surface_set_focus(ghostty_surface_t, bool);
 GHOSTTY_API void ghostty_surface_set_occlusion(ghostty_surface_t, bool);

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -508,8 +508,6 @@ typedef struct {
   ghostty_io_write_cb io_write_cb;
   void* io_write_userdata;
   ghostty_renderer_event_cb renderer_event_cb;
-  ghostty_render_presented_cb render_presented_cb;
-  void* render_presented_userdata;
 } ghostty_surface_config_s;
 
 typedef struct {
@@ -1197,9 +1195,18 @@ GHOSTTY_API void ghostty_surface_draw(ghostty_surface_t);
 // cmux fork: delete when upstream exposes a synchronous render tick for
 // embedders that drive rendering from a platform display callback.
 GHOSTTY_API void ghostty_surface_render_now(ghostty_surface_t);
+// cmux fork: install the per-surface callback for explicitly tokened renders
+// without extending ghostty_surface_config_s's public ABI. Callback userdata
+// must belong to this surface and is intentionally not inherited by children.
+// The caller must serialize callback replacement with tokened submission.
+GHOSTTY_API void ghostty_surface_set_render_presented_callback(
+    ghostty_surface_t,
+    ghostty_render_presented_cb,
+    void* userdata);
 // cmux fork: submit a forced render associated with `token`. When successful,
-// the surface's render_presented_cb fires after the exact rendered IOSurface
-// reaches the renderer CALayer. A failed or size-discarded render has no callback.
+// the installed callback fires after the exact rendered IOSurface reaches the
+// renderer CALayer on the main thread. A failed or size-discarded render has
+// no callback.
 GHOSTTY_API void ghostty_surface_render_now_with_token(ghostty_surface_t,
                                                        uint64_t token);
 GHOSTTY_API void ghostty_surface_set_content_scale(ghostty_surface_t, double, double);

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -473,8 +473,9 @@ typedef enum {
 
 typedef void (*ghostty_io_write_cb)(void*, const char*, uintptr_t);
 // cmux fork: completion for one explicitly tokened render. The callback runs
-// only after that command buffer completed and its IOSurface was assigned to
-// the renderer layer on the main thread.
+// only after the backend successfully presents that exact frame and renderer
+// bookkeeping completes. Metal delivers after assigning its IOSurface on the
+// main thread. Synchronous backends deliver on the rendering caller's thread.
 typedef void (*ghostty_render_presented_cb)(void*, uint64_t);
 
 // Content-free renderer activity events emitted only when a surface installs
@@ -1196,17 +1197,19 @@ GHOSTTY_API void ghostty_surface_draw(ghostty_surface_t);
 // embedders that drive rendering from a platform display callback.
 GHOSTTY_API void ghostty_surface_render_now(ghostty_surface_t);
 // cmux fork: install the per-surface callback for explicitly tokened renders
-// without extending ghostty_surface_config_s's public ABI. Callback userdata
-// must belong to this surface and is intentionally not inherited by children.
-// The caller must serialize callback replacement with tokened submission.
-GHOSTTY_API void ghostty_surface_set_render_presented_callback(
+// without extending ghostty_surface_config_s's public ABI. Call once directly
+// after construction, before sharing the surface or submitting a tokened
+// render. Returns false for a null callback or if this surface already has a
+// callback. Callback userdata must remain valid until ghostty_surface_free
+// returns, belongs to this exact surface, and is not inherited by children.
+GHOSTTY_API bool ghostty_surface_set_render_presented_callback(
     ghostty_surface_t,
     ghostty_render_presented_cb,
     void* userdata);
 // cmux fork: submit a forced render associated with `token`. When successful,
-// the installed callback fires after the exact rendered IOSurface reaches the
-// renderer CALayer on the main thread. A failed or size-discarded render has
-// no callback.
+// the installed callback fires after the backend presents the exact rendered
+// frame. On Metal this follows main-thread IOSurface assignment. A failed or
+// size-discarded render has no callback.
 GHOSTTY_API void ghostty_surface_render_now_with_token(ghostty_surface_t,
                                                        uint64_t token);
 GHOSTTY_API void ghostty_surface_set_content_scale(ghostty_surface_t, double, double);

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -6996,6 +6996,62 @@ test "Surface: path link selection spans an indented hard newline" {
     }
 }
 
+test "Surface: wrapped URL hit testing excludes indentation and trailing punctuation" {
+    if (comptime !@import("terminal_options").oniguruma) return error.SkipZigTest;
+
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const first = "https://github.com/manaflow-ai/cmux/issues/8059#issuecomment-";
+    const second = "0123456789";
+    const value = first ++ second;
+
+    try oni.testing.ensureInit();
+    var config = try configpkg.Config.default(alloc);
+    defer config.deinit();
+    var derived = try DerivedConfig.init(alloc, &config);
+    defer derived.deinit();
+
+    var screen = try terminal.Screen.init(alloc, .{
+        .cols = 96,
+        .rows = 3,
+        .max_scrollback = 0,
+    });
+    defer screen.deinit();
+
+    try screen.testWriteString(first ++ "\r\n    " ++ second ++ ".");
+
+    for ([_]terminal.point.Coordinate{
+        .{ .x = 20, .y = 0 },
+        .{ .x = 8, .y = 1 },
+    }) |point| {
+        const pin = screen.pages.pin(.{ .active = point }).?;
+        const link = (try linkAtScreenPin(
+            alloc,
+            &screen,
+            derived.links,
+            pin,
+            null,
+        )) orelse return error.TestExpectedEqual;
+        const opened = try linkText(alloc, &screen, link);
+        defer alloc.free(opened);
+        try testing.expectEqualStrings(value, opened);
+    }
+
+    for ([_]terminal.point.Coordinate{
+        .{ .x = 1, .y = 1 },
+        .{ .x = 14, .y = 1 },
+    }) |point| {
+        const pin = screen.pages.pin(.{ .active = point }).?;
+        try testing.expect((try linkAtScreenPin(
+            alloc,
+            &screen,
+            derived.links,
+            pin,
+            null,
+        )) == null);
+    }
+}
+
 test "Surface: oversized soft-wrapped URL candidate is rejected" {
     const testing = std.testing;
     const alloc = testing.allocator;

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -4812,9 +4812,17 @@ fn linkActionTarget(link: Link) [:0]const u8 {
     return link.value;
 }
 
-fn linkClipboardTarget(link: Link, trim_trailing_spaces: bool) []const u8 {
-    _ = trim_trailing_spaces;
-    return linkActionTarget(link);
+fn linkClipboardTarget(
+    alloc: Allocator,
+    link: Link,
+    trim_trailing_spaces: bool,
+) Allocator.Error![:0]u8 {
+    const value = linkActionTarget(link);
+    const result = if (trim_trailing_spaces)
+        std.mem.trimRight(u8, value, " ")
+    else
+        value;
+    return try alloc.dupeZ(u8, result);
 }
 
 test "link clipboard target honors trailing-space trimming" {
@@ -4827,14 +4835,13 @@ test "link clipboard target honors trailing-space trimming" {
     };
     defer link.deinit(alloc);
 
-    try testing.expectEqualStrings(
-        "/tmp/example.app",
-        linkClipboardTarget(link, true),
-    );
-    try testing.expectEqualStrings(
-        "/tmp/example.app   ",
-        linkClipboardTarget(link, false),
-    );
+    const trimmed = try linkClipboardTarget(alloc, link, true);
+    defer alloc.free(trimmed);
+    try testing.expectEqualStrings("/tmp/example.app", trimmed);
+
+    const untrimmed = try linkClipboardTarget(alloc, link, false);
+    defer alloc.free(untrimmed);
+    try testing.expectEqualStrings("/tmp/example.app   ", untrimmed);
     try testing.expectEqualStrings(
         "/tmp/example.app   ",
         linkActionTarget(link),
@@ -5738,7 +5745,12 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
                 defer link_info.deinit(self.alloc);
                 // A bounding selection can include hard-newline indentation;
                 // action consumers use the canonical exact target instead.
-                const url_text = linkActionTarget(link_info);
+                const url_text = try linkClipboardTarget(
+                    self.alloc,
+                    link_info,
+                    self.config.clipboard_trim_trailing_spaces,
+                );
+                defer self.alloc.free(url_text);
 
                 self.rt_surface.setClipboard(.standard, &.{.{
                     .mime = "text/plain",

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -22,7 +22,7 @@ const Allocator = std.mem.Allocator;
 const ArenaAllocator = std.heap.ArenaAllocator;
 const global_state = &@import("global.zig").state;
 const oni = @import("oniguruma");
-const link_wrap = @import("link_wrap.zig");
+const linkpkg = @import("link.zig");
 const crash = @import("crash/main.zig");
 const unicode = @import("unicode/main.zig");
 const rendererpkg = @import("renderer.zig");
@@ -363,6 +363,7 @@ const DerivedConfig = struct {
         highlight: input.Link.Highlight,
         candidate_scope: input.Link.CandidateScope,
         hard_wrap_continuations: bool,
+        hard_wrap_match_delimiter: bool,
     };
 
     pub fn init(alloc_gpa: Allocator, config: *const configpkg.Config) !DerivedConfig {
@@ -383,6 +384,7 @@ const DerivedConfig = struct {
                     .highlight = link.highlight,
                     .candidate_scope = link.candidate_scope,
                     .hard_wrap_continuations = link.hard_wrap_continuations,
+                    .hard_wrap_match_delimiter = link.hard_wrap_match_delimiter,
                 });
             }
 
@@ -1660,6 +1662,9 @@ fn modsChanged(self: *Surface, mods: input.Mods) void {
 /// at which this is called may matter for the correctness of other
 /// mouse events (see cursorPosCallback) but this is shared logic
 /// for multiple events.
+///
+/// The renderer state mutex must be held. Regex resolution temporarily
+/// releases it and always reacquires it before returning.
 fn mouseRefreshLinks(
     self: *Surface,
     pos: apprt.CursorPos,
@@ -1702,33 +1707,101 @@ fn mouseRefreshLinks(
             }
         }
 
-        const link = (try self.linkAtPos(pos)) orelse break :link .{ null, false };
-        switch (link.action) {
-            .open => {
-                const str = try linkText(
-                    alloc,
-                    self.io.terminal.screens.active,
-                    link,
-                );
-                break :link .{
-                    .{ .url = str },
-                    self.config.link_previews == .true,
-                };
-            },
+        const screen = self.renderer_state.terminal.screens.active;
+        const mouse_pin = screen.pages.pin(.{ .viewport = pos_vp }) orelse
+            break :link .{ null, false };
+        const effective_mods = if (self.mouse.link_click_active)
+            input.ctrlOrSuper(.{})
+        else
+            self.mouse.mods;
+        const mouse_mods = self.mouseModsWithCapture(effective_mods);
 
-            ._open_osc8 => {
-                // Show the URL in the status bar
-                const pin = link.selection.start();
-                const uri = self.osc8URI(pin) orelse {
-                    log.warn("failed to get URI for OSC8 hyperlink", .{});
-                    break :link .{ null, false };
-                };
-                break :link .{
+        // OSC 8 metadata is already exact and requires no regex work.
+        if (mouse_mods.equal(input.ctrlOrSuper(.{}))) {
+            if (osc8URI(mouse_pin)) |uri| break :link .{
+                .{ .url = try alloc.dupeZ(u8, uri) },
+                self.config.link_previews != .false,
+            };
+        }
+
+        // Copy the bounded terminal candidates while locked, then let IO and
+        // rendering proceed during potentially expensive custom regex work.
+        // Resolution only compares copied Pin identities; it never
+        // dereferences their page nodes after the lock is released.
+        var prepared = try linkpkg.prepareAt(
+            alloc,
+            screen,
+            self.config.links,
+            mouse_pin,
+            mouse_mods,
+        );
+        for (0..2) |attempt| {
+            self.renderer_state.mutex.unlock();
+            const resolved_result = linkpkg.resolveAt(
+                terminal.Pin,
+                alloc,
+                prepared,
+                self.config.links,
+                mouse_mods,
+            );
+            self.renderer_state.mutex.lock();
+
+            // IO may have changed or reflowed the hovered cells while the
+            // regex ran. Re-copy the bounded snapshot and apply the result
+            // only when its exact strings and Pin maps still match.
+            if (self.renderer_state.terminal.screens.active != screen) {
+                self.mouse.link_point = null;
+                break :link .{ null, false };
+            }
+            const current_pin = screen.pages.pin(.{ .viewport = pos_vp }) orelse {
+                self.mouse.link_point = null;
+                break :link .{ null, false };
+            };
+            if (mouse_mods.equal(input.ctrlOrSuper(.{}))) {
+                if (osc8URI(current_pin)) |uri| break :link .{
                     .{ .url = try alloc.dupeZ(u8, uri) },
                     self.config.link_previews != .false,
                 };
-            },
+            }
+            const current = try linkpkg.prepareAt(
+                alloc,
+                screen,
+                self.config.links,
+                current_pin,
+                mouse_mods,
+            );
+            switch (linkSnapshotDisposition(
+                linkPreparedSnapshotsEqual(prepared, current),
+                attempt,
+            )) {
+                .retry => {
+                    prepared = current;
+                    continue;
+                },
+                .invalidate => {
+                    // A second concurrent mutation fails closed, but
+                    // invalidate the cell cache so the next same-cell event
+                    // tries again.
+                    self.mouse.link_point = null;
+                    break :link .{ null, false };
+                },
+                .apply => {},
+            }
+
+            const resolved = (try resolved_result) orelse
+                break :link .{ null, false };
+            switch (resolved.action) {
+                .open => break :link .{
+                    .{ .url = try alloc.dupeZ(u8, resolved.value) },
+                    self.config.link_previews == .true,
+                },
+
+                // OSC 8 is handled before candidate preparation.
+                ._open_osc8 => unreachable,
+            }
         }
+
+        unreachable;
     };
 
     // If we found a link, setup our internal state and notify the
@@ -4444,8 +4517,10 @@ pub fn mouseButtonCallback(
                 if (self.linkAtPin(
                     pin,
                     null,
-                )) |result_| {
-                    if (result_) |result| {
+                )) |result_opt| {
+                    if (result_opt) |result_value| {
+                        var result = result_value;
+                        defer result.deinit(self.alloc);
                         press_selection = result.selection;
                     }
                 } else |_| {
@@ -4533,7 +4608,9 @@ pub fn mouseButtonCallback(
 
                 // If there is a link at this position, we want to
                 // select the link. Otherwise, select the word.
-                if (try self.linkAtPos(pos)) |link| {
+                if (try self.linkAtPos(pos)) |link_| {
+                    var link = link_;
+                    defer link.deinit(self.alloc);
                     try self.setSelectionAndCopy(link.selection);
                 } else {
                     const sel = screen.selectWord(
@@ -4722,8 +4799,119 @@ fn maybePromptClick(self: *Surface) !bool {
 const Link = struct {
     action: input.Link.Action,
     selection: terminal.Selection,
-    hard_wrap_continuations: bool = false,
+    value: [:0]u8,
+
+    fn deinit(self: Link, alloc: Allocator) void {
+        alloc.free(self.value);
+    }
 };
+
+/// One exact action target for preview, open, and copy, regardless of whether
+/// the source is a regex match or OSC 8 metadata.
+fn linkActionTarget(link: Link) [:0]const u8 {
+    return link.value;
+}
+
+/// Compare two lock-bounded regex snapshots without dereferencing their Pin
+/// nodes. Pointer values remain safe comparison keys even if IO pruned an old
+/// page while regex resolution ran unlocked.
+fn linkPreparedSnapshotsEqual(
+    before: linkpkg.Prepared(terminal.Pin),
+    after: linkpkg.Prepared(terminal.Pin),
+) bool {
+    if (!std.meta.eql(before.target, after.target)) return false;
+    for (before.candidates, after.candidates) |before_candidates, after_candidates| {
+        if (before_candidates.len != after_candidates.len) return false;
+        for (before_candidates, after_candidates) |before_candidate, after_candidate| {
+            if (before_candidate.mapped_len != after_candidate.mapped_len or
+                !std.mem.eql(u8, before_candidate.string, after_candidate.string) or
+                before_candidate.map.len != after_candidate.map.len)
+            {
+                return false;
+            }
+            for (before_candidate.map, after_candidate.map) |before_pin, after_pin| {
+                if (!std.meta.eql(before_pin, after_pin)) return false;
+            }
+        }
+    }
+    return true;
+}
+
+const LinkSnapshotDisposition = enum {
+    apply,
+    retry,
+    invalidate,
+};
+
+fn linkSnapshotDisposition(matches: bool, attempt: usize) LinkSnapshotDisposition {
+    if (matches) return .apply;
+    return if (attempt == 0) .retry else .invalidate;
+}
+
+test "link snapshot validation retries once and detects exact changes" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var screen = try terminal.Screen.init(alloc, .{
+        .cols = 8,
+        .rows = 2,
+        .max_scrollback = 0,
+    });
+    defer screen.deinit();
+    const first = screen.pages.getTopLeft(.active);
+    const second = first.right(1);
+    const first_map = [_]terminal.Pin{ first, second };
+    const same_map = [_]terminal.Pin{ first, second };
+    const changed_map = [_]terminal.Pin{ second, first };
+    const first_candidates = [_]linkpkg.Candidate(terminal.Pin){.{
+        .string = "ab",
+        .mapped_len = 2,
+        .map = &first_map,
+    }};
+    const same_candidates = [_]linkpkg.Candidate(terminal.Pin){.{
+        .string = "ab",
+        .mapped_len = 2,
+        .map = &same_map,
+    }};
+    const changed_value_candidates = [_]linkpkg.Candidate(terminal.Pin){.{
+        .string = "ac",
+        .mapped_len = 2,
+        .map = &same_map,
+    }};
+    const changed_map_candidates = [_]linkpkg.Candidate(terminal.Pin){.{
+        .string = "ab",
+        .mapped_len = 2,
+        .map = &changed_map,
+    }};
+
+    var before: linkpkg.Prepared(terminal.Pin) = .{ .target = first };
+    before.candidates[0] = &first_candidates;
+    var same: linkpkg.Prepared(terminal.Pin) = .{ .target = first };
+    same.candidates[0] = &same_candidates;
+    var changed_value: linkpkg.Prepared(terminal.Pin) = .{ .target = first };
+    changed_value.candidates[0] = &changed_value_candidates;
+    var changed_map_value: linkpkg.Prepared(terminal.Pin) = .{ .target = first };
+    changed_map_value.candidates[0] = &changed_map_candidates;
+    var changed_target: linkpkg.Prepared(terminal.Pin) = .{ .target = second };
+    changed_target.candidates[0] = &same_candidates;
+
+    try testing.expect(linkPreparedSnapshotsEqual(before, same));
+    try testing.expect(!linkPreparedSnapshotsEqual(before, changed_value));
+    try testing.expect(!linkPreparedSnapshotsEqual(before, changed_map_value));
+    try testing.expect(!linkPreparedSnapshotsEqual(before, changed_target));
+    try testing.expectEqual(
+        LinkSnapshotDisposition.apply,
+        linkSnapshotDisposition(true, 0),
+    );
+    try testing.expectEqual(
+        LinkSnapshotDisposition.retry,
+        linkSnapshotDisposition(false, 0),
+    );
+    try testing.expectEqual(
+        LinkSnapshotDisposition.invalidate,
+        linkSnapshotDisposition(false, 1),
+    );
+}
 
 /// Returns the link at the given cursor position, if any.
 ///
@@ -4754,17 +4942,13 @@ fn linkAtPos(
         self.mouse.mods;
     const mouse_mods = self.mouseModsWithCapture(effective_mods);
 
-    // If we have the proper modifiers set then we can check for OSC8 links.
-    if (mouse_mods.equal(input.ctrlOrSuper(.{}))) hyperlink: {
-        const rac = mouse_pin.rowAndCell();
-        const cell = rac.cell;
-        if (!cell.hyperlink) break :hyperlink;
-        const sel = terminal.Selection.init(mouse_pin, mouse_pin, false);
-        return .{ .action = ._open_osc8, .selection = sel };
-    }
-
-    // Fall back to configured links
-    return try self.linkAtPin(mouse_pin, mouse_mods);
+    return try linkAtScreenPinWithOsc8(
+        self.alloc,
+        screen,
+        self.config.links,
+        mouse_pin,
+        mouse_mods,
+    );
 }
 
 /// Detects if a link is present at the given pin.
@@ -4787,6 +4971,26 @@ fn linkAtPin(
     );
 }
 
+/// Resolve mouse links with OSC 8 ownership before configured regexes. The
+/// URI is copied into the same exact-target field consumed by preview, open,
+/// and copy actions.
+fn linkAtScreenPinWithOsc8(
+    alloc: Allocator,
+    screen: *terminal.Screen,
+    links: []const DerivedConfig.Link,
+    mouse_pin: terminal.Pin,
+    mouse_mods: input.Mods,
+) !?Link {
+    if (mouse_mods.equal(input.ctrlOrSuper(.{}))) {
+        if (osc8URI(mouse_pin)) |uri| return .{
+            .action = ._open_osc8,
+            .selection = .init(mouse_pin, mouse_pin, false),
+            .value = try alloc.dupeZ(u8, uri),
+        };
+    }
+    return try linkAtScreenPin(alloc, screen, links, mouse_pin, mouse_mods);
+}
+
 /// Detects a configured link at a terminal pin without requiring a full
 /// Surface. Keeping the grid matcher here gives link hover, click, and copy
 /// actions one shared selection path and a focused behavioral test seam.
@@ -4798,249 +5002,36 @@ fn linkAtScreenPin(
     mouse_mods: ?input.Mods,
 ) !?Link {
     if (links.len == 0) return null;
+    var arena = ArenaAllocator.init(alloc);
+    defer arena.deinit();
+    const arena_alloc = arena.allocator();
 
-    var semantic_map_initialized = false;
-    var semantic_map: ?terminal.StringMap = null;
-    defer if (semantic_map) |map| map.deinit(alloc);
-
-    var logical_map_initialized = false;
-    var logical_map: ?terminal.StringMap = null;
-    defer if (logical_map) |map| map.deinit(alloc);
-
-    var semantic_hard_map_initialized = false;
-    var semantic_hard_map: ?terminal.StringMap = null;
-    defer if (semantic_hard_map) |map| map.deinit(alloc);
-
-    var logical_hard_map_initialized = false;
-    var logical_hard_map: ?terminal.StringMap = null;
-    defer if (logical_hard_map) |map| map.deinit(alloc);
-
-    for (links) |link| {
-        // Skip highlight/mods check when mouse_mods is null (double-click mode)
-        if (mouse_mods) |mods| switch (link.highlight) {
-            .always, .hover => {},
-            .always_mods, .hover_mods => |v| if (!v.equal(mods)) continue,
-        };
-
-        const candidate_map: terminal.StringMap = switch (link.candidate_scope) {
-            .semantic => candidate: {
-                const initialized = if (link.hard_wrap_continuations)
-                    &semantic_hard_map_initialized
-                else
-                    &semantic_map_initialized;
-                const map = if (link.hard_wrap_continuations)
-                    &semantic_hard_map
-                else
-                    &semantic_map;
-                if (!initialized.*) {
-                    initialized.* = true;
-                    if (screen.selectLine(.{
-                        .pin = mouse_pin,
-                        .whitespace = null,
-                        .semantic_prompt_boundary = true,
-                    })) |selection| {
-                        const candidate_selection = if (link.hard_wrap_continuations)
-                            expandHardWrappedLinkSelection(screen, selection, .semantic)
-                        else
-                            selection;
-                        map.* = try linkCandidateMap(
-                            alloc,
-                            screen,
-                            candidate_selection,
-                            link.hard_wrap_continuations,
-                            link.hard_wrap_continuations,
-                        );
-                    }
-                }
-                break :candidate map.* orelse continue;
-            },
-
-            .bounded_logical => candidate: {
-                const initialized = if (link.hard_wrap_continuations)
-                    &logical_hard_map_initialized
-                else
-                    &logical_map_initialized;
-                const map = if (link.hard_wrap_continuations)
-                    &logical_hard_map
-                else
-                    &logical_map;
-                if (!initialized.*) {
-                    initialized.* = true;
-                    if (boundedLogicalLinkLine(mouse_pin)) |selection| {
-                        const candidate_selection = if (link.hard_wrap_continuations)
-                            expandHardWrappedLinkSelection(screen, selection, .bounded_logical)
-                        else
-                            selection;
-                        map.* = try linkCandidateMap(
-                            alloc,
-                            screen,
-                            candidate_selection,
-                            link.hard_wrap_continuations,
-                            link.hard_wrap_continuations,
-                        );
-                    }
-                }
-                break :candidate map.* orelse continue;
-            },
-        };
-
-        var it = candidate_map.searchIterator(link.regex);
-        while (true) {
-            var match = (try it.next()) orelse break;
-            defer match.deinit();
-            const sel = match.selection();
-            if (!sel.contains(screen, mouse_pin)) continue;
-            return .{
-                .action = link.action,
-                .selection = sel,
-                .hard_wrap_continuations = link.hard_wrap_continuations,
-            };
-        }
-    }
-
-    return null;
-}
-
-fn linkCandidateMap(
-    alloc: Allocator,
-    screen: *terminal.Screen,
-    selection: terminal.Selection,
-    normalize_hard_wraps: bool,
-    terminate_joined: bool,
-) !terminal.StringMap {
-    var map: terminal.StringMap = undefined;
-    alloc.free(try screen.selectionString(alloc, .{
-        .sel = selection,
-        .trim = false,
-        .map = &map,
-    }));
-    if (!normalize_hard_wraps) return map;
-
-    const normalized = link_wrap.normalize(
-        terminal.Pin,
-        alloc,
-        map.string,
-        map.map,
-        .{ .terminate_joined = terminate_joined },
-    ) catch |err| {
-        map.deinit(alloc);
-        return err;
-    };
-    map.deinit(alloc);
-    return .{
-        .string = normalized.string,
-        .map = normalized.map,
-    };
-}
-
-fn linkText(
-    alloc: Allocator,
-    screen: *terminal.Screen,
-    link: Link,
-) ![:0]const u8 {
-    if (!link.hard_wrap_continuations) return try screen.selectionString(alloc, .{
-        .sel = link.selection,
-        .trim = false,
-    });
-
-    const map = try linkCandidateMap(
-        alloc,
+    const prepared = try linkpkg.prepareAt(
+        arena_alloc,
         screen,
-        link.selection,
-        true,
-        false,
+        links,
+        mouse_pin,
+        mouse_mods,
     );
-    alloc.free(map.map);
-    return map.string;
-}
+    const resolved = (try linkpkg.resolveAt(
+        terminal.Pin,
+        arena_alloc,
+        prepared,
+        links,
+        mouse_mods,
+    )) orelse return null;
 
-/// Extend a match candidate by one adjacent logical line on either side.
-/// Literal newlines remain in the candidate unless link_wrap recognizes a
-/// punctuation-plus-indentation boundary, so unrelated lines cannot match as
-/// one link.
-fn expandHardWrappedLinkSelection(
-    screen: *terminal.Screen,
-    selection: terminal.Selection,
-    candidate_scope: input.Link.CandidateScope,
-) terminal.Selection {
-    var start = selection.topLeft(screen);
-    var end = selection.bottomRight(screen);
-
-    if (start.up(1)) |previous| {
-        if (!previous.rowAndCell().row.wrap) {
-            if (linkCandidateSelection(screen, previous, candidate_scope)) |adjacent| {
-                start = adjacent.topLeft(screen);
-            }
-        }
-    }
-
-    if (!end.rowAndCell().row.wrap) {
-        if (end.down(1)) |next| {
-            if (linkCandidateSelection(screen, next, candidate_scope)) |adjacent| {
-                end = adjacent.bottomRight(screen);
-            }
-        }
-    }
-
-    return .init(start, end, false);
-}
-
-fn linkCandidateSelection(
-    screen: *terminal.Screen,
-    pin: terminal.Pin,
-    candidate_scope: input.Link.CandidateScope,
-) ?terminal.Selection {
-    return switch (candidate_scope) {
-        .semantic => screen.selectLine(.{
-            .pin = pin,
-            .whitespace = null,
-            .semantic_prompt_boundary = true,
-        }),
-        .bounded_logical => boundedLogicalLinkLine(pin),
+    const value = try alloc.dupeZ(u8, resolved.value);
+    errdefer alloc.free(value);
+    return .{
+        .action = resolved.action,
+        .selection = .init(
+            resolved.cells[0],
+            resolved.cells[resolved.cells.len - 1],
+            false,
+        ),
+        .value = value,
     };
-}
-
-const max_logical_link_candidate_cells = 8 * 1024;
-const max_logical_link_candidate_rows = 256;
-
-/// Returns the complete soft-wrapped logical line containing `pin`, provided
-/// it fits the renderer's fixed work budget. Oversized lines return null rather
-/// than a partial selection so a truncated URL can never be opened.
-fn boundedLogicalLinkLine(pin: terminal.Pin) ?terminal.Selection {
-    const initial_cols: usize = pin.node.cols();
-    if (initial_cols == 0 or initial_cols > max_logical_link_candidate_cells) return null;
-
-    var rows: usize = 1;
-    var remaining_cells = max_logical_link_candidate_cells - initial_cols;
-    var start = pin;
-    start.x = 0;
-    while (start.up(1)) |previous| {
-        if (!previous.rowAndCell().row.wrap) break;
-        if (rows == max_logical_link_candidate_rows) return null;
-
-        const previous_cols: usize = previous.node.cols();
-        if (previous_cols == 0 or previous_cols > remaining_cells) return null;
-        remaining_cells -= previous_cols;
-        start = previous;
-        start.x = 0;
-        rows += 1;
-    }
-
-    var end = pin;
-    end.x = @intCast(initial_cols - 1);
-    while (end.rowAndCell().row.wrap) {
-        if (rows == max_logical_link_candidate_rows) return null;
-
-        const next = end.down(1) orelse return null;
-        const next_cols: usize = next.node.cols();
-        if (next_cols == 0 or next_cols > remaining_cells) return null;
-        remaining_cells -= next_cols;
-        end = next;
-        end.x = @intCast(next_cols - 1);
-        rows += 1;
-    }
-
-    return .init(start, end, false);
 }
 
 /// This returns the mouse mods to consider for link highlighting or
@@ -5067,15 +5058,11 @@ fn mouseModsWithCapture(self: *Surface, mods: input.Mods) input.Mods {
 ///
 /// Requires the renderer state mutex is held.
 fn processLinks(self: *Surface, pos: apprt.CursorPos) !bool {
-    const link = try self.linkAtPos(pos) orelse return false;
+    var link = try self.linkAtPos(pos) orelse return false;
+    defer link.deinit(self.alloc);
     switch (link.action) {
         .open => {
-            const str = try linkText(
-                self.alloc,
-                self.io.terminal.screens.active,
-                link,
-            );
-            defer self.alloc.free(str);
+            const str = linkActionTarget(link);
 
             const resolved_path = try self.resolvePathForOpening(str);
             defer if (resolved_path) |p| self.alloc.free(p);
@@ -5085,11 +5072,7 @@ fn processLinks(self: *Surface, pos: apprt.CursorPos) !bool {
         },
 
         ._open_osc8 => {
-            const uri = self.osc8URI(link.selection.start()) orelse {
-                log.warn("failed to get URI for OSC8 hyperlink", .{});
-                return false;
-            };
-            try self.openUrl(.{ .kind = .unknown, .url = uri });
+            try self.openUrl(.{ .kind = .unknown, .url = linkActionTarget(link) });
         },
     }
 
@@ -5120,8 +5103,7 @@ fn openUrl(
 
 /// Return the URI for an OSC8 hyperlink at the given position or null
 /// if there is no hyperlink.
-fn osc8URI(self: *Surface, pin: terminal.Pin) ?[]const u8 {
-    _ = self;
+fn osc8URI(pin: terminal.Pin) ?[]const u8 {
     const page = pin.node.page();
     const cell = pin.rowAndCell().cell;
     const link_id = page.lookupHyperlink(cell) orelse return null;
@@ -5722,29 +5704,12 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
 
             self.renderer_state.mutex.lock();
             defer self.renderer_state.mutex.unlock();
-            if (try self.linkAtPos(pos)) |link_info| {
-                const url_text = switch (link_info.action) {
-                    .open => url_text: {
-                        // For regex links, get the text from selection
-                        break :url_text (self.io.terminal.screens.active.selectionString(self.alloc, .{
-                            .sel = link_info.selection,
-                            .trim = self.config.clipboard_trim_trailing_spaces,
-                        })) catch |err| {
-                            log.err("error reading url string err={}", .{err});
-                            return false;
-                        };
-                    },
-
-                    ._open_osc8 => url_text: {
-                        // For OSC8 links, get the URI directly from hyperlink data
-                        const uri = self.osc8URI(link_info.selection.start()) orelse {
-                            log.warn("failed to get URI for OSC8 hyperlink", .{});
-                            return false;
-                        };
-                        break :url_text try self.alloc.dupeZ(u8, uri);
-                    },
-                };
-                defer self.alloc.free(url_text);
+            if (try self.linkAtPos(pos)) |link_info_| {
+                var link_info = link_info_;
+                defer link_info.deinit(self.alloc);
+                // A bounding selection can include hard-newline indentation;
+                // action consumers use the canonical exact target instead.
+                const url_text = linkActionTarget(link_info);
 
                 self.rt_surface.setClipboard(.standard, &.{.{
                     .mime = "text/plain",
@@ -6858,13 +6823,14 @@ test "Surface: URL link selection spans semantic change at soft wrap" {
         .{ .x = 10, .y = 1 },
     }) |point| {
         const click_pin = screen.pages.pin(.{ .active = point }).?;
-        const link = (try linkAtScreenPin(
+        var link = (try linkAtScreenPin(
             alloc,
             &screen,
             derived.links,
             click_pin,
-            null,
+            input.ctrlOrSuper(.{}),
         )) orelse return error.TestExpectedEqual;
+        defer link.deinit(alloc);
         var selection = link.selection;
         defer selection.deinit(&screen);
 
@@ -6907,13 +6873,14 @@ test "Surface: path link selection retains semantic soft-wrap boundary" {
         .{ .x = 8, .y = 1 },
     }, 0..) |point, index| {
         const click_pin = screen.pages.pin(.{ .active = point }).?;
-        const link = (try linkAtScreenPin(
+        var link = (try linkAtScreenPin(
             alloc,
             &screen,
             derived.links,
             click_pin,
-            null,
+            input.ctrlOrSuper(.{}),
         )) orelse return error.TestExpectedEqual;
+        defer link.deinit(alloc);
         var selection = link.selection;
         defer selection.deinit(&screen);
 
@@ -6932,6 +6899,7 @@ test "Surface: path link selection spans an indented hard newline" {
 
     const testing = std.testing;
     const alloc = testing.allocator;
+    const prefix = "The built app is ";
     const first = "/Users/cmux-lawrence/Applications/cmux-browser-resize-modes-";
     const second = "20260716-warm.app";
     const selected_value = first ++ "\r\n    " ++ second;
@@ -6943,43 +6911,28 @@ test "Surface: path link selection spans an indented hard newline" {
     defer derived.deinit();
 
     var screen = try terminal.Screen.init(alloc, .{
-        .cols = 96,
+        .cols = 160,
         .rows = 3,
         .max_scrollback = 0,
     });
     defer screen.deinit();
 
     screen.cursorSetSemanticContent(.output);
-    try screen.testWriteString(first ++ "\r\n    " ++ second ++ ".");
-
-    const first_pin = screen.pages.pin(.{ .active = .{ .x = 20, .y = 0 } }).?;
-    const first_selection = screen.selectLine(.{
-        .pin = first_pin,
-        .whitespace = null,
-        .semantic_prompt_boundary = true,
-    }).?;
-    var candidate_map = try linkCandidateMap(
-        alloc,
-        &screen,
-        expandHardWrappedLinkSelection(&screen, first_selection, .semantic),
-        true,
-        true,
-    );
-    defer candidate_map.deinit(alloc);
-    try testing.expectEqualStrings(first ++ second ++ ".\x00", candidate_map.string);
+    try screen.testWriteString(prefix ++ first ++ "\r\n    " ++ second ++ ".");
 
     for ([_]terminal.point.Coordinate{
-        .{ .x = 20, .y = 0 },
+        .{ .x = prefix.len + 20, .y = 0 },
         .{ .x = 10, .y = 1 },
     }) |point| {
         const click_pin = screen.pages.pin(.{ .active = point }).?;
-        const link = (try linkAtScreenPin(
+        var link = (try linkAtScreenPin(
             alloc,
             &screen,
             derived.links,
             click_pin,
-            null,
+            input.ctrlOrSuper(.{}),
         )) orelse return error.TestExpectedEqual;
+        defer link.deinit(alloc);
         var selection = link.selection;
         defer selection.deinit(&screen);
 
@@ -6990,10 +6943,23 @@ test "Surface: path link selection spans an indented hard newline" {
         defer alloc.free(selected);
         try testing.expectEqualStrings(selected_value, selected);
 
-        const opened = try linkText(alloc, &screen, link);
-        defer alloc.free(opened);
-        try testing.expectEqualStrings(first ++ second, opened);
+        // The bounding selection retains terminal representation bytes for
+        // selection UI, while every action consumes the exact canonical
+        // target with the hard newline and indentation removed.
+        try testing.expectEqualStrings(first ++ second, linkActionTarget(link));
     }
+
+    const sentence_period = screen.pages.pin(.{ .active = .{
+        .x = 4 + second.len,
+        .y = 1,
+    } }).?;
+    try testing.expect((try linkAtScreenPin(
+        alloc,
+        &screen,
+        derived.links,
+        sentence_period,
+        input.ctrlOrSuper(.{}),
+    )) == null);
 }
 
 test "Surface: wrapped URL hit testing excludes indentation and trailing punctuation" {
@@ -7002,8 +6968,9 @@ test "Surface: wrapped URL hit testing excludes indentation and trailing punctua
     const testing = std.testing;
     const alloc = testing.allocator;
     const first = "https://github.com/manaflow-ai/cmux/issues/8059#issuecomment-";
-    const second = "0123456789";
-    const value = first ++ second;
+    const second = "01234-";
+    const third = "56789";
+    const value = first ++ second ++ third;
 
     try oni.testing.ensureInit();
     var config = try configpkg.Config.default(alloc);
@@ -7018,45 +6985,580 @@ test "Surface: wrapped URL hit testing excludes indentation and trailing punctua
     });
     defer screen.deinit();
 
-    try screen.testWriteString(first ++ "\r\n    " ++ second ++ ".");
+    try screen.testWriteString(first ++ "\r\n    " ++ second ++ "\r\n    " ++ third ++ ".,");
 
     for ([_]terminal.point.Coordinate{
         .{ .x = 20, .y = 0 },
         .{ .x = 8, .y = 1 },
+        .{ .x = 6, .y = 2 },
     }) |point| {
         const pin = screen.pages.pin(.{ .active = point }).?;
-        const link = (try linkAtScreenPin(
+        var link = (try linkAtScreenPin(
             alloc,
             &screen,
             derived.links,
             pin,
-            null,
+            input.ctrlOrSuper(.{}),
         )) orelse return error.TestExpectedEqual;
-        const opened = try linkText(alloc, &screen, link);
-        defer alloc.free(opened);
-        try testing.expectEqualStrings(value, opened);
+        defer link.deinit(alloc);
+        try testing.expectEqualStrings(value, linkActionTarget(link));
     }
 
     for ([_]terminal.point.Coordinate{
         .{ .x = 1, .y = 1 },
-        .{ .x = 14, .y = 1 },
+        .{ .x = 1, .y = 2 },
+        .{ .x = 9, .y = 2 },
+        .{ .x = 10, .y = 2 },
     }) |point| {
         const pin = screen.pages.pin(.{ .active = point }).?;
-        try testing.expect((try linkAtScreenPin(
+        const link = try linkAtScreenPin(
             alloc,
             &screen,
             derived.links,
             pin,
-            null,
+            input.ctrlOrSuper(.{}),
+        );
+        defer if (link) |link_value| link_value.deinit(alloc);
+        try testing.expect(link == null);
+    }
+}
+
+test "Surface: wrapped URL retains balanced punctuation owned by its regex" {
+    if (comptime !@import("terminal_options").oniguruma) return error.SkipZigTest;
+
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const first = "https://example.com/wiki/Rust_";
+    const second = "(video_game)";
+    const value = first ++ second;
+    try oni.testing.ensureInit();
+    var config = try configpkg.Config.default(alloc);
+    defer config.deinit();
+    var derived = try DerivedConfig.init(alloc, &config);
+    defer derived.deinit();
+
+    var screen = try terminal.Screen.init(alloc, .{
+        .cols = 64,
+        .rows = 3,
+        .max_scrollback = 0,
+    });
+    defer screen.deinit();
+    try screen.testWriteString(first ++ "\r\n    " ++ second ++ ".");
+
+    const closing_paren = screen.pages.pin(.{ .active = .{
+        .x = 4 + second.len - 1,
+        .y = 1,
+    } }).?;
+    var link = (try linkAtScreenPin(
+        alloc,
+        &screen,
+        derived.links,
+        closing_paren,
+        input.ctrlOrSuper(.{}),
+    )) orelse return error.TestExpectedEqual;
+    defer link.deinit(alloc);
+    try testing.expectEqualStrings(value, link.value);
+
+    const sentence_period = screen.pages.pin(.{ .active = .{
+        .x = 4 + second.len,
+        .y = 1,
+    } }).?;
+    try testing.expect((try linkAtScreenPin(
+        alloc,
+        &screen,
+        derived.links,
+        sentence_period,
+        input.ctrlOrSuper(.{}),
+    )) == null);
+}
+
+test "Surface: hard-wrap match delimiter is isolated to the built-in path matcher" {
+    if (comptime !@import("terminal_options").oniguruma) return error.SkipZigTest;
+
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    try oni.testing.ensureInit();
+
+    var screen = try terminal.Screen.init(alloc, .{
+        .cols = 32,
+        .rows = 3,
+        .max_scrollback = 0,
+    });
+    defer screen.deinit();
+    try screen.testWriteString("/tmp/a-\r\n    b.txt.");
+
+    var custom_regex = try oni.Regex.init(
+        "/tmp/a-b\\.txt\\.\\z",
+        .{},
+        oni.Encoding.utf8,
+        oni.Syntax.default,
+        null,
+    );
+    defer custom_regex.deinit();
+    const custom_links = [_]DerivedConfig.Link{.{
+        .regex = custom_regex,
+        .action = .{ .open = {} },
+        .highlight = .hover,
+        .candidate_scope = .semantic,
+        .hard_wrap_continuations = true,
+        .hard_wrap_match_delimiter = false,
+    }};
+
+    const final_dot = screen.pages.pin(.{ .active = .{ .x = 9, .y = 1 } }).?;
+    var custom = (try linkAtScreenPin(
+        alloc,
+        &screen,
+        &custom_links,
+        final_dot,
+        null,
+    )) orelse return error.TestExpectedEqual;
+    defer custom.deinit(alloc);
+    try testing.expectEqualStrings("/tmp/a-b.txt.", custom.value);
+
+    const url = @import("config/url.zig");
+    var path_regex = try oni.Regex.init(
+        url.path_regex,
+        .{},
+        oni.Encoding.utf8,
+        oni.Syntax.default,
+        null,
+    );
+    defer path_regex.deinit();
+    const path_links = [_]DerivedConfig.Link{.{
+        .regex = path_regex,
+        .action = .{ .open = {} },
+        .highlight = .hover,
+        .candidate_scope = .semantic,
+        .hard_wrap_continuations = true,
+        .hard_wrap_match_delimiter = true,
+    }};
+    const inside = screen.pages.pin(.{ .active = .{ .x = 6, .y = 1 } }).?;
+    var path = (try linkAtScreenPin(
+        alloc,
+        &screen,
+        &path_links,
+        inside,
+        null,
+    )) orelse return error.TestExpectedEqual;
+    defer path.deinit(alloc);
+    try testing.expectEqualStrings("/tmp/a-b.txt", path.value);
+    try testing.expect((try linkAtScreenPin(
+        alloc,
+        &screen,
+        &path_links,
+        final_dot,
+        null,
+    )) == null);
+}
+
+test "Surface: wrapped bare relative path excludes sentence punctuation" {
+    if (comptime !@import("terminal_options").oniguruma) return error.SkipZigTest;
+
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const first = "src/foo-";
+    const second = "bar/file.zig";
+    try oni.testing.ensureInit();
+
+    var config = try configpkg.Config.default(alloc);
+    defer config.deinit();
+    var derived = try DerivedConfig.init(alloc, &config);
+    defer derived.deinit();
+    var screen = try terminal.Screen.init(alloc, .{
+        .cols = 32,
+        .rows = 3,
+        .max_scrollback = 0,
+    });
+    defer screen.deinit();
+    try screen.testWriteString(first ++ "\r\n    " ++ second ++ ".,");
+
+    for ([_]terminal.point.Coordinate{
+        .{ .x = 3, .y = 0 },
+        .{ .x = 7, .y = 1 },
+    }) |point| {
+        const inside = screen.pages.pin(.{ .active = point }).?;
+        var path = (try linkAtScreenPin(
+            alloc,
+            &screen,
+            derived.links,
+            inside,
+            input.ctrlOrSuper(.{}),
+        )) orelse return error.TestExpectedEqual;
+        defer path.deinit(alloc);
+        try testing.expectEqualStrings(first ++ second, path.value);
+    }
+
+    for (4 + second.len..4 + second.len + 2) |x| {
+        const punctuation = screen.pages.pin(.{ .active = .{
+            .x = @intCast(x),
+            .y = 1,
+        } }).?;
+        try testing.expect((try linkAtScreenPin(
+            alloc,
+            &screen,
+            derived.links,
+            punctuation,
+            input.ctrlOrSuper(.{}),
         )) == null);
     }
 }
 
+test "Surface: sentence-ending URL does not join an indented path" {
+    if (comptime !@import("terminal_options").oniguruma) return error.SkipZigTest;
+
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const prefix = "See ";
+    const first = "https://example.com";
+    const second = "/tmp/foo";
+    try oni.testing.ensureInit();
+
+    var config = try configpkg.Config.default(alloc);
+    defer config.deinit();
+    var derived = try DerivedConfig.init(alloc, &config);
+    defer derived.deinit();
+    var screen = try terminal.Screen.init(alloc, .{
+        .cols = 80,
+        .rows = 3,
+        .max_scrollback = 0,
+    });
+    defer screen.deinit();
+    try screen.testWriteString(prefix ++ first ++ ".\r\n    " ++ second);
+
+    const upper = screen.pages.pin(.{ .active = .{
+        .x = prefix.len + 8,
+        .y = 0,
+    } }).?;
+    var link = (try linkAtScreenPin(
+        alloc,
+        &screen,
+        derived.links,
+        upper,
+        input.ctrlOrSuper(.{}),
+    )) orelse return error.TestExpectedEqual;
+    defer link.deinit(alloc);
+    try testing.expectEqualStrings(first, link.value);
+
+    const sentence_period = screen.pages.pin(.{ .active = .{
+        .x = prefix.len + first.len,
+        .y = 0,
+    } }).?;
+    try testing.expect((try linkAtScreenPin(
+        alloc,
+        &screen,
+        derived.links,
+        sentence_period,
+        input.ctrlOrSuper(.{}),
+    )) == null);
+
+    const lower = screen.pages.pin(.{ .active = .{ .x = 6, .y = 1 } }).?;
+    var path = (try linkAtScreenPin(
+        alloc,
+        &screen,
+        derived.links,
+        lower,
+        input.ctrlOrSuper(.{}),
+    )) orelse return error.TestExpectedEqual;
+    defer path.deinit(alloc);
+    try testing.expectEqualStrings(second, path.value);
+}
+
+test "Surface: adjacent independent links own their rows" {
+    if (comptime !@import("terminal_options").oniguruma) return error.SkipZigTest;
+
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const values = [_][]const u8{
+        "/tmp/foo/",
+        "/tmp/bar",
+        "https://example.com/path-",
+        "https://example.org",
+    };
+    try oni.testing.ensureInit();
+
+    var config = try configpkg.Config.default(alloc);
+    defer config.deinit();
+    var derived = try DerivedConfig.init(alloc, &config);
+    defer derived.deinit();
+    var screen = try terminal.Screen.init(alloc, .{
+        .cols = 80,
+        .rows = values.len,
+        .max_scrollback = 0,
+    });
+    defer screen.deinit();
+    try screen.testWriteString(
+        values[0] ++ "\r\n    " ++ values[1] ++
+            "\r\n" ++ values[2] ++ "\r\n    " ++ values[3],
+    );
+
+    for (values, 0..) |expected, y| {
+        const indentation: usize = if (y == 1 or y == 3) 4 else 0;
+        const pin = screen.pages.pin(.{ .active = .{
+            .x = @intCast(indentation + expected.len / 2),
+            .y = @intCast(y),
+        } }).?;
+        var link = (try linkAtScreenPin(
+            alloc,
+            &screen,
+            derived.links,
+            pin,
+            input.ctrlOrSuper(.{}),
+        )) orelse return error.TestExpectedEqual;
+        defer link.deinit(alloc);
+        try testing.expectEqualStrings(expected, link.value);
+    }
+}
+
+test "Surface: adjacent bare paths after slash do not merge" {
+    if (comptime !@import("terminal_options").oniguruma) return error.SkipZigTest;
+
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const first = "src/foo/";
+    try oni.testing.ensureInit();
+
+    var config = try configpkg.Config.default(alloc);
+    defer config.deinit();
+    var derived = try DerivedConfig.init(alloc, &config);
+    defer derived.deinit();
+
+    for ([_][]const u8{ "src/bar.zig", "日本語/bar.zig" }) |second| {
+        var screen = try terminal.Screen.init(alloc, .{
+            .cols = 80,
+            .rows = 2,
+            .max_scrollback = 0,
+        });
+        defer screen.deinit();
+        try screen.testWriteString(first ++ "\r\n    ");
+        try screen.testWriteString(second);
+
+        const upper = screen.pages.pin(.{ .active = .{ .x = 3, .y = 0 } }).?;
+        const upper_link = try linkAtScreenPin(
+            alloc,
+            &screen,
+            derived.links,
+            upper,
+            input.ctrlOrSuper(.{}),
+        );
+        defer if (upper_link) |link| link.deinit(alloc);
+        try testing.expect(upper_link == null);
+
+        const lower = screen.pages.pin(.{ .active = .{ .x = 4, .y = 1 } }).?;
+        var lower_link = (try linkAtScreenPin(
+            alloc,
+            &screen,
+            derived.links,
+            lower,
+            input.ctrlOrSuper(.{}),
+        )) orelse return error.TestExpectedEqual;
+        defer lower_link.deinit(alloc);
+        try testing.expectEqualStrings(second, lower_link.value);
+    }
+}
+
+test "Surface: hard newline does not join across a semantic boundary" {
+    if (comptime !@import("terminal_options").oniguruma) return error.SkipZigTest;
+
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    try oni.testing.ensureInit();
+    var config = try configpkg.Config.default(alloc);
+    defer config.deinit();
+    var derived = try DerivedConfig.init(alloc, &config);
+    defer derived.deinit();
+
+    var screen = try terminal.Screen.init(alloc, .{
+        .cols = 64,
+        .rows = 3,
+        .max_scrollback = 0,
+    });
+    defer screen.deinit();
+    screen.cursorSetSemanticContent(.output);
+    try screen.testWriteString("https://example.com/foo-\r\n");
+    screen.cursorSetSemanticContent(.{ .input = .clear_explicit });
+    try screen.testWriteString("    continuation");
+
+    const continuation = screen.pages.pin(.{ .active = .{ .x = 6, .y = 1 } }).?;
+    try testing.expect((try linkAtScreenPin(
+        alloc,
+        &screen,
+        derived.links,
+        continuation,
+        input.ctrlOrSuper(.{}),
+    )) == null);
+}
+
+test "Surface: UTF-8 hard-wrap link accepts wide glyph spacer tails" {
+    if (comptime !@import("terminal_options").oniguruma) return error.SkipZigTest;
+
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const first = "https://example.com/wiki/";
+    const value = first ++ "日本語";
+    try oni.testing.ensureInit();
+    var config = try configpkg.Config.default(alloc);
+    defer config.deinit();
+    var derived = try DerivedConfig.init(alloc, &config);
+    defer derived.deinit();
+
+    var t: terminal.Terminal = try .init(alloc, .{ .cols = 64, .rows = 3 });
+    defer t.deinit(alloc);
+    var stream = t.vtStream();
+    defer stream.deinit();
+    stream.nextSlice(first ++ "\r\n    日本語.");
+
+    for ([_]terminal.point.Coordinate{
+        .{ .x = 8, .y = 0 },
+        .{ .x = 4, .y = 1 },
+        .{ .x = 5, .y = 1 },
+        .{ .x = 6, .y = 1 },
+        .{ .x = 7, .y = 1 },
+        .{ .x = 8, .y = 1 },
+        .{ .x = 9, .y = 1 },
+    }) |point| {
+        const pin = t.screens.active.pages.pin(.{ .active = point }).?;
+        var link = (try linkAtScreenPin(
+            alloc,
+            t.screens.active,
+            derived.links,
+            pin,
+            input.ctrlOrSuper(.{}),
+        )) orelse return error.TestExpectedEqual;
+        defer link.deinit(alloc);
+        try testing.expectEqualStrings(value, link.value);
+    }
+
+    for ([_]terminal.point.Coordinate{
+        .{ .x = 2, .y = 1 },
+        .{ .x = 10, .y = 1 },
+    }) |point| {
+        const pin = t.screens.active.pages.pin(.{ .active = point }).?;
+        try testing.expect((try linkAtScreenPin(
+            alloc,
+            t.screens.active,
+            derived.links,
+            pin,
+            input.ctrlOrSuper(.{}),
+        )) == null);
+    }
+}
+
+test "Surface: OSC 8 owns an overlapping regex link target" {
+    if (comptime !@import("terminal_options").oniguruma) return error.SkipZigTest;
+
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    try oni.testing.ensureInit();
+    var config = try configpkg.Config.default(alloc);
+    defer config.deinit();
+    var derived = try DerivedConfig.init(alloc, &config);
+    defer derived.deinit();
+
+    var t: terminal.Terminal = try .init(alloc, .{ .cols = 64, .rows = 2 });
+    defer t.deinit(alloc);
+    var stream = t.vtStream();
+    defer stream.deinit();
+    stream.nextSlice(
+        "\x1b]8;;https://target.example/osc8\x1b\\" ++
+            "https://visible.example" ++
+            "\x1b]8;;\x1b\\.",
+    );
+
+    const pin = t.screens.active.pages.pin(.{ .active = .{ .x = 10, .y = 0 } }).?;
+    var link = (try linkAtScreenPinWithOsc8(
+        alloc,
+        t.screens.active,
+        derived.links,
+        pin,
+        input.ctrlOrSuper(.{}),
+    )) orelse return error.TestExpectedEqual;
+    defer link.deinit(alloc);
+    try testing.expectEqual(input.Link.Action._open_osc8, std.meta.activeTag(link.action));
+    try testing.expectEqualStrings("https://target.example/osc8", link.value);
+}
+
+test "Surface: higher-priority semantic match blocks a cross-scope click" {
+    if (comptime !@import("terminal_options").oniguruma) return error.SkipZigTest;
+
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    try oni.testing.ensureInit();
+
+    var bar = try oni.Regex.init(
+        "BAR",
+        .{},
+        oni.Encoding.utf8,
+        oni.Syntax.default,
+        null,
+    );
+    defer bar.deinit();
+    var foobar = try oni.Regex.init(
+        "FOOBAR",
+        .{},
+        oni.Encoding.utf8,
+        oni.Syntax.default,
+        null,
+    );
+    defer foobar.deinit();
+    const links = [_]DerivedConfig.Link{
+        .{
+            .regex = bar,
+            .action = .{ .open = {} },
+            .highlight = .hover,
+            .candidate_scope = .semantic,
+            .hard_wrap_continuations = false,
+            .hard_wrap_match_delimiter = false,
+        },
+        .{
+            .regex = foobar,
+            .action = .{ .open = {} },
+            .highlight = .hover,
+            .candidate_scope = .bounded_logical,
+            .hard_wrap_continuations = false,
+            .hard_wrap_match_delimiter = false,
+        },
+    };
+
+    var screen = try terminal.Screen.init(alloc, .{
+        .cols = 16,
+        .rows = 2,
+        .max_scrollback = 0,
+    });
+    defer screen.deinit();
+    screen.cursorSetSemanticContent(.output);
+    try screen.testWriteString("FOO");
+    screen.cursorSetSemanticContent(.{ .input = .clear_explicit });
+    try screen.testWriteString("BAR");
+
+    const foo_pin = screen.pages.pin(.{ .active = .{ .x = 1, .y = 0 } }).?;
+    const foo_link = try linkAtScreenPin(alloc, &screen, &links, foo_pin, null);
+    defer if (foo_link) |value| value.deinit(alloc);
+    try testing.expect(foo_link == null);
+
+    const bar_pin = screen.pages.pin(.{ .active = .{ .x = 4, .y = 0 } }).?;
+    var bar_link = (try linkAtScreenPin(
+        alloc,
+        &screen,
+        &links,
+        bar_pin,
+        null,
+    )) orelse return error.TestExpectedEqual;
+    defer bar_link.deinit(alloc);
+    try testing.expectEqualStrings("BAR", linkActionTarget(bar_link));
+}
+
 test "Surface: oversized soft-wrapped URL candidate is rejected" {
+    if (comptime !@import("terminal_options").oniguruma) return error.SkipZigTest;
+
     const testing = std.testing;
     const alloc = testing.allocator;
     const cols = 256;
-    const cell_count = max_logical_link_candidate_cells + 1;
+    const cell_count = linkpkg.max_logical_candidate_cells + 1;
+    try oni.testing.ensureInit();
+    var config = try configpkg.Config.default(alloc);
+    defer config.deinit();
+    var derived = try DerivedConfig.init(alloc, &config);
+    defer derived.deinit();
 
     var screen = try terminal.Screen.init(alloc, .{
         .cols = cols,
@@ -7068,8 +7570,24 @@ test "Surface: oversized soft-wrapped URL candidate is rejected" {
     const text = try alloc.alloc(u8, cell_count);
     defer alloc.free(text);
     @memset(text, 'a');
+    @memcpy(text[0.."https://".len], "https://");
     try screen.testWriteString(text);
 
-    const pin = screen.pages.pin(.{ .active = .{ .x = 0, .y = 0 } }).?;
-    try testing.expect(boundedLogicalLinkLine(pin) == null);
+    for ([_]terminal.point.Coordinate{
+        .{ .x = 0, .y = 0 },
+        .{
+            .x = @intCast((cell_count - 1) % cols),
+            .y = @intCast((cell_count - 1) / cols),
+        },
+    }) |point| {
+        const pin = screen.pages.pin(.{ .active = point }).?;
+        try testing.expect(linkpkg.boundedLogicalLine(pin) == null);
+        try testing.expect((try linkAtScreenPin(
+            alloc,
+            &screen,
+            derived.links,
+            pin,
+            null,
+        )) == null);
+    }
 }

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -6791,6 +6791,55 @@ test "Surface: path link selection retains semantic soft-wrap boundary" {
     }
 }
 
+test "Surface: path link selection spans an indented hard newline" {
+    if (comptime !@import("terminal_options").oniguruma) return error.SkipZigTest;
+
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const first = "/Users/cmux-lawrence/Applications/cmux-browser-resize-modes-";
+    const second = "20260716-warm.app";
+    const selected_value = first ++ "\n    " ++ second;
+
+    try oni.testing.ensureInit();
+    var config = try configpkg.Config.default(alloc);
+    defer config.deinit();
+    var derived = try DerivedConfig.init(alloc, &config);
+    defer derived.deinit();
+
+    var screen = try terminal.Screen.init(alloc, .{
+        .cols = 96,
+        .rows = 3,
+        .max_scrollback = 0,
+    });
+    defer screen.deinit();
+
+    screen.cursorSetSemanticContent(.output);
+    try screen.testWriteString(first ++ "\r\n    " ++ second ++ ".");
+
+    for ([_]terminal.point.Coordinate{
+        .{ .x = 20, .y = 0 },
+        .{ .x = 10, .y = 1 },
+    }) |point| {
+        const click_pin = screen.pages.pin(.{ .active = point }).?;
+        const link = (try linkAtScreenPin(
+            alloc,
+            &screen,
+            derived.links,
+            click_pin,
+            null,
+        )) orelse return error.TestExpectedEqual;
+        var selection = link.selection;
+        defer selection.deinit(&screen);
+
+        const selected = try screen.selectionString(alloc, .{
+            .sel = selection,
+            .trim = false,
+        });
+        defer alloc.free(selected);
+        try testing.expectEqualStrings(selected_value, selected);
+    }
+}
+
 test "Surface: oversized soft-wrapped URL candidate is rejected" {
     const testing = std.testing;
     const alloc = testing.allocator;

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -22,6 +22,7 @@ const Allocator = std.mem.Allocator;
 const ArenaAllocator = std.heap.ArenaAllocator;
 const global_state = &@import("global.zig").state;
 const oni = @import("oniguruma");
+const link_wrap = @import("link_wrap.zig");
 const crash = @import("crash/main.zig");
 const unicode = @import("unicode/main.zig");
 const rendererpkg = @import("renderer.zig");
@@ -361,6 +362,7 @@ const DerivedConfig = struct {
         action: input.Link.Action,
         highlight: input.Link.Highlight,
         candidate_scope: input.Link.CandidateScope,
+        hard_wrap_continuations: bool,
     };
 
     pub fn init(alloc_gpa: Allocator, config: *const configpkg.Config) !DerivedConfig {
@@ -380,6 +382,7 @@ const DerivedConfig = struct {
                     .action = link.action,
                     .highlight = link.highlight,
                     .candidate_scope = link.candidate_scope,
+                    .hard_wrap_continuations = link.hard_wrap_continuations,
                 });
             }
 
@@ -1702,10 +1705,11 @@ fn mouseRefreshLinks(
         const link = (try self.linkAtPos(pos)) orelse break :link .{ null, false };
         switch (link.action) {
             .open => {
-                const str = try self.io.terminal.screens.active.selectionString(alloc, .{
-                    .sel = link.selection,
-                    .trim = false,
-                });
+                const str = try linkText(
+                    alloc,
+                    self.io.terminal.screens.active,
+                    link,
+                );
                 break :link .{
                     .{ .url = str },
                     self.config.link_previews == .true,
@@ -4718,6 +4722,7 @@ fn maybePromptClick(self: *Surface) !bool {
 const Link = struct {
     action: input.Link.Action,
     selection: terminal.Selection,
+    hard_wrap_continuations: bool = false,
 };
 
 /// Returns the link at the given cursor position, if any.
@@ -4802,6 +4807,14 @@ fn linkAtScreenPin(
     var logical_map: ?terminal.StringMap = null;
     defer if (logical_map) |map| map.deinit(alloc);
 
+    var semantic_hard_map_initialized = false;
+    var semantic_hard_map: ?terminal.StringMap = null;
+    defer if (semantic_hard_map) |map| map.deinit(alloc);
+
+    var logical_hard_map_initialized = false;
+    var logical_hard_map: ?terminal.StringMap = null;
+    defer if (logical_hard_map) |map| map.deinit(alloc);
+
     for (links) |link| {
         // Skip highlight/mods check when mouse_mods is null (double-click mode)
         if (mouse_mods) |mods| switch (link.highlight) {
@@ -4811,27 +4824,63 @@ fn linkAtScreenPin(
 
         const candidate_map: terminal.StringMap = switch (link.candidate_scope) {
             .semantic => candidate: {
-                if (!semantic_map_initialized) {
-                    semantic_map_initialized = true;
+                const initialized = if (link.hard_wrap_continuations)
+                    &semantic_hard_map_initialized
+                else
+                    &semantic_map_initialized;
+                const map = if (link.hard_wrap_continuations)
+                    &semantic_hard_map
+                else
+                    &semantic_map;
+                if (!initialized.*) {
+                    initialized.* = true;
                     if (screen.selectLine(.{
                         .pin = mouse_pin,
                         .whitespace = null,
                         .semantic_prompt_boundary = true,
                     })) |selection| {
-                        semantic_map = try linkCandidateMap(alloc, screen, selection);
+                        const candidate_selection = if (link.hard_wrap_continuations)
+                            expandHardWrappedLinkSelection(screen, selection, .semantic)
+                        else
+                            selection;
+                        map.* = try linkCandidateMap(
+                            alloc,
+                            screen,
+                            candidate_selection,
+                            link.hard_wrap_continuations,
+                            link.hard_wrap_continuations,
+                        );
                     }
                 }
-                break :candidate semantic_map orelse continue;
+                break :candidate map.* orelse continue;
             },
 
             .bounded_logical => candidate: {
-                if (!logical_map_initialized) {
-                    logical_map_initialized = true;
+                const initialized = if (link.hard_wrap_continuations)
+                    &logical_hard_map_initialized
+                else
+                    &logical_map_initialized;
+                const map = if (link.hard_wrap_continuations)
+                    &logical_hard_map
+                else
+                    &logical_map;
+                if (!initialized.*) {
+                    initialized.* = true;
                     if (boundedLogicalLinkLine(mouse_pin)) |selection| {
-                        logical_map = try linkCandidateMap(alloc, screen, selection);
+                        const candidate_selection = if (link.hard_wrap_continuations)
+                            expandHardWrappedLinkSelection(screen, selection, .bounded_logical)
+                        else
+                            selection;
+                        map.* = try linkCandidateMap(
+                            alloc,
+                            screen,
+                            candidate_selection,
+                            link.hard_wrap_continuations,
+                            link.hard_wrap_continuations,
+                        );
                     }
                 }
-                break :candidate logical_map orelse continue;
+                break :candidate map.* orelse continue;
             },
         };
 
@@ -4844,6 +4893,7 @@ fn linkAtScreenPin(
             return .{
                 .action = link.action,
                 .selection = sel,
+                .hard_wrap_continuations = link.hard_wrap_continuations,
             };
         }
     }
@@ -4855,6 +4905,8 @@ fn linkCandidateMap(
     alloc: Allocator,
     screen: *terminal.Screen,
     selection: terminal.Selection,
+    normalize_hard_wraps: bool,
+    terminate_joined: bool,
 ) !terminal.StringMap {
     var map: terminal.StringMap = undefined;
     alloc.free(try screen.selectionString(alloc, .{
@@ -4862,7 +4914,90 @@ fn linkCandidateMap(
         .trim = false,
         .map = &map,
     }));
-    return map;
+    if (!normalize_hard_wraps) return map;
+
+    const normalized = link_wrap.normalize(
+        terminal.Pin,
+        alloc,
+        map.string,
+        map.map,
+        .{ .terminate_joined = terminate_joined },
+    ) catch |err| {
+        map.deinit(alloc);
+        return err;
+    };
+    map.deinit(alloc);
+    return .{
+        .string = normalized.string,
+        .map = normalized.map,
+    };
+}
+
+fn linkText(
+    alloc: Allocator,
+    screen: *terminal.Screen,
+    link: Link,
+) ![:0]const u8 {
+    if (!link.hard_wrap_continuations) return try screen.selectionString(alloc, .{
+        .sel = link.selection,
+        .trim = false,
+    });
+
+    const map = try linkCandidateMap(
+        alloc,
+        screen,
+        link.selection,
+        true,
+        false,
+    );
+    alloc.free(map.map);
+    return map.string;
+}
+
+/// Extend a match candidate by one adjacent logical line on either side.
+/// Literal newlines remain in the candidate unless link_wrap recognizes a
+/// punctuation-plus-indentation boundary, so unrelated lines cannot match as
+/// one link.
+fn expandHardWrappedLinkSelection(
+    screen: *terminal.Screen,
+    selection: terminal.Selection,
+    candidate_scope: input.Link.CandidateScope,
+) terminal.Selection {
+    var start = selection.topLeft(screen);
+    var end = selection.bottomRight(screen);
+
+    if (start.up(1)) |previous| {
+        if (!previous.rowAndCell().row.wrap) {
+            if (linkCandidateSelection(screen, previous, candidate_scope)) |adjacent| {
+                start = adjacent.topLeft(screen);
+            }
+        }
+    }
+
+    if (!end.rowAndCell().row.wrap) {
+        if (end.down(1)) |next| {
+            if (linkCandidateSelection(screen, next, candidate_scope)) |adjacent| {
+                end = adjacent.bottomRight(screen);
+            }
+        }
+    }
+
+    return .init(start, end, false);
+}
+
+fn linkCandidateSelection(
+    screen: *terminal.Screen,
+    pin: terminal.Pin,
+    candidate_scope: input.Link.CandidateScope,
+) ?terminal.Selection {
+    return switch (candidate_scope) {
+        .semantic => screen.selectLine(.{
+            .pin = pin,
+            .whitespace = null,
+            .semantic_prompt_boundary = true,
+        }),
+        .bounded_logical => boundedLogicalLinkLine(pin),
+    };
 }
 
 const max_logical_link_candidate_cells = 8 * 1024;
@@ -4935,10 +5070,11 @@ fn processLinks(self: *Surface, pos: apprt.CursorPos) !bool {
     const link = try self.linkAtPos(pos) orelse return false;
     switch (link.action) {
         .open => {
-            const str = try self.io.terminal.screens.active.selectionString(self.alloc, .{
-                .sel = link.selection,
-                .trim = false,
-            });
+            const str = try linkText(
+                self.alloc,
+                self.io.terminal.screens.active,
+                link,
+            );
             defer self.alloc.free(str);
 
             const resolved_path = try self.resolvePathForOpening(str);
@@ -6798,7 +6934,7 @@ test "Surface: path link selection spans an indented hard newline" {
     const alloc = testing.allocator;
     const first = "/Users/cmux-lawrence/Applications/cmux-browser-resize-modes-";
     const second = "20260716-warm.app";
-    const selected_value = first ++ "\n    " ++ second;
+    const selected_value = first ++ "\r\n    " ++ second;
 
     try oni.testing.ensureInit();
     var config = try configpkg.Config.default(alloc);
@@ -6815,6 +6951,22 @@ test "Surface: path link selection spans an indented hard newline" {
 
     screen.cursorSetSemanticContent(.output);
     try screen.testWriteString(first ++ "\r\n    " ++ second ++ ".");
+
+    const first_pin = screen.pages.pin(.{ .active = .{ .x = 20, .y = 0 } }).?;
+    const first_selection = screen.selectLine(.{
+        .pin = first_pin,
+        .whitespace = null,
+        .semantic_prompt_boundary = true,
+    }).?;
+    var candidate_map = try linkCandidateMap(
+        alloc,
+        &screen,
+        expandHardWrappedLinkSelection(&screen, first_selection, .semantic),
+        true,
+        true,
+    );
+    defer candidate_map.deinit(alloc);
+    try testing.expectEqualStrings(first ++ second ++ ".\x00", candidate_map.string);
 
     for ([_]terminal.point.Coordinate{
         .{ .x = 20, .y = 0 },
@@ -6837,6 +6989,10 @@ test "Surface: path link selection spans an indented hard newline" {
         });
         defer alloc.free(selected);
         try testing.expectEqualStrings(selected_value, selected);
+
+        const opened = try linkText(alloc, &screen, link);
+        defer alloc.free(opened);
+        try testing.expectEqualStrings(first ++ second, opened);
     }
 }
 

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -4812,6 +4812,35 @@ fn linkActionTarget(link: Link) [:0]const u8 {
     return link.value;
 }
 
+fn linkClipboardTarget(link: Link, trim_trailing_spaces: bool) []const u8 {
+    _ = trim_trailing_spaces;
+    return linkActionTarget(link);
+}
+
+test "link clipboard target honors trailing-space trimming" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    var link: Link = .{
+        .action = .{ .open = {} },
+        .selection = undefined,
+        .value = try alloc.dupeZ(u8, "/tmp/example.app   "),
+    };
+    defer link.deinit(alloc);
+
+    try testing.expectEqualStrings(
+        "/tmp/example.app",
+        linkClipboardTarget(link, true),
+    );
+    try testing.expectEqualStrings(
+        "/tmp/example.app   ",
+        linkClipboardTarget(link, false),
+    );
+    try testing.expectEqualStrings(
+        "/tmp/example.app   ",
+        linkActionTarget(link),
+    );
+}
+
 /// Compare two lock-bounded regex snapshots without dereferencing their Pin
 /// nodes. Pointer values remain safe comparison keys even if IO pruned an old
 /// page while regex resolution ran unlocked.

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -7003,6 +7003,88 @@ test "Surface: path link selection spans an indented hard newline" {
     )) == null);
 }
 
+test "Surface: wrapped path preserves mapped trailing spaces for copy policy" {
+    if (comptime !@import("terminal_options").oniguruma) return error.SkipZigTest;
+
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const first = "/tmp/build-";
+    const second = "warm.app";
+    const spaces = "   ";
+    const value = first ++ second;
+
+    try oni.testing.ensureInit();
+    var config = try configpkg.Config.default(alloc);
+    defer config.deinit();
+    var derived = try DerivedConfig.init(alloc, &config);
+    defer derived.deinit();
+
+    var screen = try terminal.Screen.init(alloc, .{
+        .cols = 64,
+        .rows = 3,
+        .max_scrollback = 0,
+    });
+    defer screen.deinit();
+    try screen.testWriteString(first ++ "\r\n    " ++ second ++ spaces);
+
+    const inside = screen.pages.pin(.{ .active = .{ .x = 6, .y = 1 } }).?;
+    var link = (try linkAtScreenPin(
+        alloc,
+        &screen,
+        derived.links,
+        inside,
+        input.ctrlOrSuper(.{}),
+    )) orelse return error.TestExpectedEqual;
+    defer link.deinit(alloc);
+    try testing.expectEqualStrings(value ++ spaces, linkActionTarget(link));
+
+    const trimmed = try linkClipboardTarget(alloc, link, true);
+    defer alloc.free(trimmed);
+    try testing.expectEqualStrings(value, trimmed);
+
+    const untrimmed = try linkClipboardTarget(alloc, link, false);
+    defer alloc.free(untrimmed);
+    try testing.expectEqualStrings(value ++ spaces, untrimmed);
+
+    var punctuated = try terminal.Screen.init(alloc, .{
+        .cols = 64,
+        .rows = 3,
+        .max_scrollback = 0,
+    });
+    defer punctuated.deinit();
+    try punctuated.testWriteString(first ++ "\r\n    " ++ second ++ "." ++ spaces);
+
+    const punctuated_inside = punctuated.pages.pin(.{ .active = .{
+        .x = 6,
+        .y = 1,
+    } }).?;
+    var punctuated_link = (try linkAtScreenPin(
+        alloc,
+        &punctuated,
+        derived.links,
+        punctuated_inside,
+        input.ctrlOrSuper(.{}),
+    )) orelse return error.TestExpectedEqual;
+    defer punctuated_link.deinit(alloc);
+    try testing.expectEqualStrings(value, linkActionTarget(punctuated_link));
+
+    for (second.len..second.len + 1 + spaces.len) |offset| {
+        const suffix = punctuated.pages.pin(.{ .active = .{
+            .x = @intCast(4 + offset),
+            .y = 1,
+        } }).?;
+        const suffix_link = try linkAtScreenPin(
+            alloc,
+            &punctuated,
+            derived.links,
+            suffix,
+            input.ctrlOrSuper(.{}),
+        );
+        defer if (suffix_link) |owned| owned.deinit(alloc);
+        try testing.expect(suffix_link == null);
+    }
+}
+
 test "Surface: wrapped URL hit testing excludes indentation and trailing punctuation" {
     if (comptime !@import("terminal_options").oniguruma) return error.SkipZigTest;
 
@@ -7128,33 +7210,38 @@ test "Surface: hard-wrap match delimiter is isolated to the built-in path matche
     defer screen.deinit();
     try screen.testWriteString("/tmp/a-\r\n    b.txt.");
 
-    var custom_regex = try oni.Regex.init(
-        "/tmp/a-b\\.txt\\.\\z",
-        .{},
-        oni.Encoding.utf8,
-        oni.Syntax.default,
-        null,
-    );
-    defer custom_regex.deinit();
-    const custom_links = [_]DerivedConfig.Link{.{
-        .regex = custom_regex,
-        .action = .{ .open = {} },
-        .highlight = .hover,
-        .candidate_scope = .semantic,
-        .hard_wrap_continuations = true,
-        .hard_wrap_match_delimiter = false,
-    }};
-
     const final_dot = screen.pages.pin(.{ .active = .{ .x = 9, .y = 1 } }).?;
-    var custom = (try linkAtScreenPin(
-        alloc,
-        &screen,
-        &custom_links,
-        final_dot,
-        null,
-    )) orelse return error.TestExpectedEqual;
-    defer custom.deinit(alloc);
-    try testing.expectEqualStrings("/tmp/a-b.txt.", custom.value);
+    for ([_][]const u8{
+        "/tmp/a-b\\.txt\\.\\z",
+        "/tmp/a-b\\.txt\\.$",
+    }) |pattern| {
+        var custom_regex = try oni.Regex.init(
+            pattern,
+            .{},
+            oni.Encoding.utf8,
+            oni.Syntax.default,
+            null,
+        );
+        defer custom_regex.deinit();
+        const custom_links = [_]DerivedConfig.Link{.{
+            .regex = custom_regex,
+            .action = .{ .open = {} },
+            .highlight = .hover,
+            .candidate_scope = .semantic,
+            .hard_wrap_continuations = true,
+            .hard_wrap_match_delimiter = false,
+        }};
+
+        var custom = (try linkAtScreenPin(
+            alloc,
+            &screen,
+            &custom_links,
+            final_dot,
+            null,
+        )) orelse return error.TestExpectedEqual;
+        defer custom.deinit(alloc);
+        try testing.expectEqualStrings("/tmp/a-b.txt.", custom.value);
+    }
 
     const url = @import("config/url.zig");
     var path_regex = try oni.Regex.init(

--- a/src/apprt.zig
+++ b/src/apprt.zig
@@ -8,6 +8,7 @@
 //! The goal is to have different implementations share as much of the core
 //! logic as possible, and to only reach out to platform-specific implementation
 //! code when absolutely necessary.
+const builtin = @import("builtin");
 const build_config = @import("build_config.zig");
 
 const structs = @import("apprt/structs.zig");
@@ -40,7 +41,9 @@ pub const SurfaceSize = structs.SurfaceSize;
 /// Note: it is very rare to use Runtime directly; most usage will use
 /// Window or something.
 pub const runtime = switch (build_config.artifact) {
-    .exe => switch (build_config.app_runtime) {
+    .exe => if (builtin.is_test and builtin.target.os.tag.isDarwin())
+        embedded
+    else switch (build_config.app_runtime) {
         .none => none,
         .gtk => gtk,
     },

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -3617,3 +3617,31 @@ test "render grid preserves terminal color semantics" {
     try std.testing.expectEqual(CAPI.RenderGridColorSource.rgb, rgb.source);
     try std.testing.expectEqual(@as(?u8, null), rgb.palette_index);
 }
+
+test "inherited surface options preserve render presentation callback" {
+    const Callbacks = struct {
+        fn renderPresented(_: ?*anyopaque, _: u64) callconv(.c) void {}
+    };
+
+    var config = try Config.default(std.testing.allocator);
+    defer config.deinit();
+    config.@"window-inherit-font-size" = false;
+    config.@"split-inherit-working-directory" = false;
+
+    var app: App = undefined;
+    app.config = config;
+
+    var callback_userdata: u8 = 0;
+    var surface: Surface = undefined;
+    surface.app = &app;
+    surface.io_mode = .manual;
+    surface.io_write_cb = null;
+    surface.io_write_userdata = null;
+    surface.renderer_event_cb = null;
+    surface.render_presented_cb = Callbacks.renderPresented;
+    surface.render_presented_userdata = &callback_userdata;
+
+    const inherited = surface.newSurfaceOptions(.split);
+    try std.testing.expectEqual(surface.render_presented_cb, inherited.render_presented_cb);
+    try std.testing.expectEqual(surface.render_presented_userdata, inherited.render_presented_userdata);
+}

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1108,6 +1108,8 @@ pub const Surface = struct {
             .io_write_cb = self.io_write_cb,
             .io_write_userdata = self.io_write_userdata,
             .renderer_event_cb = self.renderer_event_cb,
+            .render_presented_cb = self.render_presented_cb,
+            .render_presented_userdata = self.render_presented_userdata,
         };
     }
 

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -910,7 +910,10 @@ pub const Surface = struct {
     }
 
     pub fn renderNowWithToken(self: *Surface, token: u64) void {
-        const callback = self.render_presented_cb orelse return;
+        const callback = self.render_presented_cb orelse {
+            self.renderNow();
+            return;
+        };
         self.core_surface.applyPendingResizeIfNeeded();
         self.core_surface.renderer_thread.renderNowWithPresentation(.{
             .callback = callback,

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -673,7 +673,7 @@ pub const Surface = struct {
     }
 
     test "embedded surface scrollback cap inherits when unset" {
-        try std.testing.expectEqual(@as(usize, 136), @sizeOf(Options));
+        try std.testing.expectEqual(@as(usize, 120), @sizeOf(Options));
         try std.testing.expectEqual(
             @as(usize, 50_000_000),
             effectiveScrollbackLimit(50_000_000, 0),
@@ -3620,30 +3620,45 @@ test "render grid preserves terminal color semantics" {
     try std.testing.expectEqual(@as(?u8, null), rgb.palette_index);
 }
 
-test "inherited surface options preserve render presentation callback" {
+test "render presentation callback setter is per surface" {
     const Callbacks = struct {
         fn renderPresented(_: ?*anyopaque, _: u64) callconv(.c) void {}
     };
 
-    var config = try Config.default(std.testing.allocator);
-    defer config.deinit();
-    config.@"window-inherit-font-size" = false;
-    config.@"split-inherit-working-directory" = false;
+    var parent_userdata: u8 = 0;
+    var child_userdata: u8 = 0;
+    var parent: Surface = undefined;
+    parent.render_presented_cb = null;
+    parent.render_presented_userdata = null;
+    var child: Surface = undefined;
+    child.render_presented_cb = null;
+    child.render_presented_userdata = null;
 
-    var app: App = undefined;
-    app.config = config;
+    CAPI.ghostty_surface_set_render_presented_callback(
+        &parent,
+        Callbacks.renderPresented,
+        &parent_userdata,
+    );
+    try std.testing.expectEqual(Callbacks.renderPresented, parent.render_presented_cb);
+    try std.testing.expectEqual(
+        @as(?*anyopaque, &parent_userdata),
+        parent.render_presented_userdata,
+    );
+    try std.testing.expectEqual(null, child.render_presented_cb);
+    try std.testing.expectEqual(null, child.render_presented_userdata);
 
-    var callback_userdata: u8 = 0;
-    var surface: Surface = undefined;
-    surface.app = &app;
-    surface.io_mode = .manual;
-    surface.io_write_cb = null;
-    surface.io_write_userdata = null;
-    surface.renderer_event_cb = null;
-    surface.render_presented_cb = Callbacks.renderPresented;
-    surface.render_presented_userdata = &callback_userdata;
-
-    const inherited = surface.newSurfaceOptions(.split);
-    try std.testing.expectEqual(surface.render_presented_cb, inherited.render_presented_cb);
-    try std.testing.expectEqual(surface.render_presented_userdata, inherited.render_presented_userdata);
+    CAPI.ghostty_surface_set_render_presented_callback(
+        &child,
+        Callbacks.renderPresented,
+        &child_userdata,
+    );
+    try std.testing.expectEqual(Callbacks.renderPresented, child.render_presented_cb);
+    try std.testing.expectEqual(
+        @as(?*anyopaque, &child_userdata),
+        child.render_presented_userdata,
+    );
+    try std.testing.expectEqual(
+        @as(?*anyopaque, &parent_userdata),
+        parent.render_presented_userdata,
+    );
 }

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -430,6 +430,7 @@ pub const IoMode = enum(c_int) {
 
 pub const IoWriteCallback = *const fn (?*anyopaque, [*]const u8, usize) callconv(.c) void;
 pub const RendererEventCallback = renderer.InstrumentationCallback;
+pub const RenderPresentedCallback = *const fn (?*anyopaque, u64) callconv(.c) void;
 
 pub const Surface = struct {
     app: *App,
@@ -446,6 +447,8 @@ pub const Surface = struct {
     io_write_userdata: ?*anyopaque = null,
     renderer_event_cb: ?RendererEventCallback = null,
     scrollback_limit_bytes: usize = 0,
+    render_presented_cb: ?RenderPresentedCallback = null,
+    render_presented_userdata: ?*anyopaque = null,
 
     /// The current title of the surface. The embedded apprt saves this so
     /// that getTitle works without the implementer needing to save it.
@@ -505,6 +508,13 @@ pub const Surface = struct {
         /// Optional content-free renderer activity callback. This receives the
         /// surface `userdata` and runs synchronously on the renderer thread.
         renderer_event_cb: ?RendererEventCallback = null,
+
+        /// Callback invoked after an explicitly tokened render reaches the
+        /// platform renderer layer.
+        render_presented_cb: ?RenderPresentedCallback = null,
+
+        /// Userdata passed to render_presented_cb.
+        render_presented_userdata: ?*anyopaque = null,
     };
 
     pub fn init(
@@ -530,6 +540,8 @@ pub const Surface = struct {
             .io_write_userdata = opts.io_write_userdata,
             .renderer_event_cb = opts.renderer_event_cb,
             .scrollback_limit_bytes = scrollback_limit_bytes,
+            .render_presented_cb = opts.render_presented_cb,
+            .render_presented_userdata = opts.render_presented_userdata,
         };
 
         // Add ourselves to the list of surfaces on the app.
@@ -660,7 +672,7 @@ pub const Surface = struct {
     }
 
     test "embedded surface scrollback cap inherits when unset" {
-        try std.testing.expectEqual(@as(usize, 120), @sizeOf(Options));
+        try std.testing.expectEqual(@as(usize, 136), @sizeOf(Options));
         try std.testing.expectEqual(
             @as(usize, 50_000_000),
             effectiveScrollbackLimit(50_000_000, 0),
@@ -895,6 +907,16 @@ pub const Surface = struct {
     pub fn renderNow(self: *Surface) void {
         self.core_surface.applyPendingResizeIfNeeded();
         self.core_surface.renderer_thread.renderNow();
+    }
+
+    pub fn renderNowWithToken(self: *Surface, token: u64) void {
+        const callback = self.render_presented_cb orelse return;
+        self.core_surface.applyPendingResizeIfNeeded();
+        self.core_surface.renderer_thread.renderNowWithPresentation(.{
+            .callback = callback,
+            .userdata = self.render_presented_userdata,
+            .token = token,
+        });
     }
 
     pub fn updateContentScale(self: *Surface, x: f64, y: f64) void {
@@ -2046,6 +2068,12 @@ pub const CAPI = struct {
     /// Perform a full render cycle synchronously from the calling thread.
     export fn ghostty_surface_render_now(surface: *Surface) void {
         surface.renderNow();
+    }
+
+    /// Force a render whose exact layer presentation is acknowledged with the
+    /// caller-provided token.
+    export fn ghostty_surface_render_now_with_token(surface: *Surface, token: u64) void {
+        surface.renderNowWithToken(token);
     }
 
     /// Update the size of a surface. This will trigger resize notifications

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -448,6 +448,9 @@ pub const Surface = struct {
     io_write_userdata: ?*anyopaque = null,
     renderer_event_cb: ?RendererEventCallback = null,
     scrollback_limit_bytes: usize = 0,
+    // Presentation userdata belongs to this exact embedded surface. Install
+    // it through the post-construction setter instead of inheriting it through
+    // the public by-value Options ABI.
     render_presented_cb: ?RenderPresentedCallback = null,
     render_presented_userdata: ?*anyopaque = null,
 
@@ -509,13 +512,6 @@ pub const Surface = struct {
         /// Optional content-free renderer activity callback. This receives the
         /// surface `userdata` and runs synchronously on the renderer thread.
         renderer_event_cb: ?RendererEventCallback = null,
-
-        /// Callback invoked after an explicitly tokened render reaches the
-        /// platform renderer layer.
-        render_presented_cb: ?RenderPresentedCallback = null,
-
-        /// Userdata passed to render_presented_cb.
-        render_presented_userdata: ?*anyopaque = null,
     };
 
     pub fn init(
@@ -541,8 +537,6 @@ pub const Surface = struct {
             .io_write_userdata = opts.io_write_userdata,
             .renderer_event_cb = opts.renderer_event_cb,
             .scrollback_limit_bytes = scrollback_limit_bytes,
-            .render_presented_cb = opts.render_presented_cb,
-            .render_presented_userdata = opts.render_presented_userdata,
         };
 
         // Add ourselves to the list of surfaces on the app.
@@ -1108,8 +1102,6 @@ pub const Surface = struct {
             .io_write_cb = self.io_write_cb,
             .io_write_userdata = self.io_write_userdata,
             .renderer_event_cb = self.renderer_event_cb,
-            .render_presented_cb = self.render_presented_cb,
-            .render_presented_userdata = self.render_presented_userdata,
         };
     }
 
@@ -2092,6 +2084,18 @@ pub const CAPI = struct {
     /// Perform a full render cycle synchronously from the calling thread.
     export fn ghostty_surface_render_now(surface: *Surface) void {
         surface.renderNow();
+    }
+
+    /// Install the completion callback for this surface only. Inherited
+    /// surfaces have distinct embedder userdata and install their own callback
+    /// after construction.
+    export fn ghostty_surface_set_render_presented_callback(
+        surface: *Surface,
+        callback: ?RenderPresentedCallback,
+        userdata: ?*anyopaque,
+    ) void {
+        surface.render_presented_cb = callback;
+        surface.render_presented_userdata = userdata;
     }
 
     /// Force a render whose exact layer presentation is acknowledged with the

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -3638,11 +3638,11 @@ test "render presentation callback setter is per surface" {
     child.render_presented_cb = null;
     child.render_presented_userdata = null;
 
-    CAPI.ghostty_surface_set_render_presented_callback(
+    try std.testing.expect(CAPI.ghostty_surface_set_render_presented_callback(
         &parent,
         Callbacks.renderPresented,
         &parent_userdata,
-    );
+    ));
     try std.testing.expectEqual(Callbacks.renderPresented, parent.render_presented_cb);
     try std.testing.expectEqual(
         @as(?*anyopaque, &parent_userdata),
@@ -3651,16 +3651,30 @@ test "render presentation callback setter is per surface" {
     try std.testing.expectEqual(null, child.render_presented_cb);
     try std.testing.expectEqual(null, child.render_presented_userdata);
 
-    CAPI.ghostty_surface_set_render_presented_callback(
+    try std.testing.expect(CAPI.ghostty_surface_set_render_presented_callback(
         &child,
         Callbacks.renderPresented,
         &child_userdata,
-    );
+    ));
     try std.testing.expectEqual(Callbacks.renderPresented, child.render_presented_cb);
     try std.testing.expectEqual(
         @as(?*anyopaque, &child_userdata),
         child.render_presented_userdata,
     );
+    try std.testing.expectEqual(
+        @as(?*anyopaque, &parent_userdata),
+        parent.render_presented_userdata,
+    );
+
+    // Registration is one-shot because already-submitted frames snapshot the
+    // callback and userdata. Replacing either value could otherwise let an
+    // asynchronous presentation dereference userdata the embedder has freed.
+    try std.testing.expect(!CAPI.ghostty_surface_set_render_presented_callback(
+        &parent,
+        Callbacks.renderPresented,
+        &child_userdata,
+    ));
+    try std.testing.expectEqual(Callbacks.renderPresented, parent.render_presented_cb);
     try std.testing.expectEqual(
         @as(?*anyopaque, &parent_userdata),
         parent.render_presented_userdata,

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -2086,16 +2086,23 @@ pub const CAPI = struct {
         surface.renderNow();
     }
 
-    /// Install the completion callback for this surface only. Inherited
-    /// surfaces have distinct embedder userdata and install their own callback
-    /// after construction.
+    /// Install the completion callback for this surface only. Registration is
+    /// one-shot because submitted frames snapshot this userdata. Call before
+    /// sharing the surface or submitting tokened work. Inherited surfaces have
+    /// distinct embedder userdata and install their own callback after
+    /// construction. The embedder keeps userdata alive until surface
+    /// destruction returns.
     export fn ghostty_surface_set_render_presented_callback(
         surface: *Surface,
         callback: ?RenderPresentedCallback,
         userdata: ?*anyopaque,
-    ) void {
-        surface.render_presented_cb = callback;
+    ) bool {
+        const registered_callback = callback orelse return false;
+        if (surface.render_presented_cb != null) return false;
+
+        surface.render_presented_cb = registered_callback;
         surface.render_presented_userdata = userdata;
+        return true;
     }
 
     /// Force a render whose exact layer presentation is acknowledged with the

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -3932,6 +3932,7 @@ pub fn default(alloc_gpa: Allocator) Allocator.Error!Config {
         .action = .{ .open = {} },
         .highlight = .{ .hover_mods = inputpkg.ctrlOrSuper(.{}) },
         .hard_wrap_continuations = true,
+        .hard_wrap_match_delimiter = true,
     });
     result.link.default_matchers_present = true;
 
@@ -3953,6 +3954,8 @@ test "Config: default URL and path links use owned candidate scopes" {
     );
     try std.testing.expect(config.link.links.items[0].hard_wrap_continuations);
     try std.testing.expect(config.link.links.items[1].hard_wrap_continuations);
+    try std.testing.expect(!config.link.links.items[0].hard_wrap_match_delimiter);
+    try std.testing.expect(config.link.links.items[1].hard_wrap_match_delimiter);
 }
 
 test "Config: disabling URL links is idempotent and preserves custom matchers" {

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -3925,11 +3925,13 @@ pub fn default(alloc_gpa: Allocator) Allocator.Error!Config {
         .action = .{ .open = {} },
         .highlight = .{ .hover_mods = inputpkg.ctrlOrSuper(.{}) },
         .candidate_scope = .bounded_logical,
+        .hard_wrap_continuations = true,
     });
     try result.link.links.append(alloc, .{
         .regex = url.path_regex,
         .action = .{ .open = {} },
         .highlight = .{ .hover_mods = inputpkg.ctrlOrSuper(.{}) },
+        .hard_wrap_continuations = true,
     });
     result.link.default_matchers_present = true;
 
@@ -3949,6 +3951,8 @@ test "Config: default URL and path links use owned candidate scopes" {
         inputpkg.Link.CandidateScope.semantic,
         config.link.links.items[1].candidate_scope,
     );
+    try std.testing.expect(config.link.links.items[0].hard_wrap_continuations);
+    try std.testing.expect(config.link.links.items[1].hard_wrap_continuations);
 }
 
 test "Config: disabling URL links is idempotent and preserves custom matchers" {

--- a/src/config/url.zig
+++ b/src/config/url.zig
@@ -69,7 +69,10 @@ const no_trailing_path_punctuation =
 ;
 
 const trailing_spaces_at_eol =
-    \\(?: +(?= *$))?
+    // Hard-wrap normalization may append one match-only NUL after all mapped
+    // cells. Let spaces remain part of the match so clipboard policy can trim
+    // them, without teaching the punctuation guard to accept that delimiter.
+    \\(?: +(?= *(?:\x00)?$))?
 ;
 
 const dotted_spaced_path_lookahead =

--- a/src/config/url.zig
+++ b/src/config/url.zig
@@ -86,79 +86,67 @@ const non_dotted_path_lookahead =
 
 const single_spaced_path_no_dot_segment =
     \\ (?! )(?!\w+:\/\/)(?!\.{0,2}\/)(?!~\/)
-    ++ path_chars_no_dot ++
-    "+"
-;
+++ path_chars_no_dot ++
+    "+";
 
 const single_spaced_path_no_dot_segments =
-    "(?:" ++ single_spaced_path_no_dot_segment ++ ")*"
-;
+    "(?:" ++ single_spaced_path_no_dot_segment ++ ")*";
 
 const path_body_with_undotted_leaf =
-    "(?:" ++ path_segment_chars ++ "+/)*" ++ path_segment_chars_no_dot ++ "+"
-;
+    "(?:" ++ path_segment_chars ++ "+/)*" ++ path_segment_chars_no_dot ++ "+";
 
 const path_body_with_dotted_leaf =
-    "(?:" ++ path_segment_chars ++ "+/)*" ++ path_segment_chars ++ "*\\." ++ path_segment_chars ++ "+"
-;
+    "(?:" ++ path_segment_chars ++ "+/)*" ++ path_segment_chars ++ "*\\." ++ path_segment_chars ++ "+";
 
 const malformed_spaced_path_lookahead =
-    "(?=(?:" ++ single_spaced_path_no_dot_segment ++ ")*  )"
-;
+    "(?=(?:" ++ single_spaced_path_no_dot_segment ++ ")*  )";
 
 const dotted_path_space_dir_segment_no_dot_tail =
     \\(?:(?<!:) (?! )(?!\w+:\/\/)(?!\.{0,2}\/)(?!~\/)
-    ++ path_chars_no_dot ++
+++ path_chars_no_dot ++
     "+" ++
     single_spaced_path_no_dot_segments ++
     "/" ++
     path_chars_no_dot ++
-    "*)"
-;
+    "*)";
 
 const dotted_path_space_dir_segment_dotted_tail =
     \\(?:(?<!:) (?! )(?!\w+:\/\/)(?!\.{0,2}\/)(?!~\/)
-    ++ path_chars_no_dot ++
+++ path_chars_no_dot ++
     "+" ++
     single_spaced_path_no_dot_segments ++
     "/" ++
     path_chars_no_dot ++
     "*\\." ++
     path_chars ++
-    "*)"
-;
+    "*)";
 
 const dotted_path_space_dir_prefix_segments =
-    "(?:" ++ dotted_path_space_dir_segment_no_dot_tail ++ ")*"
-;
+    "(?:" ++ dotted_path_space_dir_segment_no_dot_tail ++ ")*";
 
 const dotted_path_space_file_segment =
     \\(?:(?<!:) (?! )(?!\w+:\/\/)(?!\.{0,2}\/)(?!~\/)
-    ++ path_chars_no_dot ++
+++ path_chars_no_dot ++
     "+" ++
     single_spaced_path_no_dot_segments ++
     "\\." ++
     path_chars ++
-    "*)"
-;
+    "*)";
 
 const dotted_path_space_single_file_segment =
     \\(?:(?<!:) (?! )(?!\w+:\/\/)(?!\.{0,2}\/)(?!~\/)
-    ++ path_chars_no_dot ++
+++ path_chars_no_dot ++
     "+\\." ++
     path_chars ++
-    "*)"
-;
+    "*)";
 
 const dotted_path_space_dir_suffix =
     dotted_path_space_dir_prefix_segments ++
-    dotted_path_space_dir_segment_dotted_tail
-;
+    dotted_path_space_dir_segment_dotted_tail;
 
 const dotted_path_space_suffix =
     dotted_path_space_dir_prefix_segments ++
-    "(?:" ++ dotted_path_space_dir_segment_dotted_tail ++ "|" ++ dotted_path_space_file_segment ++ ")"
-;
+    "(?:" ++ dotted_path_space_dir_segment_dotted_tail ++ "|" ++ dotted_path_space_file_segment ++ ")";
 
 const any_path_space_segments =
     \\(?:(?<!:) (?!\w+:\/\/)(?!\.{0,2}\/)(?!~\/)[\w\-.~:\/?#@!$&*+;=%]+)*
@@ -223,6 +211,7 @@ const bare_relative_path_branch =
     dotted_path_lookahead ++
     bare_relative_path_prefix ++
     path_chars ++ "+" ++
+    no_trailing_path_punctuation ++
     no_trailing_colon ++
     trailing_spaces_at_eol;
 

--- a/src/input/Link.zig
+++ b/src/input/Link.zig
@@ -29,6 +29,12 @@ candidate_scope: CandidateScope = .semantic,
 /// custom matchers retain their literal newline behavior by default.
 hard_wrap_continuations: bool = false,
 
+/// Append a matching-only delimiter after a candidate whose hard newlines
+/// were removed. This is an internal policy for the built-in path matcher,
+/// whose end-of-input branch otherwise accepts trailing sentence punctuation.
+/// Custom matchers keep their normal end-anchor semantics by default.
+hard_wrap_match_delimiter: bool = false,
+
 pub const CandidateScope = enum {
     /// Search only the semantic prompt region containing the clicked cell.
     semantic,
@@ -90,6 +96,7 @@ pub fn clone(self: *const Link, alloc: Allocator) Allocator.Error!Link {
         .highlight = self.highlight,
         .candidate_scope = self.candidate_scope,
         .hard_wrap_continuations = self.hard_wrap_continuations,
+        .hard_wrap_match_delimiter = self.hard_wrap_match_delimiter,
     };
 }
 
@@ -99,6 +106,7 @@ pub fn equal(self: *const Link, other: *const Link) bool {
         std.meta.eql(self.highlight, other.highlight) and
         self.candidate_scope == other.candidate_scope and
         self.hard_wrap_continuations == other.hard_wrap_continuations and
+        self.hard_wrap_match_delimiter == other.hard_wrap_match_delimiter and
         std.mem.eql(u8, self.regex, other.regex);
 }
 
@@ -109,4 +117,6 @@ test "Link: candidate scope defaults to semantic" {
         .highlight = .hover,
     };
     try std.testing.expectEqual(CandidateScope.semantic, link.candidate_scope);
+    try std.testing.expect(!link.hard_wrap_continuations);
+    try std.testing.expect(!link.hard_wrap_match_delimiter);
 }

--- a/src/input/Link.zig
+++ b/src/input/Link.zig
@@ -24,6 +24,11 @@ highlight: Highlight,
 /// The terminal text region searched by this matcher.
 candidate_scope: CandidateScope = .semantic,
 
+/// Whether a real newline plus indentation after common link punctuation is
+/// treated as prose hard-wrapping. Built-in URL and path matchers enable this;
+/// custom matchers retain their literal newline behavior by default.
+hard_wrap_continuations: bool = false,
+
 pub const CandidateScope = enum {
     /// Search only the semantic prompt region containing the clicked cell.
     semantic,
@@ -84,6 +89,7 @@ pub fn clone(self: *const Link, alloc: Allocator) Allocator.Error!Link {
         .action = self.action,
         .highlight = self.highlight,
         .candidate_scope = self.candidate_scope,
+        .hard_wrap_continuations = self.hard_wrap_continuations,
     };
 }
 
@@ -92,6 +98,7 @@ pub fn equal(self: *const Link, other: *const Link) bool {
     return std.meta.eql(self.action, other.action) and
         std.meta.eql(self.highlight, other.highlight) and
         self.candidate_scope == other.candidate_scope and
+        self.hard_wrap_continuations == other.hard_wrap_continuations and
         std.mem.eql(u8, self.regex, other.regex);
 }
 

--- a/src/link.zig
+++ b/src/link.zig
@@ -1,0 +1,2022 @@
+//! Canonical resolution for interactive regex links.
+//!
+//! A resolved link retains the exact regex byte range and its exact terminal
+//! cells. Consumers must use `Resolved.value` and `Resolved.cells`; a bounding
+//! selection is only a compatibility view for selection-oriented UI.
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const oni = @import("oniguruma");
+const input = @import("input.zig");
+const link_wrap = @import("link_wrap.zig");
+const terminal = @import("terminal/main.zig");
+
+pub fn Candidate(comptime Cell: type) type {
+    return struct {
+        string: [:0]const u8,
+        mapped_len: usize,
+        map: []const Cell,
+    };
+}
+
+pub fn Prepared(comptime Cell: type) type {
+    return struct {
+        target: Cell,
+        candidates: [candidate_key_count][]const Candidate(Cell) =
+            [_][]const Candidate(Cell){&.{}} ** candidate_key_count,
+    };
+}
+
+/// A borrowed resolved match. Its slices live as long as the prepared
+/// candidates and allocator passed to `resolveAt`. Resolution is designed for
+/// a short-lived frame or operation arena, which owns every prepared and
+/// resolved slice as one unit.
+pub fn Resolved(comptime Cell: type) type {
+    return struct {
+        matcher_index: usize,
+        action: input.Link.Action,
+        value: []const u8,
+        cells: []const Cell,
+    };
+}
+
+const CandidateKey = enum(u3) {
+    semantic,
+    semantic_hard,
+    semantic_hard_delimited,
+    bounded_logical,
+    bounded_logical_hard,
+    bounded_logical_hard_delimited,
+};
+
+const candidate_key_count = @typeInfo(CandidateKey).@"enum".fields.len;
+
+fn candidateKey(link: anytype) CandidateKey {
+    return switch (link.candidate_scope) {
+        .semantic => if (!link.hard_wrap_continuations)
+            .semantic
+        else if (link.hard_wrap_match_delimiter)
+            .semantic_hard_delimited
+        else
+            .semantic_hard,
+        .bounded_logical => if (!link.hard_wrap_continuations)
+            .bounded_logical
+        else if (link.hard_wrap_match_delimiter)
+            .bounded_logical_hard_delimited
+        else
+            .bounded_logical_hard,
+    };
+}
+
+fn candidateScope(key: CandidateKey) input.Link.CandidateScope {
+    return switch (key) {
+        .semantic, .semantic_hard, .semantic_hard_delimited => .semantic,
+        .bounded_logical,
+        .bounded_logical_hard,
+        .bounded_logical_hard_delimited,
+        => .bounded_logical,
+    };
+}
+
+fn candidateNormalizesHardWraps(key: CandidateKey) bool {
+    return switch (key) {
+        .semantic, .bounded_logical => false,
+        else => true,
+    };
+}
+
+fn candidateUsesDelimiter(key: CandidateKey) bool {
+    return switch (key) {
+        .semantic_hard_delimited, .bounded_logical_hard_delimited => true,
+        else => false,
+    };
+}
+
+pub fn candidatesFor(
+    comptime Cell: type,
+    prepared: Prepared(Cell),
+    link: anytype,
+) []const Candidate(Cell) {
+    return prepared.candidates[@intFromEnum(candidateKey(link))];
+}
+
+pub fn matcherActive(
+    link: anytype,
+    mouse_mods: ?input.Mods,
+) bool {
+    const mods = mouse_mods orelse return true;
+    return switch (link.highlight) {
+        .always, .hover => true,
+        .always_mods, .hover_mods => |required| required.equal(mods),
+    };
+}
+
+pub fn alwaysMatcherActive(
+    link: anytype,
+    mouse_mods: input.Mods,
+) bool {
+    return switch (link.highlight) {
+        .always => true,
+        .always_mods => |required| required.equal(mouse_mods),
+        .hover, .hover_mods => false,
+    };
+}
+
+/// Prepare every candidate variant needed by eligible matchers around one
+/// terminal pin. Candidate construction and hard-wrap policy therefore have
+/// one owner for click, preview, copy, and renderer hover. All allocations
+/// belong to a short-lived operation arena supplied by the caller.
+pub fn prepareAt(
+    alloc: Allocator,
+    screen: *terminal.Screen,
+    links: anytype,
+    target: terminal.Pin,
+    mouse_mods: ?input.Mods,
+) !Prepared(terminal.Pin) {
+    if (target.node.pageIfResident() == null) return .{ .target = target };
+    const canonical_target = if (target.rowAndCell().cell.wide == .spacer_tail)
+        target.left(1)
+    else
+        target;
+    var needed = [_]bool{false} ** candidate_key_count;
+
+    for (links) |link| {
+        if (!matcherActive(link, mouse_mods)) continue;
+        needed[@intFromEnum(candidateKey(link))] = true;
+    }
+
+    for (needed) |value| {
+        if (value) break;
+    } else return .{ .target = canonical_target };
+
+    // Candidate scopes can overlap without sharing boundaries. Resolve the
+    // complete connected component around the target so matcher priority is
+    // identical for click, hover, and whole-viewport rendering. For example,
+    // a semantic matcher in the BAR half of FOOBAR must still suppress a
+    // lower-priority logical FOOBAR match when the pointer is over FOO.
+    var builders = [_]std.ArrayList(Candidate(terminal.Pin)){.empty} **
+        candidate_key_count;
+    defer for (&builders) |*builder| builder.deinit(alloc);
+    var covered: CandidateCoverage = .{};
+    defer covered.deinit(alloc);
+    var budget: PreparationBudget = .{};
+    var pending: std.ArrayList(terminal.Selection) = .empty;
+    defer pending.deinit(alloc);
+
+    for (needed, 0..) |is_needed, index| {
+        if (!is_needed) continue;
+        const key: CandidateKey = @enumFromInt(index);
+        if (try appendCandidate(
+            terminal.Pin,
+            alloc,
+            screen,
+            key,
+            canonical_target,
+            &covered,
+            &budget,
+            &builders,
+            {},
+            identityPin,
+        )) |selection| try pending.append(alloc, selection);
+    }
+
+    try expandCandidateComponents(
+        terminal.Pin,
+        alloc,
+        screen,
+        &needed,
+        &covered,
+        &budget,
+        &builders,
+        &pending,
+        {},
+        identityPin,
+    );
+
+    if (budget.exhausted) return .{ .target = canonical_target };
+
+    var result: Prepared(terminal.Pin) = .{ .target = canonical_target };
+    for (&builders, 0..) |*builder, index| {
+        result.candidates[index] = try builder.toOwnedSlice(alloc);
+    }
+    return result;
+}
+
+fn identityPin(
+    _: void,
+    _: *terminal.Screen,
+    pin: terminal.Pin,
+) terminal.Pin {
+    return pin;
+}
+
+pub fn VisibleCandidates(comptime Cell: type) type {
+    return struct {
+        candidates: [candidate_key_count][]const Candidate(Cell) =
+            [_][]const Candidate(Cell){&.{}} ** candidate_key_count,
+
+        pub fn deinit(self: *@This(), alloc: Allocator) void {
+            for (self.candidates) |candidates| {
+                for (candidates) |candidate| {
+                    alloc.free(candidate.string);
+                    alloc.free(candidate.map);
+                }
+                if (candidates.len > 0) alloc.free(candidates);
+            }
+            self.* = .{};
+        }
+    };
+}
+
+const CandidateRowIdentity = struct {
+    key: CandidateKey,
+    node: usize,
+    y: terminal.size.CellCountInt,
+};
+
+const CellRange = struct {
+    start: terminal.size.CellCountInt,
+    end: terminal.size.CellCountInt,
+};
+
+const CandidateCoverage = struct {
+    rows: std.AutoHashMapUnmanaged(
+        CandidateRowIdentity,
+        std.ArrayListUnmanaged(CellRange),
+    ) = .empty,
+
+    fn contains(
+        self: *const CandidateCoverage,
+        key: CandidateKey,
+        pin: terminal.Pin,
+    ) bool {
+        const ranges = self.rows.get(.{
+            .key = key,
+            .node = @intFromPtr(pin.node),
+            .y = pin.y,
+        }) orelse return false;
+        var low: usize = 0;
+        var high = ranges.items.len;
+        while (low < high) {
+            const middle = low + (high - low) / 2;
+            const range = ranges.items[middle];
+            if (pin.x < range.start) {
+                high = middle;
+            } else if (pin.x > range.end) {
+                low = middle + 1;
+            } else {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    fn add(
+        self: *CandidateCoverage,
+        alloc: Allocator,
+        key: CandidateKey,
+        row: terminal.Pin,
+        range: CellRange,
+    ) !void {
+        const entry = try self.rows.getOrPut(alloc, .{
+            .key = key,
+            .node = @intFromPtr(row.node),
+            .y = row.y,
+        });
+        if (!entry.found_existing) entry.value_ptr.* = .empty;
+        const ranges = entry.value_ptr;
+        var index = ranges.items.len;
+        if (index == 0 or ranges.items[index - 1].start <= range.start) {
+            try ranges.append(alloc, range);
+        } else {
+            var low: usize = 0;
+            var high = index;
+            while (low < high) {
+                const middle = low + (high - low) / 2;
+                if (ranges.items[middle].start < range.start)
+                    low = middle + 1
+                else
+                    high = middle;
+            }
+            index = low;
+            try ranges.insert(alloc, index, range);
+        }
+
+        // Target preparation can discover a row's middle semantic domain
+        // before its neighbors. Keep coverage sorted and coalesced so lookup
+        // remains logarithmic regardless of discovery order.
+        if (index > 0 and ranges.items[index - 1].end >= ranges.items[index].start) {
+            ranges.items[index - 1].end = @max(
+                ranges.items[index - 1].end,
+                ranges.items[index].end,
+            );
+            _ = ranges.orderedRemove(index);
+            index -= 1;
+        }
+        while (index + 1 < ranges.items.len and
+            ranges.items[index].end >= ranges.items[index + 1].start)
+        {
+            ranges.items[index].end = @max(
+                ranges.items[index].end,
+                ranges.items[index + 1].end,
+            );
+            _ = ranges.orderedRemove(index + 1);
+        }
+    }
+
+    fn deinit(self: *CandidateCoverage, alloc: Allocator) void {
+        var values = self.rows.valueIterator();
+        while (values.next()) |ranges| ranges.deinit(alloc);
+        self.rows.deinit(alloc);
+    }
+};
+
+const max_visible_candidate_cells = 128 * 1024;
+const max_visible_candidate_domains = 4 * 1024;
+const max_candidate_attempts = 512;
+const CandidateReadError = error{NonResidentPage};
+
+const PreparationBudget = struct {
+    cells_remaining: usize = max_visible_candidate_cells,
+    probe_cells_remaining: usize = max_visible_candidate_cells,
+    bytes_remaining: usize = max_candidate_bytes,
+    domains_remaining: usize = max_visible_candidate_domains,
+    attempts_remaining: usize = max_candidate_attempts,
+    exhausted: bool = false,
+
+    fn beginAttempt(self: *PreparationBudget) bool {
+        if (self.attempts_remaining == 0) {
+            self.exhausted = true;
+            return false;
+        }
+        self.attempts_remaining -= 1;
+        return true;
+    }
+
+    fn probeCells(self: *PreparationBudget, cells: usize) bool {
+        if (cells > self.probe_cells_remaining) {
+            self.exhausted = true;
+            return false;
+        }
+        self.probe_cells_remaining -= cells;
+        return true;
+    }
+
+    fn beginDomain(self: *PreparationBudget, cost: SelectionCost) bool {
+        if (self.domains_remaining == 0 or cost.cells > self.cells_remaining) {
+            self.exhausted = true;
+            return false;
+        }
+        self.domains_remaining -= 1;
+        self.cells_remaining -= cost.cells;
+        return true;
+    }
+
+    fn addBytes(self: *PreparationBudget, len: usize) bool {
+        if (len > self.bytes_remaining) {
+            self.exhausted = true;
+            return false;
+        }
+        self.bytes_remaining -= len;
+        return true;
+    }
+};
+
+/// A small-buffer writer that counts output without retaining it and fails as
+/// soon as the byte limit is crossed. This lets terminal formatting abort in
+/// the middle of an oversized grapheme instead of traversing it to completion.
+const CappedCountingWriter = struct {
+    count: usize = 0,
+    limit: usize,
+    writer: std.Io.Writer,
+
+    fn init(buffer: []u8, limit: usize) CappedCountingWriter {
+        // One byte beyond the limit ensures even a tiny final buffered write
+        // is observable by fullCount. Larger output reaches drain and aborts.
+        const buffer_len = if (limit < buffer.len) limit + 1 else buffer.len;
+        return .{
+            .limit = limit,
+            .writer = .{
+                .vtable = &.{
+                    .drain = drain,
+                    .rebase = std.Io.Writer.failingRebase,
+                },
+                .buffer = buffer[0..buffer_len],
+            },
+        };
+    }
+
+    fn fullCount(self: *const CappedCountingWriter) ?usize {
+        return std.math.add(usize, self.count, self.writer.end) catch null;
+    }
+
+    fn drain(
+        writer: *std.Io.Writer,
+        data: []const []const u8,
+        splat: usize,
+    ) std.Io.Writer.Error!usize {
+        const self: *CappedCountingWriter = @alignCast(
+            @fieldParentPtr("writer", writer),
+        );
+        std.debug.assert(data.len > 0);
+
+        var incoming: usize = 0;
+        for (data[0 .. data.len - 1]) |bytes| {
+            incoming = std.math.add(usize, incoming, bytes.len) catch
+                return error.WriteFailed;
+        }
+        const pattern_len = std.math.mul(
+            usize,
+            data[data.len - 1].len,
+            splat,
+        ) catch return error.WriteFailed;
+        incoming = std.math.add(usize, incoming, pattern_len) catch
+            return error.WriteFailed;
+        const buffered = std.math.add(
+            usize,
+            self.count,
+            writer.end,
+        ) catch return error.WriteFailed;
+        const total = std.math.add(usize, buffered, incoming) catch
+            return error.WriteFailed;
+        if (total > self.limit) return error.WriteFailed;
+
+        self.count = total;
+        writer.end = 0;
+        return incoming;
+    }
+};
+
+fn appendCandidate(
+    comptime Cell: type,
+    alloc: Allocator,
+    screen: *terminal.Screen,
+    key: CandidateKey,
+    target: terminal.Pin,
+    covered: *CandidateCoverage,
+    budget: *PreparationBudget,
+    builders: *[candidate_key_count]std.ArrayList(Candidate(Cell)),
+    mapper_context: anytype,
+    mapper: anytype,
+) !?terminal.Selection {
+    if (budget.exhausted or covered.contains(key, target)) return null;
+    if (!budget.beginAttempt()) return null;
+    const selection = candidateSelectionForKey(screen, target, key, budget) catch {
+        budget.exhausted = true;
+        return null;
+    } orelse return null;
+    const cost = selectionCost(screen, selection) catch {
+        budget.exhausted = true;
+        return null;
+    } orelse return null;
+    if (!budget.beginDomain(cost)) return null;
+
+    // Mark the complete domain before building it. Viewport enumeration can
+    // otherwise rediscover the same soft-wrapped or hard-joined candidate
+    // once per row and turn bounded selection into quadratic work.
+    // Every internal selection is constructed in terminal-forward order.
+    // Avoid Selection.topLeft/bottomRight here: ordering a selection walks
+    // from the oldest history page to both pins.
+    const top = selection.start();
+    const bottom = selection.end();
+    var rows = top.rowIterator(.right_down, bottom);
+    while (rows.next()) |row| {
+        const start_x: usize = if (row.node == top.node and row.y == top.y)
+            top.x
+        else
+            0;
+        const end_x: usize = if (row.node == bottom.node and row.y == bottom.y)
+            bottom.x
+        else
+            row.node.cols() - 1;
+        try covered.add(alloc, key, row, .{
+            .start = @intCast(start_x),
+            .end = @intCast(end_x),
+        });
+    }
+
+    const source = (try candidateMapForSelection(
+        alloc,
+        screen,
+        selection,
+        key,
+        budget.bytes_remaining,
+    )) orelse {
+        budget.exhausted = true;
+        return null;
+    };
+    if (!budget.addBytes(source.string.len)) {
+        alloc.free(source.string);
+        alloc.free(source.map);
+        return null;
+    }
+    errdefer alloc.free(source.string);
+    defer alloc.free(source.map);
+    const mapped = try alloc.alloc(Cell, source.map.len);
+    errdefer alloc.free(mapped);
+    for (source.map, mapped) |pin, *cell| {
+        cell.* = mapper(mapper_context, screen, pin);
+    }
+    try builders[@intFromEnum(key)].append(alloc, .{
+        .string = source.string,
+        .mapped_len = source.mapped_len,
+        .map = mapped,
+    });
+    return selection;
+}
+
+/// Expand the overlap-connected candidate components represented by pending
+/// selections. Every active key is enumerated across each component, so a
+/// higher-priority match can suppress an overlapping lower-priority match
+/// even when their semantic or logical boundaries differ.
+fn expandCandidateComponents(
+    comptime Cell: type,
+    alloc: Allocator,
+    screen: *terminal.Screen,
+    needed: *const [candidate_key_count]bool,
+    covered: *CandidateCoverage,
+    budget: *PreparationBudget,
+    builders: *[candidate_key_count]std.ArrayList(Candidate(Cell)),
+    pending: *std.ArrayList(terminal.Selection),
+    mapper_context: anytype,
+    mapper: anytype,
+) !void {
+    var semantic_needed = false;
+    for (needed, 0..) |is_needed, index| {
+        if (is_needed and candidateScope(@enumFromInt(index)) == .semantic) {
+            semantic_needed = true;
+            break;
+        }
+    }
+    var pending_index: usize = 0;
+    while (pending_index < pending.items.len and !budget.exhausted) : (pending_index += 1) {
+        const selection = pending.items[pending_index];
+        const top = selection.start();
+        const bottom = selection.end();
+        var rows = top.rowIterator(.right_down, bottom);
+        while (rows.next()) |row| {
+            const page = row.node.pageIfResident() orelse {
+                budget.exhausted = true;
+                break;
+            };
+            const start_x: usize = if (row.node == top.node and row.y == top.y)
+                top.x
+            else
+                0;
+            const end_x: usize = if (row.node == bottom.node and row.y == bottom.y)
+                bottom.x
+            else
+                row.node.cols() - 1;
+
+            // Each touched physical row identifies its complete bounded
+            // logical domain. Coverage prevents rediscovering soft wraps.
+            for (needed, 0..) |is_needed, index| {
+                if (!is_needed) continue;
+                const key: CandidateKey = @enumFromInt(index);
+                if (candidateScope(key) != .bounded_logical) continue;
+                var target = row;
+                target.x = @intCast(start_x);
+                if (try appendCandidate(
+                    Cell,
+                    alloc,
+                    screen,
+                    key,
+                    target,
+                    covered,
+                    budget,
+                    builders,
+                    mapper_context,
+                    mapper,
+                )) |added| try pending.append(alloc, added);
+            }
+            if (budget.exhausted) break;
+            if (!semantic_needed) continue;
+
+            // Semantic domains can begin multiple times in one row. Probe
+            // only transitions inside the intersecting range; the first cell
+            // recovers a run that began before the range.
+            const cells = page.getCells(page.getRow(row.y));
+            var previous_semantic: ?terminal.page.Cell.SemanticContent = null;
+            for (cells[start_x .. end_x + 1], start_x..) |cell, x| {
+                if (previous_semantic) |previous| {
+                    if (std.meta.eql(previous, cell.semantic_content)) continue;
+                }
+                previous_semantic = cell.semantic_content;
+                var target = row;
+                target.x = @intCast(x);
+                for (needed, 0..) |is_needed, index| {
+                    if (!is_needed) continue;
+                    const key: CandidateKey = @enumFromInt(index);
+                    if (candidateScope(key) != .semantic) continue;
+                    if (try appendCandidate(
+                        Cell,
+                        alloc,
+                        screen,
+                        key,
+                        target,
+                        covered,
+                        budget,
+                        builders,
+                        mapper_context,
+                        mapper,
+                    )) |added| try pending.append(alloc, added);
+                }
+                if (budget.exhausted) break;
+            }
+        }
+    }
+}
+
+/// Copy every unique candidate domain intersecting the viewport for active
+/// always-highlight matchers. Candidate strings and stable mapped cells can
+/// then be resolved after releasing the terminal lock.
+pub fn prepareVisibleAlways(
+    comptime Cell: type,
+    alloc: Allocator,
+    screen: *terminal.Screen,
+    links: anytype,
+    mouse_mods: input.Mods,
+    mapper_context: anytype,
+    mapper: anytype,
+) !VisibleCandidates(Cell) {
+    var needed = [_]bool{false} ** candidate_key_count;
+    for (links) |link| {
+        if (!alwaysMatcherActive(link, mouse_mods)) continue;
+        needed[@intFromEnum(candidateKey(link))] = true;
+    }
+    for (needed) |value| {
+        if (value) break;
+    } else return .{};
+    var semantic_needed = false;
+    for (needed, 0..) |is_needed, index| {
+        if (is_needed and candidateScope(@enumFromInt(index)) == .semantic) {
+            semantic_needed = true;
+            break;
+        }
+    }
+
+    var builders = [_]std.ArrayList(Candidate(Cell)){.empty} ** candidate_key_count;
+    defer for (&builders) |*builder| builder.deinit(alloc);
+    errdefer for (&builders) |*builder| {
+        for (builder.items) |candidate| {
+            alloc.free(candidate.string);
+            alloc.free(candidate.map);
+        }
+    };
+    var covered: CandidateCoverage = .{};
+    defer covered.deinit(alloc);
+    var budget: PreparationBudget = .{};
+    var pending: std.ArrayList(terminal.Selection) = .empty;
+    defer pending.deinit(alloc);
+
+    var rows = screen.pages.getTopLeft(.viewport).rowIterator(.right_down, null);
+    var previous_wrap: ?bool = null;
+    var logical_line_eligible = true;
+    viewport_rows: for (0..screen.pages.rows) |_| {
+        var row_pin = rows.next() orelse break;
+        row_pin.x = 0;
+        const page = row_pin.node.pageIfResident() orelse {
+            budget.exhausted = true;
+            break :viewport_rows;
+        };
+        const row = page.getRow(row_pin.y);
+
+        // Preflight each soft-wrapped logical line once. If it exceeds the
+        // fixed candidate budget, skip every semantic transition in that
+        // same line instead of repeating the rejected 8K scan per cell.
+        if (previous_wrap == null or !previous_wrap.?) {
+            logical_line_eligible = (boundedLogicalLineChecked(row_pin, null) catch {
+                budget.exhausted = true;
+                break :viewport_rows;
+            }) != null;
+        }
+        previous_wrap = row.wrap;
+        if (!logical_line_eligible) continue;
+
+        // Logical candidates have one domain per complete soft-wrapped line.
+        for (needed, 0..) |is_needed, index| {
+            if (!is_needed) continue;
+            const key: CandidateKey = @enumFromInt(index);
+            if (candidateScope(key) != .bounded_logical) continue;
+            if (try appendCandidate(
+                Cell,
+                alloc,
+                screen,
+                key,
+                row_pin,
+                &covered,
+                &budget,
+                &builders,
+                mapper_context,
+                mapper,
+            )) |selection| try pending.append(alloc, selection);
+            if (budget.exhausted) break :viewport_rows;
+        }
+
+        // Semantic candidates can begin more than once inside a physical row.
+        if (!semantic_needed) continue;
+        const cells = page.getCells(row);
+        var previous_semantic: ?terminal.page.Cell.SemanticContent = null;
+        for (cells, 0..) |cell, x| {
+            if (previous_semantic) |previous| {
+                if (std.meta.eql(previous, cell.semantic_content)) continue;
+            }
+            previous_semantic = cell.semantic_content;
+            var target = row_pin;
+            target.x = @intCast(x);
+            for (needed, 0..) |is_needed, index| {
+                if (!is_needed) continue;
+                const key: CandidateKey = @enumFromInt(index);
+                if (candidateScope(key) != .semantic) continue;
+                if (try appendCandidate(
+                    Cell,
+                    alloc,
+                    screen,
+                    key,
+                    target,
+                    &covered,
+                    &budget,
+                    &builders,
+                    mapper_context,
+                    mapper,
+                )) |selection| try pending.append(alloc, selection);
+                if (budget.exhausted) break :viewport_rows;
+            }
+        }
+    }
+
+    if (!budget.exhausted) try expandCandidateComponents(
+        Cell,
+        alloc,
+        screen,
+        &needed,
+        &covered,
+        &budget,
+        &builders,
+        &pending,
+        mapper_context,
+        mapper,
+    );
+
+    if (budget.exhausted) {
+        for (&builders) |*builder| {
+            for (builder.items) |candidate| {
+                alloc.free(candidate.string);
+                alloc.free(candidate.map);
+            }
+            builder.clearRetainingCapacity();
+        }
+        return .{};
+    }
+
+    var result: VisibleCandidates(Cell) = .{};
+    errdefer result.deinit(alloc);
+    for (&builders, 0..) |*builder, index| {
+        result.candidates[index] = try builder.toOwnedSlice(alloc);
+    }
+    return result;
+}
+
+/// Convert prepared terminal pins to stable caller-owned cell identities while
+/// the terminal lock is held. The candidate strings remain shared and mapped
+/// arrays belong to the same short-lived operation arena.
+pub fn mapPrepared(
+    comptime Cell: type,
+    alloc: Allocator,
+    screen: *terminal.Screen,
+    prepared: Prepared(terminal.Pin),
+    mapper_context: anytype,
+    mapper: anytype,
+) !Prepared(Cell) {
+    var result: Prepared(Cell) = .{
+        .target = mapper(mapper_context, screen, prepared.target),
+    };
+
+    for (prepared.candidates, 0..) |sources, index| {
+        if (sources.len == 0) continue;
+        const mapped_candidates = try alloc.alloc(Candidate(Cell), sources.len);
+        for (sources, mapped_candidates) |source, *mapped_candidate| {
+            const mapped = try alloc.alloc(Cell, source.map.len);
+            for (source.map, mapped) |pin, *cell| {
+                cell.* = mapper(mapper_context, screen, pin);
+            }
+            mapped_candidate.* = .{
+                .string = source.string,
+                .mapped_len = source.mapped_len,
+                .map = mapped,
+            };
+        }
+        result.candidates[index] = mapped_candidates;
+    }
+
+    return result;
+}
+
+/// Resolve every canonical match in the prepared candidate domain.
+///
+/// Matchers are considered in configuration order. Every accepted match marks
+/// its exact cells as occupied. A lower-priority overlapping match is rejected
+/// as a whole, so it cannot claim punctuation outside a higher-priority URL.
+/// All returned slices belong to the caller's short-lived operation arena.
+pub fn resolveAll(
+    comptime Cell: type,
+    alloc: Allocator,
+    prepared: Prepared(Cell),
+    links: anytype,
+    mouse_mods: ?input.Mods,
+    seed_occupied: []const Cell,
+) ![]Resolved(Cell) {
+    var occupied: std.AutoHashMapUnmanaged(Cell, void) = .empty;
+    defer occupied.deinit(alloc);
+    for (seed_occupied) |cell| try occupied.put(alloc, cell, {});
+
+    var results: std.ArrayList(Resolved(Cell)) = .empty;
+    defer results.deinit(alloc);
+    errdefer for (results.items) |match| alloc.free(match.cells);
+    var cells: std.ArrayList(Cell) = .empty;
+    defer cells.deinit(alloc);
+    var budget: SearchBudget = .{};
+
+    for (links, 0..) |link, matcher_index| {
+        if (!matcherActive(link, mouse_mods)) continue;
+        const candidates = candidatesFor(Cell, prepared, link);
+        for (candidates) |candidate| {
+            std.debug.assert(candidate.mapped_len == candidate.map.len);
+            std.debug.assert(candidate.mapped_len <= candidate.string.len);
+            if (!budget.beginCandidate(candidate.string.len)) break;
+
+            var matches = try MatchIterator.init(link.regex, candidate.string, &budget);
+            defer matches.deinit();
+            while (try matches.next()) |range| {
+                // A match-only delimiter can be present after the mapped
+                // prefix. It must never enter the target cell range.
+                if (range.end > candidate.mapped_len) continue;
+
+                cells.clearRetainingCapacity();
+                try cells.ensureTotalCapacity(alloc, range.end - range.start);
+
+                for (candidate.map[range.start..range.end]) |cell| {
+                    if (cells.getLastOrNull()) |last| {
+                        if (std.meta.eql(last, cell)) continue;
+                    }
+                    try cells.append(alloc, cell);
+                }
+                if (cells.items.len == 0) continue;
+
+                var overlaps = false;
+                for (cells.items) |cell| {
+                    if (occupied.contains(cell)) {
+                        overlaps = true;
+                        break;
+                    }
+                }
+                if (overlaps) continue;
+
+                for (cells.items) |cell| try occupied.put(alloc, cell, {});
+
+                try results.ensureUnusedCapacity(alloc, 1);
+                const owned_cells = try alloc.dupe(Cell, cells.items);
+                results.appendAssumeCapacity(.{
+                    .matcher_index = matcher_index,
+                    .action = link.action,
+                    .value = candidate.string[range.start..range.end],
+                    .cells = owned_cells,
+                });
+            }
+        }
+        if (budget.exhausted) break;
+    }
+
+    if (budget.exhausted) {
+        for (results.items) |match| alloc.free(match.cells);
+        return &.{};
+    }
+    return try results.toOwnedSlice(alloc);
+}
+
+/// Resolve all active always-highlight matches across unique visible
+/// candidate domains. Matcher priority and exact-cell overlap arbitration are
+/// identical to interactive resolution.
+pub fn resolveVisibleAlways(
+    comptime Cell: type,
+    alloc: Allocator,
+    prepared: VisibleCandidates(Cell),
+    links: anytype,
+    mouse_mods: input.Mods,
+    seed_occupied: []const Cell,
+) ![]Resolved(Cell) {
+    var occupied: std.AutoHashMapUnmanaged(Cell, void) = .empty;
+    defer occupied.deinit(alloc);
+    for (seed_occupied) |cell| try occupied.put(alloc, cell, {});
+    var results: std.ArrayList(Resolved(Cell)) = .empty;
+    defer results.deinit(alloc);
+    errdefer for (results.items) |match| alloc.free(match.cells);
+    var cells: std.ArrayList(Cell) = .empty;
+    defer cells.deinit(alloc);
+    var budget: SearchBudget = .{};
+
+    for (links, 0..) |link, matcher_index| {
+        if (!alwaysMatcherActive(link, mouse_mods)) continue;
+        const candidates = prepared.candidates[@intFromEnum(candidateKey(link))];
+        for (candidates) |candidate| {
+            std.debug.assert(candidate.mapped_len == candidate.map.len);
+            std.debug.assert(candidate.mapped_len <= candidate.string.len);
+            if (!budget.beginCandidate(candidate.string.len)) break;
+
+            var matches = try MatchIterator.init(link.regex, candidate.string, &budget);
+            defer matches.deinit();
+            while (try matches.next()) |range| {
+                if (range.end > candidate.mapped_len) continue;
+
+                cells.clearRetainingCapacity();
+                try cells.ensureTotalCapacity(alloc, range.end - range.start);
+                for (candidate.map[range.start..range.end]) |cell| {
+                    if (cells.getLastOrNull()) |last| {
+                        if (std.meta.eql(last, cell)) continue;
+                    }
+                    try cells.append(alloc, cell);
+                }
+                if (cells.items.len == 0) continue;
+
+                var overlaps = false;
+                for (cells.items) |cell| {
+                    if (occupied.contains(cell)) {
+                        overlaps = true;
+                        break;
+                    }
+                }
+                if (overlaps) continue;
+
+                for (cells.items) |cell| try occupied.put(alloc, cell, {});
+                try results.ensureUnusedCapacity(alloc, 1);
+                const owned_cells = try alloc.dupe(Cell, cells.items);
+                results.appendAssumeCapacity(.{
+                    .matcher_index = matcher_index,
+                    .action = link.action,
+                    .value = candidate.string[range.start..range.end],
+                    .cells = owned_cells,
+                });
+            }
+        }
+        if (budget.exhausted) break;
+    }
+
+    // Never render a prefix of the candidate set when a hostile matcher or an
+    // oversized viewport exhausts the finite work budget.
+    if (budget.exhausted) {
+        for (results.items) |match| alloc.free(match.cells);
+        return &.{};
+    }
+    return try results.toOwnedSlice(alloc);
+}
+
+/// Resolve the accepted match that owns the target cell.
+pub fn resolveAt(
+    comptime Cell: type,
+    alloc: Allocator,
+    prepared: Prepared(Cell),
+    links: anytype,
+    mouse_mods: ?input.Mods,
+) !?Resolved(Cell) {
+    var occupied: std.AutoHashMapUnmanaged(Cell, void) = .empty;
+    defer occupied.deinit(alloc);
+    var cells: std.ArrayList(Cell) = .empty;
+    defer cells.deinit(alloc);
+    var budget: SearchBudget = .{};
+
+    for (links, 0..) |link, matcher_index| {
+        if (!matcherActive(link, mouse_mods)) continue;
+        const candidates = candidatesFor(Cell, prepared, link);
+        for (candidates) |candidate| {
+            std.debug.assert(candidate.mapped_len == candidate.map.len);
+            std.debug.assert(candidate.mapped_len <= candidate.string.len);
+            if (!budget.beginCandidate(candidate.string.len)) break;
+
+            var matches = try MatchIterator.init(link.regex, candidate.string, &budget);
+            defer matches.deinit();
+            while (try matches.next()) |range| {
+                if (range.end > candidate.mapped_len) continue;
+
+                cells.clearRetainingCapacity();
+                try cells.ensureTotalCapacity(alloc, range.end - range.start);
+                for (candidate.map[range.start..range.end]) |cell| {
+                    if (cells.getLastOrNull()) |last| {
+                        if (std.meta.eql(last, cell)) continue;
+                    }
+                    try cells.append(alloc, cell);
+                }
+                if (cells.items.len == 0) continue;
+
+                var overlaps = false;
+                for (cells.items) |cell| {
+                    if (occupied.contains(cell)) {
+                        overlaps = true;
+                        break;
+                    }
+                }
+                if (overlaps) continue;
+
+                var owns_target = false;
+                for (cells.items) |cell| {
+                    try occupied.put(alloc, cell, {});
+                    owns_target = owns_target or std.meta.eql(cell, prepared.target);
+                }
+                if (owns_target) return .{
+                    .matcher_index = matcher_index,
+                    .action = link.action,
+                    .value = candidate.string[range.start..range.end],
+                    .cells = try alloc.dupe(Cell, cells.items),
+                };
+            }
+        }
+        if (budget.exhausted) break;
+    }
+    return null;
+}
+
+pub const MatchRange = struct {
+    start: usize,
+    end: usize,
+};
+
+const oni_search_retry_limit = 10_000;
+const max_search_calls = 2 * 1024;
+const max_candidate_bytes = 1024 * 1024;
+
+/// Shared finite work budget for one link resolution or renderer scan.
+pub const SearchBudget = struct {
+    searches_remaining: usize = max_search_calls,
+    candidate_bytes_remaining: usize = max_candidate_bytes,
+    exhausted: bool = false,
+
+    pub fn beginCandidate(self: *SearchBudget, len: usize) bool {
+        if (self.exhausted) return false;
+        if (len > self.candidate_bytes_remaining) {
+            self.exhausted = true;
+            return false;
+        }
+        self.candidate_bytes_remaining -= len;
+        return true;
+    }
+
+    fn beginSearch(self: *SearchBudget) bool {
+        if (self.searches_remaining == 0) {
+            self.exhausted = true;
+            return false;
+        }
+        self.searches_remaining -= 1;
+        return true;
+    }
+
+    fn exhaust(self: *SearchBudget) void {
+        self.exhausted = true;
+        self.searches_remaining = 0;
+    }
+};
+
+pub const MatchIterator = struct {
+    regex: oni.Regex,
+    string: []const u8,
+    offset: usize = 0,
+    budget: *SearchBudget,
+    match_param: oni.MatchParam,
+    region: oni.Region = .{},
+
+    pub fn init(
+        regex: oni.Regex,
+        string: []const u8,
+        budget: *SearchBudget,
+    ) !MatchIterator {
+        var match_param = try oni.MatchParam.init();
+        errdefer match_param.deinit();
+        try match_param.setRetryLimitInSearch(oni_search_retry_limit);
+        return .{
+            .regex = regex,
+            .string = string,
+            .budget = budget,
+            .match_param = match_param,
+        };
+    }
+
+    pub fn deinit(self: *MatchIterator) void {
+        self.region.deinit();
+        self.match_param.deinit();
+    }
+
+    pub fn next(self: *MatchIterator) !?MatchRange {
+        if (self.offset >= self.string.len) return null;
+        if (!self.budget.beginSearch()) {
+            self.offset = self.string.len;
+            return null;
+        }
+
+        _ = self.regex.searchAdvancedWithParam(
+            self.string,
+            self.offset,
+            self.string.len,
+            &self.region,
+            .{ .find_not_empty = true },
+            &self.match_param,
+        ) catch |err| switch (err) {
+            error.Mismatch => {
+                self.offset = self.string.len;
+                return null;
+            },
+            error.RetryLimitInMatchOver,
+            error.RetryLimitInSearchOver,
+            error.MatchStackLimitOver,
+            error.SubexpCallLimitInSearchOver,
+            => {
+                self.budget.exhaust();
+                self.offset = self.string.len;
+                return null;
+            },
+            else => return err,
+        };
+
+        const start: usize = @intCast(self.region.starts()[0]);
+        const end: usize = @intCast(self.region.ends()[0]);
+        if (end <= start or end <= self.offset) {
+            // `find_not_empty` should make this impossible. Keep a defensive
+            // stop so malformed engine output can never spin the renderer.
+            self.offset = self.string.len;
+            return null;
+        }
+
+        self.offset = end;
+        return .{ .start = start, .end = end };
+    }
+};
+
+fn candidateSelectionForKey(
+    screen: *terminal.Screen,
+    target: terminal.Pin,
+    key: CandidateKey,
+    budget: *PreparationBudget,
+) CandidateReadError!?terminal.Selection {
+    const scope = candidateScope(key);
+    const base = try candidateSelection(screen, target, scope, budget) orelse return null;
+    if (candidateNormalizesHardWraps(key)) {
+        return try expandHardWrappedSelection(screen, base, scope, budget);
+    }
+    _ = try selectionCost(screen, base) orelse return null;
+    return base;
+}
+
+fn candidateMapForSelection(
+    alloc: Allocator,
+    screen: *terminal.Screen,
+    selection: terminal.Selection,
+    key: CandidateKey,
+    max_bytes: usize,
+) !?Candidate(terminal.Pin) {
+    const normalize_hard_wraps = candidateNormalizesHardWraps(key);
+
+    // Reserve the synthetic delimiter up front. A no-allocation counting pass
+    // rejects a cell with unusually large grapheme data before it can allocate
+    // or copy past the shared candidate byte budget while the terminal is
+    // locked. The mapped pass then allocates exactly the measured size, which
+    // matters because runtime callers use an arena that cannot reclaim an
+    // oversized per-candidate reservation.
+    const delimiter_bytes: usize = if (candidateUsesDelimiter(key)) 1 else 0;
+    if (max_bytes <= delimiter_bytes) return null;
+    const output_limit = max_bytes - delimiter_bytes;
+
+    // Internal candidates are already terminal-forward. Drive the PageList
+    // formatter with those ordered endpoints directly, avoiding Selection's
+    // full-scrollback ordering walk and selectionString's duplicate text.
+    var formatter: terminal.formatter.PageListFormatter = .init(
+        &screen.pages,
+        .{ .emit = .plain, .unwrap = true, .trim = false },
+    );
+    formatter.top_left = selection.start();
+    formatter.bottom_right = selection.end();
+
+    var count_buffer: [256]u8 = undefined;
+    var counter: CappedCountingWriter = .init(&count_buffer, output_limit);
+    formatter.format(&counter.writer) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        error.WriteFailed => return null,
+    };
+    const output_len = counter.fullCount() orelse return null;
+    if (output_len > output_limit) return null;
+
+    var storage = try alloc.alloc(u8, output_len + 1);
+    errdefer alloc.free(storage);
+    var writer = std.Io.Writer.fixed(storage[0..output_len]);
+    var pins: std.ArrayList(terminal.Pin) = .empty;
+    defer pins.deinit(alloc);
+    formatter.pin_map = .{ .alloc = alloc, .map = &pins };
+    formatter.format(&writer) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        error.WriteFailed => return null,
+    };
+
+    std.debug.assert(writer.end == output_len);
+    storage[output_len] = 0;
+    const string: [:0]u8 = storage[0..output_len :0];
+    const map = try pins.toOwnedSlice(alloc);
+    errdefer alloc.free(map);
+    if (!normalize_hard_wraps) return .{
+        .string = string,
+        .mapped_len = map.len,
+        .map = map,
+    };
+
+    const normalized = try link_wrap.normalize(
+        terminal.Pin,
+        alloc,
+        string,
+        map,
+        .{ .terminate_joined = candidateUsesDelimiter(key) },
+    );
+    alloc.free(string);
+    alloc.free(map);
+    return .{
+        .string = normalized.string,
+        .mapped_len = normalized.mapped_len,
+        .map = normalized.map,
+    };
+}
+
+fn expandHardWrappedSelection(
+    screen: *terminal.Screen,
+    selection: terminal.Selection,
+    candidate_scope: input.Link.CandidateScope,
+    budget: *PreparationBudget,
+) CandidateReadError!?terminal.Selection {
+    var start = selection.start();
+    var end = selection.end();
+    var cost = try selectionCost(screen, selection) orelse return null;
+
+    // Walk to the beginning of the complete join-connected component. A
+    // connected neighbor that would exceed the shared budget rejects the
+    // candidate instead of returning a target-dependent truncated match.
+    while (try previousCandidate(screen, start, candidate_scope, budget)) |adjacent| {
+        const adjacent_end = adjacent.end();
+        if (!try hardWrapBoundary(adjacent_end, start)) break;
+        const adjacent_cost = try selectionCost(screen, adjacent) orelse return null;
+        if (!cost.add(adjacent_cost)) return null;
+        start = adjacent.start();
+    }
+
+    // Walk independently to the end. Expansion order cannot affect the
+    // result: any connected component that exceeds the budget is rejected.
+    while (try nextCandidate(screen, end, candidate_scope, budget)) |adjacent| {
+        const adjacent_start = adjacent.start();
+        if (!try hardWrapBoundary(end, adjacent_start)) break;
+        const adjacent_cost = try selectionCost(screen, adjacent) orelse return null;
+        if (!cost.add(adjacent_cost)) return null;
+        end = adjacent.end();
+    }
+
+    return .init(start, end, false);
+}
+
+fn previousCandidate(
+    screen: *terminal.Screen,
+    start: terminal.Pin,
+    candidate_scope: input.Link.CandidateScope,
+    budget: *PreparationBudget,
+) CandidateReadError!?terminal.Selection {
+    // A semantic boundary inside a physical row is never a prose line break.
+    if (start.x != 0) return null;
+    var previous = start.up(1) orelse return null;
+    const page = previous.node.pageIfResident() orelse
+        return error.NonResidentPage;
+    if (page.getRow(previous.y).wrap) return null;
+    previous.x = 0;
+    return try candidateSelection(screen, previous, candidate_scope, budget);
+}
+
+fn nextCandidate(
+    screen: *terminal.Screen,
+    end: terminal.Pin,
+    candidate_scope: input.Link.CandidateScope,
+    budget: *PreparationBudget,
+) CandidateReadError!?terminal.Selection {
+    // A semantic boundary inside a physical row is never a prose line break.
+    if (end.x + 1 != end.node.cols()) return null;
+    const page = end.node.pageIfResident() orelse return error.NonResidentPage;
+    if (page.getRow(end.y).wrap) return null;
+    var next = end.down(1) orelse return null;
+    if (next.node.pageIfResident() == null) return error.NonResidentPage;
+    next.x = 0;
+    return try candidateSelection(screen, next, candidate_scope, budget);
+}
+
+/// Check a boundary directly from terminal cells. This avoids allocating an
+/// oversized neighboring line merely to discover that it is unrelated.
+fn hardWrapBoundary(
+    upper_end: terminal.Pin,
+    lower_start: terminal.Pin,
+) CandidateReadError!bool {
+    if (upper_end.x + 1 != upper_end.node.cols()) return false;
+    if (lower_start.x != 0) return false;
+    const upper_page = upper_end.node.pageIfResident() orelse
+        return error.NonResidentPage;
+    const lower_page = lower_start.node.pageIfResident() orelse
+        return error.NonResidentPage;
+    const upper_rac = upper_page.getRowAndCell(upper_end.x, upper_end.y);
+    if (upper_rac.row.wrap) return false;
+
+    const upper_cells = upper_page.getCells(upper_rac.row);
+    var upper_x: usize = upper_end.x + 1;
+    const before: u21 = while (upper_x > 0) {
+        upper_x -= 1;
+        const cp = upper_cells[upper_x].codepoint();
+        if (cp != 0 and cp != '\r') break cp;
+    } else return false;
+
+    const semantic = upper_cells[upper_x].semantic_content;
+
+    const lower_cells = lower_page.getCells(lower_page.getRow(lower_start.y));
+    var lower_x: usize = lower_start.x;
+    var indentation: usize = 0;
+    while (lower_x < lower_cells.len) : (lower_x += 1) {
+        const cell = lower_cells[lower_x];
+        // A real newline is only prose continuation inside one semantic
+        // region. Soft wraps may legitimately straddle shell metadata, but a
+        // hard newline entering a new prompt or command must never join.
+        if (cell.semantic_content != semantic) return false;
+        const cp = cell.codepoint();
+        if (cp == ' ' or cp == '\t') {
+            indentation += 1;
+            continue;
+        }
+        if (!link_wrap.canJoinCodepoints(before, indentation, cp)) return false;
+
+        // Probe a bounded UTF-8 prefix without allocating under the terminal
+        // lock. Filling the probe is ambiguous, so fail closed rather than
+        // joining a token whose independent prefix we could not disprove.
+        var prefix: [256]u8 = undefined;
+        var prefix_len: usize = 0;
+        for (lower_cells[lower_x..]) |prefix_cell| {
+            switch (prefix_cell.wide) {
+                .spacer_head, .spacer_tail => continue,
+                .narrow, .wide => {},
+            }
+            const prefix_cp = prefix_cell.codepoint();
+            if (prefix_cp == 0) break;
+            var encoded: [4]u8 = undefined;
+            const encoded_len = std.unicode.utf8Encode(
+                prefix_cp,
+                &encoded,
+            ) catch return false;
+            if (encoded_len > prefix.len - prefix_len) return false;
+            @memcpy(
+                prefix[prefix_len..][0..encoded_len],
+                encoded[0..encoded_len],
+            );
+            prefix_len += encoded_len;
+        }
+        return !link_wrap.startsIndependentLink(
+            prefix[0..prefix_len],
+            before,
+        );
+    }
+    return false;
+}
+
+const SelectionCost = struct {
+    rows: usize,
+    cells: usize,
+
+    fn add(self: *SelectionCost, other: SelectionCost) bool {
+        if (other.rows > max_logical_candidate_rows - self.rows or
+            other.cells > max_logical_candidate_cells - self.cells)
+        {
+            return false;
+        }
+        self.rows += other.rows;
+        self.cells += other.cells;
+        return true;
+    }
+};
+
+fn selectionCost(
+    screen: *terminal.Screen,
+    selection: terminal.Selection,
+) CandidateReadError!?SelectionCost {
+    _ = screen;
+    const top = selection.start();
+    const bottom = selection.end();
+    var result: SelectionCost = .{ .rows = 0, .cells = 0 };
+    var it = top.rowIterator(.right_down, bottom);
+    while (it.next()) |row_pin| {
+        if (row_pin.node.pageIfResident() == null) return error.NonResidentPage;
+        if (result.rows == max_logical_candidate_rows) return null;
+        result.rows += 1;
+
+        const start_x: usize = if (row_pin.node == top.node and row_pin.y == top.y)
+            top.x
+        else
+            0;
+        const end_x: usize = if (row_pin.node == bottom.node and row_pin.y == bottom.y)
+            bottom.x
+        else
+            row_pin.node.cols() - 1;
+        const row_cells = end_x - start_x + 1;
+        if (row_cells > max_logical_candidate_cells - result.cells) return null;
+        result.cells += row_cells;
+    }
+    return result;
+}
+
+fn candidateSelection(
+    screen: *terminal.Screen,
+    pin: terminal.Pin,
+    candidate_scope: input.Link.CandidateScope,
+    budget: *PreparationBudget,
+) CandidateReadError!?terminal.Selection {
+    return switch (candidate_scope) {
+        .semantic => semantic: {
+            // selectLine scans the complete soft-wrapped line before finding
+            // semantic boundaries, so preflight the same physical domain.
+            _ = try boundedLogicalLineChecked(pin, budget) orelse break :semantic null;
+            break :semantic screen.selectLine(.{
+                .pin = pin,
+                .whitespace = null,
+                .semantic_prompt_boundary = true,
+            });
+        },
+        .bounded_logical => try boundedLogicalLineChecked(pin, budget),
+    };
+}
+
+pub const max_logical_candidate_cells = 8 * 1024;
+pub const max_logical_candidate_rows = 256;
+
+/// Return a complete soft-wrapped logical line within a fixed work budget.
+pub fn boundedLogicalLine(pin: terminal.Pin) ?terminal.Selection {
+    return boundedLogicalLineChecked(pin, null) catch null;
+}
+
+fn boundedLogicalLineChecked(
+    pin: terminal.Pin,
+    budget: ?*PreparationBudget,
+) CandidateReadError!?terminal.Selection {
+    const initial_cols: usize = pin.node.cols();
+    if (initial_cols == 0 or initial_cols > max_logical_candidate_cells) return null;
+    if (pin.node.pageIfResident() == null) return error.NonResidentPage;
+    if (budget) |value| if (!value.probeCells(initial_cols)) return null;
+
+    var rows: usize = 1;
+    var remaining_cells = max_logical_candidate_cells - initial_cols;
+    var start = pin;
+    start.x = 0;
+    while (start.up(1)) |previous| {
+        const previous_page = previous.node.pageIfResident() orelse
+            return error.NonResidentPage;
+        if (!previous_page.getRow(previous.y).wrap) break;
+        if (rows == max_logical_candidate_rows) return null;
+
+        const previous_cols: usize = previous.node.cols();
+        if (budget) |value| if (!value.probeCells(previous_cols)) return null;
+        if (previous_cols == 0 or previous_cols > remaining_cells) return null;
+        remaining_cells -= previous_cols;
+        start = previous;
+        start.x = 0;
+        rows += 1;
+    }
+
+    var end = pin;
+    end.x = @intCast(initial_cols - 1);
+    while (true) {
+        const end_page = end.node.pageIfResident() orelse
+            return error.NonResidentPage;
+        if (!end_page.getRow(end.y).wrap) break;
+        if (rows == max_logical_candidate_rows) return null;
+
+        const next = end.down(1) orelse return null;
+        if (next.node.pageIfResident() == null) return error.NonResidentPage;
+        const next_cols: usize = next.node.cols();
+        if (budget) |value| if (!value.probeCells(next_cols)) return null;
+        if (next_cols == 0 or next_cols > remaining_cells) return null;
+        remaining_cells -= next_cols;
+        end = next;
+        end.x = @intCast(next_cols - 1);
+        rows += 1;
+    }
+
+    return .init(start, end, false);
+}
+
+test "link preparation never restores a compressed adjacent page" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    try oni.testing.ensureInit();
+
+    var t: terminal.Terminal = try .init(alloc, .{
+        .cols = 80,
+        .rows = 24,
+    });
+    defer t.deinit(alloc);
+    var stream = t.vtStream();
+    defer stream.deinit();
+
+    const pages = &t.screens.active.pages;
+    const first_page_rows = pages.pages.first.?.capacity().rows;
+    for (0..first_page_rows + 24) |_| stream.nextSlice("history\r\n");
+    _ = pages.compress(.full);
+
+    const target_node = pages.getTopLeft(.active).node;
+    const previous = target_node.prev orelse return error.TestExpectedEqual;
+    try testing.expectEqual(.compressed, previous.storage());
+    const target: terminal.Pin = .{ .node = target_node, .x = 0, .y = 0 };
+
+    // Detecting a logical line across this boundary fails closed. The probe
+    // must not call Node.page(), which would permanently restore history.
+    try testing.expect(boundedLogicalLine(target) == null);
+    try testing.expectEqual(.compressed, previous.storage());
+
+    var regex = try oni.Regex.init(
+        "history",
+        .{},
+        oni.Encoding.utf8,
+        oni.Syntax.default,
+        null,
+    );
+    defer regex.deinit();
+    const TestLink = struct {
+        regex: oni.Regex,
+        action: input.Link.Action = .{ .open = {} },
+        highlight: input.Link.Highlight = .hover,
+        candidate_scope: input.Link.CandidateScope = .bounded_logical,
+        hard_wrap_continuations: bool = false,
+        hard_wrap_match_delimiter: bool = false,
+    };
+    var arena = std.heap.ArenaAllocator.init(alloc);
+    defer arena.deinit();
+    const prepared = try prepareAt(
+        arena.allocator(),
+        t.screens.active,
+        &[_]TestLink{.{ .regex = regex }},
+        target,
+        null,
+    );
+    for (prepared.candidates) |candidates| try testing.expectEqual(0, candidates.len);
+    try testing.expectEqual(.compressed, previous.storage());
+}
+
+test "candidate formatting stops at its byte budget" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var t: terminal.Terminal = try .init(alloc, .{ .cols = 16, .rows = 1 });
+    defer t.deinit(alloc);
+    var stream = t.vtStream();
+    defer stream.deinit();
+    stream.nextSlice("abcdef");
+
+    const screen = t.screens.active;
+    const start = screen.pages.pin(.{ .active = .{ .x = 0, .y = 0 } }).?;
+    const end = screen.pages.pin(.{ .active = .{ .x = 5, .y = 0 } }).?;
+    const selection: terminal.Selection = .init(start, end, false);
+
+    try testing.expect((try candidateMapForSelection(
+        alloc,
+        screen,
+        selection,
+        .semantic,
+        5,
+    )) == null);
+
+    const exact = (try candidateMapForSelection(
+        alloc,
+        screen,
+        selection,
+        .semantic,
+        6,
+    )) orelse return error.TestExpectedEqual;
+    defer {
+        alloc.free(exact.string);
+        alloc.free(exact.map);
+    }
+    try testing.expectEqualStrings("abcdef", exact.string);
+    try testing.expectEqual(exact.string.len, exact.mapped_len);
+    try testing.expectEqual(exact.mapped_len, exact.map.len);
+}
+
+test "capped counting writer aborts when output crosses its limit" {
+    const testing = std.testing;
+
+    var overflow_buffer: [4]u8 = undefined;
+    var overflow: CappedCountingWriter = .init(&overflow_buffer, 5);
+    try testing.expectError(
+        error.WriteFailed,
+        overflow.writer.writeAll("abcdef"),
+    );
+    try testing.expect(overflow.fullCount().? <= 5);
+
+    var exact_buffer: [4]u8 = undefined;
+    var exact: CappedCountingWriter = .init(&exact_buffer, 6);
+    try exact.writer.writeAll("abcdef");
+    try testing.expectEqual(@as(usize, 6), exact.fullCount().?);
+}
+
+test "visible preparation discards partial domains at the probe-cell limit" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    // Every semantic candidate first scans its complete logical line. Keep
+    // the number of candidates below the attempt cap while making their
+    // aggregate probes exceed the independent cell-work budget.
+    const cols = 400;
+    comptime {
+        std.debug.assert(cols < max_candidate_attempts);
+        std.debug.assert(cols * cols > max_visible_candidate_cells);
+    }
+
+    var t: terminal.Terminal = try .init(alloc, .{ .cols = cols, .rows = 1 });
+    defer t.deinit(alloc);
+    var stream = t.vtStream();
+    defer stream.deinit();
+    for (0..cols) |index| {
+        t.screens.active.cursorSetSemanticContent(if (index % 2 == 0)
+            .output
+        else
+            .{ .input = .clear_explicit });
+        stream.nextSlice("a");
+    }
+
+    const TestLink = struct {
+        highlight: input.Link.Highlight = .always,
+        candidate_scope: input.Link.CandidateScope = .semantic,
+        hard_wrap_continuations: bool = false,
+        hard_wrap_match_delimiter: bool = false,
+    };
+    var prepared = try prepareVisibleAlways(
+        terminal.Pin,
+        alloc,
+        t.screens.active,
+        &[_]TestLink{.{}},
+        .{},
+        {},
+        identityPin,
+    );
+    defer prepared.deinit(alloc);
+    for (prepared.candidates) |candidates| try testing.expectEqual(0, candidates.len);
+}
+
+test "visible preparation discards partial domains at the attempt limit" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const rows = max_candidate_attempts + 1;
+
+    var t: terminal.Terminal = try .init(alloc, .{ .cols = 1, .rows = rows });
+    defer t.deinit(alloc);
+    var stream = t.vtStream();
+    defer stream.deinit();
+    for (0..rows) |row| {
+        stream.nextSlice("a");
+        if (row + 1 < rows) stream.nextSlice("\r\n");
+    }
+
+    const TestLink = struct {
+        highlight: input.Link.Highlight = .always,
+        candidate_scope: input.Link.CandidateScope = .semantic,
+        hard_wrap_continuations: bool = false,
+        hard_wrap_match_delimiter: bool = false,
+    };
+    var prepared = try prepareVisibleAlways(
+        terminal.Pin,
+        alloc,
+        t.screens.active,
+        &[_]TestLink{.{}},
+        .{},
+        {},
+        identityPin,
+    );
+    defer prepared.deinit(alloc);
+    for (prepared.candidates) |candidates| try testing.expectEqual(0, candidates.len);
+}
+
+test "resolveAt preserves matcher priority outside the winning match" {
+    const testing = std.testing;
+    try oni.testing.ensureInit();
+
+    var scheme_regex = try oni.Regex.init(
+        "https://example\\.com",
+        .{},
+        oni.Encoding.utf8,
+        oni.Syntax.default,
+        null,
+    );
+    defer scheme_regex.deinit();
+    var path_regex = try oni.Regex.init(
+        "[[:alnum:]/:.-]+",
+        .{},
+        oni.Encoding.utf8,
+        oni.Syntax.default,
+        null,
+    );
+    defer path_regex.deinit();
+
+    const TestLink = struct {
+        regex: oni.Regex,
+        action: input.Link.Action = .{ .open = {} },
+        highlight: input.Link.Highlight = .hover,
+        candidate_scope: input.Link.CandidateScope = .semantic,
+        hard_wrap_continuations: bool = false,
+        hard_wrap_match_delimiter: bool = false,
+    };
+    const links = [_]TestLink{
+        .{ .regex = scheme_regex },
+        .{ .regex = path_regex },
+    };
+
+    const string: [:0]const u8 = "https://example.com.";
+    var map: [string.len]usize = undefined;
+    for (&map, 0..) |*cell, index| cell.* = index;
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    var prepared: Prepared(usize) = .{
+        .target = 8,
+    };
+    prepared.candidates[@intFromEnum(CandidateKey.semantic)] = &.{.{
+        .string = string,
+        .mapped_len = map.len,
+        .map = &map,
+    }};
+
+    const inside = (try resolveAt(
+        usize,
+        alloc,
+        prepared,
+        &links,
+        null,
+    )) orelse return error.TestExpectedEqual;
+    try testing.expectEqual(@as(usize, 0), inside.matcher_index);
+    try testing.expectEqualStrings("https://example.com", inside.value);
+    try testing.expectEqual(@as(usize, 19), inside.cells.len);
+
+    prepared.target = string.len - 1;
+    try testing.expect((try resolveAt(
+        usize,
+        alloc,
+        prepared,
+        &links,
+        null,
+    )) == null);
+}
+
+test "resolveAt skips empty alternatives and rejects synthetic match bytes" {
+    const testing = std.testing;
+    try oni.testing.ensureInit();
+
+    const TestLink = struct {
+        regex: oni.Regex,
+        action: input.Link.Action = .{ .open = {} },
+        highlight: input.Link.Highlight = .hover,
+        candidate_scope: input.Link.CandidateScope = .semantic,
+        hard_wrap_continuations: bool = false,
+        hard_wrap_match_delimiter: bool = false,
+    };
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    var nonempty_regex = try oni.Regex.init(
+        "(?:|https://example\\.com)",
+        .{},
+        oni.Encoding.utf8,
+        oni.Syntax.default,
+        null,
+    );
+    defer nonempty_regex.deinit();
+    const string: [:0]const u8 = "https://example.com";
+    var map: [string.len]usize = undefined;
+    for (&map, 0..) |*cell, index| cell.* = index;
+    const links = [_]TestLink{.{ .regex = nonempty_regex }};
+    var prepared: Prepared(usize) = .{ .target = 8 };
+    prepared.candidates[@intFromEnum(CandidateKey.semantic)] = &.{.{
+        .string = string,
+        .mapped_len = map.len,
+        .map = &map,
+    }};
+    const resolved = (try resolveAt(
+        usize,
+        alloc,
+        prepared,
+        &links,
+        null,
+    )) orelse return error.TestExpectedEqual;
+    try testing.expectEqualStrings(string, resolved.value);
+
+    var terminator_regex = try oni.Regex.init(
+        "/tmp/build\\.\\x00",
+        .{},
+        oni.Encoding.utf8,
+        oni.Syntax.default,
+        null,
+    );
+    defer terminator_regex.deinit();
+    const terminated: [:0]const u8 = "/tmp/build.\x00";
+    var terminated_map: [terminated.len - 1]usize = undefined;
+    for (&terminated_map, 0..) |*cell, index| cell.* = index;
+    const terminated_links = [_]TestLink{.{ .regex = terminator_regex }};
+    prepared = .{ .target = 3 };
+    prepared.candidates[@intFromEnum(CandidateKey.semantic)] = &.{.{
+        .string = terminated,
+        .mapped_len = terminated_map.len,
+        .map = &terminated_map,
+    }};
+    try testing.expect((try resolveAt(
+        usize,
+        alloc,
+        prepared,
+        &terminated_links,
+        null,
+    )) == null);
+}
+
+test "resolveAt maps multibyte text to one terminal cell" {
+    const testing = std.testing;
+    try oni.testing.ensureInit();
+
+    var regex = try oni.Regex.init(
+        "https://x/日",
+        .{},
+        oni.Encoding.utf8,
+        oni.Syntax.default,
+        null,
+    );
+    defer regex.deinit();
+    const TestLink = struct {
+        regex: oni.Regex,
+        action: input.Link.Action = .{ .open = {} },
+        highlight: input.Link.Highlight = .hover,
+        candidate_scope: input.Link.CandidateScope = .semantic,
+        hard_wrap_continuations: bool = false,
+        hard_wrap_match_delimiter: bool = false,
+    };
+    const links = [_]TestLink{.{ .regex = regex }};
+
+    const string: [:0]const u8 = "https://x/日";
+    const ascii_len = "https://x/".len;
+    var map: [string.len]usize = undefined;
+    for (&map, 0..) |*cell, index| {
+        cell.* = if (index < ascii_len) index else ascii_len;
+    }
+    var prepared: Prepared(usize) = .{ .target = ascii_len };
+    prepared.candidates[@intFromEnum(CandidateKey.semantic)] = &.{.{
+        .string = string,
+        .mapped_len = map.len,
+        .map = &map,
+    }};
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const resolved = (try resolveAt(
+        usize,
+        arena.allocator(),
+        prepared,
+        &links,
+        null,
+    )) orelse return error.TestExpectedEqual;
+    try testing.expectEqualStrings(string, resolved.value);
+    try testing.expectEqual(ascii_len + 1, resolved.cells.len);
+    try testing.expectEqual(ascii_len, resolved.cells[resolved.cells.len - 1]);
+}
+
+test "MatchIterator stops without returning a partial unbounded scan" {
+    const testing = std.testing;
+    try oni.testing.ensureInit();
+    var regex = try oni.Regex.init(
+        "a",
+        .{},
+        oni.Encoding.utf8,
+        oni.Syntax.default,
+        null,
+    );
+    defer regex.deinit();
+
+    var budget: SearchBudget = .{ .searches_remaining = 2 };
+    try testing.expect(budget.beginCandidate(3));
+    var matches = try MatchIterator.init(regex, "aaa", &budget);
+    defer matches.deinit();
+    try testing.expectEqual(MatchRange{ .start = 0, .end = 1 }, (try matches.next()).?);
+    try testing.expectEqual(MatchRange{ .start = 1, .end = 2 }, (try matches.next()).?);
+    try testing.expect((try matches.next()) == null);
+    try testing.expect(budget.exhausted);
+}
+
+test "resolvers discard partial results when the search budget is exhausted" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    try oni.testing.ensureInit();
+
+    const len = max_search_calls + 1;
+    const string = try alloc.allocSentinel(u8, len, 0);
+    defer alloc.free(string);
+    @memset(string, 'a');
+    const map = try alloc.alloc(usize, len);
+    defer alloc.free(map);
+    for (map, 0..) |*cell, index| cell.* = index;
+
+    var each = try oni.Regex.init(
+        "a",
+        .{},
+        oni.Encoding.utf8,
+        oni.Syntax.default,
+        null,
+    );
+    defer each.deinit();
+    var final = try oni.Regex.init(
+        "a\\z",
+        .{},
+        oni.Encoding.utf8,
+        oni.Syntax.default,
+        null,
+    );
+    defer final.deinit();
+    const TestLink = struct {
+        regex: oni.Regex,
+        action: input.Link.Action = .{ .open = {} },
+        highlight: input.Link.Highlight = .hover,
+        candidate_scope: input.Link.CandidateScope = .semantic,
+        hard_wrap_continuations: bool = false,
+        hard_wrap_match_delimiter: bool = false,
+    };
+    const links = [_]TestLink{
+        .{ .regex = each },
+        .{ .regex = final },
+    };
+    const prepared: Prepared(usize) = .{
+        .target = len - 1,
+        .candidates = candidate: {
+            var candidates: [candidate_key_count][]const Candidate(usize) =
+                [_][]const Candidate(usize){&.{}} ** candidate_key_count;
+            candidates[@intFromEnum(CandidateKey.semantic)] = &.{.{
+                .string = string,
+                .mapped_len = map.len,
+                .map = map,
+            }};
+            break :candidate candidates;
+        },
+    };
+
+    const all = try resolveAll(usize, alloc, prepared, &links, null, &.{});
+    try testing.expectEqual(@as(usize, 0), all.len);
+    try testing.expect((try resolveAt(usize, alloc, prepared, &links, null)) == null);
+
+    const AlwaysLink = struct {
+        regex: oni.Regex,
+        action: input.Link.Action = .{ .open = {} },
+        highlight: input.Link.Highlight = .always,
+        candidate_scope: input.Link.CandidateScope = .semantic,
+        hard_wrap_continuations: bool = false,
+        hard_wrap_match_delimiter: bool = false,
+    };
+    const always_links = [_]AlwaysLink{
+        .{ .regex = each },
+        .{ .regex = final },
+    };
+    var visible: VisibleCandidates(usize) = .{};
+    visible.candidates = prepared.candidates;
+    const visible_all = try resolveVisibleAlways(
+        usize,
+        alloc,
+        visible,
+        &always_links,
+        .{},
+        &.{},
+    );
+    try testing.expectEqual(@as(usize, 0), visible_all.len);
+}
+
+test "default scheme regex handles a near-limit URL ending in punctuation" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    try oni.testing.ensureInit();
+
+    const prefix = "https://";
+    const len = max_logical_candidate_cells;
+    const value = try alloc.allocSentinel(u8, len, 0);
+    defer alloc.free(value);
+    @memcpy(value[0..prefix.len], prefix);
+    @memset(value[prefix.len .. value.len - 1], 'a');
+    value[value.len - 1] = '.';
+
+    var regex = try oni.Regex.init(
+        @import("config/url.zig").scheme_regex,
+        .{},
+        oni.Encoding.utf8,
+        oni.Syntax.default,
+        null,
+    );
+    defer regex.deinit();
+
+    var budget: SearchBudget = .{};
+    try testing.expect(budget.beginCandidate(value.len));
+    var matches = try MatchIterator.init(regex, value, &budget);
+    defer matches.deinit();
+    try testing.expectEqual(
+        MatchRange{ .start = 0, .end = value.len - 1 },
+        (try matches.next()) orelse return error.TestExpectedEqual,
+    );
+    try testing.expect(!budget.exhausted);
+}

--- a/src/link.zig
+++ b/src/link.zig
@@ -1614,6 +1614,32 @@ test "capped counting writer aborts when output crosses its limit" {
     try testing.expectEqual(@as(usize, 6), exact.fullCount().?);
 }
 
+test "hard-wrap continuation rejects a later semantic transition" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var t: terminal.Terminal = try .init(alloc, .{ .cols = 40, .rows = 2 });
+    defer t.deinit(alloc);
+    var stream = t.vtStream();
+    defer stream.deinit();
+
+    t.screens.active.cursorSetSemanticContent(.output);
+    stream.nextSlice("https://example.com/a-");
+    stream.nextSlice("\r\n    continu");
+    t.screens.active.cursorSetSemanticContent(.{ .input = .clear_explicit });
+    stream.nextSlice("ation");
+
+    const upper_end = t.screens.active.pages.pin(.{ .active = .{
+        .x = 39,
+        .y = 0,
+    } }).?;
+    const lower_start = t.screens.active.pages.pin(.{ .active = .{
+        .x = 0,
+        .y = 1,
+    } }).?;
+    try testing.expect(!try hardWrapBoundary(upper_end, lower_start));
+}
+
 test "visible preparation discards partial domains at the probe-cell limit" {
     const testing = std.testing;
     const alloc = testing.allocator;
@@ -1624,6 +1650,50 @@ test "visible preparation discards partial domains at the probe-cell limit" {
     comptime {
         std.debug.assert(cols < max_candidate_attempts);
         std.debug.assert(cols * cols > max_visible_candidate_cells);
+    }
+
+    var t: terminal.Terminal = try .init(alloc, .{ .cols = cols, .rows = 1 });
+    defer t.deinit(alloc);
+    var stream = t.vtStream();
+    defer stream.deinit();
+    for (0..cols) |index| {
+        t.screens.active.cursorSetSemanticContent(if (index % 2 == 0)
+            .output
+        else
+            .{ .input = .clear_explicit });
+        stream.nextSlice("a");
+    }
+
+    const TestLink = struct {
+        highlight: input.Link.Highlight = .always,
+        candidate_scope: input.Link.CandidateScope = .semantic,
+        hard_wrap_continuations: bool = false,
+        hard_wrap_match_delimiter: bool = false,
+    };
+    var prepared = try prepareVisibleAlways(
+        terminal.Pin,
+        alloc,
+        t.screens.active,
+        &[_]TestLink{.{}},
+        .{},
+        {},
+        identityPin,
+    );
+    defer prepared.deinit(alloc);
+    for (prepared.candidates) |candidates| try testing.expectEqual(0, candidates.len);
+}
+
+test "always preparation has a dedicated per-frame probe-cell limit" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    // Every semantic candidate first scans its complete logical line. Keep
+    // the number of candidates below the attempt cap while making aggregate
+    // probes exceed the 16K per-frame cap but not the 128K interactive cap.
+    const cols = 200;
+    comptime {
+        std.debug.assert(cols < max_candidate_attempts);
+        std.debug.assert(cols * cols > 16 * 1024);
+        std.debug.assert(cols * cols < max_visible_candidate_cells);
     }
 
     var t: terminal.Terminal = try .init(alloc, .{ .cols = cols, .rows = 1 });

--- a/src/link.zig
+++ b/src/link.zig
@@ -333,6 +333,11 @@ const CandidateCoverage = struct {
 const max_visible_candidate_cells = 128 * 1024;
 const max_visible_candidate_domains = 4 * 1024;
 const max_candidate_attempts = 512;
+// Always-highlight preparation runs while holding the terminal lock on every
+// rendered frame. Keep that recurring work far below the larger interactive
+// preparation allowance while still accepting one maximum-size 8K domain.
+const max_always_frame_candidate_cells = 16 * 1024;
+const max_always_frame_candidate_bytes = 64 * 1024;
 const CandidateReadError = error{NonResidentPage};
 
 const PreparationBudget = struct {
@@ -664,7 +669,11 @@ pub fn prepareVisibleAlways(
     };
     var covered: CandidateCoverage = .{};
     defer covered.deinit(alloc);
-    var budget: PreparationBudget = .{};
+    var budget: PreparationBudget = .{
+        .cells_remaining = max_always_frame_candidate_cells,
+        .probe_cells_remaining = max_always_frame_candidate_cells,
+        .bytes_remaining = max_always_frame_candidate_bytes,
+    };
     var pending: std.ArrayList(terminal.Selection) = .empty;
     defer pending.deinit(alloc);
 
@@ -1357,6 +1366,7 @@ fn hardWrapBoundary(
             }
             const prefix_cp = prefix_cell.codepoint();
             if (prefix_cp == 0) break;
+            if (prefix_cell.semantic_content != semantic) return false;
             var encoded: [4]u8 = undefined;
             const encoded_len = std.unicode.utf8Encode(
                 prefix_cp,

--- a/src/link_wrap.zig
+++ b/src/link_wrap.zig
@@ -1,0 +1,180 @@
+//! Normalization for terminal links split by prose hard-wrapping.
+//!
+//! Formatters commonly break long URLs and paths after punctuation, emit a
+//! real newline, and indent the continuation. Link regexes need a contiguous
+//! string, while hover rendering still needs each retained byte mapped back
+//! to its original terminal cell.
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+
+pub const Options = struct {
+    /// Add a non-link delimiter after a joined candidate. This prevents path
+    /// regexes from treating sentence punctuation as a valid end-of-string
+    /// path character. The delimiter is for matching only, never opening.
+    terminate_joined: bool = false,
+};
+
+pub fn Normalized(comptime MapItem: type) type {
+    return struct {
+        string: [:0]const u8,
+        map: []MapItem,
+
+        pub fn deinit(self: @This(), alloc: Allocator) void {
+            alloc.free(self.string);
+            alloc.free(self.map);
+        }
+    };
+}
+
+/// Remove recognized hard-wrap boundaries while preserving a byte-for-byte
+/// coordinate map. A boundary must have indentation and follow punctuation
+/// that prose formatters commonly choose as a link break point. This avoids
+/// joining unrelated adjacent output lines.
+pub fn normalize(
+    comptime MapItem: type,
+    alloc: Allocator,
+    input: []const u8,
+    input_map: []const MapItem,
+    options: Options,
+) Allocator.Error!Normalized(MapItem) {
+    std.debug.assert(input.len == input_map.len);
+
+    var string: std.ArrayList(u8) = .empty;
+    defer string.deinit(alloc);
+    try string.ensureTotalCapacity(alloc, input.len);
+
+    var map: std.ArrayList(MapItem) = .empty;
+    defer map.deinit(alloc);
+    try map.ensureTotalCapacity(alloc, input_map.len);
+
+    var i: usize = 0;
+    var joined = false;
+    while (i < input.len) {
+        if (input[i] == '\n') {
+            var boundary = string.items.len;
+            if (boundary > 0 and string.items[boundary - 1] == '\r') {
+                boundary -= 1;
+            }
+            while (boundary > 0 and string.items[boundary - 1] == 0) {
+                boundary -= 1;
+            }
+
+            var next = i + 1;
+            while (next < input.len and
+                (input[next] == ' ' or input[next] == '\t'))
+            {
+                next += 1;
+            }
+
+            if (next > i + 1 and
+                boundary > 0 and
+                next < input.len and
+                isBreakPunctuation(string.items[boundary - 1]) and
+                isLinkByte(input[next]))
+            {
+                string.shrinkRetainingCapacity(boundary);
+                map.shrinkRetainingCapacity(boundary);
+                joined = true;
+                i = next;
+                continue;
+            }
+        }
+
+        try string.append(alloc, input[i]);
+        try map.append(alloc, input_map[i]);
+        i += 1;
+    }
+
+    if (joined and options.terminate_joined) {
+        try string.append(alloc, 0);
+        try map.append(alloc, input_map[input_map.len - 1]);
+    }
+
+    const owned_string = try string.toOwnedSliceSentinel(alloc, 0);
+    errdefer alloc.free(owned_string);
+    return .{
+        .string = owned_string,
+        .map = try map.toOwnedSlice(alloc),
+    };
+}
+
+fn isBreakPunctuation(byte: u8) bool {
+    return switch (byte) {
+        '-', '_', '.', '/', '?', '#', '&', '=', '%' => true,
+        else => false,
+    };
+}
+
+fn isLinkByte(byte: u8) bool {
+    return switch (byte) {
+        'a'...'z',
+        'A'...'Z',
+        '0'...'9',
+        '-',
+        '_',
+        '.',
+        '~',
+        ':',
+        '/',
+        '?',
+        '#',
+        '@',
+        '!',
+        '$',
+        '&',
+        '*',
+        '+',
+        ';',
+        '=',
+        '%',
+        => true,
+        else => false,
+    };
+}
+
+test "normalize joins indented link continuation and preserves mapped cells" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const input = "/tmp/build-\n    warm.app.";
+    var input_map: [input.len]usize = undefined;
+    for (&input_map, 0..) |*item, index| item.* = index;
+
+    const normalized = try normalize(usize, alloc, input, &input_map, .{});
+    defer normalized.deinit(alloc);
+
+    try testing.expectEqualStrings("/tmp/build-warm.app.", normalized.string);
+    try testing.expectEqual(input.len - 5, normalized.map.len);
+    try testing.expectEqual(@as(usize, 10), normalized.map[10]);
+    try testing.expectEqual(@as(usize, 16), normalized.map[11]);
+}
+
+test "normalize joins a CRLF link continuation" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const input = "/tmp/build-\r\n    warm.app";
+    var input_map: [input.len]usize = undefined;
+    for (&input_map, 0..) |*item, index| item.* = index;
+
+    const normalized = try normalize(usize, alloc, input, &input_map, .{});
+    defer normalized.deinit(alloc);
+
+    try testing.expectEqualStrings("/tmp/build-warm.app", normalized.string);
+}
+
+test "normalize does not join unindented or unpunctuated lines" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    for ([_][]const u8{
+        "/tmp/build-\nwarm.app",
+        "/tmp/build\n    warm.app",
+    }) |input| {
+        const input_map = try alloc.alloc(usize, input.len);
+        defer alloc.free(input_map);
+        for (input_map, 0..) |*item, index| item.* = index;
+
+        const normalized = try normalize(usize, alloc, input, input_map, .{});
+        defer normalized.deinit(alloc);
+        try testing.expectEqualStrings(input, normalized.string);
+    }
+}

--- a/src/link_wrap.zig
+++ b/src/link_wrap.zig
@@ -10,13 +10,23 @@ const Allocator = std.mem.Allocator;
 pub const Options = struct {
     /// Add a non-link delimiter after a joined candidate. This prevents path
     /// regexes from treating sentence punctuation as a valid end-of-string
-    /// path character. The delimiter is for matching only, never opening.
+    /// path character. The delimiter is for matching only and has no terminal
+    /// cell mapping.
     terminate_joined: bool = false,
 };
 
 pub fn Normalized(comptime MapItem: type) type {
     return struct {
+        /// Bytes available to regex matching. This may contain one synthetic
+        /// terminator immediately after `mapped_len`.
         string: [:0]const u8,
+
+        /// Number of leading string bytes that came from terminal cells.
+        /// `map.len` is always equal to this value.
+        mapped_len: usize,
+
+        /// Terminal cell mapping for `string[0..mapped_len]`. Synthetic match
+        /// bytes intentionally have no mapped cell.
         map: []MapItem,
 
         pub fn deinit(self: @This(), alloc: Allocator) void {
@@ -66,11 +76,17 @@ pub fn normalize(
                 next += 1;
             }
 
-            if (next > i + 1 and
-                boundary > 0 and
+            if (boundary > 0 and
                 next < input.len and
-                isBreakPunctuation(string.items[boundary - 1]) and
-                isLinkByte(input[next]))
+                canJoinCodepoints(
+                    string.items[boundary - 1],
+                    next - (i + 1),
+                    input[next],
+                ) and
+                !startsIndependentLink(
+                    input[next..],
+                    string.items[boundary - 1],
+                ))
             {
                 string.shrinkRetainingCapacity(boundary);
                 map.shrinkRetainingCapacity(boundary);
@@ -87,25 +103,113 @@ pub fn normalize(
 
     if (joined and options.terminate_joined) {
         try string.append(alloc, 0);
-        try map.append(alloc, input_map[input_map.len - 1]);
     }
 
     const owned_string = try string.toOwnedSliceSentinel(alloc, 0);
     errdefer alloc.free(owned_string);
+    const owned_map = try map.toOwnedSlice(alloc);
     return .{
         .string = owned_string,
-        .map = try map.toOwnedSlice(alloc),
+        .mapped_len = owned_map.len,
+        .map = owned_map,
     };
 }
 
 fn isBreakPunctuation(byte: u8) bool {
     return switch (byte) {
-        '-', '_', '.', '/', '?', '#', '&', '=', '%' => true,
+        // A period is deliberately excluded. At a real newline it is much
+        // stronger evidence of a completed sentence than a continued token.
+        // The remaining bytes are common break opportunities inside URLs and
+        // paths without also being ordinary sentence terminators.
+        '-', '_', '/', '?', '#', '&', '=', '%' => true,
         else => false,
     };
 }
 
+pub const max_continuation_indentation = 16;
+
+/// Return whether the first token should own its row instead of continuing
+/// the preceding token. Explicit roots and schemes always qualify. A bare
+/// relative path qualifies only after `/`, where joining two complete
+/// path-shaped rows would silently produce a different target.
+pub fn startsIndependentLink(input: []const u8, before: u21) bool {
+    if (input.len == 0) return false;
+    if (input[0] == '/') return true;
+    if (std.mem.startsWith(u8, input, "./") or
+        std.mem.startsWith(u8, input, "../") or
+        std.mem.startsWith(u8, input, "~/")) return true;
+
+    if (input[0] == '$' and input.len > 2 and isAsciiWordStart(input[1])) {
+        var index: usize = 2;
+        while (index < input.len and isAsciiWord(input[index])) : (index += 1) {}
+        if (index < input.len and input[index] == '/') return true;
+    }
+
+    // RFC 3986 scheme prefix. This covers Ghostty's built-in schemes without
+    // duplicating their list here, and treats other valid schemes safely.
+    if (std.ascii.isAlphabetic(input[0])) {
+        var index: usize = 1;
+        while (index < input.len and isSchemeByte(input[index])) : (index += 1) {}
+        if (index < input.len and input[index] == ':') return true;
+    }
+
+    // A hidden relative path has an explicit root-like marker. A plain bare
+    // relative path is only treated as independent after `/`: in that case
+    // both rows are complete path-shaped tokens, so joining would silently
+    // turn adjacent list items into a different target. This deliberately
+    // fails closed for the ambiguous case of a real wrap after `/`.
+    var index: usize = if (input[0] == '.' and
+        input.len > 1 and isWordByte(input[1]))
+        2
+    else if (before == '/' and isWordByte(input[0]))
+        1
+    else
+        return false;
+    while (index < input.len and isBareSegmentByte(input[index])) : (index += 1) {}
+    return index < input.len and input[index] == '/';
+}
+
+fn isAsciiWordStart(byte: u8) bool {
+    return std.ascii.isAlphanumeric(byte) or byte == '_';
+}
+
+fn isAsciiWord(byte: u8) bool {
+    return isAsciiWordStart(byte);
+}
+
+fn isWordByte(byte: u8) bool {
+    return isAsciiWord(byte) or byte >= 0x80;
+}
+
+fn isSchemeByte(byte: u8) bool {
+    return std.ascii.isAlphanumeric(byte) or byte == '+' or byte == '-' or byte == '.';
+}
+
+fn isBareSegmentByte(byte: u8) bool {
+    return isWordByte(byte) or byte == '-' or byte == '.';
+}
+
+/// Return whether two terminal rows form a recognized prose hard-wrap
+/// boundary. Keeping this predicate shared with grid expansion prevents the
+/// selected candidate and normalized bytes from disagreeing.
+pub fn canJoinCodepoints(
+    before: u21,
+    indentation: usize,
+    after: u21,
+) bool {
+    if (indentation == 0 or
+        indentation > max_continuation_indentation or
+        before > std.math.maxInt(u8)) return false;
+    if (!isBreakPunctuation(@intCast(before))) return false;
+    if (after > std.math.maxInt(u8)) return true;
+    return isLinkByte(@intCast(after));
+}
+
 fn isLinkByte(byte: u8) bool {
+    // Any non-ASCII byte can be part of a UTF-8 codepoint matched by `\w` in
+    // the default URL expressions. Validation remains the regex's job.
+    if (byte >= 0x80) return true;
+
     return switch (byte) {
         'a'...'z',
         'A'...'Z',
@@ -124,9 +228,14 @@ fn isLinkByte(byte: u8) bool {
         '&',
         '*',
         '+',
+        ',',
         ';',
         '=',
         '%',
+        '(',
+        ')',
+        '[',
+        ']',
         => true,
         else => false,
     };
@@ -177,4 +286,149 @@ test "normalize does not join unindented or unpunctuated lines" {
         defer normalized.deinit(alloc);
         try testing.expectEqualStrings(input, normalized.string);
     }
+}
+
+test "startsIndependentLink recognizes independent URL and path prefixes" {
+    const testing = std.testing;
+
+    for ([_][]const u8{
+        "/tmp/foo",
+        "./foo",
+        "../foo",
+        "~/foo",
+        "$HOME/foo",
+        "https://example.com",
+        "file:///tmp/foo",
+    }) |input| try testing.expect(startsIndependentLink(input, '-'));
+
+    try testing.expect(startsIndependentLink(".config/foo", '-'));
+    try testing.expect(startsIndependentLink("src/foo", '/'));
+    try testing.expect(startsIndependentLink("日本語/foo", '/'));
+
+    for ([_][]const u8{
+        "20260716-warm.app",
+        "012345",
+        "(video_game)",
+        "日本語",
+        "continuation",
+    }) |input| try testing.expect(!startsIndependentLink(input, '-'));
+
+    try testing.expect(!startsIndependentLink("src/foo", '-'));
+}
+
+test "normalize keeps adjacent independent links separate" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    for ([_][]const u8{
+        "/tmp/foo/\n    /tmp/bar",
+        "https://example.com/path-\n    https://example.org",
+        "src/foo/\n    other/bar.zig",
+    }) |input| {
+        const input_map = try alloc.alloc(usize, input.len);
+        defer alloc.free(input_map);
+        for (input_map, 0..) |*item, index| item.* = index;
+
+        const normalized = try normalize(usize, alloc, input, input_map, .{});
+        defer normalized.deinit(alloc);
+        try testing.expectEqualStrings(input, normalized.string);
+        try testing.expectEqual(input.len, normalized.mapped_len);
+    }
+}
+
+test "normalize rejects sentence endings and deep indentation" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    const cases = [_][]const u8{
+        "See https://example.com.\n    /tmp/foo",
+        "/tmp/build-\n                 warm.app",
+    };
+    for (cases) |input| {
+        const input_map = try alloc.alloc(usize, input.len);
+        defer alloc.free(input_map);
+        for (input_map, 0..) |*item, index| item.* = index;
+
+        const normalized = try normalize(
+            usize,
+            alloc,
+            input,
+            input_map,
+            .{},
+        );
+        defer normalized.deinit(alloc);
+
+        try testing.expectEqualStrings(input, normalized.string);
+        try testing.expectEqual(input.len, normalized.mapped_len);
+    }
+}
+
+test "normalize accepts every default URL continuation class" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    const cases = [_]struct {
+        input: []const u8,
+        expected: []const u8,
+    }{
+        .{
+            .input = "https://example.com/foo-\n    ,bar",
+            .expected = "https://example.com/foo-,bar",
+        },
+        .{
+            .input = "https://example.com/foo#\n    [section]",
+            .expected = "https://example.com/foo#[section]",
+        },
+        .{
+            .input = "https://example.com/wiki/\n    日本語",
+            .expected = "https://example.com/wiki/日本語",
+        },
+    };
+
+    for (cases) |case| {
+        const input_map = try alloc.alloc(usize, case.input.len);
+        defer alloc.free(input_map);
+        for (input_map, 0..) |*item, index| item.* = index;
+
+        const normalized = try normalize(
+            usize,
+            alloc,
+            case.input,
+            input_map,
+            .{},
+        );
+        defer normalized.deinit(alloc);
+
+        try testing.expectEqualStrings(case.expected, normalized.string);
+        try testing.expectEqual(normalized.string.len, normalized.mapped_len);
+        try testing.expectEqual(normalized.mapped_len, normalized.map.len);
+    }
+}
+
+test "normalize match terminator has no terminal cell mapping" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const input = "/tmp/build-\n    warm.app.";
+    var input_map: [input.len]usize = undefined;
+    for (&input_map, 0..) |*item, index| item.* = index;
+
+    const normalized = try normalize(
+        usize,
+        alloc,
+        input,
+        &input_map,
+        .{ .terminate_joined = true },
+    );
+    defer normalized.deinit(alloc);
+
+    const expected = "/tmp/build-warm.app.";
+    try testing.expectEqual(expected.len, normalized.mapped_len);
+    try testing.expectEqual(normalized.mapped_len, normalized.map.len);
+    try testing.expectEqual(normalized.mapped_len + 1, normalized.string.len);
+    try testing.expectEqualSlices(
+        u8,
+        expected ++ "\x00",
+        normalized.string,
+    );
+    try testing.expectEqual(@as(u8, 0), normalized.string[normalized.mapped_len]);
 }

--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -112,6 +112,9 @@ pub const Health = enum(c_int) {
 test {
     // Our comptime-chosen renderer
     _ = Renderer;
+    // Backend completion contracts must remain covered even when the build's
+    // selected renderer is Metal.
+    _ = OpenGL.Frame;
 
     _ = cursor;
     _ = instrumentation;

--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -44,7 +44,50 @@ pub const FramePresentation = struct {
     callback: *const fn (?*anyopaque, u64) callconv(.c) void,
     userdata: ?*anyopaque,
     token: u64,
+    delivery_gate: ?*const fn (?*anyopaque) callconv(.c) void = null,
+    delivery_gate_userdata: ?*anyopaque = null,
+
+    /// Deliver only after the backend-specific gate confirms the renderer has
+    /// left its draw critical section.
+    pub fn deliver(self: FramePresentation) void {
+        if (self.delivery_gate) |gate| gate(self.delivery_gate_userdata);
+        self.callback(self.userdata, self.token);
+    }
 };
+
+test "frame presentation waits for its delivery gate" {
+    const testing = @import("std").testing;
+    const TestState = struct {
+        events: [2]u8 = @splat(0),
+        len: usize = 0,
+
+        fn append(self: *@This(), event: u8) void {
+            self.events[self.len] = event;
+            self.len += 1;
+        }
+
+        fn gate(userdata: ?*anyopaque) callconv(.c) void {
+            const self: *@This() = @ptrCast(@alignCast(userdata.?));
+            self.append(1);
+        }
+
+        fn callback(userdata: ?*anyopaque, _: u64) callconv(.c) void {
+            const self: *@This() = @ptrCast(@alignCast(userdata.?));
+            self.append(2);
+        }
+    };
+
+    var state: TestState = .{};
+    const presentation: FramePresentation = .{
+        .callback = &TestState.callback,
+        .userdata = &state,
+        .token = 42,
+        .delivery_gate = &TestState.gate,
+        .delivery_gate_userdata = &state,
+    };
+    presentation.deliver();
+    try testing.expectEqualSlices(u8, &.{ 1, 2 }, state.events[0..state.len]);
+}
 
 /// The implementation to use for the renderer. This is comptime chosen
 /// so that every build has exactly one renderer implementation.

--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -37,6 +37,15 @@ pub const Padding = size.Padding;
 pub const cursorStyle = cursor.style;
 pub const lib = @import("lib/main.zig");
 
+/// Completion attached to one forced embedder render. Graphics backends that
+/// support it invoke the callback only after the exact frame is presented to
+/// the platform layer.
+pub const FramePresentation = struct {
+    callback: *const fn (?*anyopaque, u64) callconv(.c) void,
+    userdata: ?*anyopaque,
+    token: u64,
+};
+
 /// The implementation to use for the renderer. This is comptime chosen
 /// so that every build has exactly one renderer implementation.
 pub const Renderer = switch (build_config.renderer) {

--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -89,6 +89,14 @@ test "frame presentation waits for its delivery gate" {
     try testing.expectEqualSlices(u8, &.{ 1, 2 }, state.events[0..state.len]);
 }
 
+test "forced draw transfers synchronous presentation to its caller" {
+    const testing = @import("std").testing;
+    const draw_fn = @typeInfo(@TypeOf(Renderer.drawFrameWithPresentation)).@"fn";
+    const result = draw_fn.return_type.?;
+    const payload = @typeInfo(result).error_union.payload;
+    try testing.expect(payload == ?FramePresentation);
+}
+
 /// The implementation to use for the renderer. This is comptime chosen
 /// so that every build has exactly one renderer implementation.
 pub const Renderer = switch (build_config.renderer) {

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -17,6 +17,7 @@ const shadertoy = @import("shadertoy.zig");
 
 const mtl = @import("metal/api.zig");
 const IOSurfaceLayer = @import("metal/IOSurfaceLayer.zig");
+const CompletionLifetime = @import("metal/CompletionLifetime.zig");
 
 pub const GraphicsAPI = Metal;
 pub const Target = @import("metal/Target.zig");
@@ -28,6 +29,8 @@ pub const Buffer = bufferpkg.Buffer;
 pub const Sampler = @import("metal/Sampler.zig");
 pub const Texture = @import("metal/Texture.zig");
 pub const shaders = @import("metal/shaders.zig");
+pub const RendererCompletionLifetime = CompletionLifetime.Lifetime(Renderer);
+const RendererCompletionGeneration = CompletionLifetime.Generation(Renderer);
 
 pub const custom_shader_target: shadertoy.Target = .msl;
 // The fragCoord for Metal shaders is +Y = down.
@@ -61,13 +64,17 @@ max_texture_size: u32,
 /// We start an AutoreleasePool before `drawFrame` and end it afterwards.
 autorelease_pool: ?*objc.AutoreleasePool = null,
 
+/// Owns the ref-counted gate for the current swap-chain generation.
+completion_generation: RendererCompletionGeneration,
+
 pub fn init(alloc: Allocator, opts: rendererpkg.Options) !Metal {
     comptime switch (builtin.os.tag) {
         .macos, .ios => {},
         else => @compileError("unsupported platform for Metal"),
     };
 
-    _ = alloc;
+    var completion_generation = try RendererCompletionGeneration.init(alloc);
+    errdefer completion_generation.deinit();
 
     // Choose our MTLDevice and create a MTLCommandQueue for that device.
     const device = try chooseDevice();
@@ -152,10 +159,14 @@ pub fn init(alloc: Allocator, opts: rendererpkg.Options) !Metal {
         .blending = opts.config.blending,
         .default_storage_mode = default_storage_mode,
         .max_texture_size = max_texture_size,
+        .completion_generation = completion_generation,
     };
 }
 
 pub fn deinit(self: *Metal) void {
+    // Init failures can deinitialize Metal without the generic renderer's
+    // prepare/finish hooks. Invalidation is idempotent.
+    self.completion_generation.deinit();
     self.queue.release();
     self.device.release();
     self.layer.release();
@@ -175,8 +186,21 @@ pub fn prepareDeinit(self: *Metal) void {
     }
 }
 
+/// Called after the swap chain had a bounded opportunity to drain. From this
+/// point, a late GPU callback must not touch renderer or target state.
+pub fn finishFrameGeneration(self: *Metal) void {
+    self.completion_generation.finish();
+}
+
+/// Install a distinct gate before replacement swap-chain frames can be used.
+pub fn startFrameGeneration(self: *Metal) !void {
+    const renderer: *Renderer = @alignCast(@fieldParentPtr("api", self));
+    try self.completion_generation.restart(renderer);
+}
+
 pub fn loopEnter(self: *Metal) void {
-    const renderer: *align(1) Renderer = @fieldParentPtr("api", self);
+    const renderer: *Renderer = @alignCast(@fieldParentPtr("api", self));
+    self.completion_generation.bind(renderer);
     self.layer.setDisplayCallback(
         @ptrCast(&displayCallback),
         @ptrCast(renderer),
@@ -426,28 +450,38 @@ pub fn initAtlasTexture(
 
 /// Begin a frame.
 pub inline fn beginFrame(
-    self: *const Metal,
+    self: *Metal,
     /// Once the frame has been completed, the `frameCompleted` method
     /// on the renderer is called with the health status of the frame.
     renderer: *Renderer,
     /// The target is presented via the provided renderer's API when completed.
     target: *Target,
 ) !Frame {
-    return try Frame.begin(.{ .queue = self.queue }, renderer, target, null);
+    // `loopEnter` normally binds first, but an embedder-owned synchronous
+    // render can race renderer-thread startup. Binding is idempotent.
+    self.completion_generation.bind(renderer);
+    return try Frame.begin(.{
+        .queue = self.queue,
+        .completion_lifetime = self.completion_generation.lifetime(),
+    }, target, null);
 }
 
 /// Begin a frame whose exact CALayer assignment must be acknowledged to the
 /// embedder after GPU completion.
 pub inline fn beginFrameWithPresentation(
-    self: *const Metal,
+    self: *Metal,
     renderer: *Renderer,
     target: *Target,
     presentation: rendererpkg.FramePresentation,
 ) !Frame {
+    self.completion_generation.bind(renderer);
     var gated = presentation;
     gated.delivery_gate = &waitForDrawCriticalSection;
     gated.delivery_gate_userdata = renderer;
-    return try Frame.begin(.{ .queue = self.queue }, renderer, target, gated);
+    return try Frame.begin(.{
+        .queue = self.queue,
+        .completion_lifetime = self.completion_generation.lifetime(),
+    }, target, gated);
 }
 
 fn waitForDrawCriticalSection(userdata: ?*anyopaque) callconv(.c) void {

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -171,7 +171,7 @@ pub fn prepareDeinit(self: *Metal) void {
             );
         },
 
-        else => {},
+        else => self.layer.invalidateSurfaceUpdates(),
     }
 }
 
@@ -444,7 +444,16 @@ pub inline fn beginFrameWithPresentation(
     target: *Target,
     presentation: rendererpkg.FramePresentation,
 ) !Frame {
-    return try Frame.begin(.{ .queue = self.queue }, renderer, target, presentation);
+    var gated = presentation;
+    gated.delivery_gate = &waitForDrawCriticalSection;
+    gated.delivery_gate_userdata = renderer;
+    return try Frame.begin(.{ .queue = self.queue }, renderer, target, gated);
+}
+
+fn waitForDrawCriticalSection(userdata: ?*anyopaque) callconv(.c) void {
+    const renderer: *Renderer = @ptrCast(@alignCast(userdata.?));
+    renderer.draw_mutex.lock();
+    renderer.draw_mutex.unlock();
 }
 
 fn chooseDevice() error{NoMetalDevice}!objc.Object {

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -600,3 +600,33 @@ test "metal completion invalidation waits for an active callback lease" {
     try testing.expect(invalidation_done.load(.seq_cst));
     try testing.expect(lifetime.acquire() == null);
 }
+
+test "metal completion generation rejects old callbacks after rotation" {
+    const testing = std.testing;
+    const Context = struct {
+        generation: usize,
+    };
+    const Generation = CompletionLifetime.Generation(Context);
+
+    var old_context: Context = .{ .generation = 1 };
+    var new_context: Context = .{ .generation = 2 };
+    var generation = try Generation.init(testing.allocator);
+    defer generation.deinit();
+    generation.bind(&old_context);
+
+    // Model a copied old-generation MTL completion block.
+    const old_lifetime = generation.lifetime();
+    old_lifetime.retain();
+    defer old_lifetime.release();
+
+    generation.finish();
+    try generation.restart(&new_context);
+    try testing.expect(generation.lifetime() != old_lifetime);
+
+    // The old command must be rejected even though the replacement generation
+    // is live at the same renderer address.
+    try testing.expect(old_lifetime.acquire() == null);
+    var live = generation.lifetime().acquire().?;
+    defer live.deinit();
+    try testing.expectEqual(@as(usize, 2), live.context.generation);
+}

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -272,6 +272,23 @@ pub inline fn present(self: *Metal, target: Target, sync: bool) !void {
     }
 }
 
+/// Present one explicitly tokened frame. iOS acknowledges only after the
+/// exact IOSurface passes the main-thread layer size guard and is assigned.
+pub inline fn presentWithPresentation(
+    self: *Metal,
+    target: Target,
+    sync: bool,
+    presentation: rendererpkg.FramePresentation,
+) !void {
+    switch (comptime builtin.os.tag) {
+        .ios => try self.layer.setSurfaceWithPresentation(target.surface, presentation),
+        else => {
+            try self.present(target, sync);
+            presentation.callback(presentation.userdata, presentation.token);
+        },
+    }
+}
+
 /// Present the last presented target again. (noop for Metal)
 pub inline fn presentLastTarget(self: *Metal) !void {
     _ = self;
@@ -418,7 +435,18 @@ pub inline fn beginFrame(
     /// The target is presented via the provided renderer's API when completed.
     target: *Target,
 ) !Frame {
-    return try Frame.begin(.{ .queue = self.queue }, renderer, target);
+    return try Frame.begin(.{ .queue = self.queue }, renderer, target, null);
+}
+
+/// Begin a frame whose exact CALayer assignment must be acknowledged to the
+/// embedder after GPU completion.
+pub inline fn beginFrameWithPresentation(
+    self: *const Metal,
+    renderer: *Renderer,
+    target: *Target,
+    presentation: rendererpkg.FramePresentation,
+) !Frame {
+    return try Frame.begin(.{ .queue = self.queue }, renderer, target, presentation);
 }
 
 fn chooseDevice() error{NoMetalDevice}!objc.Object {

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -31,6 +31,7 @@ pub const Texture = @import("metal/Texture.zig");
 pub const shaders = @import("metal/shaders.zig");
 pub const RendererCompletionLifetime = CompletionLifetime.Lifetime(Renderer);
 const RendererCompletionGeneration = CompletionLifetime.Generation(Renderer);
+pub const PreparedPresentation = IOSurfaceLayer.PreparedSurfaceUpdate;
 
 pub const custom_shader_target: shadertoy.Target = .msl;
 // The fragCoord for Metal shaders is +Y = down.
@@ -294,6 +295,30 @@ pub inline fn present(self: *Metal, target: Target, sync: bool) !void {
     } else {
         try self.layer.setSurface(target.surface);
     }
+}
+
+/// Replace an exclusively owned swap-chain target and return the rendered
+/// target as an immutable presentation snapshot. The replacement copies the
+/// target's creation parameters, so this GPU callback never races mutable
+/// renderer configuration.
+pub fn detachPresentationTarget(self: *Metal, target: *Target) !Target {
+    const replacement = try target.replacement(self.device);
+    const frozen = target.*;
+    target.* = replacement;
+    return frozen;
+}
+
+/// Retain a frozen target's layer update before its replacement-backed frame
+/// is returned to the swap chain.
+pub fn preparePresentation(
+    self: *Metal,
+    target: Target,
+    presentation: rendererpkg.FramePresentation,
+) PreparedPresentation {
+    return self.layer.prepareSurfaceWithPresentation(
+        target.surface,
+        presentation,
+    );
 }
 
 /// Present one explicitly tokened frame. iOS acknowledges only after the

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -505,3 +505,98 @@ fn queryMaxTextureSize(device: objc.Object) u32 {
 
     return 8192;
 }
+
+test "metal completion lifetime rejects late target access and retains itself" {
+    const testing = std.testing;
+    const Context = struct {
+        calls: usize = 0,
+    };
+    const Lifetime = CompletionLifetime.Lifetime(Context);
+
+    var context: Context = .{};
+    const lifetime = try Lifetime.create(testing.allocator);
+    lifetime.bind(&context);
+
+    {
+        var live = lifetime.acquire().?;
+        defer live.deinit();
+        live.context.calls += 1;
+    }
+    try testing.expectEqual(@as(usize, 1), context.calls);
+
+    // Model the copied MTL completion block retaining the lifetime after the
+    // renderer-owned reference is released during API teardown.
+    lifetime.retain();
+    lifetime.invalidate();
+    lifetime.release();
+    defer lifetime.release();
+
+    // A stale target is intentionally poisonous. Invalidated completion work
+    // must reject the lease before it can dereference target-owned state.
+    const stale_target: *usize = @ptrFromInt(@alignOf(usize));
+    var touched_target = false;
+    if (lifetime.acquire()) |live_value| {
+        var live = live_value;
+        defer live.deinit();
+        stale_target.* = 1;
+        touched_target = true;
+    }
+    try testing.expect(!touched_target);
+}
+
+test "metal completion invalidation waits for an active callback lease" {
+    const testing = std.testing;
+    const Context = struct {};
+    const Lifetime = CompletionLifetime.Lifetime(Context);
+    const State = struct {
+        lifetime: *Lifetime,
+        callback_entered: *std.Thread.Semaphore,
+        callback_can_exit: *std.Thread.Semaphore,
+        invalidation_started: *std.Thread.Semaphore,
+        invalidation_done: *std.atomic.Value(bool),
+
+        fn callback(self: *@This()) void {
+            var live = self.lifetime.acquire().?;
+            defer live.deinit();
+            self.callback_entered.post();
+            self.callback_can_exit.wait();
+        }
+
+        fn invalidate(self: *@This()) void {
+            self.invalidation_started.post();
+            self.lifetime.invalidate();
+            self.invalidation_done.store(true, .seq_cst);
+        }
+    };
+
+    var context: Context = .{};
+    const lifetime = try Lifetime.create(testing.allocator);
+    defer lifetime.release();
+    lifetime.bind(&context);
+
+    var callback_entered: std.Thread.Semaphore = .{};
+    var callback_can_exit: std.Thread.Semaphore = .{};
+    var invalidation_started: std.Thread.Semaphore = .{};
+    var invalidation_done = std.atomic.Value(bool).init(false);
+    var state: State = .{
+        .lifetime = lifetime,
+        .callback_entered = &callback_entered,
+        .callback_can_exit = &callback_can_exit,
+        .invalidation_started = &invalidation_started,
+        .invalidation_done = &invalidation_done,
+    };
+
+    const callback_thread = try std.Thread.spawn(.{}, State.callback, .{&state});
+    callback_entered.wait();
+    const invalidation_thread = try std.Thread.spawn(.{}, State.invalidate, .{&state});
+    invalidation_started.wait();
+
+    // The callback owns the live lease and therefore the lifetime mutex.
+    try testing.expect(!invalidation_done.load(.seq_cst));
+    callback_can_exit.post();
+    callback_thread.join();
+    invalidation_thread.join();
+
+    try testing.expect(invalidation_done.load(.seq_cst));
+    try testing.expect(lifetime.acquire() == null);
+}

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -280,17 +280,11 @@ pub inline fn presentWithPresentation(
     sync: bool,
     presentation: rendererpkg.FramePresentation,
 ) !void {
-    switch (comptime builtin.os.tag) {
-        .ios => try self.layer.setSurfaceWithPresentation(target.surface, presentation),
-        else => {
-            if (sync) {
-                self.layer.setSurfaceSync(target.surface);
-                presentation.callback(presentation.userdata, presentation.token);
-            } else {
-                try self.layer.setSurfaceWithPresentation(target.surface, presentation);
-            }
-        },
-    }
+    // A tokened render may be submitted from any embedder-owned queue. Layer
+    // assignment and acknowledgement must therefore use the main-thread path
+    // even when the GPU frame itself completed synchronously.
+    _ = sync;
+    try self.layer.setSurfaceWithPresentation(target.surface, presentation);
 }
 
 /// Present the last presented target again. (noop for Metal)

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -283,8 +283,12 @@ pub inline fn presentWithPresentation(
     switch (comptime builtin.os.tag) {
         .ios => try self.layer.setSurfaceWithPresentation(target.surface, presentation),
         else => {
-            try self.present(target, sync);
-            presentation.callback(presentation.userdata, presentation.token);
+            if (sync) {
+                self.layer.setSurfaceSync(target.surface);
+                presentation.callback(presentation.userdata, presentation.token);
+            } else {
+                try self.layer.setSurfaceWithPresentation(target.surface, presentation);
+            }
         },
     }
 }

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -345,6 +345,152 @@ pub fn presentLastTarget(self: *OpenGL) !void {
     if (self.last_target) |target| try self.present(target);
 }
 
+test "OpenGL presentation preserves blit errors through state restoration" {
+    const testing = std.testing;
+    const Failure = error{
+        BlitFailed,
+        BindFailed,
+        RestoreFailed,
+    };
+    const Event = enum {
+        disable_srgb,
+        bind_read,
+        blit,
+        capture_blit,
+        unbind_read,
+        restore_srgb,
+        restore_srgb_unchecked,
+    };
+    const MockTarget = struct { id: u8 };
+    const State = struct {
+        events: [8]Event = undefined,
+        len: usize = 0,
+        fail_bind: bool = false,
+        fail_blit: bool = false,
+        fail_restore: bool = false,
+        pending_error: ?Failure = null,
+
+        fn append(self: *@This(), event: Event) void {
+            self.events[self.len] = event;
+            self.len += 1;
+        }
+    };
+    const MockRenderer = struct {
+        last_target: ?MockTarget = null,
+    };
+    const MockOps = struct {
+        state: *State,
+
+        fn disableSRGB(self: *@This()) Failure!void {
+            self.state.append(.disable_srgb);
+        }
+
+        fn bindRead(self: *@This(), target: MockTarget) Failure!u8 {
+            self.state.append(.bind_read);
+            if (self.state.fail_bind) return error.BindFailed;
+            return target.id;
+        }
+
+        fn blit(self: *@This(), _: MockTarget) void {
+            self.state.append(.blit);
+            if (self.state.fail_blit) {
+                self.state.pending_error = error.BlitFailed;
+            }
+        }
+
+        fn captureBlitResult(self: *@This()) Failure!void {
+            self.state.append(.capture_blit);
+            if (self.state.pending_error) |err| {
+                self.state.pending_error = null;
+                return err;
+            }
+        }
+
+        fn unbindRead(self: *@This(), _: u8) void {
+            self.state.append(.unbind_read);
+        }
+
+        fn restoreSRGB(self: *@This()) Failure!void {
+            self.state.append(.restore_srgb);
+            // The pre-fix checked restore consumes a pending blit error.
+            if (self.state.pending_error) |err| {
+                self.state.pending_error = null;
+                return err;
+            }
+            if (self.state.fail_restore) return error.RestoreFailed;
+        }
+
+        fn restoreSRGBUnchecked(self: *@This()) void {
+            self.state.append(.restore_srgb_unchecked);
+        }
+    };
+    const Harness = struct {
+        fn present(
+            renderer: *MockRenderer,
+            target: MockTarget,
+            ops: *MockOps,
+        ) Failure!void {
+            if (@hasDecl(OpenGL, "presentWithOps")) {
+                return OpenGL.presentWithOps(renderer, target, ops);
+            }
+
+            // Exercise the pre-fix defer order: last_target is committed,
+            // then unbind runs, then checked restore drains and logs the blit
+            // error while the caller incorrectly observes success.
+            try ops.disableSRGB();
+            const binding = ops.bindRead(target) catch |err| {
+                ops.restoreSRGBUnchecked();
+                return err;
+            };
+            ops.blit(target);
+            renderer.last_target = target;
+            ops.unbindRead(binding);
+            ops.restoreSRGB() catch {};
+        }
+    };
+
+    const target: MockTarget = .{ .id = 7 };
+    var state: State = .{ .fail_blit = true };
+    var renderer: MockRenderer = .{};
+    var ops: MockOps = .{ .state = &state };
+    const blit_result = Harness.present(&renderer, target, &ops);
+    const blit_token: ?u64 = if (blit_result) |_| 42 else |_| null;
+    try testing.expectEqual(null, blit_token);
+    try testing.expectError(error.BlitFailed, blit_result);
+    try testing.expectEqual(null, renderer.last_target);
+    try testing.expectEqualSlices(Event, &.{
+        .disable_srgb,
+        .bind_read,
+        .blit,
+        .capture_blit,
+        .unbind_read,
+        .restore_srgb,
+    }, state.events[0..state.len]);
+
+    state = .{ .fail_restore = true };
+    renderer = .{};
+    ops = .{ .state = &state };
+    const restore_result = Harness.present(&renderer, target, &ops);
+    const restore_token: ?u64 = if (restore_result) |_| 42 else |_| null;
+    try testing.expectEqual(null, restore_token);
+    try testing.expectError(error.RestoreFailed, restore_result);
+    try testing.expectEqual(null, renderer.last_target);
+
+    state = .{ .fail_bind = true };
+    renderer = .{};
+    ops = .{ .state = &state };
+    try testing.expectError(
+        error.BindFailed,
+        Harness.present(&renderer, target, &ops),
+    );
+    try testing.expectEqualSlices(Event, &.{
+        .disable_srgb,
+        .bind_read,
+        .restore_srgb_unchecked,
+    }, state.events[0..state.len]);
+    try testing.expectEqual(null, renderer.last_target);
+}
+
 /// Returns the options to use when constructing buffers.
 pub inline fn bufferOptions(self: OpenGL) bufferpkg.Options {
     _ = self;

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -457,5 +457,16 @@ pub inline fn beginFrame(
     target: *Target,
 ) !Frame {
     _ = self;
-    return try Frame.begin(.{}, renderer, target);
+    return try Frame.begin(.{}, renderer, target, null);
+}
+
+/// Begin a frame whose successful presentation acknowledges an opaque token.
+pub inline fn beginFrameWithPresentation(
+    self: *const OpenGL,
+    renderer: *Renderer,
+    target: *Target,
+    presentation: rendererpkg.FramePresentation,
+) !Frame {
+    _ = self;
+    return try Frame.begin(.{}, renderer, target, presentation);
 }

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -297,36 +297,92 @@ pub fn initTarget(self: *const OpenGL, width: usize, height: usize) !Target {
 
 /// Present the provided target.
 pub fn present(self: *OpenGL, target: Target) !void {
-    // In order to present a target we blit it to the default framebuffer.
+    var ops: PresentationOps = .{};
+    return presentWithOps(self, target, &ops);
+}
 
+const PresentationOps = struct {
+    fn disableSRGB(_: *@This()) !void {
+        return gl.disable(gl.c.GL_FRAMEBUFFER_SRGB);
+    }
+
+    fn bindRead(_: *@This(), target: Target) !gl.Framebuffer.Binding {
+        return target.framebuffer.bind(.read);
+    }
+
+    fn blit(_: *@This(), target: Target) void {
+        gl.glad.context.BlitFramebuffer.?(
+            0,
+            0,
+            @intCast(target.width),
+            @intCast(target.height),
+            0,
+            0,
+            @intCast(target.width),
+            @intCast(target.height),
+            gl.c.GL_COLOR_BUFFER_BIT,
+            gl.c.GL_NEAREST,
+        );
+    }
+
+    fn captureBlitResult(_: *@This()) gl.errors.Error!void {
+        return gl.errors.getError();
+    }
+
+    fn unbindRead(_: *@This(), binding: gl.Framebuffer.Binding) void {
+        binding.unbind();
+    }
+
+    fn restoreSRGB(_: *@This()) !void {
+        return gl.enable(gl.c.GL_FRAMEBUFFER_SRGB);
+    }
+
+    fn restoreSRGBUnchecked(_: *@This()) void {
+        gl.glad.context.Enable.?(gl.c.GL_FRAMEBUFFER_SRGB);
+    }
+};
+
+/// Blit a target while preserving both the presentation result and the state
+/// restoration result. This is generic so the error-ordering contract can be
+/// tested without a live OpenGL context.
+fn presentWithOps(
+    self: anytype,
+    target: anytype,
+    ops: anytype,
+) !void {
     // We disable GL_FRAMEBUFFER_SRGB while doing this blit, otherwise the
     // values may be linearized as they're copied, but even though the draw
     // framebuffer has a linear internal format, the values in it should be
-    // sRGB, not linear!
-    try gl.disable(gl.c.GL_FRAMEBUFFER_SRGB);
-    defer gl.enable(gl.c.GL_FRAMEBUFFER_SRGB) catch |err| {
-        log.err("Error re-enabling GL_FRAMEBUFFER_SRGB, err={}", .{err});
+    // sRGB, not linear.
+    ops.disableSRGB() catch |err| {
+        // Do not run a checked cleanup here because it could drain an error
+        // that belongs to the failed operation we are returning.
+        ops.restoreSRGBUnchecked();
+        return err;
     };
 
-    // Bind the target for reading.
-    const fbobind = try target.framebuffer.bind(.read);
-    defer fbobind.unbind();
+    // Bind the target for reading. A setup failure still restores the default
+    // framebuffer's sRGB state without consuming the original error.
+    const binding = ops.bindRead(target) catch |err| {
+        ops.restoreSRGBUnchecked();
+        return err;
+    };
 
-    // Blit
-    gl.glad.context.BlitFramebuffer.?(
-        0,
-        0,
-        @intCast(target.width),
-        @intCast(target.height),
-        0,
-        0,
-        @intCast(target.width),
-        @intCast(target.height),
-        gl.c.GL_COLOR_BUFFER_BIT,
-        gl.c.GL_NEAREST,
-    );
+    // Capture the blit result before either cleanup operation can call
+    // glGetError and consume it.
+    ops.blit(target);
+    const blit_result = ops.captureBlitResult();
 
-    // Keep track of this target in case we need to repeat it.
+    // Always restore the read framebuffer binding and sRGB state. The checked
+    // sRGB restore also reports any error raised by the unchecked unbind.
+    ops.unbindRead(binding);
+    const restore_result = ops.restoreSRGB();
+
+    // Both cleanup operations have run before either stored result propagates.
+    try blit_result;
+    try restore_result;
+
+    // Repeat only a fully validated, state-restored presentation.
     self.last_target = target;
 }
 

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -330,6 +330,16 @@ pub fn present(self: *OpenGL, target: Target) !void {
     self.last_target = target;
 }
 
+/// Block until every command for the presented frame has completed.
+pub fn finishFrame(_: *OpenGL) void {
+    gl.finish();
+}
+
+/// Inspect the GL error state only after the presentation fence completes.
+pub fn frameHealth(_: *OpenGL) rendererpkg.Health {
+    return if (gl.errors.getError()) .healthy else |_| .unhealthy;
+}
+
 /// Present the last presented target again.
 pub fn presentLastTarget(self: *OpenGL) !void {
     if (self.last_target) |target| try self.present(target);

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -1159,6 +1159,101 @@ test "visibility drain coalesces rapid hide show ordering" {
     try std.testing.expectEqual(null, canceled.rendererTransition());
 }
 
+test "synchronous presentation is delivered after thread draw cleanup" {
+    const Event = enum { begin, renderer_cleanup, end, callback };
+    const State = struct {
+        events: [4]Event = undefined,
+        len: usize = 0,
+        owner_alive: bool = true,
+        owner_access_after_callback: bool = false,
+
+        fn append(self: *@This(), event: Event) void {
+            self.events[self.len] = event;
+            self.len += 1;
+        }
+
+        fn presented(userdata: ?*anyopaque, _: u64) callconv(.c) void {
+            const self: *@This() = @ptrCast(@alignCast(userdata.?));
+            self.append(.callback);
+            // Models a reentrant ghostty_surface_free destroying Thread.
+            self.owner_alive = false;
+        }
+    };
+    const MockInstrumentation = struct {
+        state: *State,
+
+        fn emit(
+            self: *const @This(),
+            event: instrumentationpkg.Event,
+        ) void {
+            if (!self.state.owner_alive) {
+                self.state.owner_access_after_callback = true;
+            }
+            self.state.append(switch (event) {
+                .draw_frame_begin => .begin,
+                .draw_frame_end => .end,
+                else => unreachable,
+            });
+        }
+    };
+    const MockRenderer = struct {
+        state: *State,
+
+        fn drawFrameWithPresentation(
+            self: *@This(),
+            _: bool,
+            presentation: rendererpkg.FramePresentation,
+        ) anyerror!?rendererpkg.FramePresentation {
+            // Models generic renderer defers completing before ownership is
+            // returned to Thread.
+            self.state.append(.renderer_cleanup);
+            return presentation;
+        }
+    };
+    const Harness = struct {
+        fn run(
+            renderer: *MockRenderer,
+            instrumentation: *const MockInstrumentation,
+            presentation: rendererpkg.FramePresentation,
+        ) void {
+            if (@hasDecl(Thread, "finishRenderNowWithPresentation")) {
+                return Thread.finishRenderNowWithPresentation(
+                    renderer,
+                    instrumentation,
+                    presentation,
+                );
+            }
+
+            // Exercise the pre-fix ownership order. The generic renderer
+            // delivered before returning, then Thread ran its end defer.
+            instrumentation.emit(.draw_frame_begin);
+            const completed = renderer.drawFrameWithPresentation(
+                true,
+                presentation,
+            ) catch unreachable;
+            if (completed) |value| value.deliver();
+            instrumentation.emit(.draw_frame_end);
+        }
+    };
+
+    var state: State = .{};
+    var renderer: MockRenderer = .{ .state = &state };
+    const instrumentation: MockInstrumentation = .{ .state = &state };
+    Harness.run(&renderer, &instrumentation, .{
+        .callback = &State.presented,
+        .userdata = &state,
+        .token = 42,
+    });
+
+    try std.testing.expectEqualSlices(Event, &.{
+        .begin,
+        .renderer_cleanup,
+        .end,
+        .callback,
+    }, state.events[0..state.len]);
+    try std.testing.expect(!state.owner_access_after_callback);
+}
+
 test "mailbox drain error fallback reconciles deferred renderer visibility" {
     const ErrorFallbackRenderer = struct {
         flags_visible: bool = true,

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -474,12 +474,34 @@ pub fn renderNowWithPresentation(
         return;
     };
 
-    self.instrumentation.emit(.draw_frame_begin);
-    defer self.instrumentation.emit(.draw_frame_end);
-    self.renderer.drawFrameWithPresentation(true, presentation) catch |err| switch (err) {
-        error.Timeout => log.warn("renderNowWithPresentation: frame acquire timeout", .{}),
-        else => log.warn("renderNowWithPresentation: error drawing err={}", .{err}),
+    return finishRenderNowWithPresentation(
+        self.renderer,
+        &self.instrumentation,
+        presentation,
+    );
+}
+
+/// Finish a forced draw before delivering a synchronous backend presentation.
+/// Delivery is the final operation because it may reentrantly destroy Thread.
+fn finishRenderNowWithPresentation(
+    renderer: anytype,
+    instrumentation: anytype,
+    presentation: rendererpkg.FramePresentation,
+) void {
+    instrumentation.emit(.draw_frame_begin);
+    const result = renderer.drawFrameWithPresentation(true, presentation);
+    instrumentation.emit(.draw_frame_end);
+
+    const completed = result catch |err| {
+        switch (err) {
+            error.Timeout => log.warn("renderNowWithPresentation: frame acquire timeout", .{}),
+            else => log.warn("renderNowWithPresentation: error drawing err={}", .{err}),
+        }
+        return;
     };
+
+    const value = completed orelse return;
+    value.deliver();
 }
 
 /// Drain the renderer mailbox once, applying every queued message.

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -454,6 +454,35 @@ pub fn renderNow(self: *Thread) void {
     _ = self.drawFrame(true);
 }
 
+/// Force a new frame and attach an exact platform-presentation completion.
+/// iOS keeps Metal completion asynchronous even though `sync=true` is used to
+/// force allocation of a fresh swap-chain target.
+pub fn renderNowWithPresentation(
+    self: *Thread,
+    presentation: rendererpkg.FramePresentation,
+) void {
+    self.enterExternalDrainMode();
+    _ = self.drainMailbox() catch |err| fallback: {
+        log.err("renderNowWithPresentation: error draining mailbox err={}", .{err});
+        break :fallback MailboxDrainResult{};
+    };
+
+    self.notifySelectionChanged();
+
+    self.renderer.updateFrame(
+        self.state,
+        self.effectiveCursorBlinkVisible(),
+    ) catch |err| {
+        log.warn("renderNowWithPresentation: error updating frame err={}", .{err});
+        return;
+    };
+
+    self.renderer.drawFrameWithPresentation(true, presentation) catch |err| switch (err) {
+        error.Timeout => log.warn("renderNowWithPresentation: frame acquire timeout", .{}),
+        else => log.warn("renderNowWithPresentation: error drawing err={}", .{err}),
+    };
+}
+
 /// Drain the renderer mailbox once, applying every queued message.
 ///
 /// cmux iOS fork: a public seam over the private `drainMailbox` so a producer

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -469,14 +469,13 @@ pub fn renderNowWithPresentation(
 
     self.notifySelectionChanged();
 
-    self.renderer.updateFrame(
-        self.state,
-        self.effectiveCursorBlinkVisible(),
-    ) catch |err| {
+    self.updateFrame(self.effectiveCursorBlinkVisible()) catch |err| {
         log.warn("renderNowWithPresentation: error updating frame err={}", .{err});
         return;
     };
 
+    self.instrumentation.emit(.draw_frame_begin);
+    defer self.instrumentation.emit(.draw_frame_end);
     self.renderer.drawFrameWithPresentation(true, presentation) catch |err| switch (err) {
         error.Timeout => log.warn("renderNowWithPresentation: frame acquire timeout", .{}),
         else => log.warn("renderNowWithPresentation: error drawing err={}", .{err}),

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -3659,3 +3659,28 @@ test "stalled swap chain teardown releases exact non-prefix idle frames" {
     try testing.expectEqual(@as(usize, 1), frames[1].deinit_count);
     try testing.expectEqual(@as(usize, 0), frames[2].deinit_count);
 }
+
+test "swap chain claims the exact non-prefix idle frame" {
+    const testing = std.testing;
+    const TestFrame = struct {
+        in_flight: std.atomic.Value(bool),
+
+        fn init(in_flight: bool) @This() {
+            return .{ .in_flight = std.atomic.Value(bool).init(in_flight) };
+        }
+    };
+
+    // The cursor's nominal next slot (1) is still busy because slot 2
+    // completed first. One aggregate permit exists for slot 2 specifically.
+    var frames = [_]TestFrame{
+        .init(true),
+        .init(true),
+        .init(false),
+    };
+    var frame_index: usize = 0;
+    const claimed = claimNextIdleFrame(frames[0..], &frame_index).?;
+
+    try testing.expect(claimed == &frames[2]);
+    try testing.expectEqual(@as(usize, 2), frame_index);
+    try testing.expect(frames[2].in_flight.load(.acquire));
+}

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -1638,16 +1638,17 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             self: *Self,
             sync: bool,
         ) !void {
-            return self.drawFrameWithOptionalPresentation(sync, null);
+            _ = try self.drawFrameWithOptionalPresentation(sync, null);
         }
 
         /// Draw a forced frame whose backend presentation carries an opaque
-        /// completion token to the embedder.
+        /// completion token. A synchronous backend transfers that completion
+        /// to the caller after every renderer cleanup defer has run.
         pub fn drawFrameWithPresentation(
             self: *Self,
             sync: bool,
             presentation: renderer.FramePresentation,
-        ) !void {
+        ) !?renderer.FramePresentation {
             return self.drawFrameWithOptionalPresentation(sync, presentation);
         }
 
@@ -1655,14 +1656,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             self: *Self,
             sync: bool,
             presentation: ?renderer.FramePresentation,
-        ) !void {
-            // Registered before every renderer cleanup defer so synchronous
-            // backends deliver only after draw bookkeeping and mutex release.
-            var completed_presentation: ?renderer.FramePresentation = null;
-            defer if (completed_presentation) |value| {
-                value.deliver();
-            };
-
+        ) !?renderer.FramePresentation {
             // const start = std.time.Instant.now() catch unreachable;
             // const start_micro = std.time.microTimestamp();
             // defer {
@@ -1698,7 +1692,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
 
             // If either of our surface dimensions is zero
             // then drawing is absurd, so we just return.
-            if (surface_size.width == 0 or surface_size.height == 0) return;
+            if (surface_size.width == 0 or surface_size.height == 0) return null;
 
             const size_changed =
                 self.size.screen.width != surface_size.width or
@@ -1717,7 +1711,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 // apprt may be swapping buffers and display an outdated frame
                 // if we don't draw something new.
                 try self.api.presentLastTarget();
-                return;
+                return null;
             }
             var damage = DrawDamageCommit.begin(&self.cells_rebuilt);
             defer damage.deinit();
@@ -1968,8 +1962,9 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             // Arm backend presentation only after every fallible encoding
             // operation succeeded. Errors above discard the unsubmitted frame
             // through the swap-chain errdefer and acknowledge no token.
-            completed_presentation = frame_ctx.complete(sync);
+            const completed_presentation = frame_ctx.complete(sync);
             damage.commit();
+            return completed_presentation;
         }
 
         // Callback from the graphics API when a frame is completed.

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -1716,10 +1716,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
 
             // Get a frame context from the graphics API.
             var frame_ctx = if (presentation) |value|
-                if (@hasDecl(GraphicsAPI, "beginFrameWithPresentation"))
-                    try self.api.beginFrameWithPresentation(self, &frame.target, value)
-                else
-                    try self.api.beginFrame(self, &frame.target)
+                try self.api.beginFrameWithPresentation(self, &frame.target, value)
             else
                 try self.api.beginFrame(self, &frame.target);
             defer frame_ctx.complete(sync);

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -3630,3 +3630,32 @@ test "prepared frame damage remains retryable until draw commit" {
     }
     try std.testing.expect(!cells_rebuilt);
 }
+
+test "stalled swap chain teardown releases exact non-prefix idle frames" {
+    const testing = std.testing;
+    const TestFrame = struct {
+        in_flight: std.atomic.Value(bool),
+        deinit_count: usize = 0,
+
+        fn init(in_flight: bool) @This() {
+            return .{ .in_flight = std.atomic.Value(bool).init(in_flight) };
+        }
+
+        fn deinit(self: *@This()) void {
+            self.deinit_count += 1;
+        }
+    };
+
+    // Only the middle slot is idle. A counting semaphore can report one
+    // permit, but that permit does not identify frames[0] as the idle slot.
+    var frames = [_]TestFrame{
+        .init(true),
+        .init(false),
+        .init(true),
+    };
+    deinitIdleFrames(frames[0..]);
+
+    try testing.expectEqual(@as(usize, 0), frames[0].deinit_count);
+    try testing.expectEqual(@as(usize, 1), frames[1].deinit_count);
+    try testing.expectEqual(@as(usize, 0), frames[2].deinit_count);
+}

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -1597,6 +1597,13 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             sync: bool,
             presentation: ?renderer.FramePresentation,
         ) !void {
+            // Registered before every renderer cleanup defer so synchronous
+            // backends deliver only after draw bookkeeping and mutex release.
+            var completed_presentation: ?renderer.FramePresentation = null;
+            defer if (completed_presentation) |value| {
+                value.deliver();
+            };
+
             // const start = std.time.Instant.now() catch unreachable;
             // const start_micro = std.time.microTimestamp();
             // defer {
@@ -1757,7 +1764,6 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 try self.api.beginFrameWithPresentation(self, &frame.target, value)
             else
                 try self.api.beginFrame(self, &frame.target);
-            defer frame_ctx.complete(sync);
 
             {
                 var pass = frame_ctx.renderPass(&.{.{
@@ -1900,6 +1906,10 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 }
             }
 
+            // Arm backend presentation only after every fallible encoding
+            // operation succeeded. Errors above discard the unsubmitted frame
+            // through the swap-chain errdefer and acknowledge no token.
+            completed_presentation = frame_ctx.complete(sync);
             damage.commit();
         }
 

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -1541,6 +1541,24 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             self: *Self,
             sync: bool,
         ) !void {
+            return self.drawFrameWithOptionalPresentation(sync, null);
+        }
+
+        /// Draw a forced frame whose backend presentation carries an opaque
+        /// completion token to the embedder.
+        pub fn drawFrameWithPresentation(
+            self: *Self,
+            sync: bool,
+            presentation: renderer.FramePresentation,
+        ) !void {
+            return self.drawFrameWithOptionalPresentation(sync, presentation);
+        }
+
+        fn drawFrameWithOptionalPresentation(
+            self: *Self,
+            sync: bool,
+            presentation: ?renderer.FramePresentation,
+        ) !void {
             // const start = std.time.Instant.now() catch unreachable;
             // const start_micro = std.time.microTimestamp();
             // defer {
@@ -1697,7 +1715,13 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             }
 
             // Get a frame context from the graphics API.
-            var frame_ctx = try self.api.beginFrame(self, &frame.target);
+            var frame_ctx = if (presentation) |value|
+                if (@hasDecl(GraphicsAPI, "beginFrameWithPresentation"))
+                    try self.api.beginFrameWithPresentation(self, &frame.target, value)
+                else
+                    try self.api.beginFrame(self, &frame.target)
+            else
+                try self.api.beginFrame(self, &frame.target);
             defer frame_ctx.complete(sync);
 
             {

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -1241,6 +1241,8 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             // Data we extract out of the critical area.
             const Critical = struct {
                 links: terminal.RenderState.CellSet,
+                regex_always: link.PreparedAlways,
+                regex_hover: ?link.PreparedHover,
                 mouse: renderer.State.Mouse,
                 preedit: ?renderer.State.Preedit,
                 scrollbar: terminal.Scrollbar,
@@ -1357,6 +1359,31 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                     };
                 };
 
+                // OSC8 is the canonical link when present. Otherwise copy
+                // regex candidates and stable cell identities while the
+                // terminal lock is held, then run regexes after unlocking.
+                const regex_hover: ?link.PreparedHover = regex_hover: {
+                    break :regex_hover self.config.links.prepareHover(
+                        arena_alloc,
+                        state.terminal.screens.active,
+                        state.mouse.point,
+                        state.mouse.mods,
+                        links.count() > 0,
+                    ) catch |err| {
+                        log.warn("error preparing regex links err={}", .{err});
+                        break :regex_hover null;
+                    };
+                };
+
+                const regex_always = self.config.links.prepareAlways(
+                    arena_alloc,
+                    state.terminal.screens.active,
+                    state.mouse.mods,
+                ) catch |err| always: {
+                    log.warn("error preparing always regex links err={}", .{err});
+                    break :always link.PreparedAlways{};
+                };
+
                 const overlay_features: []const Overlay.Feature = overlay: {
                     const insp = state.inspector orelse break :overlay &.{};
                     const renderer_info = insp.rendererInfo();
@@ -1367,6 +1394,8 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
 
                 break :critical .{
                     .links = links,
+                    .regex_always = regex_always,
+                    .regex_hover = regex_hover,
                     .mouse = state.mouse,
                     .preedit = preedit,
                     .scrollbar = scrollbar,
@@ -1379,16 +1408,25 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             // render state (e.g. rebuildCells).
             self.terminal_state.endUpdate();
 
-            // Outside the critical area we can update our links to contain
-            // our regex results.
-            self.config.links.renderCellMap(
+            self.config.links.renderPreparedAlways(
                 arena_alloc,
                 &critical.links,
-                &self.terminal_state,
-                state.mouse.point,
-                state.mouse.mods,
+                critical.regex_always,
+                critical.mouse.mods,
             ) catch |err| {
-                log.warn("error searching for regex links err={}", .{err});
+                log.warn("error searching for always regex links err={}", .{err});
+            };
+
+            // Interactive resolution then canonicalizes the pointer's
+            // candidate domain, including mixed always and hover priority.
+            // Regex evaluation stays outside the terminal critical section.
+            if (critical.regex_hover) |prepared| self.config.links.renderPreparedHover(
+                arena_alloc,
+                &critical.links,
+                prepared,
+                critical.mouse.mods,
+            ) catch |err| {
+                log.warn("error resolving regex hover link err={}", .{err});
             };
 
             // Clear our highlight state and update.

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -64,6 +64,40 @@ const DrawDamageCommit = struct {
     }
 };
 
+/// Deinitialize only slots whose exact ownership state is idle. A counting
+/// semaphore reports how many slots are idle, not which slots are idle.
+fn deinitIdleFrames(frames: anytype) void {
+    for (frames) |*frame| {
+        if (!frame.in_flight.load(.acquire)) frame.deinit();
+    }
+}
+
+/// Claim the next exact idle slot in circular order. The semaphore guarantees
+/// an idle count, while this compare-exchange identifies and owns that slot.
+fn claimNextIdleFrame(
+    frames: anytype,
+    frame_index: anytype,
+) ?@TypeOf(&frames[0]) {
+    if (frames.len == 0) return null;
+
+    const start: usize = @intCast(frame_index.*);
+    for (1..frames.len + 1) |offset| {
+        const index = (start + offset) % frames.len;
+        const frame = &frames[index];
+        if (frame.in_flight.cmpxchgStrong(
+            false,
+            true,
+            .acq_rel,
+            .acquire,
+        ) == null) {
+            frame_index.* = @intCast(index);
+            return frame;
+        }
+    }
+
+    return null;
+}
+
 fn advanceShaperCellIndexToX(
     run_offset: usize,
     shaped_cells: []const font.shape.Cell,
@@ -329,18 +363,17 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 // Wait for all of our inflight draws to complete so that we can
                 // cleanly deinit our GPU state. cmux iOS fork: bound each wait
                 // on iOS so a permit leaked by a stalled completion handler
-                // can't deadlock teardown. A slot we fail to reacquire may have
-                // a command buffer still in flight, so we must NOT free its
-                // FrameState (that would be a use-after-free of GPU-referenced
-                // resources); we only deinit slots we actually reacquired and
-                // leak the rest (a one-time teardown leak, only on a stalled
-                // permit). `defunct` is already set, so no new acquire races us.
+                // can't deadlock teardown. A semaphore permit has no slot
+                // identity, so after the drain deadline we consult each frame's
+                // exact ownership bit, deinit idle slots, and leak only slots
+                // whose command buffers are still in flight. `defunct` is
+                // already set, so no new acquire races us.
                 if (comptime builtin.os.tag == .ios) {
                     var acquired: usize = 0;
                     while (acquired < buf_count) : (acquired += 1) {
                         self.frame_sema.timedWait(frame_acquire_timeout_ns) catch break;
                     }
-                    for (self.frames[0..acquired]) |*frame| frame.deinit();
+                    deinitIdleFrames(&self.frames);
                 } else {
                     for (0..buf_count) |_| self.frame_sema.wait();
                     for (&self.frames) |*frame| frame.deinit();
@@ -350,7 +383,9 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             /// Get the next frame state to draw to. This will wait on the
             /// semaphore to ensure that the frame is available. This must
             /// always be paired with a call to releaseFrame.
-            pub fn nextFrame(self: *SwapChain) error{ Defunct, Timeout }!*FrameState {
+            pub fn nextFrame(
+                self: *SwapChain,
+            ) error{ Defunct, Timeout, FrameUnavailable }!*FrameState {
                 if (self.defunct) return error.Defunct;
 
                 // cmux iOS fork: bound the acquire so a stalled GPU completion
@@ -366,13 +401,19 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 } else {
                     self.frame_sema.wait();
                 }
+                // Restore the aggregate permit if the supposedly impossible
+                // no-idle-slot invariant fails after a successful wait.
                 errdefer self.frame_sema.post();
-                self.frame_index = (self.frame_index + 1) % buf_count;
-                return &self.frames[self.frame_index];
+                return claimNextIdleFrame(
+                    &self.frames,
+                    &self.frame_index,
+                ) orelse error.FrameUnavailable;
             }
 
             /// This should be called when the frame has completed drawing.
-            pub fn releaseFrame(self: *SwapChain) void {
+            pub fn releaseFrame(self: *SwapChain, frame: *FrameState) void {
+                const was_in_flight = frame.in_flight.swap(false, .acq_rel);
+                assert(was_in_flight);
                 self.frame_sema.post();
             }
         };
@@ -387,6 +428,10 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
         ///
         /// This is used to implement double/triple buffering.
         const FrameState = struct {
+            /// Exact ownership state for bounded teardown. The semaphore only
+            /// carries an aggregate count and cannot identify an idle slot.
+            in_flight: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+
             uniforms: UniformBuffer,
             cells: CellTextBuffer,
             cells_bg: CellBgBuffer,
@@ -889,6 +934,9 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             if (self.search_selected_match) |*m| m.arena.deinit();
             if (self.search_matches) |*m| m.arena.deinit();
             self.swap_chain.deinit();
+            if (@hasDecl(GraphicsAPI, "finishFrameGeneration")) {
+                self.api.finishFrameGeneration();
+            }
 
             if (DisplayLink != void) {
                 if (self.display_link) |display_link| {
@@ -1037,12 +1085,20 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             // marked defunct. If not, we have a problem.
             assert(self.swap_chain.defunct);
 
-            // We reinitialize our shaders and our swap chain.
+            // Reinitialize shaders and the swap chain before installing a
+            // distinct completion generation. If any step fails, leave this
+            // renderer unrealized and safe to retry.
             try self.initShaders();
-            self.swap_chain = try SwapChain.init(
+            errdefer self.shaders.deinit(self.alloc);
+            var swap_chain = try SwapChain.init(
                 self.api,
                 self.has_custom_shaders,
             );
+            errdefer swap_chain.deinit();
+            if (@hasDecl(GraphicsAPI, "startFrameGeneration")) {
+                try self.api.startFrameGeneration();
+            }
+            self.swap_chain = swap_chain;
             self.reinitialize_shaders = false;
             self.target_config_modified = 1;
         }
@@ -1066,6 +1122,9 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             // This will mark them as defunct so that they
             // can't be double-freed or used in draw calls.
             self.swap_chain.deinit();
+            if (@hasDecl(GraphicsAPI, "finishFrameGeneration")) {
+                self.api.finishFrameGeneration();
+            }
             self.shaders.deinit(self.alloc);
         }
 
@@ -1665,7 +1724,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
 
             // Wait for a frame to be available.
             const frame = try self.swap_chain.nextFrame();
-            errdefer self.swap_chain.releaseFrame();
+            errdefer self.swap_chain.releaseFrame(frame);
             // log.debug("drawing frame index={}", .{self.swap_chain.frame_index});
 
             // If we need to reinitialize our shaders, do so.
@@ -1916,6 +1975,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
         // Callback from the graphics API when a frame is completed.
         pub fn frameCompleted(
             self: *Self,
+            target: *Target,
             health: Health,
         ) void {
             // If our health value hasn't changed, then we do nothing. We don't
@@ -1942,8 +2002,11 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 if (pushed > 0) self.health.store(health, .seq_cst);
             }
 
-            // Always release our semaphore
-            self.swap_chain.releaseFrame();
+            // Always release the exact frame before reposting the aggregate
+            // semaphore permit. Metal completion order does not identify a
+            // slot during bounded teardown.
+            const frame: *FrameState = @fieldParentPtr("target", target);
+            self.swap_chain.releaseFrame(frame);
         }
 
         /// Call this any time the background image path changes.

--- a/src/renderer/link.zig
+++ b/src/renderer/link.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const assert = std.debug.assert;
 const Allocator = std.mem.Allocator;
 const oni = @import("oniguruma");
-const link_wrap = @import("../link_wrap.zig");
+const linkpkg = @import("../link.zig");
 const inputpkg = @import("../input.zig");
 const terminal = @import("../terminal/main.zig");
 const point = terminal.point;
@@ -19,27 +19,140 @@ pub const Link = struct {
     /// The situations in which the link should be highlighted.
     highlight: inputpkg.Link.Highlight,
 
+    /// The action to perform when this matcher resolves.
+    action: inputpkg.Link.Action,
+
+    /// The terminal text region searched by this matcher.
+    candidate_scope: inputpkg.Link.CandidateScope,
+
     /// Whether prose hard-wrap boundaries are removed before matching.
     hard_wrap_continuations: bool,
+
+    /// Whether joined candidates receive the built-in path match delimiter.
+    hard_wrap_match_delimiter: bool,
 
     pub fn deinit(self: *Link) void {
         self.regex.deinit();
     }
 
-    /// Returns true if this link's highlight condition matches the given mouse state.
-    fn active(
+    /// Returns true when this matcher contributes whole-viewport highlights.
+    fn alwaysActive(
         self: *const Link,
-        mouse_viewport: ?point.Coordinate,
         mouse_mods: inputpkg.Mods,
     ) bool {
         return switch (self.highlight) {
             .always => true,
             .always_mods => |v| mouse_mods.equal(v),
-            .hover => mouse_viewport != null,
-            .hover_mods => |v| mouse_viewport != null and mouse_mods.equal(v),
+            .hover, .hover_mods => false,
+        };
+    }
+
+    /// Returns true when pointer-local hover resolution is required.
+    fn hoverActive(
+        self: *const Link,
+        mouse_mods: inputpkg.Mods,
+    ) bool {
+        return switch (self.highlight) {
+            .hover => true,
+            .hover_mods => |v| mouse_mods.equal(v),
+            .always, .always_mods => false,
         };
     }
 };
+
+/// A terminal cell identity copied while the terminal lock is held. The
+/// viewport coordinate is optional because a candidate may extend outside the
+/// viewport, but its stable page identity must still participate in matching.
+pub const HoverCell = struct {
+    node: usize,
+    y: terminal.size.CellCountInt,
+    x: terminal.size.CellCountInt,
+    viewport: ?point.Coordinate,
+    wide: bool,
+};
+
+pub const PreparedHover = linkpkg.Prepared(HoverCell);
+pub const PreparedAlways = linkpkg.VisibleCandidates(HoverCell);
+
+const RowKey = struct {
+    node: usize,
+    y: terminal.size.CellCountInt,
+};
+
+/// Bulk index from stable page rows to viewport rows. Building this once per
+/// preparation avoids an expensive PageList traversal for every candidate
+/// byte while the terminal lock is held.
+const ViewportRows = struct {
+    rows: std.AutoHashMapUnmanaged(RowKey, terminal.size.CellCountInt) = .empty,
+
+    fn init(alloc: Allocator, screen: *Screen) !ViewportRows {
+        var result: ViewportRows = .{};
+        errdefer result.deinit(alloc);
+
+        var it = screen.pages.getTopLeft(.viewport).rowIterator(.right_down, null);
+        for (0..screen.pages.rows) |viewport_y| {
+            const pin = it.next() orelse break;
+            try result.rows.put(alloc, .{
+                .node = @intFromPtr(pin.node),
+                .y = pin.y,
+            }, @intCast(viewport_y));
+        }
+        return result;
+    }
+
+    fn deinit(self: *ViewportRows, alloc: Allocator) void {
+        self.rows.deinit(alloc);
+    }
+};
+
+fn hoverCell(
+    viewport_rows: *const ViewportRows,
+    screen: *Screen,
+    pin: terminal.Pin,
+) HoverCell {
+    _ = screen;
+    const viewport_y = viewport_rows.rows.get(.{
+        .node = @intFromPtr(pin.node),
+        .y = pin.y,
+    });
+    return .{
+        .node = @intFromPtr(pin.node),
+        .y = pin.y,
+        .x = pin.x,
+        .viewport = if (viewport_y) |y| .{ .x = pin.x, .y = y } else null,
+        .wide = if (pin.node.pageIfResident()) |page|
+            page.getRowAndCell(pin.x, pin.y).cell.wide == .wide
+        else
+            false,
+    };
+}
+
+fn putHoverCell(
+    alloc: Allocator,
+    result: *terminal.RenderState.CellSet,
+    cell: HoverCell,
+) !void {
+    const viewport = cell.viewport orelse return;
+    try result.put(alloc, viewport, {});
+    if (cell.wide) {
+        var tail = viewport;
+        tail.x += 1;
+        try result.put(alloc, tail, {});
+    }
+}
+
+fn removeHoverCell(
+    result: *terminal.RenderState.CellSet,
+    cell: HoverCell,
+) void {
+    const viewport = cell.viewport orelse return;
+    _ = result.swapRemove(viewport);
+    if (cell.wide) {
+        var tail = viewport;
+        tail.x += 1;
+        _ = result.swapRemove(tail);
+    }
+}
 
 /// A set of links. This provides a higher level API for renderers
 /// to match against a viewport and determine if cells are part of
@@ -61,7 +174,10 @@ pub const Set = struct {
             try links.append(alloc, .{
                 .regex = regex,
                 .highlight = link.highlight,
+                .action = link.action,
+                .candidate_scope = link.candidate_scope,
                 .hard_wrap_continuations = link.hard_wrap_continuations,
+                .hard_wrap_match_delimiter = link.hard_wrap_match_delimiter,
             });
         }
 
@@ -73,122 +189,229 @@ pub const Set = struct {
         alloc.free(self.links);
     }
 
-    /// Fills matches with the matches from regex link matches.
-    pub fn renderCellMap(
+    /// Copies the candidates required to resolve an interactive hover while
+    /// the terminal lock is held. Regex evaluation can then happen after the
+    /// lock is released without retaining terminal pins.
+    pub fn prepareHover(
+        self: *const Set,
+        alloc: Allocator,
+        screen: *Screen,
+        mouse_viewport: ?point.Coordinate,
+        mouse_mods: inputpkg.Mods,
+        osc8_owned: bool,
+    ) !?PreparedHover {
+        // OSC 8 metadata is the canonical owner of the hovered cells. Keep
+        // this gate in the shared preparation entrypoint so renderer
+        // orchestration cannot accidentally add an overlapping regex hover.
+        if (osc8_owned) return null;
+        const vp = mouse_viewport orelse return null;
+
+        for (self.links) |*link| {
+            if (link.hoverActive(mouse_mods)) break;
+        } else return null;
+
+        const target = screen.pages.pin(.{ .viewport = vp }) orelse return null;
+        const prepared = try linkpkg.prepareAt(
+            alloc,
+            screen,
+            self.links,
+            target,
+            mouse_mods,
+        );
+        var viewport_rows = try ViewportRows.init(alloc, screen);
+        defer viewport_rows.deinit(alloc);
+        return try linkpkg.mapPrepared(
+            HoverCell,
+            alloc,
+            screen,
+            prepared,
+            &viewport_rows,
+            hoverCell,
+        );
+    }
+
+    /// Copies unique visible candidate domains for active always matchers
+    /// while the terminal lock is held. Regex resolution happens later.
+    pub fn prepareAlways(
+        self: *const Set,
+        alloc: Allocator,
+        screen: *Screen,
+        mouse_mods: inputpkg.Mods,
+    ) !PreparedAlways {
+        for (self.links) |link| {
+            if (linkpkg.alwaysMatcherActive(link, mouse_mods)) break;
+        } else return .{};
+
+        var viewport_rows = try ViewportRows.init(alloc, screen);
+        defer viewport_rows.deinit(alloc);
+        return try linkpkg.prepareVisibleAlways(
+            HoverCell,
+            alloc,
+            screen,
+            self.links,
+            mouse_mods,
+            &viewport_rows,
+            hoverCell,
+        );
+    }
+
+    /// Resolves visible always matchers with canonical candidate scope and
+    /// whole-match priority, then emits only cells currently in the viewport.
+    pub fn renderPreparedAlways(
         self: *const Set,
         alloc: Allocator,
         result: *terminal.RenderState.CellSet,
-        render_state: *const terminal.RenderState,
-        mouse_viewport: ?point.Coordinate,
+        prepared: PreparedAlways,
         mouse_mods: inputpkg.Mods,
     ) !void {
-        // Fast path, not very likely since we have default links.
-        if (self.links.len == 0) return;
+        // OSC 8 is resolved before regex links. Translate its viewport cells
+        // back to stable candidate identities so overlapping always regexes
+        // are rejected as a whole instead of widening the underline.
+        var seed: std.ArrayList(HoverCell) = .empty;
+        defer seed.deinit(alloc);
+        var seen: std.AutoHashMapUnmanaged(HoverCell, void) = .empty;
+        defer seen.deinit(alloc);
+        if (result.count() > 0) {
+            for (prepared.candidates) |candidates| {
+                for (candidates) |candidate| {
+                    for (candidate.map) |cell| {
+                        const viewport = cell.viewport orelse continue;
+                        if (!result.contains(viewport) or seen.contains(cell)) continue;
+                        try seen.put(alloc, cell, {});
+                        try seed.append(alloc, cell);
+                    }
+                }
+            }
+        }
 
-        // Determine if any links are active before building the string and
-        // byte-to-cell map. Those buffers scale with viewport size and this
-        // function runs during frame updates, so avoid allocating them when
-        // the current mouse/modifier state can't highlight any regex links.
+        const resolved = try linkpkg.resolveVisibleAlways(
+            HoverCell,
+            alloc,
+            prepared,
+            self.links,
+            mouse_mods,
+            seed.items,
+        );
+        defer {
+            for (resolved) |match| alloc.free(match.cells);
+            if (resolved.len > 0) alloc.free(resolved);
+        }
+        for (resolved) |match| {
+            for (match.cells) |cell| {
+                try putHoverCell(alloc, result, cell);
+            }
+        }
+    }
+
+    /// Replaces raw always highlights in the pointer's canonical candidate
+    /// domain, then records accepted always matches and the one hover match
+    /// that owns the target. Mixed highlight modes therefore obey the same
+    /// matcher priority as click and preview.
+    pub fn renderPreparedHover(
+        self: *const Set,
+        alloc: Allocator,
+        result: *terminal.RenderState.CellSet,
+        prepared: PreparedHover,
+        mouse_mods: inputpkg.Mods,
+    ) !void {
+        for (self.links) |link| {
+            if (link.alwaysActive(mouse_mods)) break;
+        } else {
+            const match = try linkpkg.resolveAt(
+                HoverCell,
+                alloc,
+                prepared,
+                self.links,
+                mouse_mods,
+            ) orelse return;
+            defer alloc.free(match.cells);
+            for (match.cells) |cell| {
+                try putHoverCell(alloc, result, cell);
+            }
+            return;
+        }
+
         for (self.links) |*link| {
-            if (link.active(mouse_viewport, mouse_mods)) break;
-        } else return;
+            if (!link.alwaysActive(mouse_mods)) continue;
+            const candidates = linkpkg.candidatesFor(
+                HoverCell,
+                prepared,
+                link.*,
+            );
+            for (candidates) |candidate| {
+                for (candidate.map) |cell| {
+                    removeHoverCell(result, cell);
+                }
+            }
+        }
 
-        // Convert our render state to a string + byte map.
-        var builder: std.Io.Writer.Allocating = .init(alloc);
-        defer builder.deinit();
-        var map: terminal.RenderState.StringMap = .empty;
-        defer map.deinit(alloc);
-        try render_state.string(&builder.writer, .{
-            .alloc = alloc,
-            .map = &map,
-        });
+        const resolved = try linkpkg.resolveAll(
+            HoverCell,
+            alloc,
+            prepared,
+            self.links,
+            mouse_mods,
+            &.{},
+        );
+        defer {
+            for (resolved) |match| alloc.free(match.cells);
+            if (resolved.len > 0) alloc.free(resolved);
+        }
 
-        const str = builder.writer.buffered();
-        var normalized: ?link_wrap.Normalized(point.Coordinate) = null;
-        defer if (normalized) |value| value.deinit(alloc);
-
-        // A click resolves the first configured matcher containing the mouse.
-        // Hover must use the same priority or overlapping lower-priority
-        // matchers can widen the underline beyond the value that opens.
-        var hover_claimed = false;
-
-        // Go through each link and see if we have any matches.
-        for (self.links) |*link| {
-            if (!link.active(mouse_viewport, mouse_mods)) continue;
-            const hover_link = switch (link.highlight) {
-                .hover, .hover_mods => true,
-                .always, .always_mods => false,
+        for (resolved) |match| {
+            const emit = switch (self.links[match.matcher_index].highlight) {
+                .always, .always_mods => true,
+                .hover, .hover_mods => emit: {
+                    for (match.cells) |cell| {
+                        if (std.meta.eql(cell, prepared.target)) break :emit true;
+                    }
+                    break :emit false;
+                },
             };
-            if (hover_link and hover_claimed) continue;
+            if (!emit) continue;
 
-            const Candidate = struct {
-                string: []const u8,
-                map: []const point.Coordinate,
-            };
-            const candidate: Candidate = if (!link.hard_wrap_continuations)
-                .{
-                    .string = @as([]const u8, str),
-                    .map = @as([]const point.Coordinate, map.items),
-                }
-            else candidate: {
-                if (normalized == null) normalized = try link_wrap.normalize(
-                    point.Coordinate,
-                    alloc,
-                    str,
-                    map.items,
-                    .{ .terminate_joined = true },
-                );
-                break :candidate .{
-                    .string = @as([]const u8, normalized.?.string),
-                    .map = @as([]const point.Coordinate, normalized.?.map),
-                };
-            };
-
-            var offset: usize = 0;
-            while (offset < candidate.string.len) {
-                var region = link.regex.search(
-                    candidate.string[offset..],
-                    .{},
-                ) catch |err| switch (err) {
-                    error.Mismatch => break,
-                    else => return err,
-                };
-                defer region.deinit();
-
-                // We have a match!
-                const offset_start: usize = @intCast(region.starts()[0]);
-                const offset_end: usize = @intCast(region.ends()[0]);
-                const start = offset + offset_start;
-                const end = offset + offset_end;
-
-                // Increment our offset by the number of bytes in the match.
-                // We defer this so that we can return the match before
-                // modifying the offset.
-                defer offset = end;
-
-                switch (link.highlight) {
-                    .always, .always_mods => {},
-                    .hover, .hover_mods => if (mouse_viewport) |vp| {
-                        for (candidate.map[start..end]) |pt| {
-                            if (pt.eql(vp)) break;
-                        } else continue;
-                    } else continue,
-                }
-
-                // Record the match
-                for (candidate.map[start..end]) |pt| {
-                    try result.put(alloc, pt, {});
-                }
-                if (hover_link) {
-                    hover_claimed = true;
-                    break;
-                }
+            for (match.cells) |cell| {
+                try putHoverCell(alloc, result, cell);
             }
         }
     }
 };
 
-test "renderCellMap" {
+fn renderHoverForTest(
+    set: *const Set,
+    alloc: Allocator,
+    terminal_: *Terminal,
+    result: *terminal.RenderState.CellSet,
+    mouse: ?point.Coordinate,
+    mods: inputpkg.Mods,
+) !void {
+    const prepared = try set.prepareHover(
+        alloc,
+        terminal_.screens.active,
+        mouse,
+        mods,
+        false,
+    ) orelse return;
+    try set.renderPreparedHover(alloc, result, prepared, mods);
+}
+
+fn renderAlwaysForTest(
+    set: *const Set,
+    alloc: Allocator,
+    terminal_: *Terminal,
+    result: *terminal.RenderState.CellSet,
+    mods: inputpkg.Mods,
+) !void {
+    var prepared = try set.prepareAlways(
+        alloc,
+        terminal_.screens.active,
+        mods,
+    );
+    defer prepared.deinit(alloc);
+    try set.renderPreparedAlways(alloc, result, prepared, mods);
+}
+
+test "renderPreparedAlways" {
     const testing = std.testing;
     const alloc = testing.allocator;
 
@@ -202,10 +425,6 @@ test "renderCellMap" {
     defer s.deinit();
     const str = "1ABCD2EFGH\r\n3IJKL";
     s.nextSlice(str);
-
-    var state: terminal.RenderState = .empty;
-    defer state.deinit(alloc);
-    try state.update(alloc, &t);
 
     // Get a set
     var set = try Set.fromConfig(alloc, &.{
@@ -226,11 +445,11 @@ test "renderCellMap" {
     // Get our matches
     var result: terminal.RenderState.CellSet = .empty;
     defer result.deinit(alloc);
-    try set.renderCellMap(
+    try renderAlwaysForTest(
+        &set,
         alloc,
+        &t,
         &result,
-        &state,
-        null,
         .{},
     );
     try testing.expect(!result.contains(.{ .x = 0, .y = 0 }));
@@ -241,65 +460,766 @@ test "renderCellMap" {
     try testing.expect(!result.contains(.{ .x = 1, .y = 2 }));
 }
 
-test "renderCellMap highlights both sides of an indented hard-wrapped link" {
+test "renderPreparedAlways honors semantic scope and matcher priority" {
     const testing = std.testing;
     const alloc = testing.allocator;
 
+    var t: terminal.Terminal = try .init(alloc, .{ .cols = 32, .rows = 2 });
+    defer t.deinit(alloc);
+    var stream = t.vtStream();
+    defer stream.deinit();
+    t.screens.active.cursorSetSemanticContent(.output);
+    stream.nextSlice("FOO");
+    t.screens.active.cursorSetSemanticContent(.{ .input = .clear_explicit });
+    stream.nextSlice("BAR");
+
+    for ([_]struct {
+        scope: inputpkg.Link.CandidateScope,
+        expected: usize,
+    }{
+        .{ .scope = .semantic, .expected = 0 },
+        .{ .scope = .bounded_logical, .expected = 6 },
+    }) |case| {
+        var set = try Set.fromConfig(alloc, &.{.{
+            .regex = "FOOBAR",
+            .action = .{ .open = {} },
+            .highlight = .always,
+            .candidate_scope = case.scope,
+        }});
+        defer set.deinit(alloc);
+        var arena = std.heap.ArenaAllocator.init(alloc);
+        defer arena.deinit();
+        var result: terminal.RenderState.CellSet = .empty;
+        try renderAlwaysForTest(&set, arena.allocator(), &t, &result, .{});
+        try testing.expectEqual(case.expected, result.count());
+    }
+
+    var url_terminal: terminal.Terminal = try .init(alloc, .{ .cols = 32, .rows = 2 });
+    defer url_terminal.deinit(alloc);
+    var url_stream = url_terminal.vtStream();
+    defer url_stream.deinit();
+    const value = "https://example.com.";
+    url_stream.nextSlice(value);
+
+    for ([_]struct {
+        broad_first: bool,
+        expected: usize,
+    }{
+        .{ .broad_first = false, .expected = value.len - 1 },
+        .{ .broad_first = true, .expected = value.len },
+    }) |case| {
+        const exact: inputpkg.Link = .{
+            .regex = "https://example\\.com",
+            .action = .{ .open = {} },
+            .highlight = .always,
+        };
+        const broad: inputpkg.Link = .{
+            .regex = "https://example\\.com\\.",
+            .action = .{ .open = {} },
+            .highlight = .always,
+            .candidate_scope = .bounded_logical,
+        };
+        const links = if (case.broad_first)
+            [_]inputpkg.Link{ broad, exact }
+        else
+            [_]inputpkg.Link{ exact, broad };
+        var set = try Set.fromConfig(alloc, &links);
+        defer set.deinit(alloc);
+        var arena = std.heap.ArenaAllocator.init(alloc);
+        defer arena.deinit();
+        var result: terminal.RenderState.CellSet = .empty;
+        try renderAlwaysForTest(
+            &set,
+            arena.allocator(),
+            &url_terminal,
+            &result,
+            .{},
+        );
+        try testing.expectEqual(case.expected, result.count());
+    }
+}
+
+test "renderPreparedHover matches cross-scope click priority" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var t: terminal.Terminal = try .init(alloc, .{ .cols = 16, .rows = 2 });
+    defer t.deinit(alloc);
+    var stream = t.vtStream();
+    defer stream.deinit();
+    t.screens.active.cursorSetSemanticContent(.output);
+    stream.nextSlice("FOO");
+    t.screens.active.cursorSetSemanticContent(.{ .input = .clear_explicit });
+    stream.nextSlice("BAR");
+
+    var set = try Set.fromConfig(alloc, &.{
+        .{
+            .regex = "BAR",
+            .action = .{ .open = {} },
+            .highlight = .hover,
+            .candidate_scope = .semantic,
+        },
+        .{
+            .regex = "FOOBAR",
+            .action = .{ .open = {} },
+            .highlight = .hover,
+            .candidate_scope = .bounded_logical,
+        },
+    });
+    defer set.deinit(alloc);
+
+    for ([_]struct {
+        mouse: point.Coordinate,
+        expected: usize,
+    }{
+        .{ .mouse = .{ .x = 1, .y = 0 }, .expected = 0 },
+        .{ .mouse = .{ .x = 4, .y = 0 }, .expected = 3 },
+    }) |case| {
+        var arena = std.heap.ArenaAllocator.init(alloc);
+        defer arena.deinit();
+        var result: terminal.RenderState.CellSet = .empty;
+        try renderHoverForTest(
+            &set,
+            arena.allocator(),
+            &t,
+            &result,
+            case.mouse,
+            .{},
+        );
+        try testing.expectEqual(case.expected, result.count());
+        for (0..3) |x| try testing.expect(!result.contains(.{ .x = @intCast(x), .y = 0 }));
+        if (case.expected == 3) {
+            for (3..6) |x| try testing.expect(result.contains(.{ .x = @intCast(x), .y = 0 }));
+        }
+    }
+}
+
+test "renderPreparedAlways applies priority from an offscreen joined domain" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var t: terminal.Terminal = try .init(alloc, .{ .cols = 16, .rows = 1 });
+    defer t.deinit(alloc);
+    var stream = t.vtStream();
+    defer stream.deinit();
+    stream.nextSlice("BAR-\r\nFOO");
+
+    var set = try Set.fromConfig(alloc, &.{
+        .{
+            .regex = "BAR-",
+            .action = .{ .open = {} },
+            .highlight = .always,
+            .candidate_scope = .semantic,
+        },
+        .{
+            .regex = "BAR-FOO",
+            .action = .{ .open = {} },
+            .highlight = .always,
+            .candidate_scope = .bounded_logical,
+            .hard_wrap_continuations = true,
+        },
+    });
+    defer set.deinit(alloc);
+
+    var arena = std.heap.ArenaAllocator.init(alloc);
+    defer arena.deinit();
+    var result: terminal.RenderState.CellSet = .empty;
+    try renderAlwaysForTest(&set, arena.allocator(), &t, &result, .{});
+
+    // BAR- is above the viewport, but still owns cells in the joined
+    // candidate. The overlapping lower-priority match is rejected as a
+    // whole, so its visible FOO suffix must not be underlined.
+    try testing.expectEqual(@as(usize, 0), result.count());
+}
+
+test "renderPreparedHover preserves an unrelated always candidate domain" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    var t: terminal.Terminal = try .init(alloc, .{ .cols = 32, .rows = 2 });
+    defer t.deinit(alloc);
+    var stream = t.vtStream();
+    defer stream.deinit();
+    t.screens.active.cursorSetSemanticContent(.output);
+    stream.nextSlice("FOO ");
+    t.screens.active.cursorSetSemanticContent(.{ .input = .clear_explicit });
+    stream.nextSlice("BAR");
+
+    var set = try Set.fromConfig(alloc, &.{
+        .{
+            .regex = "FOO",
+            .action = .{ .open = {} },
+            .highlight = .always,
+        },
+        .{
+            .regex = "BAR",
+            .action = .{ .open = {} },
+            .highlight = .hover,
+            .candidate_scope = .bounded_logical,
+        },
+    });
+    defer set.deinit(alloc);
+    var arena = std.heap.ArenaAllocator.init(alloc);
+    defer arena.deinit();
+    const frame_alloc = arena.allocator();
+    var result: terminal.RenderState.CellSet = .empty;
+    try renderAlwaysForTest(&set, frame_alloc, &t, &result, .{});
+    try renderHoverForTest(
+        &set,
+        frame_alloc,
+        &t,
+        &result,
+        .{ .x = 5, .y = 0 },
+        .{},
+    );
+    for (0..3) |x| try testing.expect(result.contains(.{ .x = @intCast(x), .y = 0 }));
+    for (4..7) |x| try testing.expect(result.contains(.{ .x = @intCast(x), .y = 0 }));
+}
+
+test "renderPreparedAlways preserves custom hard-wrap end anchors" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
     var t: terminal.Terminal = try .init(alloc, .{
         .cols = 32,
+        .rows = 3,
+    });
+    defer t.deinit(alloc);
+    var stream = t.vtStream();
+    defer stream.deinit();
+    stream.nextSlice("/tmp/a-\r\n    b.txt.");
+
+    var set = try Set.fromConfig(alloc, &.{.{
+        .regex = "/tmp/a-b\\.txt\\.\\z",
+        .action = .{ .open = {} },
+        .highlight = .always,
+        .hard_wrap_continuations = true,
+    }});
+    defer set.deinit(alloc);
+    var arena = std.heap.ArenaAllocator.init(alloc);
+    defer arena.deinit();
+    var result: terminal.RenderState.CellSet = .empty;
+    try renderAlwaysForTest(&set, arena.allocator(), &t, &result, .{});
+    try testing.expectEqual(@as(usize, 13), result.count());
+    for (0..7) |x| {
+        try testing.expect(result.contains(.{ .x = @intCast(x), .y = 0 }));
+    }
+    for (0..4) |x| try testing.expect(!result.contains(.{ .x = @intCast(x), .y = 1 }));
+    for (4..10) |x| {
+        try testing.expect(result.contains(.{ .x = @intCast(x), .y = 1 }));
+    }
+    try testing.expect(!result.contains(.{ .x = 10, .y = 1 }));
+
+    var hover_set = try Set.fromConfig(alloc, &.{.{
+        .regex = "/tmp/a-b\\.txt\\.\\z",
+        .action = .{ .open = {} },
+        .highlight = .hover,
+        .hard_wrap_continuations = true,
+    }});
+    defer hover_set.deinit(alloc);
+    var hover_arena = std.heap.ArenaAllocator.init(alloc);
+    defer hover_arena.deinit();
+    var hover: terminal.RenderState.CellSet = .empty;
+    try renderHoverForTest(
+        &hover_set,
+        hover_arena.allocator(),
+        &t,
+        &hover,
+        .{ .x = 9, .y = 1 },
+        .{},
+    );
+    try testing.expectEqual(result.count(), hover.count());
+    var always_it = result.iterator();
+    while (always_it.next()) |entry| {
+        try testing.expect(hover.contains(entry.key_ptr.*));
+    }
+}
+
+test "renderPreparedHover matches exact user path with default matchers" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const url = @import("../config/url.zig");
+    const prefix = "The built app is ";
+    const first = "/Users/cmux-lawrence/Applications/cmux-browser-resize-modes-";
+    const second = "20260716-warm.app";
+
+    var t: terminal.Terminal = try .init(alloc, .{
+        .cols = 160,
         .rows = 3,
     });
     defer t.deinit(alloc);
 
     var stream = t.vtStream();
     defer stream.deinit();
-    stream.nextSlice("/tmp/build-\r\n    warm.app.");
+    stream.nextSlice(prefix ++ first ++ "\r\n    " ++ second ++ ".");
 
-    var state: terminal.RenderState = .empty;
-    defer state.deinit(alloc);
-    try state.update(alloc, &t);
-
-    var set = try Set.fromConfig(alloc, &.{.{
-        .regex = "/tmp/build-warm\\.app",
-        .action = .{ .open = {} },
-        .highlight = .{ .hover_mods = inputpkg.ctrlOrSuper(.{}) },
-        .hard_wrap_continuations = true,
-    }});
+    var set = try Set.fromConfig(alloc, &.{
+        .{
+            .regex = url.scheme_regex,
+            .action = .{ .open = {} },
+            .highlight = .{ .hover_mods = inputpkg.ctrlOrSuper(.{}) },
+            .candidate_scope = .bounded_logical,
+            .hard_wrap_continuations = true,
+        },
+        .{
+            .regex = url.path_regex,
+            .action = .{ .open = {} },
+            .highlight = .{ .hover_mods = inputpkg.ctrlOrSuper(.{}) },
+            .hard_wrap_continuations = true,
+            .hard_wrap_match_delimiter = true,
+        },
+    });
     defer set.deinit(alloc);
 
     for ([_]point.Coordinate{
-        .{ .x = 5, .y = 0 },
-        .{ .x = 7, .y = 1 },
+        .{ .x = prefix.len + 20, .y = 0 },
+        .{ .x = 10, .y = 1 },
     }) |mouse| {
+        var arena = std.heap.ArenaAllocator.init(alloc);
+        defer arena.deinit();
+        const frame_alloc = arena.allocator();
         var result: terminal.RenderState.CellSet = .empty;
-        defer result.deinit(alloc);
-        try set.renderCellMap(
-            alloc,
+        try renderHoverForTest(
+            &set,
+            frame_alloc,
+            &t,
             &result,
-            &state,
             mouse,
             inputpkg.ctrlOrSuper(.{}),
         );
 
-        for (0..11) |x| {
+        try testing.expectEqual(first.len + second.len, result.count());
+        for (0..prefix.len) |x| {
+            try testing.expect(!result.contains(.{ .x = @intCast(x), .y = 0 }));
+        }
+        for (prefix.len..prefix.len + first.len) |x| {
             try testing.expect(result.contains(.{ .x = @intCast(x), .y = 0 }));
         }
         for (0..4) |x| {
             try testing.expect(!result.contains(.{ .x = @intCast(x), .y = 1 }));
         }
-        for (4..12) |x| {
+        for (4..4 + second.len) |x| {
             try testing.expect(result.contains(.{ .x = @intCast(x), .y = 1 }));
         }
-        try testing.expect(!result.contains(.{ .x = 12, .y = 1 }));
+        try testing.expect(!result.contains(.{
+            .x = 4 + second.len,
+            .y = 1,
+        }));
     }
 }
 
-test "renderCellMap default matcher priority excludes trailing URL punctuation" {
+test "renderPreparedHover excludes punctuation from a wrapped bare relative path" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const url = @import("../config/url.zig");
+    const first = "src/foo-";
+    const second = "bar/file.zig";
+
+    var t: terminal.Terminal = try .init(alloc, .{
+        .cols = 32,
+        .rows = 3,
+    });
+    defer t.deinit(alloc);
+    var stream = t.vtStream();
+    defer stream.deinit();
+    stream.nextSlice(first ++ "\r\n    " ++ second ++ ".,");
+
+    var set = try Set.fromConfig(alloc, &.{.{
+        .regex = url.path_regex,
+        .action = .{ .open = {} },
+        .highlight = .{ .hover_mods = inputpkg.ctrlOrSuper(.{}) },
+        .hard_wrap_continuations = true,
+        .hard_wrap_match_delimiter = true,
+    }});
+    defer set.deinit(alloc);
+
+    for ([_]point.Coordinate{
+        .{ .x = 3, .y = 0 },
+        .{ .x = 7, .y = 1 },
+    }) |mouse| {
+        var arena = std.heap.ArenaAllocator.init(alloc);
+        defer arena.deinit();
+        var result: terminal.RenderState.CellSet = .empty;
+        try renderHoverForTest(
+            &set,
+            arena.allocator(),
+            &t,
+            &result,
+            mouse,
+            inputpkg.ctrlOrSuper(.{}),
+        );
+        for (0..first.len) |x| {
+            try testing.expect(result.contains(.{ .x = @intCast(x), .y = 0 }));
+        }
+        for (0..4) |x| {
+            try testing.expect(!result.contains(.{ .x = @intCast(x), .y = 1 }));
+        }
+        for (4..4 + second.len) |x| {
+            try testing.expect(result.contains(.{ .x = @intCast(x), .y = 1 }));
+        }
+        for (4 + second.len..4 + second.len + 2) |x| {
+            try testing.expect(!result.contains(.{ .x = @intCast(x), .y = 1 }));
+        }
+    }
+}
+
+test "renderPreparedHover keeps sentence URL and indented path separate" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const url = @import("../config/url.zig");
+    const prefix = "See ";
+    const first = "https://example.com";
+    const second = "/tmp/foo";
+
+    var t: terminal.Terminal = try .init(alloc, .{ .cols = 80, .rows = 3 });
+    defer t.deinit(alloc);
+    var stream = t.vtStream();
+    defer stream.deinit();
+    stream.nextSlice(prefix ++ first ++ ".\r\n    " ++ second);
+
+    var set = try Set.fromConfig(alloc, &.{
+        .{
+            .regex = url.scheme_regex,
+            .action = .{ .open = {} },
+            .highlight = .{ .hover_mods = inputpkg.ctrlOrSuper(.{}) },
+            .candidate_scope = .bounded_logical,
+            .hard_wrap_continuations = true,
+        },
+        .{
+            .regex = url.path_regex,
+            .action = .{ .open = {} },
+            .highlight = .{ .hover_mods = inputpkg.ctrlOrSuper(.{}) },
+            .hard_wrap_continuations = true,
+            .hard_wrap_match_delimiter = true,
+        },
+    });
+    defer set.deinit(alloc);
+
+    const cases = [_]struct {
+        mouse: point.Coordinate,
+        row: terminal.size.CellCountInt,
+        start: usize,
+        len: usize,
+    }{
+        .{
+            .mouse = .{ .x = prefix.len + 8, .y = 0 },
+            .row = 0,
+            .start = prefix.len,
+            .len = first.len,
+        },
+        .{
+            .mouse = .{ .x = 6, .y = 1 },
+            .row = 1,
+            .start = 4,
+            .len = second.len,
+        },
+    };
+    for (cases) |case| {
+        var arena = std.heap.ArenaAllocator.init(alloc);
+        defer arena.deinit();
+        var result: terminal.RenderState.CellSet = .empty;
+        try renderHoverForTest(
+            &set,
+            arena.allocator(),
+            &t,
+            &result,
+            case.mouse,
+            inputpkg.ctrlOrSuper(.{}),
+        );
+        try testing.expectEqual(case.len, result.count());
+        for (case.start..case.start + case.len) |x| {
+            try testing.expect(result.contains(.{
+                .x = @intCast(x),
+                .y = case.row,
+            }));
+        }
+    }
+}
+
+test "renderPreparedHover keeps adjacent independent links separate" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const url = @import("../config/url.zig");
+    const values = [_][]const u8{
+        "/tmp/foo/",
+        "/tmp/bar",
+        "https://example.com/path-",
+        "https://example.org",
+    };
+
+    var t: terminal.Terminal = try .init(alloc, .{
+        .cols = 80,
+        .rows = values.len,
+    });
+    defer t.deinit(alloc);
+    var stream = t.vtStream();
+    defer stream.deinit();
+    stream.nextSlice(
+        values[0] ++ "\r\n    " ++ values[1] ++
+            "\r\n" ++ values[2] ++ "\r\n    " ++ values[3],
+    );
+
+    var set = try Set.fromConfig(alloc, &.{
+        .{
+            .regex = url.scheme_regex,
+            .action = .{ .open = {} },
+            .highlight = .{ .hover_mods = inputpkg.ctrlOrSuper(.{}) },
+            .candidate_scope = .bounded_logical,
+            .hard_wrap_continuations = true,
+        },
+        .{
+            .regex = url.path_regex,
+            .action = .{ .open = {} },
+            .highlight = .{ .hover_mods = inputpkg.ctrlOrSuper(.{}) },
+            .hard_wrap_continuations = true,
+            .hard_wrap_match_delimiter = true,
+        },
+    });
+    defer set.deinit(alloc);
+
+    for (values, 0..) |expected, y| {
+        const indentation: usize = if (y == 1 or y == 3) 4 else 0;
+        var arena = std.heap.ArenaAllocator.init(alloc);
+        defer arena.deinit();
+        var result: terminal.RenderState.CellSet = .empty;
+        try renderHoverForTest(
+            &set,
+            arena.allocator(),
+            &t,
+            &result,
+            .{
+                .x = @intCast(indentation + expected.len / 2),
+                .y = @intCast(y),
+            },
+            inputpkg.ctrlOrSuper(.{}),
+        );
+        try testing.expectEqual(expected.len, result.count());
+        for (indentation..indentation + expected.len) |x| {
+            try testing.expect(result.contains(.{
+                .x = @intCast(x),
+                .y = @intCast(y),
+            }));
+        }
+    }
+}
+
+test "renderPreparedHover does not merge adjacent bare path after slash" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const url = @import("../config/url.zig");
+    const first = "src/foo/";
+    const second = "src/bar.zig";
+
+    var t: terminal.Terminal = try .init(alloc, .{ .cols = 80, .rows = 2 });
+    defer t.deinit(alloc);
+    var stream = t.vtStream();
+    defer stream.deinit();
+    stream.nextSlice(first ++ "\r\n    " ++ second);
+
+    var set = try Set.fromConfig(alloc, &.{.{
+        .regex = url.path_regex,
+        .action = .{ .open = {} },
+        .highlight = .{ .hover_mods = inputpkg.ctrlOrSuper(.{}) },
+        .hard_wrap_continuations = true,
+        .hard_wrap_match_delimiter = true,
+    }});
+    defer set.deinit(alloc);
+
+    var upper_arena = std.heap.ArenaAllocator.init(alloc);
+    defer upper_arena.deinit();
+    var upper: terminal.RenderState.CellSet = .empty;
+    try renderHoverForTest(
+        &set,
+        upper_arena.allocator(),
+        &t,
+        &upper,
+        .{ .x = 3, .y = 0 },
+        inputpkg.ctrlOrSuper(.{}),
+    );
+    try testing.expectEqual(@as(usize, 0), upper.count());
+
+    var lower_arena = std.heap.ArenaAllocator.init(alloc);
+    defer lower_arena.deinit();
+    var lower: terminal.RenderState.CellSet = .empty;
+    try renderHoverForTest(
+        &set,
+        lower_arena.allocator(),
+        &t,
+        &lower,
+        .{ .x = 8, .y = 1 },
+        inputpkg.ctrlOrSuper(.{}),
+    );
+    try testing.expectEqual(second.len, lower.count());
+    for (4..4 + second.len) |x| {
+        try testing.expect(lower.contains(.{ .x = @intCast(x), .y = 1 }));
+    }
+}
+
+test "renderPreparedHover highlights both columns of wide UTF-8 glyphs" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const first = "https://example.com/wiki/";
+
+    var t: terminal.Terminal = try .init(alloc, .{
+        .cols = 64,
+        .rows = 3,
+    });
+    defer t.deinit(alloc);
+    var stream = t.vtStream();
+    defer stream.deinit();
+    stream.nextSlice(first ++ "\r\n    日本語.");
+
+    var set = try Set.fromConfig(alloc, &.{.{
+        .regex = "https://example\\.com/wiki/日本語",
+        .action = .{ .open = {} },
+        .highlight = .hover,
+        .hard_wrap_continuations = true,
+    }});
+    defer set.deinit(alloc);
+
+    for ([_]point.Coordinate{
+        .{ .x = 8, .y = 0 },
+        .{ .x = 4, .y = 1 },
+        .{ .x = 5, .y = 1 },
+        .{ .x = 9, .y = 1 },
+    }) |mouse| {
+        var arena = std.heap.ArenaAllocator.init(alloc);
+        defer arena.deinit();
+        var result: terminal.RenderState.CellSet = .empty;
+        try renderHoverForTest(
+            &set,
+            arena.allocator(),
+            &t,
+            &result,
+            mouse,
+            .{},
+        );
+        for (0..first.len) |x| {
+            try testing.expect(result.contains(.{ .x = @intCast(x), .y = 0 }));
+        }
+        for (0..4) |x| {
+            try testing.expect(!result.contains(.{ .x = @intCast(x), .y = 1 }));
+        }
+        for (4..10) |x| {
+            try testing.expect(result.contains(.{ .x = @intCast(x), .y = 1 }));
+        }
+        try testing.expect(!result.contains(.{ .x = 10, .y = 1 }));
+    }
+}
+
+test "renderPreparedAlways cannot widen an OSC 8 link" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const visible = "https://visible.example";
+
+    var t: terminal.Terminal = try .init(alloc, .{ .cols = 64, .rows = 2 });
+    defer t.deinit(alloc);
+    var stream = t.vtStream();
+    defer stream.deinit();
+    stream.nextSlice(
+        "\x1b]8;;https://target.example/osc8\x1b\\" ++ visible ++
+            "\x1b]8;;\x1b\\.",
+    );
+    var state: terminal.RenderState = .empty;
+    defer state.deinit(alloc);
+    try state.update(alloc, &t);
+
+    var set = try Set.fromConfig(alloc, &.{.{
+        .regex = "https://visible\\.example\\.",
+        .action = .{ .open = {} },
+        .highlight = .always,
+    }});
+    defer set.deinit(alloc);
+
+    var arena = std.heap.ArenaAllocator.init(alloc);
+    defer arena.deinit();
+    const frame_alloc = arena.allocator();
+    var result = try state.linkCells(frame_alloc, .{ .x = 8, .y = 0 });
+    const prepared = try set.prepareAlways(frame_alloc, t.screens.active, .{});
+    try set.renderPreparedAlways(frame_alloc, &result, prepared, .{});
+    try testing.expectEqual(visible.len, result.count());
+    try testing.expect(!result.contains(.{ .x = @intCast(visible.len), .y = 0 }));
+}
+
+test "prepareHover gives OSC 8 ownership over an overlapping regex" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const visible = "https://visible.example";
+
+    var t: terminal.Terminal = try .init(alloc, .{ .cols = 64, .rows = 2 });
+    defer t.deinit(alloc);
+    var stream = t.vtStream();
+    defer stream.deinit();
+    stream.nextSlice(
+        "\x1b]8;;https://target.example/osc8\x1b\\" ++ visible ++
+            "\x1b]8;;\x1b\\.",
+    );
+    var state: terminal.RenderState = .empty;
+    defer state.deinit(alloc);
+    try state.update(alloc, &t);
+
+    var set = try Set.fromConfig(alloc, &.{.{
+        .regex = "https://visible\\.example\\.",
+        .action = .{ .open = {} },
+        .highlight = .{ .hover_mods = inputpkg.ctrlOrSuper(.{}) },
+    }});
+    defer set.deinit(alloc);
+
+    var arena = std.heap.ArenaAllocator.init(alloc);
+    defer arena.deinit();
+    const frame_alloc = arena.allocator();
+    const mouse: point.Coordinate = .{ .x = 8, .y = 0 };
+    const result = try state.linkCells(frame_alloc, mouse);
+    const prepared = try set.prepareHover(
+        frame_alloc,
+        t.screens.active,
+        mouse,
+        inputpkg.ctrlOrSuper(.{}),
+        result.count() > 0,
+    );
+    try testing.expect(prepared == null);
+    try testing.expectEqual(visible.len, result.count());
+    try testing.expect(!result.contains(.{ .x = @intCast(visible.len), .y = 0 }));
+}
+
+test "mapPrepared does not restore a compressed target page" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var t: terminal.Terminal = try .init(alloc, .{ .cols = 80, .rows = 24 });
+    defer t.deinit(alloc);
+    var stream = t.vtStream();
+    defer stream.deinit();
+    const pages = &t.screens.active.pages;
+    const first_page_rows = pages.pages.first.?.capacity().rows;
+    for (0..first_page_rows + 24) |_| stream.nextSlice("history\r\n");
+    _ = pages.compress(.full);
+
+    const compressed = pages.pages.first.?;
+    try testing.expectEqual(.compressed, compressed.storage());
+    var viewport_rows = try ViewportRows.init(alloc, t.screens.active);
+    defer viewport_rows.deinit(alloc);
+    const prepared: linkpkg.Prepared(terminal.Pin) = .{
+        .target = .{ .node = compressed, .x = 0, .y = 0 },
+    };
+    const mapped = try linkpkg.mapPrepared(
+        HoverCell,
+        alloc,
+        t.screens.active,
+        prepared,
+        &viewport_rows,
+        hoverCell,
+    );
+    try testing.expect(mapped.target.viewport == null);
+    try testing.expect(!mapped.target.wide);
+    try testing.expectEqual(.compressed, compressed.storage());
+}
+
+test "renderPreparedHover default matcher priority excludes non-link cells" {
     const testing = std.testing;
     const alloc = testing.allocator;
     const url = @import("../config/url.zig");
     const first = "https://github.com/manaflow-ai/cmux/issues/8059#issuecomment-";
-    const second = "0123456789";
+    const second = "01234-";
+    const third = "56789";
 
     var t: terminal.Terminal = try .init(alloc, .{
         .cols = 96,
@@ -309,17 +1229,14 @@ test "renderCellMap default matcher priority excludes trailing URL punctuation" 
 
     var stream = t.vtStream();
     defer stream.deinit();
-    stream.nextSlice(first ++ "\r\n    " ++ second ++ ".");
-
-    var state: terminal.RenderState = .empty;
-    defer state.deinit(alloc);
-    try state.update(alloc, &t);
+    stream.nextSlice(first ++ "\r\n    " ++ second ++ "\r\n    " ++ third ++ ".,");
 
     var set = try Set.fromConfig(alloc, &.{
         .{
             .regex = url.scheme_regex,
             .action = .{ .open = {} },
             .highlight = .{ .hover_mods = inputpkg.ctrlOrSuper(.{}) },
+            .candidate_scope = .bounded_logical,
             .hard_wrap_continuations = true,
         },
         .{
@@ -327,29 +1244,178 @@ test "renderCellMap default matcher priority excludes trailing URL punctuation" 
             .action = .{ .open = {} },
             .highlight = .{ .hover_mods = inputpkg.ctrlOrSuper(.{}) },
             .hard_wrap_continuations = true,
+            .hard_wrap_match_delimiter = true,
         },
     });
     defer set.deinit(alloc);
 
-    var result: terminal.RenderState.CellSet = .empty;
-    defer result.deinit(alloc);
-    try set.renderCellMap(
-        alloc,
-        &result,
-        &state,
-        // Hover the continuation, where both the scheme URL matcher and the
-        // lower-priority bare-path matcher overlap.
+    // Hovering either segment resolves the same exact URL cells.
+    for ([_]point.Coordinate{
+        .{ .x = 20, .y = 0 },
         .{ .x = 8, .y = 1 },
-        inputpkg.ctrlOrSuper(.{}),
-    );
+        .{ .x = 6, .y = 2 },
+    }) |mouse| {
+        var arena = std.heap.ArenaAllocator.init(alloc);
+        defer arena.deinit();
+        const frame_alloc = arena.allocator();
+        var result: terminal.RenderState.CellSet = .empty;
+        try renderHoverForTest(
+            &set,
+            frame_alloc,
+            &t,
+            &result,
+            mouse,
+            inputpkg.ctrlOrSuper(.{}),
+        );
 
-    try testing.expect(!result.contains(.{ .x = 3, .y = 1 }));
-    try testing.expect(result.contains(.{ .x = 4, .y = 1 }));
-    try testing.expect(result.contains(.{ .x = 13, .y = 1 }));
-    try testing.expect(!result.contains(.{ .x = 14, .y = 1 }));
+        for (0..first.len) |x| {
+            try testing.expect(result.contains(.{ .x = @intCast(x), .y = 0 }));
+        }
+        try testing.expect(!result.contains(.{ .x = 3, .y = 1 }));
+        for (4..10) |x| {
+            try testing.expect(result.contains(.{ .x = @intCast(x), .y = 1 }));
+        }
+        for (0..4) |x| {
+            try testing.expect(!result.contains(.{ .x = @intCast(x), .y = 2 }));
+        }
+        for (4..9) |x| {
+            try testing.expect(result.contains(.{ .x = @intCast(x), .y = 2 }));
+        }
+        try testing.expect(!result.contains(.{ .x = 9, .y = 2 }));
+        try testing.expect(!result.contains(.{ .x = 10, .y = 2 }));
+    }
+
+    // Indentation and sentence punctuation are not hover targets, including
+    // where the lower-priority path matcher would otherwise claim the period.
+    for ([_]point.Coordinate{
+        .{ .x = 3, .y = 1 },
+        .{ .x = 3, .y = 2 },
+        .{ .x = 9, .y = 2 },
+        .{ .x = 10, .y = 2 },
+    }) |mouse| {
+        var arena = std.heap.ArenaAllocator.init(alloc);
+        defer arena.deinit();
+        const frame_alloc = arena.allocator();
+        var result: terminal.RenderState.CellSet = .empty;
+        try renderHoverForTest(
+            &set,
+            frame_alloc,
+            &t,
+            &result,
+            mouse,
+            inputpkg.ctrlOrSuper(.{}),
+        );
+        try testing.expectEqual(@as(usize, 0), result.count());
+    }
 }
 
-test "renderCellMap hover links" {
+test "renderPreparedHover arbitrates mixed always and hover matchers" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const value = "https://example.com.";
+    const exact_len = value.len - 1;
+
+    var t: terminal.Terminal = try .init(alloc, .{
+        .cols = 32,
+        .rows = 2,
+    });
+    defer t.deinit(alloc);
+    var stream = t.vtStream();
+    defer stream.deinit();
+    stream.nextSlice(value);
+
+    const cases = [_]struct {
+        exact_highlight: inputpkg.Link.Highlight,
+        broad_highlight: inputpkg.Link.Highlight,
+        mouse_x: usize,
+        expected_count: usize,
+    }{
+        .{
+            .exact_highlight = .always,
+            .broad_highlight = .hover,
+            .mouse_x = exact_len,
+            .expected_count = exact_len,
+        },
+        .{
+            .exact_highlight = .hover,
+            .broad_highlight = .always,
+            .mouse_x = 8,
+            .expected_count = exact_len,
+        },
+        .{
+            .exact_highlight = .hover,
+            .broad_highlight = .always,
+            .mouse_x = exact_len,
+            .expected_count = 0,
+        },
+    };
+
+    for (cases) |case| {
+        var set = try Set.fromConfig(alloc, &.{
+            .{
+                .regex = "https://example\\.com",
+                .action = .{ .open = {} },
+                .highlight = case.exact_highlight,
+            },
+            .{
+                .regex = "https://example\\.com\\.",
+                .action = .{ .open = {} },
+                .highlight = case.broad_highlight,
+            },
+        });
+        defer set.deinit(alloc);
+
+        var arena = std.heap.ArenaAllocator.init(alloc);
+        defer arena.deinit();
+        const frame_alloc = arena.allocator();
+        var result: terminal.RenderState.CellSet = .empty;
+        try renderAlwaysForTest(&set, frame_alloc, &t, &result, .{});
+        try renderHoverForTest(
+            &set,
+            frame_alloc,
+            &t,
+            &result,
+            .{ .x = @intCast(case.mouse_x), .y = 0 },
+            .{},
+        );
+
+        try testing.expectEqual(case.expected_count, result.count());
+        try testing.expect(!result.contains(.{ .x = @intCast(exact_len), .y = 0 }));
+    }
+
+    // Reversing matcher order intentionally gives the broad matcher ownership
+    // of the sentence period.
+    var reverse = try Set.fromConfig(alloc, &.{
+        .{
+            .regex = "https://example\\.com\\.",
+            .action = .{ .open = {} },
+            .highlight = .always,
+        },
+        .{
+            .regex = "https://example\\.com",
+            .action = .{ .open = {} },
+            .highlight = .hover,
+        },
+    });
+    defer reverse.deinit(alloc);
+    var arena = std.heap.ArenaAllocator.init(alloc);
+    defer arena.deinit();
+    const frame_alloc = arena.allocator();
+    var result: terminal.RenderState.CellSet = .empty;
+    try renderAlwaysForTest(&reverse, frame_alloc, &t, &result, .{});
+    try renderHoverForTest(
+        &reverse,
+        frame_alloc,
+        &t,
+        &result,
+        .{ .x = @intCast(exact_len), .y = 0 },
+        .{},
+    );
+    try testing.expectEqual(value.len, result.count());
+    try testing.expect(result.contains(.{ .x = @intCast(exact_len), .y = 0 }));
+}
+
+test "render hover links alongside always links" {
     const testing = std.testing;
     const alloc = testing.allocator;
 
@@ -363,10 +1429,6 @@ test "renderCellMap hover links" {
     defer s.deinit();
     const str = "1ABCD2EFGH\r\n3IJKL";
     s.nextSlice(str);
-
-    var state: terminal.RenderState = .empty;
-    defer state.deinit(alloc);
-    try state.update(alloc, &t);
 
     // Get a set
     var set = try Set.fromConfig(alloc, &.{
@@ -386,15 +1448,18 @@ test "renderCellMap hover links" {
 
     // Not hovering over the first link
     {
+        var arena = std.heap.ArenaAllocator.init(alloc);
+        defer arena.deinit();
+        const frame_alloc = arena.allocator();
         var result: terminal.RenderState.CellSet = .empty;
-        defer result.deinit(alloc);
-        try set.renderCellMap(
-            alloc,
+        try renderAlwaysForTest(
+            &set,
+            frame_alloc,
+            &t,
             &result,
-            &state,
-            null,
             .{},
         );
+        try renderHoverForTest(&set, frame_alloc, &t, &result, null, .{});
 
         // Test our matches
         try testing.expect(!result.contains(.{ .x = 0, .y = 0 }));
@@ -407,12 +1472,22 @@ test "renderCellMap hover links" {
 
     // Hovering over the first link
     {
+        var arena = std.heap.ArenaAllocator.init(alloc);
+        defer arena.deinit();
+        const frame_alloc = arena.allocator();
         var result: terminal.RenderState.CellSet = .empty;
-        defer result.deinit(alloc);
-        try set.renderCellMap(
-            alloc,
+        try renderAlwaysForTest(
+            &set,
+            frame_alloc,
+            &t,
             &result,
-            &state,
+            .{},
+        );
+        try renderHoverForTest(
+            &set,
+            frame_alloc,
+            &t,
+            &result,
             .{ .x = 1, .y = 0 },
             .{},
         );
@@ -427,7 +1502,7 @@ test "renderCellMap hover links" {
     }
 }
 
-test "renderCellMap inactive links don't allocate" {
+test "inactive links don't allocate" {
     const testing = std.testing;
     const alloc = testing.allocator;
 
@@ -441,10 +1516,6 @@ test "renderCellMap inactive links don't allocate" {
     defer s.deinit();
     const str = "1ABCD2EFGH\r\n3IJKL";
     s.nextSlice(str);
-
-    var state: terminal.RenderState = .empty;
-    defer state.deinit(alloc);
-    try state.update(alloc, &t);
 
     var set = try Set.fromConfig(alloc, &.{
         .{
@@ -475,18 +1546,24 @@ test "renderCellMap inactive links don't allocate" {
 
     var result: terminal.RenderState.CellSet = .empty;
     defer result.deinit(failing_alloc);
-    try set.renderCellMap(
+    const prepared_always = try set.prepareAlways(
         failing_alloc,
-        &result,
-        &state,
-        null,
+        t.screens.active,
         .{},
     );
+    try set.renderPreparedAlways(failing_alloc, &result, prepared_always, .{});
+    try testing.expect(try set.prepareHover(
+        failing_alloc,
+        t.screens.active,
+        null,
+        .{},
+        false,
+    ) == null);
 
     try testing.expectEqual(@as(usize, 0), result.count());
 }
 
-test "renderCellMap mods no match" {
+test "renderPreparedAlways mods no match" {
     const testing = std.testing;
     const alloc = testing.allocator;
 
@@ -500,10 +1577,6 @@ test "renderCellMap mods no match" {
     defer s.deinit();
     const str = "1ABCD2EFGH\r\n3IJKL";
     s.nextSlice(str);
-
-    var state: terminal.RenderState = .empty;
-    defer state.deinit(alloc);
-    try state.update(alloc, &t);
 
     // Get a set
     var set = try Set.fromConfig(alloc, &.{
@@ -524,11 +1597,11 @@ test "renderCellMap mods no match" {
     // Get our matches
     var result: terminal.RenderState.CellSet = .empty;
     defer result.deinit(alloc);
-    try set.renderCellMap(
+    try renderAlwaysForTest(
+        &set,
         alloc,
+        &t,
         &result,
-        &state,
-        null,
         .{},
     );
 

--- a/src/renderer/link.zig
+++ b/src/renderer/link.zig
@@ -107,9 +107,19 @@ pub const Set = struct {
         var normalized: ?link_wrap.Normalized(point.Coordinate) = null;
         defer if (normalized) |value| value.deinit(alloc);
 
+        // A click resolves the first configured matcher containing the mouse.
+        // Hover must use the same priority or overlapping lower-priority
+        // matchers can widen the underline beyond the value that opens.
+        var hover_claimed = false;
+
         // Go through each link and see if we have any matches.
         for (self.links) |*link| {
             if (!link.active(mouse_viewport, mouse_mods)) continue;
+            const hover_link = switch (link.highlight) {
+                .hover, .hover_mods => true,
+                .always, .always_mods => false,
+            };
+            if (hover_link and hover_claimed) continue;
 
             const Candidate = struct {
                 string: []const u8,
@@ -168,6 +178,10 @@ pub const Set = struct {
                 // Record the match
                 for (candidate.map[start..end]) |pt| {
                     try result.put(alloc, pt, {});
+                }
+                if (hover_link) {
+                    hover_claimed = true;
+                    break;
                 }
             }
         }

--- a/src/renderer/link.zig
+++ b/src/renderer/link.zig
@@ -280,6 +280,61 @@ test "renderCellMap highlights both sides of an indented hard-wrapped link" {
     }
 }
 
+test "renderCellMap default matcher priority excludes trailing URL punctuation" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const url = @import("../config/url.zig");
+    const first = "https://github.com/manaflow-ai/cmux/issues/8059#issuecomment-";
+    const second = "0123456789";
+
+    var t: terminal.Terminal = try .init(alloc, .{
+        .cols = 96,
+        .rows = 3,
+    });
+    defer t.deinit(alloc);
+
+    var stream = t.vtStream();
+    defer stream.deinit();
+    stream.nextSlice(first ++ "\r\n    " ++ second ++ ".");
+
+    var state: terminal.RenderState = .empty;
+    defer state.deinit(alloc);
+    try state.update(alloc, &t);
+
+    var set = try Set.fromConfig(alloc, &.{
+        .{
+            .regex = url.scheme_regex,
+            .action = .{ .open = {} },
+            .highlight = .{ .hover_mods = inputpkg.ctrlOrSuper(.{}) },
+            .hard_wrap_continuations = true,
+        },
+        .{
+            .regex = url.path_regex,
+            .action = .{ .open = {} },
+            .highlight = .{ .hover_mods = inputpkg.ctrlOrSuper(.{}) },
+            .hard_wrap_continuations = true,
+        },
+    });
+    defer set.deinit(alloc);
+
+    var result: terminal.RenderState.CellSet = .empty;
+    defer result.deinit(alloc);
+    try set.renderCellMap(
+        alloc,
+        &result,
+        &state,
+        // Hover the continuation, where both the scheme URL matcher and the
+        // lower-priority bare-path matcher overlap.
+        .{ .x = 8, .y = 1 },
+        inputpkg.ctrlOrSuper(.{}),
+    );
+
+    try testing.expect(!result.contains(.{ .x = 3, .y = 1 }));
+    try testing.expect(result.contains(.{ .x = 4, .y = 1 }));
+    try testing.expect(result.contains(.{ .x = 13, .y = 1 }));
+    try testing.expect(!result.contains(.{ .x = 14, .y = 1 }));
+}
+
 test "renderCellMap hover links" {
     const testing = std.testing;
     const alloc = testing.allocator;

--- a/src/renderer/link.zig
+++ b/src/renderer/link.zig
@@ -806,6 +806,68 @@ test "renderPreparedHover matches exact user path with default matchers" {
     }
 }
 
+test "renderPreparedHover owns mapped spaces but not sentence punctuation" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const url = @import("../config/url.zig");
+    const first = "/tmp/build-";
+    const second = "warm.app";
+    const cases = [_]struct {
+        suffix: []const u8,
+        owned_suffix_cells: usize,
+    }{
+        .{ .suffix = "   ", .owned_suffix_cells = 3 },
+        .{ .suffix = ".   ", .owned_suffix_cells = 0 },
+    };
+
+    for (cases) |case| {
+        var t: terminal.Terminal = try .init(alloc, .{ .cols = 64, .rows = 3 });
+        defer t.deinit(alloc);
+        var stream = t.vtStream();
+        defer stream.deinit();
+        stream.nextSlice(first ++ "\r\n    " ++ second);
+        stream.nextSlice(case.suffix);
+
+        var set = try Set.fromConfig(alloc, &.{.{
+            .regex = url.path_regex,
+            .action = .{ .open = {} },
+            .highlight = .{ .hover_mods = inputpkg.ctrlOrSuper(.{}) },
+            .hard_wrap_continuations = true,
+            .hard_wrap_match_delimiter = true,
+        }});
+        defer set.deinit(alloc);
+
+        var arena = std.heap.ArenaAllocator.init(alloc);
+        defer arena.deinit();
+        var result: terminal.RenderState.CellSet = .empty;
+        try renderHoverForTest(
+            &set,
+            arena.allocator(),
+            &t,
+            &result,
+            .{ .x = 6, .y = 1 },
+            inputpkg.ctrlOrSuper(.{}),
+        );
+
+        try testing.expectEqual(
+            first.len + second.len + case.owned_suffix_cells,
+            result.count(),
+        );
+        for (0..first.len) |x| {
+            try testing.expect(result.contains(.{ .x = @intCast(x), .y = 0 }));
+        }
+        for (0..4) |x| {
+            try testing.expect(!result.contains(.{ .x = @intCast(x), .y = 1 }));
+        }
+        for (4..4 + second.len + case.owned_suffix_cells) |x| {
+            try testing.expect(result.contains(.{ .x = @intCast(x), .y = 1 }));
+        }
+        for (4 + second.len + case.owned_suffix_cells..4 + second.len + case.suffix.len) |x| {
+            try testing.expect(!result.contains(.{ .x = @intCast(x), .y = 1 }));
+        }
+    }
+}
+
 test "renderPreparedHover excludes punctuation from a wrapped bare relative path" {
     const testing = std.testing;
     const alloc = testing.allocator;

--- a/src/renderer/link.zig
+++ b/src/renderer/link.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const assert = std.debug.assert;
 const Allocator = std.mem.Allocator;
 const oni = @import("oniguruma");
+const link_wrap = @import("../link_wrap.zig");
 const inputpkg = @import("../input.zig");
 const terminal = @import("../terminal/main.zig");
 const point = terminal.point;
@@ -17,6 +18,9 @@ pub const Link = struct {
 
     /// The situations in which the link should be highlighted.
     highlight: inputpkg.Link.Highlight,
+
+    /// Whether prose hard-wrap boundaries are removed before matching.
+    hard_wrap_continuations: bool,
 
     pub fn deinit(self: *Link) void {
         self.regex.deinit();
@@ -57,6 +61,7 @@ pub const Set = struct {
             try links.append(alloc, .{
                 .regex = regex,
                 .highlight = link.highlight,
+                .hard_wrap_continuations = link.hard_wrap_continuations,
             });
         }
 
@@ -99,15 +104,40 @@ pub const Set = struct {
         });
 
         const str = builder.writer.buffered();
+        var normalized: ?link_wrap.Normalized(point.Coordinate) = null;
+        defer if (normalized) |value| value.deinit(alloc);
 
         // Go through each link and see if we have any matches.
         for (self.links) |*link| {
             if (!link.active(mouse_viewport, mouse_mods)) continue;
 
+            const Candidate = struct {
+                string: []const u8,
+                map: []const point.Coordinate,
+            };
+            const candidate: Candidate = if (!link.hard_wrap_continuations)
+                .{
+                    .string = @as([]const u8, str),
+                    .map = @as([]const point.Coordinate, map.items),
+                }
+            else candidate: {
+                if (normalized == null) normalized = try link_wrap.normalize(
+                    point.Coordinate,
+                    alloc,
+                    str,
+                    map.items,
+                    .{ .terminate_joined = true },
+                );
+                break :candidate .{
+                    .string = @as([]const u8, normalized.?.string),
+                    .map = @as([]const point.Coordinate, normalized.?.map),
+                };
+            };
+
             var offset: usize = 0;
-            while (offset < str.len) {
+            while (offset < candidate.string.len) {
                 var region = link.regex.search(
-                    str[offset..],
+                    candidate.string[offset..],
                     .{},
                 ) catch |err| switch (err) {
                     error.Mismatch => break,
@@ -129,14 +159,14 @@ pub const Set = struct {
                 switch (link.highlight) {
                     .always, .always_mods => {},
                     .hover, .hover_mods => if (mouse_viewport) |vp| {
-                        for (map.items[start..end]) |pt| {
+                        for (candidate.map[start..end]) |pt| {
                             if (pt.eql(vp)) break;
                         } else continue;
                     } else continue,
                 }
 
                 // Record the match
-                for (map.items[start..end]) |pt| {
+                for (candidate.map[start..end]) |pt| {
                     try result.put(alloc, pt, {});
                 }
             }
@@ -195,6 +225,59 @@ test "renderCellMap" {
     try testing.expect(!result.contains(.{ .x = 3, .y = 0 }));
     try testing.expect(result.contains(.{ .x = 1, .y = 1 }));
     try testing.expect(!result.contains(.{ .x = 1, .y = 2 }));
+}
+
+test "renderCellMap highlights both sides of an indented hard-wrapped link" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var t: terminal.Terminal = try .init(alloc, .{
+        .cols = 32,
+        .rows = 3,
+    });
+    defer t.deinit(alloc);
+
+    var stream = t.vtStream();
+    defer stream.deinit();
+    stream.nextSlice("/tmp/build-\r\n    warm.app.");
+
+    var state: terminal.RenderState = .empty;
+    defer state.deinit(alloc);
+    try state.update(alloc, &t);
+
+    var set = try Set.fromConfig(alloc, &.{.{
+        .regex = "/tmp/build-warm\\.app",
+        .action = .{ .open = {} },
+        .highlight = .{ .hover_mods = inputpkg.ctrlOrSuper(.{}) },
+        .hard_wrap_continuations = true,
+    }});
+    defer set.deinit(alloc);
+
+    for ([_]point.Coordinate{
+        .{ .x = 5, .y = 0 },
+        .{ .x = 7, .y = 1 },
+    }) |mouse| {
+        var result: terminal.RenderState.CellSet = .empty;
+        defer result.deinit(alloc);
+        try set.renderCellMap(
+            alloc,
+            &result,
+            &state,
+            mouse,
+            inputpkg.ctrlOrSuper(.{}),
+        );
+
+        for (0..11) |x| {
+            try testing.expect(result.contains(.{ .x = @intCast(x), .y = 0 }));
+        }
+        for (0..4) |x| {
+            try testing.expect(!result.contains(.{ .x = @intCast(x), .y = 1 }));
+        }
+        for (4..12) |x| {
+            try testing.expect(result.contains(.{ .x = @intCast(x), .y = 1 }));
+        }
+        try testing.expect(!result.contains(.{ .x = 12, .y = 1 }));
+    }
 }
 
 test "renderCellMap hover links" {

--- a/src/renderer/metal/CompletionLifetime.zig
+++ b/src/renderer/metal/CompletionLifetime.zig
@@ -1,0 +1,133 @@
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const assert = @import("../../quirks.zig").inlineAssert;
+
+/// A ref-counted gate between backend completion handlers and renderer-owned
+/// state. The renderer owns one reference. Every armed asynchronous completion
+/// owns another, so a permanently stalled command can outlive renderer teardown
+/// without retaining or dereferencing the renderer itself.
+pub fn Lifetime(comptime Context: type) type {
+    return struct {
+        const Self = @This();
+
+        alloc: Allocator,
+        refs: std.atomic.Value(usize) = std.atomic.Value(usize).init(1),
+        mutex: std.Thread.Mutex = .{},
+        context: ?*Context = null,
+        invalidated: bool = false,
+
+        pub const Live = struct {
+            owner: *Self,
+            context: *Context,
+
+            pub fn deinit(self: *Live) void {
+                self.owner.mutex.unlock();
+            }
+        };
+
+        pub fn create(alloc: Allocator) Allocator.Error!*Self {
+            const self = try alloc.create(Self);
+            self.* = .{ .alloc = alloc };
+            return self;
+        }
+
+        /// Bind only after the containing renderer reaches its stable address.
+        pub fn bind(self: *Self, context: *Context) void {
+            self.mutex.lock();
+            defer self.mutex.unlock();
+
+            assert(!self.invalidated);
+            assert(self.context == null or self.context == context);
+            self.context = context;
+        }
+
+        /// Returns a live context while keeping teardown excluded. Callers must
+        /// hold the returned lease across every renderer/target dereference.
+        pub fn acquire(self: *Self) ?Live {
+            self.mutex.lock();
+            if (self.invalidated or self.context == null) {
+                self.mutex.unlock();
+                return null;
+            }
+
+            return .{
+                .owner = self,
+                .context = self.context.?,
+            };
+        }
+
+        /// Prevent new completion work and wait for any active lease to leave.
+        pub fn invalidate(self: *Self) void {
+            self.mutex.lock();
+            defer self.mutex.unlock();
+
+            self.invalidated = true;
+            self.context = null;
+        }
+
+        pub fn retain(self: *Self) void {
+            const previous = self.refs.fetchAdd(1, .seq_cst);
+            assert(previous > 0);
+        }
+
+        pub fn release(self: *Self) void {
+            const previous = self.refs.fetchSub(1, .seq_cst);
+            assert(previous > 0);
+            if (previous == 1) {
+                const alloc = self.alloc;
+                alloc.destroy(self);
+            }
+        }
+    };
+}
+
+/// Owns one completion lifetime per swap-chain generation. Rotation must
+/// allocate a distinct lifetime because old copied blocks retain the previous
+/// pointer and may execute after a replacement swap chain becomes live.
+pub fn Generation(comptime Context: type) type {
+    return struct {
+        const Self = @This();
+        const ContextLifetime = Lifetime(Context);
+
+        alloc: Allocator,
+        current: ?*ContextLifetime,
+
+        pub fn init(alloc: Allocator) Allocator.Error!Self {
+            return .{
+                .alloc = alloc,
+                .current = try ContextLifetime.create(alloc),
+            };
+        }
+
+        pub fn deinit(self: *Self) void {
+            self.finish();
+        }
+
+        pub fn lifetime(self: *const Self) *ContextLifetime {
+            return self.current orelse unreachable;
+        }
+
+        pub fn bind(self: *Self, context: *Context) void {
+            self.lifetime().bind(context);
+        }
+
+        /// Invalidate and drop the generation owner's reference. Copied
+        /// completion blocks keep the old allocation alive until they run.
+        pub fn finish(self: *Self) void {
+            const current = self.current orelse return;
+            current.invalidate();
+            self.current = null;
+            current.release();
+        }
+
+        pub fn restart(
+            self: *Self,
+            context: *Context,
+        ) Allocator.Error!void {
+            assert(self.current == null);
+            const current = try ContextLifetime.create(self.alloc);
+            current.bind(context);
+            self.current = current;
+        }
+    };
+}

--- a/src/renderer/metal/Frame.zig
+++ b/src/renderer/metal/Frame.zig
@@ -180,3 +180,119 @@ pub inline fn complete(self: *Self, sync: bool) ?FramePresentation {
     // handler and main-queue layer block.
     return null;
 }
+
+test "tokened completion freezes target before recycling slot" {
+    const testing = std.testing;
+    const Event = struct {
+        kind: enum { detach, prepare, present, complete, dispatch, deinit },
+        target_id: u8,
+    };
+    const State = struct {
+        events: [8]Event = undefined,
+        len: usize = 0,
+        fail_detach: bool = false,
+
+        fn append(self: *@This(), kind: Event.kind, target_id: u8) void {
+            self.events[self.len] = .{ .kind = kind, .target_id = target_id };
+            self.len += 1;
+        }
+    };
+    const MockTarget = struct {
+        id: u8,
+        state: *State,
+
+        fn deinit(self: *@This()) void {
+            self.state.append(.deinit, self.id);
+        }
+    };
+    const Prepared = struct {
+        target_id: u8,
+        state: *State,
+
+        fn dispatch(self: @This()) void {
+            self.state.append(.dispatch, self.target_id);
+        }
+    };
+    const MockAPI = struct {
+        state: *State,
+
+        fn detachPresentationTarget(
+            self: *@This(),
+            target: *MockTarget,
+        ) !MockTarget {
+            if (self.state.fail_detach) return error.OutOfMemory;
+            self.state.append(.detach, target.id);
+            const frozen = target.*;
+            target.id += 1;
+            return frozen;
+        }
+
+        fn preparePresentation(
+            self: *@This(),
+            target: MockTarget,
+            _: FramePresentation,
+        ) Prepared {
+            self.state.append(.prepare, target.id);
+            return .{ .target_id = target.id, .state = self.state };
+        }
+
+        fn present(self: *@This(), target: MockTarget, _: bool) !void {
+            self.state.append(.present, target.id);
+        }
+    };
+    const MockRenderer = struct {
+        api: MockAPI,
+
+        fn frameCompleted(
+            self: *@This(),
+            target: *MockTarget,
+            health: Health,
+        ) void {
+            std.debug.assert(health == .healthy);
+            self.api.state.append(.complete, target.id);
+            // Model immediate swap-chain reuse. The prepared update must keep
+            // observing the detached target instead of this mutation.
+            target.id += 10;
+        }
+    };
+    const Callbacks = struct {
+        fn presented(_: ?*anyopaque, _: u64) callconv(.c) void {}
+    };
+    const presentation: FramePresentation = .{
+        .callback = &Callbacks.presented,
+        .userdata = null,
+        .token = 42,
+    };
+
+    var state: State = .{};
+    var renderer: MockRenderer = .{ .api = .{ .state = &state } };
+    var target: MockTarget = .{ .id = 1, .state = &state };
+    completeHealthyFrame(&renderer, &target, false, presentation);
+    try testing.expectEqualSlices(Event, &.{
+        .{ .kind = .detach, .target_id = 1 },
+        .{ .kind = .prepare, .target_id = 1 },
+        .{ .kind = .complete, .target_id = 2 },
+        .{ .kind = .dispatch, .target_id = 1 },
+        .{ .kind = .deinit, .target_id = 1 },
+    }, state.events[0..state.len]);
+
+    // Replacement failure emits no token and still recycles the original
+    // frame exactly once.
+    state = .{ .fail_detach = true };
+    renderer.api.state = &state;
+    target = .{ .id = 4, .state = &state };
+    completeHealthyFrame(&renderer, &target, false, presentation);
+    try testing.expectEqualSlices(Event, &.{
+        .{ .kind = .complete, .target_id = 4 },
+    }, state.events[0..state.len]);
+
+    // Ordinary frames retain the allocation-free presentation path.
+    state = .{};
+    renderer.api.state = &state;
+    target = .{ .id = 7, .state = &state };
+    completeHealthyFrame(&renderer, &target, false, null);
+    try testing.expectEqualSlices(Event, &.{
+        .{ .kind = .present, .target_id = 7 },
+        .{ .kind = .complete, .target_id = 7 },
+    }, state.events[0..state.len]);
+}

--- a/src/renderer/metal/Frame.zig
+++ b/src/renderer/metal/Frame.zig
@@ -13,6 +13,7 @@ const Target = @import("Target.zig");
 const RenderPass = @import("RenderPass.zig");
 
 const Health = @import("../../renderer.zig").Health;
+const FramePresentation = @import("../../renderer.zig").FramePresentation;
 
 const log = std.log.scoped(.metal);
 
@@ -35,6 +36,7 @@ pub fn begin(
     renderer: *Renderer,
     /// The target is presented via the provided renderer's API when completed.
     target: *Target,
+    presentation: ?FramePresentation,
 ) !Self {
     const buffer = opts.queue.msgSend(
         objc.Object,
@@ -49,6 +51,9 @@ pub fn begin(
             .renderer = renderer,
             .target = target,
             .sync = false,
+            .presentation_callback = if (presentation) |value| value.callback else null,
+            .presentation_userdata = if (presentation) |value| value.userdata else null,
+            .presentation_token = if (presentation) |value| value.token else 0,
         },
         &bufferCompleted,
     );
@@ -61,6 +66,9 @@ const CompletionBlock = objc.Block(struct {
     renderer: *Renderer,
     target: *Target,
     sync: bool,
+    presentation_callback: ?*const fn (?*anyopaque, u64) callconv(.c) void,
+    presentation_userdata: ?*anyopaque,
+    presentation_token: u64,
 }, .{
     objc.c.id, // MTLCommandBuffer
 }, void);
@@ -80,10 +88,19 @@ fn bufferCompleted(
 
     // If the frame is healthy, present it.
     if (health == .healthy) {
-        block.renderer.api.present(
-            block.target.*,
-            block.sync,
-        ) catch |err| {
+        const result = if (block.presentation_callback) |callback|
+            block.renderer.api.presentWithPresentation(
+                block.target.*,
+                block.sync,
+                .{
+                    .callback = callback,
+                    .userdata = block.presentation_userdata,
+                    .token = block.presentation_token,
+                },
+            )
+        else
+            block.renderer.api.present(block.target.*, block.sync);
+        result catch |err| {
             log.err("Failed to present render target: err={}", .{err});
         };
     }

--- a/src/renderer/metal/Frame.zig
+++ b/src/renderer/metal/Frame.zig
@@ -3,11 +3,9 @@ const Self = @This();
 
 const std = @import("std");
 const builtin = @import("builtin");
-const Allocator = std.mem.Allocator;
 const objc = @import("objc");
 
 const mtl = @import("api.zig");
-const Renderer = @import("../generic.zig").Renderer(Metal);
 const Metal = @import("../Metal.zig");
 const Target = @import("Target.zig");
 const RenderPass = @import("RenderPass.zig");
@@ -21,6 +19,9 @@ const log = std.log.scoped(.metal);
 pub const Options = struct {
     /// MTLCommandQueue
     queue: objc.Object,
+
+    /// Ref-counted renderer access gate for asynchronous completion.
+    completion_lifetime: *Metal.RendererCompletionLifetime,
 };
 
 /// MTLCommandBuffer
@@ -31,9 +32,6 @@ block: CompletionBlock.Context,
 /// Begin encoding a frame.
 pub fn begin(
     opts: Options,
-    /// Once the frame has been completed, the `frameCompleted` method
-    /// on the renderer is called with the health status of the frame.
-    renderer: *Renderer,
     /// The target is presented via the provided renderer's API when completed.
     target: *Target,
     presentation: ?FramePresentation,
@@ -48,7 +46,7 @@ pub fn begin(
     // The block is deallocated by the objC runtime on success.
     const block = CompletionBlock.init(
         .{
-            .renderer = renderer,
+            .completion_lifetime = opts.completion_lifetime,
             .target = target,
             .sync = false,
             .presentation_callback = if (presentation) |value| value.callback else null,
@@ -65,7 +63,7 @@ pub fn begin(
 
 /// This is the block type used for the addCompletedHandler callback.
 const CompletionBlock = objc.Block(struct {
-    renderer: *Renderer,
+    completion_lifetime: *Metal.RendererCompletionLifetime,
     target: *Target,
     sync: bool,
     presentation_callback: ?*const fn (?*anyopaque, u64) callconv(.c) void,
@@ -81,6 +79,16 @@ fn bufferCompleted(
     block: *const CompletionBlock.Context,
     buffer_id: objc.c.id,
 ) callconv(.c) void {
+    // This reference was acquired immediately before the handler was armed.
+    // It keeps only the gate alive, not renderer or target state.
+    defer block.completion_lifetime.release();
+
+    // Teardown invalidates this gate before freeing renderer-owned memory.
+    // Do not even inspect the raw target pointer until a live lease exists.
+    var live = block.completion_lifetime.acquire() orelse return;
+    defer live.deinit();
+    const renderer = live.context;
+
     const buffer = objc.Object.fromId(buffer_id);
 
     // Get our command buffer status to pass back to the generic renderer.
@@ -93,7 +101,7 @@ fn bufferCompleted(
     // If the frame is healthy, present it.
     if (health == .healthy) {
         const result = if (block.presentation_callback) |callback|
-            block.renderer.api.presentWithPresentation(
+            renderer.api.presentWithPresentation(
                 block.target.*,
                 block.sync,
                 .{
@@ -105,13 +113,13 @@ fn bufferCompleted(
                 },
             )
         else
-            block.renderer.api.present(block.target.*, block.sync);
+            renderer.api.present(block.target.*, block.sync);
         result catch |err| {
             log.err("Failed to present render target: err={}", .{err});
         };
     }
 
-    block.renderer.frameCompleted(health);
+    renderer.frameCompleted(block.target, health);
 }
 
 /// Add a render pass to this frame with the provided attachments.
@@ -143,6 +151,10 @@ pub inline fn complete(self: *Self, sync: bool) ?FramePresentation {
     // the SINGLE source of truth for both branches so exactly one completion
     // path runs per committed buffer (net-zero frame_sema balance).
     const use_sync = sync and builtin.os.tag != .ios;
+
+    // The ObjC block copy retains Objective-C captures but not this raw Zig
+    // pointer. Give every armed completion one explicit lifetime reference.
+    self.block.completion_lifetime.retain();
 
     // If we don't complete synchronously, add our block as a completion
     // handler. It is copied when added and freed by the objc runtime.

--- a/src/renderer/metal/Frame.zig
+++ b/src/renderer/metal/Frame.zig
@@ -98,28 +98,58 @@ fn bufferCompleted(
         else => .healthy,
     };
 
-    // If the frame is healthy, present it.
+    // If the frame is healthy, present it. Tokened frames first detach their
+    // rendered target so the reusable slot cannot overwrite the pixels queued
+    // for main-thread layer assignment.
     if (health == .healthy) {
-        const result = if (block.presentation_callback) |callback|
-            renderer.api.presentWithPresentation(
-                block.target.*,
-                block.sync,
-                .{
-                    .callback = callback,
-                    .userdata = block.presentation_userdata,
-                    .token = block.presentation_token,
-                    .delivery_gate = block.presentation_delivery_gate,
-                    .delivery_gate_userdata = block.presentation_delivery_gate_userdata,
-                },
-            )
-        else
-            renderer.api.present(block.target.*, block.sync);
-        result catch |err| {
-            log.err("Failed to present render target: err={}", .{err});
-        };
+        completeHealthyFrame(
+            renderer,
+            block.target,
+            block.sync,
+            if (block.presentation_callback) |callback| .{
+                .callback = callback,
+                .userdata = block.presentation_userdata,
+                .token = block.presentation_token,
+                .delivery_gate = block.presentation_delivery_gate,
+                .delivery_gate_userdata = block.presentation_delivery_gate_userdata,
+            } else null,
+        );
+        return;
     }
 
     renderer.frameCompleted(block.target, health);
+}
+
+/// Present one healthy completed frame and recycle its exact swap-chain slot.
+/// Explicitly tokened frames queue a detached IOSurface so both assignment and
+/// the external callback remain independent of later slot reuse or teardown.
+fn completeHealthyFrame(
+    renderer: anytype,
+    target: anytype,
+    sync: bool,
+    presentation: ?FramePresentation,
+) void {
+    if (presentation) |value| {
+        var frozen = renderer.api.detachPresentationTarget(target) catch |err| {
+            log.warn("Failed to detach tokened render target: err={}", .{err});
+            renderer.frameCompleted(target, .healthy);
+            return;
+        };
+        defer frozen.deinit();
+
+        // Prepare retains the layer and IOSurface while renderer ownership is
+        // still protected by this frame. Recycling happens before dispatch,
+        // so an external callback can never precede renderer bookkeeping.
+        const prepared = renderer.api.preparePresentation(frozen, value);
+        renderer.frameCompleted(target, .healthy);
+        prepared.dispatch();
+        return;
+    }
+
+    renderer.api.present(target.*, sync) catch |err| {
+        log.err("Failed to present render target: err={}", .{err});
+    };
+    renderer.frameCompleted(target, .healthy);
 }
 
 /// Add a render pass to this frame with the provided attachments.
@@ -183,8 +213,9 @@ pub inline fn complete(self: *Self, sync: bool) ?FramePresentation {
 
 test "tokened completion freezes target before recycling slot" {
     const testing = std.testing;
+    const EventKind = enum { detach, prepare, present, complete, dispatch, deinit };
     const Event = struct {
-        kind: enum { detach, prepare, present, complete, dispatch, deinit },
+        kind: EventKind,
         target_id: u8,
     };
     const State = struct {
@@ -192,7 +223,7 @@ test "tokened completion freezes target before recycling slot" {
         len: usize = 0,
         fail_detach: bool = false,
 
-        fn append(self: *@This(), kind: Event.kind, target_id: u8) void {
+        fn append(self: *@This(), kind: EventKind, target_id: u8) void {
             self.events[self.len] = .{ .kind = kind, .target_id = target_id };
             self.len += 1;
         }

--- a/src/renderer/metal/Frame.zig
+++ b/src/renderer/metal/Frame.zig
@@ -135,7 +135,7 @@ fn completeHealthyFrame(
             renderer.frameCompleted(target, .healthy);
             return;
         };
-        defer frozen.deinit();
+        defer frozen.releasePresentationOwnership();
 
         // Prepare retains the layer and IOSurface while renderer ownership is
         // still protected by this frame. Recycling happens before dispatch,

--- a/src/renderer/metal/Frame.zig
+++ b/src/renderer/metal/Frame.zig
@@ -213,7 +213,15 @@ pub inline fn complete(self: *Self, sync: bool) ?FramePresentation {
 
 test "tokened completion freezes target before recycling slot" {
     const testing = std.testing;
-    const EventKind = enum { detach, prepare, present, complete, dispatch, deinit };
+    const EventKind = enum {
+        detach,
+        prepare,
+        present,
+        complete,
+        dispatch,
+        deinit,
+        release_presentation_ownership,
+    };
     const Event = struct {
         kind: EventKind,
         target_id: u8,
@@ -234,6 +242,10 @@ test "tokened completion freezes target before recycling slot" {
 
         fn deinit(self: *@This()) void {
             self.state.append(.deinit, self.id);
+        }
+
+        fn releasePresentationOwnership(self: *@This()) void {
+            self.state.append(.release_presentation_ownership, self.id);
         }
     };
     const Prepared = struct {
@@ -304,7 +316,7 @@ test "tokened completion freezes target before recycling slot" {
         .{ .kind = .prepare, .target_id = 1 },
         .{ .kind = .complete, .target_id = 2 },
         .{ .kind = .dispatch, .target_id = 1 },
-        .{ .kind = .deinit, .target_id = 1 },
+        .{ .kind = .release_presentation_ownership, .target_id = 1 },
     }, state.events[0..state.len]);
 
     // Replacement failure emits no token and still recycles the original

--- a/src/renderer/metal/Frame.zig
+++ b/src/renderer/metal/Frame.zig
@@ -54,6 +54,8 @@ pub fn begin(
             .presentation_callback = if (presentation) |value| value.callback else null,
             .presentation_userdata = if (presentation) |value| value.userdata else null,
             .presentation_token = if (presentation) |value| value.token else 0,
+            .presentation_delivery_gate = if (presentation) |value| value.delivery_gate else null,
+            .presentation_delivery_gate_userdata = if (presentation) |value| value.delivery_gate_userdata else null,
         },
         &bufferCompleted,
     );
@@ -69,6 +71,8 @@ const CompletionBlock = objc.Block(struct {
     presentation_callback: ?*const fn (?*anyopaque, u64) callconv(.c) void,
     presentation_userdata: ?*anyopaque,
     presentation_token: u64,
+    presentation_delivery_gate: ?*const fn (?*anyopaque) callconv(.c) void,
+    presentation_delivery_gate_userdata: ?*anyopaque,
 }, .{
     objc.c.id, // MTLCommandBuffer
 }, void);
@@ -96,6 +100,8 @@ fn bufferCompleted(
                     .callback = callback,
                     .userdata = block.presentation_userdata,
                     .token = block.presentation_token,
+                    .delivery_gate = block.presentation_delivery_gate,
+                    .delivery_gate_userdata = block.presentation_delivery_gate_userdata,
                 },
             )
         else
@@ -123,7 +129,7 @@ pub inline fn renderPass(
 /// Complete this frame and present the target.
 ///
 /// If `sync` is true, this will block until the frame is presented.
-pub inline fn complete(self: *Self, sync: bool) void {
+pub inline fn complete(self: *Self, sync: bool) ?FramePresentation {
     // cmux iOS fork: iOS has no renderer-thread vsync pump; `render_now`
     // produces frames synchronously on a single serial dispatch queue. A
     // blocking `waitUntilCompleted` here would park that queue forever if the
@@ -157,4 +163,8 @@ pub inline fn complete(self: *Self, sync: bool) void {
         self.block.sync = true;
         CompletionBlock.invoke(&self.block, .{self.buffer.value});
     }
+
+    // Metal owns asynchronous presentation delivery through its completion
+    // handler and main-queue layer block.
+    return null;
 }

--- a/src/renderer/metal/IOSurfaceLayer.zig
+++ b/src/renderer/metal/IOSurfaceLayer.zig
@@ -89,7 +89,51 @@ pub inline fn setSurfaceWithPresentation(
     surface: *IOSurface,
     presentation: FramePresentation,
 ) !void {
-    return self.setSurface_(surface, presentation);
+    self.prepareSurfaceWithPresentation(surface, presentation).dispatch();
+}
+
+/// A layer update whose Objective-C layer and IOSurface ownership no longer
+/// depends on the renderer that prepared it. This lets the renderer recycle a
+/// replacement-backed frame before the update can invoke external callbacks.
+pub const PreparedSurfaceUpdate = struct {
+    layer: objc.Object,
+    surface: *IOSurface,
+    presentation: FramePresentation,
+
+    /// Transfer this update to the main queue. Dispatch copies and retains the
+    /// Objective-C layer capture; the callback consumes the IOSurface retain.
+    pub fn dispatch(self: PreparedSurfaceUpdate) void {
+        defer self.layer.release();
+
+        var block = SetSurfaceBlock.init(.{
+            .layer = self.layer.value,
+            .surface = self.surface,
+            .presentation_callback = self.presentation.callback,
+            .presentation_userdata = self.presentation.userdata,
+            .presentation_token = self.presentation.token,
+            .presentation_delivery_gate = self.presentation.delivery_gate,
+            .presentation_delivery_gate_userdata = self.presentation.delivery_gate_userdata,
+        }, &setSurfaceCallback);
+        macos.dispatch.dispatch_async(
+            @ptrCast(macos.dispatch.queue.getMain()),
+            @ptrCast(&block),
+        );
+    }
+};
+
+/// Retain everything a tokened main-thread layer update needs before its
+/// rendered target is detached from the swap chain.
+pub fn prepareSurfaceWithPresentation(
+    self: *IOSurfaceLayer,
+    surface: *IOSurface,
+    presentation: FramePresentation,
+) PreparedSurfaceUpdate {
+    surface.retain();
+    return .{
+        .layer = self.layer.retain(),
+        .surface = surface,
+        .presentation = presentation,
+    };
 }
 
 fn setSurface_(

--- a/src/renderer/metal/IOSurfaceLayer.zig
+++ b/src/renderer/metal/IOSurfaceLayer.zig
@@ -253,3 +253,17 @@ fn getSubclass() error{ObjCFailed}!objc.Class {
 
     return subclass;
 }
+
+test "tokened surface updates defer delivery and teardown invalidates them" {
+    const testing = std.testing;
+
+    try testing.expect(!surfaceUpdateRunsInline(true, true));
+    try testing.expect(surfaceUpdateRunsInline(true, false));
+    try testing.expect(!surfaceUpdateRunsInline(false, false));
+
+    var layer = try IOSurfaceLayer.init();
+    defer layer.layer.release();
+    try testing.expect(layer.surfaceUpdatesActive());
+    layer.invalidateSurfaceUpdates();
+    try testing.expect(!layer.surfaceUpdatesActive());
+}

--- a/src/renderer/metal/IOSurfaceLayer.zig
+++ b/src/renderer/metal/IOSurfaceLayer.zig
@@ -8,6 +8,7 @@ const objc = @import("objc");
 const macos = @import("macos");
 
 const IOSurface = macos.iosurface.IOSurface;
+const FramePresentation = @import("../../renderer.zig").FramePresentation;
 
 const log = std.log.scoped(.IOSurfaceLayer);
 
@@ -74,6 +75,16 @@ pub fn detachFromHostIfDisplayCallbackOwned(
 ///
 /// Makes sure to do so on the main thread to avoid visual artifacts.
 pub inline fn setSurface(self: *IOSurfaceLayer, surface: *IOSurface) !void {
+    return self.setSurfaceWithPresentation(surface, null);
+}
+
+/// Sets the layer contents and acknowledges the exact token after the size
+/// guard succeeds. This callback runs on main in the same block as assignment.
+pub inline fn setSurfaceWithPresentation(
+    self: *IOSurfaceLayer,
+    surface: *IOSurface,
+    presentation: ?FramePresentation,
+) !void {
     // We retain the surface to make sure it's not GC'd
     // before we can set it as the contents of the layer.
     //
@@ -86,6 +97,9 @@ pub inline fn setSurface(self: *IOSurfaceLayer, surface: *IOSurface) !void {
     var block = SetSurfaceBlock.init(.{
         .layer = self.layer.value,
         .surface = surface,
+        .presentation_callback = if (presentation) |value| value.callback else null,
+        .presentation_userdata = if (presentation) |value| value.userdata else null,
+        .presentation_token = if (presentation) |value| value.token else 0,
     }, &setSurfaceCallback);
 
     // We check if we're on the main thread and run the block directly if so.
@@ -114,6 +128,9 @@ pub inline fn setSurfaceSync(self: *IOSurfaceLayer, surface: *IOSurface) void {
 const SetSurfaceBlock = objc.Block(struct {
     layer: objc.c.id,
     surface: *IOSurface,
+    presentation_callback: ?*const fn (?*anyopaque, u64) callconv(.c) void,
+    presentation_userdata: ?*anyopaque,
+    presentation_token: u64,
 }, .{}, void);
 
 const DetachFromHostBlock = objc.Block(struct {
@@ -149,6 +166,9 @@ fn setSurfaceCallback(
     }
 
     layer.setProperty("contents", surface);
+    if (block.presentation_callback) |callback| {
+        callback(block.presentation_userdata, block.presentation_token);
+    }
 }
 
 fn detachFromHostCallback(

--- a/src/renderer/metal/IOSurfaceLayer.zig
+++ b/src/renderer/metal/IOSurfaceLayer.zig
@@ -329,6 +329,21 @@ fn getSubclass() error{ObjCFailed}!objc.Class {
 test "tokened surface updates defer delivery and teardown invalidates them" {
     const testing = std.testing;
 
+    const CallbackState = struct {
+        gate_count: usize = 0,
+        callback_count: usize = 0,
+
+        fn gate(userdata: ?*anyopaque) callconv(.c) void {
+            const self: *@This() = @ptrCast(@alignCast(userdata.?));
+            self.gate_count += 1;
+        }
+
+        fn callback(userdata: ?*anyopaque, _: u64) callconv(.c) void {
+            const self: *@This() = @ptrCast(@alignCast(userdata.?));
+            self.callback_count += 1;
+        }
+    };
+
     try testing.expect(!surfaceUpdateRunsInline(true, true));
     try testing.expect(surfaceUpdateRunsInline(true, false));
     try testing.expect(!surfaceUpdateRunsInline(false, false));
@@ -338,4 +353,32 @@ test "tokened surface updates defer delivery and teardown invalidates them" {
     try testing.expect(layer.surfaceUpdatesActive());
     layer.invalidateSurfaceUpdates();
     try testing.expect(!layer.surfaceUpdatesActive());
+
+    // Exercise the queued block's actual entrypoint after invalidation. The
+    // retained IOSurface is released, but neither presentation function may
+    // observe surface-owned userdata after teardown begins.
+    var surface = try IOSurface.init(.{
+        .width = 1,
+        .height = 1,
+        .pixel_format = .@"32BGRA",
+        .bytes_per_element = 4,
+        .colorspace = null,
+    });
+    defer surface.deinit();
+    surface.retain();
+
+    var state: CallbackState = .{};
+    var block = SetSurfaceBlock.init(.{
+        .layer = layer.layer.value,
+        .surface = surface,
+        .presentation_callback = &CallbackState.callback,
+        .presentation_userdata = &state,
+        .presentation_token = 42,
+        .presentation_delivery_gate = &CallbackState.gate,
+        .presentation_delivery_gate_userdata = &state,
+    }, &setSurfaceCallback);
+    setSurfaceCallback(&block);
+
+    try testing.expectEqual(@as(usize, 0), state.gate_count);
+    try testing.expectEqual(@as(usize, 0), state.callback_count);
 }

--- a/src/renderer/metal/IOSurfaceLayer.zig
+++ b/src/renderer/metal/IOSurfaceLayer.zig
@@ -15,6 +15,7 @@ const log = std.log.scoped(.IOSurfaceLayer);
 /// We subclass CALayer with a custom display handler, we only need
 /// to make the subclass once, and then we can use it as a singleton.
 var Subclass: ?objc.Class = null;
+var surface_updates_active_sentinel: usize = 0;
 
 /// The underlying CALayer
 layer: objc.Object,
@@ -36,6 +37,9 @@ pub fn init() !IOSurfaceLayer {
 
     layer.setInstanceVariable("display_cb", .{ .value = null });
     layer.setInstanceVariable("display_ctx", .{ .value = null });
+    layer.setInstanceVariable("surface_updates_active", .{
+        .value = @ptrCast(&surface_updates_active_sentinel),
+    });
 
     return .{ .layer = layer };
 }
@@ -75,12 +79,20 @@ pub fn detachFromHostIfDisplayCallbackOwned(
 ///
 /// Makes sure to do so on the main thread to avoid visual artifacts.
 pub inline fn setSurface(self: *IOSurfaceLayer, surface: *IOSurface) !void {
-    return self.setSurfaceWithPresentation(surface, null);
+    return self.setSurface_(surface, null);
 }
 
 /// Sets the layer contents and acknowledges the exact token after the size
 /// guard succeeds. This callback runs on main in the same block as assignment.
 pub inline fn setSurfaceWithPresentation(
+    self: *IOSurfaceLayer,
+    surface: *IOSurface,
+    presentation: FramePresentation,
+) !void {
+    return self.setSurface_(surface, presentation);
+}
+
+fn setSurface_(
     self: *IOSurfaceLayer,
     surface: *IOSurface,
     presentation: ?FramePresentation,
@@ -100,11 +112,18 @@ pub inline fn setSurfaceWithPresentation(
         .presentation_callback = if (presentation) |value| value.callback else null,
         .presentation_userdata = if (presentation) |value| value.userdata else null,
         .presentation_token = if (presentation) |value| value.token else 0,
+        .presentation_delivery_gate = if (presentation) |value| value.delivery_gate else null,
+        .presentation_delivery_gate_userdata = if (presentation) |value| value.delivery_gate_userdata else null,
     }, &setSurfaceCallback);
 
-    // We check if we're on the main thread and run the block directly if so.
+    // Ordinary updates retain their proven inline-on-main behavior. Tokened
+    // updates always queue, even from main, so their external callback cannot
+    // run inside the renderer draw mutex.
     const NSThread = objc.getClass("NSThread").?;
-    if (NSThread.msgSend(bool, "isMainThread", .{})) {
+    if (surfaceUpdateRunsInline(
+        NSThread.msgSend(bool, "isMainThread", .{}),
+        presentation != null,
+    )) {
         setSurfaceCallback(&block);
     } else {
         // NOTE: The block will be copied when we pass it to dispatch_async,
@@ -112,6 +131,33 @@ pub inline fn setSurfaceWithPresentation(
         //       once it's executed.
 
         macos.dispatch.dispatch_async(
+            @ptrCast(macos.dispatch.queue.getMain()),
+            @ptrCast(&block),
+        );
+    }
+}
+
+fn surfaceUpdateRunsInline(is_main_thread: bool, tokened: bool) bool {
+    return is_main_thread and !tokened;
+}
+
+fn surfaceUpdatesActive(self: *const IOSurfaceLayer) bool {
+    return self.layer.getInstanceVariable("surface_updates_active").value != null;
+}
+
+/// Prevent queued surface assignments and presentation callbacks from running.
+/// The synchronous main-queue barrier orders invalidation after blocks already
+/// queued and before any later GPU completion blocks inspect the flag.
+pub fn invalidateSurfaceUpdates(self: *IOSurfaceLayer) void {
+    var block = InvalidateSurfaceUpdatesBlock.init(.{
+        .layer = self.layer.value,
+    }, &invalidateSurfaceUpdatesCallback);
+
+    const NSThread = objc.getClass("NSThread").?;
+    if (NSThread.msgSend(bool, "isMainThread", .{})) {
+        invalidateSurfaceUpdatesCallback(&block);
+    } else {
+        macos.dispatch.dispatch_sync(
             @ptrCast(macos.dispatch.queue.getMain()),
             @ptrCast(&block),
         );
@@ -131,12 +177,18 @@ const SetSurfaceBlock = objc.Block(struct {
     presentation_callback: ?*const fn (?*anyopaque, u64) callconv(.c) void,
     presentation_userdata: ?*anyopaque,
     presentation_token: u64,
+    presentation_delivery_gate: ?*const fn (?*anyopaque) callconv(.c) void,
+    presentation_delivery_gate_userdata: ?*anyopaque,
 }, .{}, void);
 
 const DetachFromHostBlock = objc.Block(struct {
     layer: objc.c.id,
     display_cb: ?*anyopaque,
     display_ctx: ?*anyopaque,
+}, .{}, void);
+
+const InvalidateSurfaceUpdatesBlock = objc.Block(struct {
+    layer: objc.c.id,
 }, .{}, void);
 
 fn setSurfaceCallback(
@@ -147,6 +199,11 @@ fn setSurfaceCallback(
 
     // See explanation of why we retain and release in `setSurface`.
     defer surface.release();
+
+    // Teardown invalidates on main. Blocks queued by a late GPU completion
+    // retain the layer and IOSurface but must not touch detached UI state or
+    // surface-owned callback userdata.
+    if (layer.getInstanceVariable("surface_updates_active").value == null) return;
 
     // We check to see if the surface is the appropriate size for
     // the layer, if it's not then we discard it. This is because
@@ -167,6 +224,9 @@ fn setSurfaceCallback(
 
     layer.setProperty("contents", surface);
     if (block.presentation_callback) |callback| {
+        if (block.presentation_delivery_gate) |gate| {
+            gate(block.presentation_delivery_gate_userdata);
+        }
         callback(block.presentation_userdata, block.presentation_token);
     }
 }
@@ -175,6 +235,10 @@ fn detachFromHostCallback(
     block: *const DetachFromHostBlock.Context,
 ) callconv(.c) void {
     const layer = objc.Object.fromId(block.layer);
+
+    // This layer is terminally owned by the renderer being destroyed, even if
+    // another display callback replaced the one recorded by the detach guard.
+    layer.setInstanceVariable("surface_updates_active", .{ .value = null });
 
     // Ownership guard: if this layer's callback has been rebound to another
     // renderer, leave the binding alone.
@@ -188,6 +252,13 @@ fn detachFromHostCallback(
     layer.setInstanceVariable("display_ctx", .{ .value = null });
     layer.setProperty("contents", @as(?*anyopaque, null));
     layer.msgSend(void, objc.sel("removeFromSuperlayer"), .{});
+}
+
+fn invalidateSurfaceUpdatesCallback(
+    block: *const InvalidateSurfaceUpdatesBlock.Context,
+) callconv(.c) void {
+    const layer = objc.Object.fromId(block.layer);
+    layer.setInstanceVariable("surface_updates_active", .{ .value = null });
 }
 
 pub const DisplayCallback = ?*align(8) const fn (?*anyopaque) void;
@@ -219,6 +290,7 @@ fn getSubclass() error{ObjCFailed}!objc.Class {
 
     if (!subclass.addIvar("display_cb")) return error.ObjCFailed;
     if (!subclass.addIvar("display_ctx")) return error.ObjCFailed;
+    if (!subclass.addIvar("surface_updates_active")) return error.ObjCFailed;
 
     subclass.replaceMethod("display", struct {
         fn display(target: objc.c.id, sel: objc.c.SEL) callconv(.c) void {

--- a/src/renderer/metal/Target.zig
+++ b/src/renderer/metal/Target.zig
@@ -41,6 +41,11 @@ width: usize,
 /// Current height of this target.
 height: usize,
 
+/// Immutable creation parameters used when a completed presentation must
+/// detach this target from its reusable swap-chain slot.
+pixel_format: mtl.MTLPixelFormat,
+storage_mode: mtl.MTLResourceOptions.StorageMode,
+
 pub fn init(opts: Options) !Self {
     // We set our surface's color space to Display P3.
     // This allows us to have "Apple-style" alpha blending,
@@ -58,6 +63,7 @@ pub fn init(opts: Options) !Self {
         .bytes_per_element = 4,
         .colorspace = colorspace,
     });
+    errdefer surface.deinit();
 
     // Create our descriptor
     const desc = init: {
@@ -99,7 +105,20 @@ pub fn init(opts: Options) !Self {
         .texture = texture,
         .width = opts.width,
         .height = opts.height,
+        .pixel_format = opts.pixel_format,
+        .storage_mode = opts.storage_mode,
     };
+}
+
+/// Allocate an empty target with the same immutable format and dimensions.
+pub fn replacement(self: *const Self, device: objc.Object) !Self {
+    return try .init(.{
+        .device = device,
+        .width = self.width,
+        .height = self.height,
+        .pixel_format = self.pixel_format,
+        .storage_mode = self.storage_mode,
+    });
 }
 
 pub fn deinit(self: *Self) void {

--- a/src/renderer/metal/Target.zig
+++ b/src/renderer/metal/Target.zig
@@ -121,6 +121,14 @@ pub fn replacement(self: *const Self, device: objc.Object) !Self {
     });
 }
 
+/// Release a target whose IOSurface ownership has been retained by a queued
+/// presentation. Unlike deinit, this must not make the IOSurface purgeable
+/// before the main-thread layer assignment consumes the retained pixels.
+pub fn releasePresentationOwnership(self: Self) void {
+    self.surface.release();
+    self.texture.release();
+}
+
 pub fn deinit(self: *Self) void {
     self.surface.deinit();
     self.texture.release();

--- a/src/renderer/opengl/Frame.zig
+++ b/src/renderer/opengl/Frame.zig
@@ -10,7 +10,9 @@ const OpenGL = @import("../OpenGL.zig");
 const Target = @import("Target.zig");
 const RenderPass = @import("RenderPass.zig");
 
-const Health = @import("../../renderer.zig").Health;
+const rendererpkg = @import("../../renderer.zig");
+const FramePresentation = rendererpkg.FramePresentation;
+const Health = rendererpkg.Health;
 
 const log = std.log.scoped(.opengl);
 
@@ -19,6 +21,7 @@ pub const Options = struct {};
 
 renderer: *Renderer,
 target: *Target,
+presentation: ?FramePresentation,
 
 /// Begin encoding a frame.
 pub fn begin(
@@ -28,12 +31,14 @@ pub fn begin(
     renderer: *Renderer,
     /// The target is presented via the provided renderer's API when completed.
     target: *Target,
+    presentation: ?FramePresentation,
 ) !Self {
     _ = opts;
 
     return .{
         .renderer = renderer,
         .target = target,
+        .presentation = presentation,
     };
 }
 
@@ -63,7 +68,12 @@ pub fn complete(self: *const Self, sync: bool) void {
     if (health == .healthy) {
         self.renderer.api.present(self.target.*) catch |err| {
             log.err("Failed to present render target: err={}", .{err});
+            self.renderer.frameCompleted(health);
+            return;
         };
+        if (self.presentation) |presentation| {
+            presentation.callback(presentation.userdata, presentation.token);
+        }
     }
 
     // Report the health to the renderer.

--- a/src/renderer/opengl/Frame.zig
+++ b/src/renderer/opengl/Frame.zig
@@ -64,20 +64,34 @@ pub fn complete(self: *const Self, sync: bool) ?FramePresentation {
     // If there are any GL errors, consider the frame unhealthy.
     const health: Health = if (gl.errors.getError()) .healthy else |_| .unhealthy;
 
+    return completeAfterFinish(
+        self.renderer,
+        self.target,
+        health,
+        self.presentation,
+    );
+}
+
+fn completeAfterFinish(
+    renderer: anytype,
+    target: anytype,
+    health: Health,
+    presentation: ?FramePresentation,
+) ?FramePresentation {
     // If the frame is healthy, present it.
     if (health == .healthy) {
-        self.renderer.api.present(self.target.*) catch |err| {
+        renderer.api.present(target.*) catch |err| {
             log.err("Failed to present render target: err={}", .{err});
-            self.renderer.frameCompleted(health);
+            renderer.frameCompleted(.unhealthy);
             return null;
         };
     }
 
     // Complete renderer bookkeeping while the draw lock is still held. The
-    // generic renderer delivers a successful presentation callback only after
+    // generic renderer receives the returned value and delivers it only after
     // all of its cleanup and lock-release defers have run.
-    self.renderer.frameCompleted(health);
-    return if (health == .healthy) self.presentation else null;
+    renderer.frameCompleted(health);
+    return if (health == .healthy) presentation else null;
 }
 
 test "OpenGL completion defers successful delivery and drops failed frames" {

--- a/src/renderer/opengl/Frame.zig
+++ b/src/renderer/opengl/Frame.zig
@@ -82,7 +82,7 @@ fn completeAfterFinish(
     if (health == .healthy) {
         renderer.api.present(target.*) catch |err| {
             log.err("Failed to present render target: err={}", .{err});
-            renderer.frameCompleted(.unhealthy);
+            renderer.frameCompleted(target, .unhealthy);
             return null;
         };
     }
@@ -90,7 +90,7 @@ fn completeAfterFinish(
     // Complete renderer bookkeeping while the draw lock is still held. The
     // generic renderer receives the returned value and delivers it only after
     // all of its cleanup and lock-release defers have run.
-    renderer.frameCompleted(health);
+    renderer.frameCompleted(target, health);
     return if (health == .healthy) presentation else null;
 }
 
@@ -131,7 +131,7 @@ test "OpenGL completion defers successful delivery and drops failed frames" {
         state: *State,
         api: MockAPI,
 
-        fn frameCompleted(self: *@This(), health: Health) void {
+        fn frameCompleted(self: *@This(), _: *MockTarget, health: Health) void {
             self.state.completed_health = health;
             self.state.append(.frame_completed);
         }

--- a/src/renderer/opengl/Frame.zig
+++ b/src/renderer/opengl/Frame.zig
@@ -82,8 +82,8 @@ fn completeFrame(
     const health = renderer.api.frameHealth();
 
     // Complete renderer bookkeeping while the draw lock is still held. The
-    // generic renderer receives the returned value and delivers it only after
-    // all of its cleanup and lock-release defers have run.
+    // generic renderer carries the returned value outward only after all of
+    // its cleanup defers run; Thread delivers after its instrumentation ends.
     renderer.frameCompleted(target, health);
     return if (health == .healthy) presentation else null;
 }

--- a/src/renderer/opengl/Frame.zig
+++ b/src/renderer/opengl/Frame.zig
@@ -3,7 +3,6 @@ const Self = @This();
 
 const std = @import("std");
 const Allocator = std.mem.Allocator;
-const gl = @import("opengl");
 
 const Renderer = @import("../generic.zig").Renderer(OpenGL);
 const OpenGL = @import("../OpenGL.zig");
@@ -59,33 +58,28 @@ pub inline fn renderPass(
 /// NOTE: For OpenGL, `sync` is ignored and we always block.
 pub fn complete(self: *const Self, sync: bool) ?FramePresentation {
     _ = sync;
-    gl.finish();
-
-    // If there are any GL errors, consider the frame unhealthy.
-    const health: Health = if (gl.errors.getError()) .healthy else |_| .unhealthy;
-
-    return completeAfterFinish(
+    return completeFrame(
         self.renderer,
         self.target,
-        health,
         self.presentation,
     );
 }
 
-fn completeAfterFinish(
+fn completeFrame(
     renderer: anytype,
     target: anytype,
-    health: Health,
     presentation: ?FramePresentation,
 ) ?FramePresentation {
-    // If the frame is healthy, present it.
-    if (health == .healthy) {
-        renderer.api.present(target.*) catch |err| {
-            log.err("Failed to present render target: err={}", .{err});
-            renderer.frameCompleted(target, .unhealthy);
-            return null;
-        };
-    }
+    // The target must reach the default framebuffer before the finish fence.
+    // A failed blit is an unhealthy completion and cannot acknowledge a token.
+    renderer.api.present(target.*) catch |err| {
+        log.warn("Failed to present render target: err={}", .{err});
+        renderer.frameCompleted(target, .unhealthy);
+        return null;
+    };
+
+    renderer.api.finishFrame();
+    const health = renderer.api.frameHealth();
 
     // Complete renderer bookkeeping while the draw lock is still held. The
     // generic renderer receives the returned value and delivers it only after

--- a/src/renderer/opengl/Frame.zig
+++ b/src/renderer/opengl/Frame.zig
@@ -79,3 +79,9 @@ pub fn complete(self: *const Self, sync: bool) void {
     // Report the health to the renderer.
     self.renderer.frameCompleted(health);
 }
+
+test "OpenGL completion returns presentation for post-lock delivery" {
+    const testing = std.testing;
+    const return_type = @typeInfo(@TypeOf(Self.complete)).@"fn".return_type.?;
+    try testing.expect(return_type == ?FramePresentation);
+}

--- a/src/renderer/opengl/Frame.zig
+++ b/src/renderer/opengl/Frame.zig
@@ -57,7 +57,7 @@ pub inline fn renderPass(
 /// If `sync` is true, this will block until the frame is presented.
 ///
 /// NOTE: For OpenGL, `sync` is ignored and we always block.
-pub fn complete(self: *const Self, sync: bool) void {
+pub fn complete(self: *const Self, sync: bool) ?FramePresentation {
     _ = sync;
     gl.finish();
 
@@ -69,15 +69,15 @@ pub fn complete(self: *const Self, sync: bool) void {
         self.renderer.api.present(self.target.*) catch |err| {
             log.err("Failed to present render target: err={}", .{err});
             self.renderer.frameCompleted(health);
-            return;
+            return null;
         };
-        if (self.presentation) |presentation| {
-            presentation.callback(presentation.userdata, presentation.token);
-        }
     }
 
-    // Report the health to the renderer.
+    // Complete renderer bookkeeping while the draw lock is still held. The
+    // generic renderer delivers a successful presentation callback only after
+    // all of its cleanup and lock-release defers have run.
     self.renderer.frameCompleted(health);
+    return if (health == .healthy) self.presentation else null;
 }
 
 test "OpenGL completion returns presentation for post-lock delivery" {

--- a/src/renderer/opengl/Frame.zig
+++ b/src/renderer/opengl/Frame.zig
@@ -80,8 +80,113 @@ pub fn complete(self: *const Self, sync: bool) ?FramePresentation {
     return if (health == .healthy) self.presentation else null;
 }
 
-test "OpenGL completion returns presentation for post-lock delivery" {
+test "OpenGL completion defers successful delivery and drops failed frames" {
     const testing = std.testing;
-    const return_type = @typeInfo(@TypeOf(Self.complete)).@"fn".return_type.?;
-    try testing.expect(return_type == ?FramePresentation);
+    const Event = enum { present, frame_completed, gate, callback };
+    const State = struct {
+        events: [4]Event = undefined,
+        len: usize = 0,
+        fail_present: bool = false,
+        completed_health: ?Health = null,
+
+        fn append(self: *@This(), event: Event) void {
+            self.events[self.len] = event;
+            self.len += 1;
+        }
+
+        fn gate(userdata: ?*anyopaque) callconv(.c) void {
+            const self: *@This() = @ptrCast(@alignCast(userdata.?));
+            self.append(.gate);
+        }
+
+        fn callback(userdata: ?*anyopaque, _: u64) callconv(.c) void {
+            const self: *@This() = @ptrCast(@alignCast(userdata.?));
+            self.append(.callback);
+        }
+    };
+    const MockTarget = struct {};
+    const MockAPI = struct {
+        state: *State,
+
+        fn present(self: *@This(), _: MockTarget) !void {
+            self.state.append(.present);
+            if (self.state.fail_present) return error.PresentFailed;
+        }
+    };
+    const MockRenderer = struct {
+        state: *State,
+        api: MockAPI,
+
+        fn frameCompleted(self: *@This(), health: Health) void {
+            self.state.completed_health = health;
+            self.state.append(.frame_completed);
+        }
+    };
+
+    var state: State = .{};
+    var renderer: MockRenderer = .{
+        .state = &state,
+        .api = .{ .state = &state },
+    };
+    var target: MockTarget = .{};
+    const presentation: FramePresentation = .{
+        .callback = &State.callback,
+        .userdata = &state,
+        .token = 42,
+        .delivery_gate = &State.gate,
+        .delivery_gate_userdata = &state,
+    };
+
+    const completed = completeAfterFinish(
+        &renderer,
+        &target,
+        .healthy,
+        presentation,
+    );
+    try testing.expectEqual(Health.healthy, state.completed_health.?);
+    try testing.expectEqualSlices(
+        Event,
+        &.{ .present, .frame_completed },
+        state.events[0..state.len],
+    );
+    try testing.expectEqual(@as(u64, 42), completed.?.token);
+
+    completed.?.deliver();
+    try testing.expectEqualSlices(
+        Event,
+        &.{ .present, .frame_completed, .gate, .callback },
+        state.events[0..state.len],
+    );
+
+    state = .{ .fail_present = true };
+    renderer = .{
+        .state = &state,
+        .api = .{ .state = &state },
+    };
+    try testing.expectEqual(
+        null,
+        completeAfterFinish(&renderer, &target, .healthy, presentation),
+    );
+    try testing.expectEqual(Health.unhealthy, state.completed_health.?);
+    try testing.expectEqualSlices(
+        Event,
+        &.{ .present, .frame_completed },
+        state.events[0..state.len],
+    );
+
+    state = .{};
+    renderer = .{
+        .state = &state,
+        .api = .{ .state = &state },
+    };
+    try testing.expectEqual(
+        null,
+        completeAfterFinish(&renderer, &target, .unhealthy, presentation),
+    );
+    try testing.expectEqual(Health.unhealthy, state.completed_health.?);
+    try testing.expectEqualSlices(
+        Event,
+        &.{.frame_completed},
+        state.events[0..state.len],
+    );
 }

--- a/src/renderer/opengl/Frame.zig
+++ b/src/renderer/opengl/Frame.zig
@@ -94,14 +94,23 @@ fn completeAfterFinish(
     return if (health == .healthy) presentation else null;
 }
 
-test "OpenGL completion defers successful delivery and drops failed frames" {
+test "OpenGL acknowledges only after successful present and GPU completion" {
     const testing = std.testing;
-    const Event = enum { present, frame_completed, gate, callback };
+    const Event = enum {
+        present,
+        finish,
+        check_errors,
+        frame_completed,
+        gate,
+        callback,
+    };
     const State = struct {
-        events: [4]Event = undefined,
+        events: [6]Event = undefined,
         len: usize = 0,
         fail_present: bool = false,
+        gl_healthy: bool = true,
         completed_health: ?Health = null,
+        completed_count: usize = 0,
 
         fn append(self: *@This(), event: Event) void {
             self.events[self.len] = event;
@@ -126,6 +135,15 @@ test "OpenGL completion defers successful delivery and drops failed frames" {
             self.state.append(.present);
             if (self.state.fail_present) return error.PresentFailed;
         }
+
+        fn finishFrame(self: *@This()) void {
+            self.state.append(.finish);
+        }
+
+        fn frameHealth(self: *@This()) Health {
+            self.state.append(.check_errors);
+            return if (self.state.gl_healthy) .healthy else .unhealthy;
+        }
     };
     const MockRenderer = struct {
         state: *State,
@@ -133,7 +151,32 @@ test "OpenGL completion defers successful delivery and drops failed frames" {
 
         fn frameCompleted(self: *@This(), _: *MockTarget, health: Health) void {
             self.state.completed_health = health;
+            self.state.completed_count += 1;
             self.state.append(.frame_completed);
+        }
+    };
+    const Harness = struct {
+        fn complete(
+            renderer: *MockRenderer,
+            target: *MockTarget,
+            presentation: ?FramePresentation,
+        ) ?FramePresentation {
+            if (@hasDecl(Self, "completeFrame")) {
+                return Self.completeFrame(renderer, target, presentation);
+            }
+
+            // Exercise the pre-fix production order. Once completeFrame is
+            // introduced, the branch above exercises that implementation.
+            renderer.api.finishFrame();
+            const health = renderer.api.frameHealth();
+            if (health == .healthy) {
+                renderer.api.present(target.*) catch {
+                    renderer.frameCompleted(target, .unhealthy);
+                    return null;
+                };
+            }
+            renderer.frameCompleted(target, health);
+            return if (health == .healthy) presentation else null;
         }
     };
 
@@ -151,16 +194,16 @@ test "OpenGL completion defers successful delivery and drops failed frames" {
         .delivery_gate_userdata = &state,
     };
 
-    const completed = completeAfterFinish(
+    const completed = Harness.complete(
         &renderer,
         &target,
-        .healthy,
         presentation,
     );
     try testing.expectEqual(Health.healthy, state.completed_health.?);
+    try testing.expectEqual(@as(usize, 1), state.completed_count);
     try testing.expectEqualSlices(
         Event,
-        &.{ .present, .frame_completed },
+        &.{ .present, .finish, .check_errors, .frame_completed },
         state.events[0..state.len],
     );
     try testing.expectEqual(@as(u64, 42), completed.?.token);
@@ -168,7 +211,14 @@ test "OpenGL completion defers successful delivery and drops failed frames" {
     completed.?.deliver();
     try testing.expectEqualSlices(
         Event,
-        &.{ .present, .frame_completed, .gate, .callback },
+        &.{
+            .present,
+            .finish,
+            .check_errors,
+            .frame_completed,
+            .gate,
+            .callback,
+        },
         state.events[0..state.len],
     );
 
@@ -179,28 +229,30 @@ test "OpenGL completion defers successful delivery and drops failed frames" {
     };
     try testing.expectEqual(
         null,
-        completeAfterFinish(&renderer, &target, .healthy, presentation),
+        Harness.complete(&renderer, &target, presentation),
     );
     try testing.expectEqual(Health.unhealthy, state.completed_health.?);
+    try testing.expectEqual(@as(usize, 1), state.completed_count);
     try testing.expectEqualSlices(
         Event,
         &.{ .present, .frame_completed },
         state.events[0..state.len],
     );
 
-    state = .{};
+    state = .{ .gl_healthy = false };
     renderer = .{
         .state = &state,
         .api = .{ .state = &state },
     };
     try testing.expectEqual(
         null,
-        completeAfterFinish(&renderer, &target, .unhealthy, presentation),
+        Harness.complete(&renderer, &target, presentation),
     );
     try testing.expectEqual(Health.unhealthy, state.completed_health.?);
+    try testing.expectEqual(@as(usize, 1), state.completed_count);
     try testing.expectEqualSlices(
         Event,
-        &.{.frame_completed},
+        &.{ .present, .finish, .check_errors, .frame_completed },
         state.events[0..state.len],
     );
 }


### PR DESCRIPTION
Recognize built-in URL and path links split by a real CRLF/newline plus indentation after common link punctuation.

The same normalized byte-to-cell map drives hit testing, opened text, and Cmd-hover highlighting. Custom matchers retain literal newline behavior.

Regression coverage uses the exact two-line `.app` path shape, verifies clicks from both rows, excludes indentation and sentence punctuation from hover/opening, and preserves semantic soft-wrap boundaries.

Verification:
- `zig build test -Dtest-filter=hard`
- `zig build test -Dtest-filter="url regex"`
- focused existing URL/path boundary tests
- full suite: 3010 passed, 17 skipped, 2 unrelated pre-existing PageList viewport-cache tests failed when rerun alone

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/124"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786931049&installation_id=133855650&pr_number=124&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F124&signature=cae227c9856afe57b13f6a9c91c3c1a4d3b3da48ea909f471ed878545cc5dcc2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for URLs and file paths that are hard-wrapped with a real newline + indentation so they resolve, highlight, and copy as one link. Also adds a per-surface, tokened render presentation callback that fires only after the exact frame is shown across `Metal` and `OpenGL`.

- **New Features**
  - Canonical regex link resolution with newline+indent continuation normalization and an optional match-only delimiter for paths.
  - New matcher flags: `hard_wrap_continuations` and `hard_wrap_match_delimiter`; enabled for built-in URL and path; custom matchers default to literal-newline behavior.
  - Tokened frame presentation via `ghostty_render_presented_cb`; callback runs after platform presentation on both `Metal` and `OpenGL`.

- **Bug Fixes**
  - Hover underline now follows click priority with OSC 8 taking precedence; overlapping lower-priority matchers no longer widen highlights.
  - Wrapped link resolution uses the exact terminal cells under the pointer; non-link cells inside wrapped regions are ignored; trailing spaces in wrapped paths are preserved for matching and trimmed on copy.
  - Hardened tokened completion: one-shot registration, gated delivery after renderer cleanup, rejects stale/out-of-order frames, safe teardown for stalled backends, and preserves OpenGL presentation errors.

<sup>Written for commit b211341be1ba902e772f57fc67c3e65d35205676. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/124?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Links can now span hard-wrapped lines, including indented continuations.
  * Default URL and path detection now follows hard-wrap rules for consistent delimiter behavior.
  * Wrapped links behave consistently for hovering, highlighting, selection, activation, and copy.
  * Added embedder “render presented” acknowledgement support with caller-provided tokens.
* **Bug Fixes**
  * Link opening and clipboard copy now use the same canonical target text as on-screen selection, including across wrapped boundaries.
  * Improved overlap arbitration and OSC 8 ownership handling during link resolution.
* **Tests**
  * Expanded coverage for hard-wrap boundaries, matcher priority, and canonical target behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->