### PR TITLE
Fix runaway os-open stderr logging loop

### DIFF
--- a/src/os/open.zig
+++ b/src/os/open.zig
@@ -3,6 +3,7 @@ const builtin = @import("builtin");
 const Allocator = std.mem.Allocator;
 const build_config = @import("../build_config.zig");
 const apprt = @import("../apprt.zig");
+const open_reader = @import("open_reader.zig");
 
 const log = std.log.scoped(.@"os-open");
 
@@ -82,14 +83,7 @@ fn openThread(exe_: std.process.Child) void {
         var stream = stderr.readerStreaming(&buffer);
         const reader = &stream.interface;
         while (true) {
-            const line = reader.takeDelimiterExclusive('\n') catch |outer| switch (outer) {
-                error.EndOfStream => break,
-                error.ReadFailed => break,
-                error.StreamTooLong => reader.take(buffer.len) catch |inner| switch (inner) {
-                    error.ReadFailed => break,
-                    error.EndOfStream => break,
-                },
-            };
+            const line = (open_reader.takeLine(reader, buffer.len) catch break) orelse break;
             log.warn("open stderr={s}", .{line});
         }
     }

--- a/src/os/open_reader.zig
+++ b/src/os/open_reader.zig
@@ -1,0 +1,20 @@
+const std = @import("std");
+
+pub fn takeLine(reader: *std.Io.Reader, chunk_size: usize) error{ReadFailed}!?[]u8 {
+    return reader.takeDelimiterExclusive('\n') catch |outer| switch (outer) {
+        error.EndOfStream => null,
+        error.ReadFailed => error.ReadFailed,
+        error.StreamTooLong => reader.take(chunk_size) catch |inner| switch (inner) {
+            error.ReadFailed => error.ReadFailed,
+            error.EndOfStream => null,
+        },
+    };
+}
+
+test "open stderr reader consumes delimiters and reaches EOF" {
+    var reader = std.Io.Reader.fixed("first\nsecond\n");
+
+    try std.testing.expectEqualStrings("first", (try takeLine(&reader, 256)).?);
+    try std.testing.expectEqualStrings("second", (try takeLine(&reader, 256)).?);
+    try std.testing.expectEqual(null, try takeLine(&reader, 256));
+}

--- a/src/os/open_reader.zig
+++ b/src/os/open_reader.zig
@@ -1,8 +1,7 @@
 const std = @import("std");
 
 pub fn takeLine(reader: *std.Io.Reader, chunk_size: usize) error{ReadFailed}!?[]u8 {
-    return reader.takeDelimiterExclusive('\n') catch |outer| switch (outer) {
-        error.EndOfStream => null,
+    return reader.takeDelimiter('\n') catch |outer| switch (outer) {
         error.ReadFailed => error.ReadFailed,
         error.StreamTooLong => reader.take(chunk_size) catch |inner| switch (inner) {
             error.ReadFailed => error.ReadFailed,


### PR DESCRIPTION
## Summary
- consume stderr delimiters correctly in the asynchronous `open` process reader
- stop the reader at EOF so `exe.wait()` reaps the child process
- add a regression test covering multiple newline-delimited records followed by EOF

## Root cause
Ghostty is pinned to Zig 0.15.2. Its `Reader.takeDelimiterExclusive` regression leaves the delimiter buffered, so after the first stderr line the loop repeatedly returns an empty slice. Each affected `open` call then creates a permanent logging thread and an unreaped child process, driving both cmux and macOS `logd` CPU usage.

## Testing
- Added the regression test in a first commit and confirmed it fails by returning an empty second line.
- Switched the reader to `takeDelimiter`; the same Zig 0.15.2 test now passes.
- Result: `1/1` targeted tests passed.

A full local GhosttyKit build is blocked on macOS 26.5 because Zig 0.15.2 cannot link against that SDK; the isolated test was compiled with the pinned Zig toolchain to WASI and executed successfully.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/126"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786958967&installation_id=133855650&pr_number=126&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F126&signature=231ffd2c5bec39260d34a905d26dd0aa37b2bd4d8ecf29110f9f8e7492d4b50b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a runaway stderr logging loop in `os.open` by correctly consuming newline delimiters and stopping at EOF. Prevents permanent logging threads and unreaped child processes that could spike CPU usage.

- Bug Fixes
  - Use `open_reader.takeLine` (based on `takeDelimiter`) instead of `takeDelimiterExclusive` to consume newline delimiters and handle long lines.
  - Break the reader loop at EOF so `exe.wait()` can reap the child process.
  - Add a regression test for multiple newline-delimited stderr records followed by EOF.
  - Notes the Zig 0.15.2 `takeDelimiterExclusive` regression that left delimiters buffered, causing empty-line loops.

<sup>Written for commit 71ef84ef2dabe011b484dc5943f1f8d85fe42777. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/126?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stderr line reading during open operations.
  * Ensured streams are handled cleanly when reaching end-of-file or encountering read errors.
  * Preserved warning logs for collected stderr messages.
* **Tests**
  * Added coverage for reading multiple lines and correctly handling end-of-stream.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->