### PR TITLE
Integrate cmux external renderer stack with current Ghostty main

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -29,6 +29,7 @@ Makefile text eol=lf
 *.txt text eol=lf
 
 # Windows resource files - preserve as-is (native Windows tooling)
+*.cmd text eol=crlf
 *.rc -text
 *.manifest -text
 

--- a/build.zig
+++ b/build.zig
@@ -199,10 +199,12 @@ pub fn build(b: *std.Build) !void {
                 lib_shared.install("ghostty-internal.dll");
                 lib_static.install("ghostty-internal-static.lib");
             } else {
-                lib_shared.install("ghostty-internal.so");
+                lib_shared.install("libghostty-internal.so");
                 lib_static.install("ghostty-internal.a");
             }
         }
+        resources.install();
+        if (i18n) |v| v.install();
     }
 
     // macOS only artifacts. These will error if they're initialized for

--- a/example/electron-embed-windows/.gitignore
+++ b/example/electron-embed-windows/.gitignore
@@ -1,0 +1,5 @@
+artifacts/*.json
+artifacts/*.log
+artifacts/computer-use/
+build/
+node_modules/

--- a/example/electron-embed-windows/README.md
+++ b/example/electron-embed-windows/README.md
@@ -71,3 +71,8 @@ WGL frame, or retained memory growth above the limit.
 `npm run stress:cycles` repeats the test in five fresh Electron processes for
 cold-start coverage. The aggregate report is
 `artifacts\stress-cycles.json`.
+
+`npm run stress:teardown` is the focused ConPTY reader teardown regression
+harness. It creates and immediately frees 1,000 native surfaces in one
+Electron process and fails if any `ghostty_surface_free` call blocks long
+enough to hit the process watchdog.

--- a/example/electron-embed-windows/README.md
+++ b/example/electron-embed-windows/README.md
@@ -1,0 +1,73 @@
+# Electron + native libghostty on Windows
+
+This demo embeds a real libghostty surface in Electron 43.1.0. The Node-API
+addon creates a child `HWND` under `BrowserWindow.getNativeWindowHandle()`,
+owns a WGL OpenGL 4.3 context, and supplies that context through
+`GHOSTTY_PLATFORM_OPENGL`. Chromium renders the panel beside it.
+
+There is no xterm.js dependency. `ghostty_surface_new` starts the Windows
+ConPTY-backed shell, and Ghostty's OpenGL renderer presents every terminal
+frame through the addon's `SwapBuffers` callback.
+
+## Build
+
+Install Zig 0.15.2, Visual Studio 2022 Build Tools with the Desktop C++
+workload, Node.js, and npm. From this directory:
+
+```powershell
+npm install
+npm run build:ghostty
+npm run build
+npm start
+```
+
+The Ghostty build now installs `ghostty-internal.lib` with
+`ghostty-internal.dll`, so MSVC embedders link against stable files under
+`zig-out\lib`.
+
+Ghostty requires desktop OpenGL 4.3. Many Windows cloud VMs expose only the
+Microsoft OpenGL 1.1 RDP driver. Install a trusted OpenGL 4.3-capable GPU
+driver for production. For software-rendered cloud validation, extract a
+trusted Mesa Windows x64 build, then run:
+
+```powershell
+$env:GHOSTTY_MESA_DIR = "C:\path\to\mesa"
+npm run deploy:mesa
+.\scripts\start-software-renderer.cmd
+```
+
+The deploy script renames Mesa's `opengl32.dll` and places it beside the addon
+with `libgallium_wgl.dll`. The addon loads that private WGL table through
+`GHOSTTY_MESA_OPENGL_PATH`; it does not replace Electron's `opengl32.dll` or
+alter Chromium's graphics stack. The addon rejects contexts older than 4.3 and
+reports the exact GL version instead of showing a blank pseudo-terminal.
+
+## Input and lifecycle
+
+The child window routes physical scan codes, committed UTF-16 text, focus,
+selection drags, wheel scrolling, and terminal mouse reporting directly to
+libghostty. Right-click first checks `ghostty_surface_mouse_captured`: captured
+applications receive the button, while an uncaptured shell gets a native
+Copy/Paste menu backed by Ghostty's clipboard callbacks.
+
+`destroy()` is idempotent. It first joins and frees the Ghostty surface while
+WGL callbacks remain alive, then frees the app and config, deletes the GL
+context, and destroys the child window. N-API finalization repeats the same
+safe path, so closing during active output does not depend on garbage
+collection order. Embedded surface creation also waits until renderer and IO
+stop watchers are armed, so an immediate destroy cannot lose a startup stop
+notification and deadlock teardown.
+
+## Stress
+
+`npm run stress` immediately creates and destroys 25 surfaces to exercise the
+thread-startup race, then recreates 50 rendered surfaces, performs 2,500 native
+resizes, closes each shell during active output, and injects five Chromium
+renderer deaths while retaining the native terminal host. It writes a JSON
+report under `artifacts` and fails on unexpected renderer loss, unresponsive
+windows, native renderer health failures, a surface that never swaps a real
+WGL frame, or retained memory growth above the limit.
+
+`npm run stress:cycles` repeats the test in five fresh Electron processes for
+cold-start coverage. The aggregate report is
+`artifacts\stress-cycles.json`.

--- a/example/electron-embed-windows/binding.gyp
+++ b/example/electron-embed-windows/binding.gyp
@@ -1,0 +1,34 @@
+{
+  "variables": {
+    "ghostty_root%": "<!(node -p \"process.env.GHOSTTY_ROOT || require('node:path').resolve('../..')\")",
+    "ghostty_lib_dir%": "<!(node -p \"process.env.GHOSTTY_LIB_DIR || require('node:path').resolve('../../zig-out/lib')\")"
+  },
+  "targets": [
+    {
+      "target_name": "ghostty_embed",
+      "sources": ["src/libghostty_embed_win.cc"],
+      "include_dirs": ["<(ghostty_root)/include"],
+      "libraries": [
+        "<(ghostty_lib_dir)/ghostty-internal.lib",
+        "user32.lib",
+        "gdi32.lib",
+        "vcruntime.lib",
+        "ucrt.lib",
+        "msvcrt.lib"
+      ],
+      "defines": ["NAPI_VERSION=9"],
+      "msvs_settings": {
+        "VCCLCompilerTool": {
+          "AdditionalOptions": ["/std:c++20", "/EHsc"],
+          "RuntimeLibrary": 2
+        }
+      },
+      "copies": [
+        {
+          "destination": "<(PRODUCT_DIR)",
+          "files": ["<(ghostty_lib_dir)/ghostty-internal.dll"]
+        }
+      ]
+    }
+  ]
+}

--- a/example/electron-embed-windows/main.js
+++ b/example/electron-embed-windows/main.js
@@ -1,0 +1,299 @@
+const fs = require('node:fs/promises')
+const path = require('node:path')
+const { once } = require('node:events')
+const { app, BrowserWindow } = require('electron')
+const ghostty = require('./build/Release/ghostty_embed.node')
+
+const trace = (message) => console.error(`[electron-libghostty] ${message}`)
+trace('main module loaded')
+
+delete process.env.NO_COLOR
+
+let window
+let terminal
+let diagnosticsTimer
+const expectedRendererDeaths = new Set()
+const artifacts = path.join(__dirname, 'artifacts')
+const stressMode = process.argv.includes('--stress')
+const integerArgument = (name, fallback) => {
+  const argument = process.argv.find((value) => value.startsWith(`${name}=`))
+  const parsed = Number.parseInt(argument?.split('=')[1], 10)
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback
+}
+const stressIterations = integerArgument('--stress-iterations', 50)
+const stressResizes = integerArgument('--stress-resizes', 50)
+const stressRendererDeaths = integerArgument('--stress-renderer-deaths', 5)
+const stressImmediateDestroys = integerArgument('--stress-immediate-destroys', 25)
+const stressCycle = integerArgument('--stress-cycle', 0)
+const diagnostics = {
+  renderProcessGone: [],
+  unexpectedRendererDeaths: [],
+  unresponsive: [],
+  native: [],
+  memory: []
+}
+
+const terminalBounds = () => {
+  const [width, height] = window.getContentSize()
+  return {
+    x: 16,
+    y: 68,
+    width: Math.max(360, Math.floor(width * 0.62) - 22),
+    height: Math.max(260, height - 84)
+  }
+}
+
+const nextTurn = () => new Promise((resolve) => setImmediate(resolve))
+
+async function waitForNativeFrame(handle, timeoutMs = 2000) {
+  const deadline = Date.now() + timeoutMs
+  let native
+  do {
+    native = ghostty.diagnostics(handle)
+    if (native.rendererHealthy === false) {
+      throw new Error(`libghostty renderer became unhealthy: ${JSON.stringify(native)}`)
+    }
+    if (native.swaps > 0n) return native
+    await new Promise((resolve) => setTimeout(resolve, 10))
+  } while (Date.now() < deadline)
+  throw new Error(`libghostty produced no WGL frame within ${timeoutMs}ms`)
+}
+
+async function loadRenderer() {
+  await window.loadFile(path.join(__dirname, 'renderer.html'))
+}
+
+async function publishDiagnostics() {
+  if (!terminal || window.webContents.isDestroyed()) return
+  const native = ghostty.diagnostics(terminal)
+  const display = {
+    ...native,
+    swaps: native.swaps.toString(),
+    electron: process.versions.electron,
+    chrome: process.versions.chrome
+  }
+  diagnostics.native.push(display)
+  await window.webContents.executeJavaScript(
+    `document.querySelector('#status').textContent = ${JSON.stringify(JSON.stringify(display, null, 2))}`
+  )
+}
+
+async function sampleMemory(iteration) {
+  diagnostics.memory.push({
+    iteration,
+    browser: await process.getProcessMemoryInfo(),
+    processes: app.getAppMetrics().map((metric) => ({
+      pid: metric.pid,
+      type: metric.type,
+      memory: metric.memory
+    }))
+  })
+}
+
+function createTerminal() {
+  trace('reading BrowserWindow native handle')
+  const nativeHandle = window.getNativeWindowHandle()
+  trace(`native handle acquired (${nativeHandle.length} bytes)`)
+  const bounds = terminalBounds()
+  trace(`creating terminal at ${JSON.stringify(bounds)}`)
+  return ghostty.create(nativeHandle, {
+    ...bounds,
+    workingDirectory: process.cwd(),
+    command: 'cmd.exe'
+  })
+}
+
+async function crashAndRecoverRenderer(sequence) {
+  const death = once(window.webContents, 'render-process-gone')
+  expectedRendererDeaths.add(sequence)
+  window.webContents.forcefullyCrashRenderer()
+  await death
+  await loadRenderer()
+  if (terminal) ghostty.setBounds(terminal, terminalBounds())
+  if (terminal) await waitForNativeFrame(terminal)
+  await publishDiagnostics()
+}
+
+async function runStress() {
+  await fs.mkdir(artifacts, { recursive: true })
+  await sampleMemory(0)
+  for (let immediate = 1; immediate <= stressImmediateDestroys; immediate += 1) {
+    terminal = createTerminal()
+    ghostty.destroy(terminal)
+    terminal = undefined
+    if (immediate % 5 === 0) await nextTurn()
+  }
+  let injectedRendererDeaths = 0
+  for (let iteration = 1; iteration <= stressIterations; iteration += 1) {
+    terminal = createTerminal()
+    ghostty.sendText(
+      terminal,
+      `echo ghostty-stress-${stressCycle}-${iteration} & ` +
+        'powershell.exe -NoProfile -Command "1..400 | ForEach-Object { Write-Output (\'row-{0:D4}\' -f $_) }"\r'
+    )
+    for (let resize = 0; resize < stressResizes; resize += 1) {
+      const bounds = terminalBounds()
+      ghostty.setBounds(terminal, {
+        ...bounds,
+        width: Math.max(360, bounds.width - ((resize * 17) % 220)),
+        height: Math.max(260, bounds.height - ((resize * 13) % 180))
+      })
+      if (resize % 5 === 0) await nextTurn()
+    }
+    if (
+      stressRendererDeaths > 0 &&
+      injectedRendererDeaths < stressRendererDeaths &&
+      iteration % Math.max(1, Math.floor(stressIterations / stressRendererDeaths)) === 0
+    ) {
+      injectedRendererDeaths += 1
+      await crashAndRecoverRenderer(injectedRendererDeaths)
+    }
+    const native = await waitForNativeFrame(terminal)
+    diagnostics.native.push({
+      iteration,
+      ...native,
+      swaps: native.swaps.toString()
+    })
+    ghostty.destroy(terminal)
+    terminal = undefined
+    await nextTurn()
+    if (iteration % 5 === 0 || iteration === stressIterations) {
+      await sampleMemory(iteration)
+    }
+  }
+
+  const totalWorkingSet = (sample) => sample.processes.reduce(
+    (total, metric) => total + (metric.memory?.workingSetSize || 0),
+    0
+  )
+  const first = diagnostics.memory.at(0)
+  const last = diagnostics.memory.at(-1)
+  const warmup = diagnostics.memory.find(
+    (sample) => sample.iteration >= Math.min(10, stressIterations)
+  ) || first
+  const retainedGrowthAfterWarmupMB =
+    (totalWorkingSet(last) - totalWorkingSet(warmup)) / 1024
+  const peakGrowthAfterWarmupMB = (
+    Math.max(...diagnostics.memory
+      .filter((sample) => sample.iteration >= warmup.iteration)
+      .map(totalWorkingSet)) - totalWorkingSet(warmup)
+  ) / 1024
+  const maxGrowthMB = Number.parseInt(
+    process.env.GHOSTTY_STRESS_MAX_RETAINED_GROWTH_MB || '96',
+    10
+  )
+  const nativeFailures = diagnostics.native.filter(
+    (sample) => sample.rendererHealthy === false ||
+      sample.realLibghostty === false ||
+      BigInt(sample.swaps) === 0n
+  )
+  const report = {
+    electron: process.versions.electron,
+    chrome: process.versions.chrome,
+    cycle: stressCycle,
+    immediateDestroys: stressImmediateDestroys,
+    surfacesCreated: stressImmediateDestroys + stressIterations,
+    iterations: stressIterations,
+    resizesPerIteration: stressResizes,
+    injectedRendererDeaths,
+    retainedGrowthAfterWarmupMB,
+    peakGrowthAfterWarmupMB,
+    maxGrowthMB,
+    diagnostics,
+    pass: diagnostics.unexpectedRendererDeaths.length === 0 &&
+      diagnostics.unresponsive.length === 0 &&
+      nativeFailures.length === 0 &&
+      retainedGrowthAfterWarmupMB <= maxGrowthMB &&
+      peakGrowthAfterWarmupMB <= maxGrowthMB
+  }
+  await fs.writeFile(
+    path.join(artifacts, `stress-${stressCycle}.json`),
+    `${JSON.stringify(report, null, 2)}\n`
+  )
+  if (!report.pass) throw new Error(`Windows libghostty stress failed: ${JSON.stringify({
+    unexpectedRendererDeaths: diagnostics.unexpectedRendererDeaths.length,
+    unresponsive: diagnostics.unresponsive.length,
+    nativeFailures: nativeFailures.length,
+    retainedGrowthAfterWarmupMB,
+    peakGrowthAfterWarmupMB
+  })}`)
+}
+
+app.whenReady().then(async () => {
+  trace('app ready')
+  window = new BrowserWindow({
+    width: 1280,
+    height: 800,
+    show: false,
+    backgroundColor: '#090c10',
+    webPreferences: {
+      contextIsolation: true,
+      sandbox: true
+    }
+  })
+  trace('BrowserWindow created')
+
+  window.webContents.on('render-process-gone', (_event, details) => {
+    trace(`renderer gone: ${JSON.stringify(details)}`)
+    diagnostics.renderProcessGone.push(details)
+    if (expectedRendererDeaths.size > 0) {
+      const first = expectedRendererDeaths.values().next().value
+      expectedRendererDeaths.delete(first)
+    } else {
+      diagnostics.unexpectedRendererDeaths.push(details)
+    }
+  })
+  window.on('unresponsive', () => {
+    trace('BrowserWindow unresponsive')
+    diagnostics.unresponsive.push({ time: new Date().toISOString() })
+  })
+
+  const readyToShow = once(window, 'ready-to-show')
+  await Promise.all([loadRenderer().then(() => trace('renderer document loaded')), readyToShow])
+  trace('ready-to-show received')
+  terminal = createTerminal()
+  trace('native terminal created')
+  window.show()
+  ghostty.focus(terminal)
+  if (!stressMode) {
+    await publishDiagnostics()
+    diagnosticsTimer = setInterval(() => {
+      publishDiagnostics().catch((error) => trace(`diagnostics failed: ${error}`))
+    }, 1000)
+  }
+
+  window.on('resize', () => {
+    if (terminal) ghostty.setBounds(terminal, terminalBounds())
+  })
+  // Tear down while Electron's parent HWND and the child's HDC are valid.
+  // The later `closed` event is too late because Chromium has destroyed the
+  // native parent by then.
+  window.on('close', () => {
+    trace('BrowserWindow close')
+    clearInterval(diagnosticsTimer)
+    diagnosticsTimer = undefined
+    if (terminal) ghostty.destroy(terminal)
+    terminal = undefined
+  })
+  window.on('closed', () => {
+    trace('BrowserWindow closed')
+    window = undefined
+  })
+
+  if (stressMode) {
+    ghostty.destroy(terminal)
+    terminal = undefined
+    await runStress()
+    app.exit(0)
+  }
+}).catch((error) => {
+  console.error(error)
+  app.exit(1)
+})
+
+app.on('window-all-closed', () => app.quit())
+app.on('child-process-gone', (_event, details) => {
+  trace(`child process gone: ${JSON.stringify(details)}`)
+})
+app.on('before-quit', () => trace('app before-quit'))
+app.on('will-quit', () => trace('app will-quit'))

--- a/example/electron-embed-windows/package-lock.json
+++ b/example/electron-embed-windows/package-lock.json
@@ -1,0 +1,411 @@
+{
+  "name": "electron-libghostty-windows-embed",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "electron-libghostty-windows-embed",
+      "version": "0.0.1",
+      "hasInstallScript": true,
+      "devDependencies": {
+        "electron": "43.1.0",
+        "node-gyp": "13.0.1"
+      }
+    },
+    "node_modules/@electron-internal/extract-zip": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@electron-internal/extract-zip/-/extract-zip-1.0.4.tgz",
+      "integrity": "sha512-Zr1Vs7E9tpCNhZHDAbFVXc2gEVCG9RqPDjrno5+bdgB6LRAuvgyMHJut4NCVyYwtAieapMzc3fiQ3CSTi75ARg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@electron/get": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@electron/get/-/get-5.0.0.tgz",
+      "integrity": "sha512-pjoBpru1KdEtcExBnuHAP1cAc/5faoedw0hzJkL3o4/IJp7HNF1+fbrdxT3gMYRX2oJfvnA/WXeCTVQpYYxyJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "env-paths": "^3.0.0",
+        "graceful-fs": "^4.2.11",
+        "progress": "^2.0.3",
+        "semver": "^7.6.3",
+        "sumchecker": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      },
+      "optionalDependencies": {
+        "undici": "^7.24.4"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/abbrev": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-5.0.0.tgz",
+      "integrity": "sha512-/XrFJgzQQQHpti1raDJC6m4ws6aNktmjBlhk8Fdlk7LwCEuDoieEJJY9OFHjfiFJFFRM2tK+Ky/IsfbbmlMu1w==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/electron": {
+      "version": "43.1.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-43.1.0.tgz",
+      "integrity": "sha512-DPfxpQLd4NL3BJ8DBxYAfmLUKKesF5Rx9dQx5FyczAP8bhOPScjHE48GArVeXu68LlAainuwkmQTQvdZwpIIAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@electron-internal/extract-zip": "^1.0.1",
+        "@electron/get": "^5.0.0",
+        "@types/node": "^24.9.0"
+      },
+      "bin": {
+        "electron": "cli.js",
+        "install-electron": "install.js"
+      },
+      "engines": {
+        "node": ">= 22.12.0"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
+      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/exponential-backoff": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
+      "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/isexe": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+      "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-gyp": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-13.0.1.tgz",
+      "integrity": "sha512-piOr0S10qy5THB+q5BdqkoOx65XL/tjTMUAit3vciPNp+snTOBnGunWH1Rz7XZUxf2T9uFrfT/Ty4+aC3yPeyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.0",
+        "exponential-backoff": "^3.1.1",
+        "graceful-fs": "^4.2.6",
+        "nopt": "^10.0.0",
+        "proc-log": "^7.0.0",
+        "semver": "^7.3.5",
+        "tar": "^7.5.4",
+        "tinyglobby": "^0.2.12",
+        "undici": "^8.4.1",
+        "which": "^7.0.0"
+      },
+      "bin": {
+        "node-gyp": "bin/node-gyp.js"
+      },
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      }
+    },
+    "node_modules/node-gyp/node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/node-gyp/node_modules/undici": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.7.0.tgz",
+      "integrity": "sha512-N7iQtfyLhIMOFgQubvmLV26svHpO0bqKnAiWotTQCVKCmWrcGbBotPuW1x+xwYZ2VHdSTVUfPQQnlEt1/LouTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/nopt": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-10.0.1.tgz",
+      "integrity": "sha512-df3sBr/6ax9hSGuC3CspvLlbnX8cP5L5nZwXF8cGN8l0zSWR6BvzmQ6jPUKjvo6+/xdpkNvEcucBNUdBeeV13g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^5.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/proc-log": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-7.0.0.tgz",
+      "integrity": "sha512-FYgfaA69XZ93zaXLoMNQ+ViDXGGBgR8aLh03txzcFhV+9xOXx7+8DLCULrKKpR9+GsH9ZfHm82aSUPpozX0Ztg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      }
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sumchecker": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
+      "integrity": "sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      }
+    },
+    "node_modules/tar": {
+      "version": "7.5.20",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.20.tgz",
+      "integrity": "sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/which": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-7.0.0.tgz",
+      "integrity": "sha512-RancgH2dmbLdHl6LRhEqvklWMgl/Hdnun0Y90KhBOLkMefg8Qa7/Zel8Sm+8HEcP6DEjzsWzpkuBQEZok58isA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^4.0.0"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/example/electron-embed-windows/package.json
+++ b/example/electron-embed-windows/package.json
@@ -12,7 +12,8 @@
     "deploy:mesa": "powershell -NoProfile -ExecutionPolicy Bypass -File scripts/deploy-mesa.ps1",
     "start": "electron .",
     "stress": "electron . --stress",
-    "stress:cycles": "node scripts/stress-cycles.mjs"
+    "stress:cycles": "node scripts/stress-cycles.mjs",
+    "stress:teardown": "node scripts/stress-cycles.mjs --cycles=1 --iterations=0 --resizes=0 --renderer-deaths=0 --immediate-destroys=1000 --timeout-ms=240000"
   },
   "devDependencies": {
     "electron": "43.1.0",

--- a/example/electron-embed-windows/package.json
+++ b/example/electron-embed-windows/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "electron-libghostty-windows-embed",
+  "private": true,
+  "version": "0.0.1",
+  "description": "Real libghostty WGL child HWND embedded in Electron",
+  "main": "main.js",
+  "scripts": {
+    "install": "node -e \"console.log('Run npm run build:ghostty and npm run build after installing dependencies')\"",
+    "build:ghostty": "powershell -NoProfile -ExecutionPolicy Bypass -File scripts/build-ghostty.ps1",
+    "build:addon": "node-gyp rebuild --target=43.1.0 --dist-url=https://electronjs.org/headers",
+    "build": "npm run build:addon",
+    "deploy:mesa": "powershell -NoProfile -ExecutionPolicy Bypass -File scripts/deploy-mesa.ps1",
+    "start": "electron .",
+    "stress": "electron . --stress",
+    "stress:cycles": "node scripts/stress-cycles.mjs"
+  },
+  "devDependencies": {
+    "electron": "43.1.0",
+    "node-gyp": "13.0.1"
+  }
+}

--- a/example/electron-embed-windows/renderer.html
+++ b/example/electron-embed-windows/renderer.html
@@ -1,0 +1,61 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Electron + native libghostty on Windows</title>
+    <style>
+      :root {
+        color-scheme: dark;
+        font-family: Inter, "Segoe UI", sans-serif;
+        background: #090c10;
+        color: #e8edf4;
+      }
+      * { box-sizing: border-box; }
+      body { margin: 0; min-height: 100vh; background: #090c10; }
+      header {
+        height: 52px;
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        padding: 0 18px;
+        border-bottom: 1px solid #252c36;
+        background: #11161d;
+        font-weight: 650;
+      }
+      .dot {
+        width: 10px;
+        height: 10px;
+        border-radius: 50%;
+        background: #58d68d;
+        box-shadow: 0 0 12px rgba(88, 214, 141, 0.55);
+      }
+      main {
+        margin-left: 64%;
+        padding: 22px;
+        min-height: calc(100vh - 52px);
+      }
+      .panel {
+        border: 1px solid #303947;
+        border-radius: 14px;
+        background: #151b24;
+        padding: 20px;
+      }
+      h1 { margin: 0 0 12px; font-size: 18px; }
+      p { color: #aeb8c8; line-height: 1.55; }
+      code { color: #79e2a8; }
+      #status { white-space: pre-wrap; font: 13px/1.5 "Cascadia Mono", monospace; }
+    </style>
+  </head>
+  <body>
+    <header><span class="dot"></span>Native libghostty surface + Chromium UI</header>
+    <main>
+      <section class="panel">
+        <h1>Windows HWND/WGL embedding</h1>
+        <p>The terminal at left is a native child HWND. Ghostty renders it through an embedder-owned OpenGL context. This page is ordinary Chromium content.</p>
+        <p><code>No xterm.js dependency exists in this package.</code></p>
+        <div id="status">Waiting for native diagnostics...</div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/example/electron-embed-windows/scripts/build-ghostty.ps1
+++ b/example/electron-embed-windows/scripts/build-ghostty.ps1
@@ -1,0 +1,32 @@
+$ErrorActionPreference = "Stop"
+
+$repo = (Resolve-Path (Join-Path $PSScriptRoot "..\..\..")).Path
+$zig = $env:GHOSTTY_ZIG
+if (-not $zig) {
+  $command = Get-Command zig.exe -ErrorAction SilentlyContinue
+  if ($command) { $zig = $command.Source }
+}
+if (-not $zig -and (Test-Path "C:\tools\zig\zig.exe")) {
+  $zig = "C:\tools\zig\zig.exe"
+}
+if (-not $zig) {
+  throw "Zig 0.15.2 was not found. Set GHOSTTY_ZIG or add zig.exe to PATH."
+}
+
+Push-Location $repo
+try {
+  & $zig build -Doptimize=ReleaseFast
+} finally {
+  Pop-Location
+}
+
+$required = @(
+  (Join-Path $repo "zig-out\lib\ghostty-internal.dll"),
+  (Join-Path $repo "zig-out\lib\ghostty-internal.lib"),
+  (Join-Path $repo "zig-out\include\ghostty.h")
+)
+foreach ($path in $required) {
+  if (-not (Test-Path $path)) {
+    throw "Ghostty build did not produce $path"
+  }
+}

--- a/example/electron-embed-windows/scripts/deploy-mesa.ps1
+++ b/example/electron-embed-windows/scripts/deploy-mesa.ps1
@@ -1,0 +1,20 @@
+param(
+  [string]$MesaDir = $env:GHOSTTY_MESA_DIR
+)
+
+$ErrorActionPreference = "Stop"
+
+if (-not $MesaDir) {
+  throw "Set GHOSTTY_MESA_DIR to an extracted Mesa Windows x64 directory."
+}
+
+$openGl = Join-Path $MesaDir "opengl32.dll"
+$gallium = Join-Path $MesaDir "libgallium_wgl.dll"
+if (-not (Test-Path $openGl) -or -not (Test-Path $gallium)) {
+  throw "GHOSTTY_MESA_DIR must contain opengl32.dll and libgallium_wgl.dll."
+}
+
+$destination = Join-Path $PSScriptRoot "..\build\Release"
+New-Item -ItemType Directory -Force $destination | Out-Null
+Copy-Item -Force $openGl (Join-Path $destination "opengl32.mesa.dll")
+Copy-Item -Force $gallium (Join-Path $destination "libgallium_wgl.dll")

--- a/example/electron-embed-windows/scripts/start-software-renderer.cmd
+++ b/example/electron-embed-windows/scripts/start-software-renderer.cmd
@@ -1,0 +1,18 @@
+@echo off
+setlocal
+set GALLIUM_DRIVER=llvmpipe
+set LIBGL_ALWAYS_SOFTWARE=true
+set MESA_LOADER_DRIVER_OVERRIDE=llvmpipe
+set GHOSTTY_MESA_OPENGL_PATH=%~dp0..\build\Release\opengl32.mesa.dll
+if not exist "%GHOSTTY_MESA_OPENGL_PATH%" (
+  echo Missing %GHOSTTY_MESA_OPENGL_PATH%. Run npm run deploy:mesa first.
+  exit /b 1
+)
+if not exist "%~dp0..\build\Release\libgallium_wgl.dll" (
+  echo Missing libgallium_wgl.dll. Run npm run deploy:mesa first.
+  exit /b 1
+)
+if not exist "%~dp0..\artifacts" mkdir "%~dp0..\artifacts"
+set GHOSTTY_EMBED_TRACE=%~dp0..\artifacts\native.log
+del "%GHOSTTY_EMBED_TRACE%" 2>nul
+"%~dp0..\node_modules\electron\dist\electron.exe" "%~dp0.." %* --enable-logging --v=1 > "%~dp0..\artifacts\electron.log" 2>&1

--- a/example/electron-embed-windows/scripts/stress-cycles.mjs
+++ b/example/electron-embed-windows/scripts/stress-cycles.mjs
@@ -1,0 +1,136 @@
+import { spawn } from 'node:child_process'
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import process from 'node:process'
+
+const root = path.resolve(import.meta.dirname, '..')
+const artifacts = path.join(root, 'artifacts')
+const electron = path.join(root, 'node_modules', 'electron', 'dist', 'electron.exe')
+const mesaOpenGl = path.join(root, 'build', 'Release', 'opengl32.mesa.dll')
+const mesaGallium = path.join(root, 'build', 'Release', 'libgallium_wgl.dll')
+const integerArgument = (name, fallback) => {
+  const argument = process.argv.find((value) => value.startsWith(`${name}=`))
+  const parsed = Number.parseInt(argument?.split('=')[1], 10)
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback
+}
+const cycles = integerArgument('--cycles', 5)
+const iterations = integerArgument('--iterations', 50)
+const resizes = integerArgument('--resizes', 50)
+const rendererDeaths = integerArgument('--renderer-deaths', 5)
+const immediateDestroys = integerArgument('--immediate-destroys', 25)
+const timeoutMs = integerArgument('--timeout-ms', 240000)
+
+await fs.mkdir(artifacts, { recursive: true })
+const childEnvironment = { ...process.env, NO_COLOR: '' }
+try {
+  await Promise.all([fs.access(mesaOpenGl), fs.access(mesaGallium)])
+  childEnvironment.GHOSTTY_MESA_OPENGL_PATH ||= mesaOpenGl
+  childEnvironment.GALLIUM_DRIVER ||= 'llvmpipe'
+  childEnvironment.LIBGL_ALWAYS_SOFTWARE ||= 'true'
+  childEnvironment.MESA_LOADER_DRIVER_OVERRIDE ||= 'llvmpipe'
+} catch {
+  // A production GPU driver can supply OpenGL without the optional Mesa files.
+}
+const results = []
+for (let cycle = 1; cycle <= cycles; cycle += 1) {
+  const reportPath = path.join(artifacts, `stress-${cycle}.json`)
+  const stdoutPath = path.join(artifacts, `stress-${cycle}.stdout.log`)
+  const stderrPath = path.join(artifacts, `stress-${cycle}.stderr.log`)
+  const nativeTracePath = path.join(artifacts, `stress-${cycle}.native.log`)
+  await Promise.all([
+    fs.rm(reportPath, { force: true }),
+    fs.rm(stdoutPath, { force: true }),
+    fs.rm(stderrPath, { force: true }),
+    fs.rm(nativeTracePath, { force: true })
+  ])
+  const stdout = await fs.open(stdoutPath, 'w')
+  const stderr = await fs.open(stderrPath, 'w')
+  const started = Date.now()
+  const result = await new Promise((resolve) => {
+    let settled = false
+    const finish = (value) => {
+      if (settled) return
+      settled = true
+      resolve(value)
+    }
+    const child = spawn(electron, [
+      root,
+      '--stress',
+      `--stress-cycle=${cycle}`,
+      `--stress-iterations=${iterations}`,
+      `--stress-resizes=${resizes}`,
+      `--stress-renderer-deaths=${rendererDeaths}`,
+      `--stress-immediate-destroys=${immediateDestroys}`
+    ], {
+      cwd: root,
+      env: { ...childEnvironment, GHOSTTY_EMBED_TRACE: nativeTracePath },
+      stdio: ['ignore', stdout.fd, stderr.fd],
+      windowsHide: false
+    })
+    const timeout = setTimeout(() => {
+      if (process.platform === 'win32' && child.pid) {
+        spawn('taskkill.exe', ['/pid', String(child.pid), '/T', '/F'], {
+          stdio: 'ignore',
+          windowsHide: true
+        })
+      } else {
+        child.kill('SIGKILL')
+      }
+      setTimeout(
+        () => finish({ cycle, exitCode: null, signal: 'timeout' }),
+        10000
+      ).unref()
+    }, timeoutMs)
+    child.once('exit', (exitCode, signal) => {
+      clearTimeout(timeout)
+      finish({ cycle, exitCode, signal })
+    })
+    child.once('error', (error) => {
+      clearTimeout(timeout)
+      finish({ cycle, exitCode: null, signal: null, error: error.message })
+    })
+  })
+  await stdout.close()
+  await stderr.close()
+  result.durationMs = Date.now() - started
+  try {
+    result.report = JSON.parse(
+      await fs.readFile(reportPath, 'utf8')
+    )
+  } catch (error) {
+    result.reportError = error.message
+  }
+  result.pass = result.exitCode === 0 && result.report?.pass === true
+  results.push(result)
+  if (!result.pass) break
+}
+
+const summary = {
+  cyclesRequested: cycles,
+  cyclesCompleted: results.length,
+  iterationsPerCycle: iterations,
+  resizesPerIteration: resizes,
+  rendererDeathsPerCycle: rendererDeaths,
+  immediateDestroysPerCycle: immediateDestroys,
+  totalSurfaces: results.reduce(
+    (sum, value) => sum + (value.report?.surfacesCreated || 0),
+    0
+  ),
+  totalResizes: results.reduce(
+    (sum, value) => sum +
+      (value.report?.iterations || 0) * (value.report?.resizesPerIteration || 0),
+    0
+  ),
+  totalInjectedRendererDeaths: results.reduce(
+    (sum, value) => sum + (value.report?.injectedRendererDeaths || 0),
+    0
+  ),
+  results,
+  pass: results.length === cycles && results.every((value) => value.pass)
+}
+await fs.writeFile(
+  path.join(artifacts, 'stress-cycles.json'),
+  `${JSON.stringify(summary, null, 2)}\n`
+)
+console.log(JSON.stringify(summary, null, 2))
+if (!summary.pass) process.exitCode = 1

--- a/example/electron-embed-windows/src/libghostty_embed_win.cc
+++ b/example/electron-embed-windows/src/libghostty_embed_win.cc
@@ -94,6 +94,7 @@ struct GhosttyHost {
   wchar_t pending_high_surrogate = 0;
   int modifier_latch = GHOSTTY_MODS_NONE;
   std::string gl_version;
+  std::string pixel_format_api;
 };
 
 void Throw(napi_env env, const char* message) {
@@ -331,7 +332,9 @@ bool LoadWglApi(GhosttyHost* host, std::string* error) {
   wchar_t override_path[MAX_PATH] = {};
   const DWORD override_length = GetEnvironmentVariableW(
       L"GHOSTTY_MESA_OPENGL_PATH", override_path, std::size(override_path));
-  if (override_length > 0 && override_length < std::size(override_path)) {
+  const bool has_opengl_override =
+      override_length > 0 && override_length < std::size(override_path);
+  if (has_opengl_override) {
     host->opengl_module = LoadLibraryExW(
         override_path, nullptr, LOAD_WITH_ALTERED_SEARCH_PATH);
   } else {
@@ -347,8 +350,6 @@ bool LoadWglApi(GhosttyHost* host, std::string* error) {
   };
   host->wgl_create_context =
       reinterpret_cast<WglCreateContextFn>(load("wglCreateContext"));
-  host->wgl_choose_pixel_format = reinterpret_cast<WglChoosePixelFormatFn>(
-      load("wglChoosePixelFormat"));
   host->wgl_delete_context =
       reinterpret_cast<WglDeleteContextFn>(load("wglDeleteContext"));
   host->wgl_get_current_context = reinterpret_cast<WglGetCurrentContextFn>(
@@ -357,12 +358,27 @@ bool LoadWglApi(GhosttyHost* host, std::string* error) {
       reinterpret_cast<WglGetProcAddressFn>(load("wglGetProcAddress"));
   host->wgl_make_current =
       reinterpret_cast<WglMakeCurrentFn>(load("wglMakeCurrent"));
-  host->wgl_set_pixel_format = reinterpret_cast<WglSetPixelFormatFn>(
-      load("wglSetPixelFormat"));
-  host->wgl_swap_buffers =
-      reinterpret_cast<WglSwapBuffersFn>(load("wglSwapBuffers"));
   host->gl_get_string =
       reinterpret_cast<GlGetStringFn>(load("glGetString"));
+
+  // Mesa's drop-in OpenGL DLL owns its pixel-format and swap entrypoints.
+  // The Windows system OpenGL path instead requires the public GDI APIs.
+  // opengl32.dll exports similarly named WGL helpers, but its
+  // wglSetPixelFormat can report success without setting the HDC format.
+  if (has_opengl_override) {
+    host->wgl_choose_pixel_format = reinterpret_cast<WglChoosePixelFormatFn>(
+        load("wglChoosePixelFormat"));
+    host->wgl_set_pixel_format = reinterpret_cast<WglSetPixelFormatFn>(
+        load("wglSetPixelFormat"));
+    host->wgl_swap_buffers =
+        reinterpret_cast<WglSwapBuffersFn>(load("wglSwapBuffers"));
+    host->pixel_format_api = "OpenGL override DLL";
+  } else {
+    host->wgl_choose_pixel_format = &::ChoosePixelFormat;
+    host->wgl_set_pixel_format = &::SetPixelFormat;
+    host->wgl_swap_buffers = &::SwapBuffers;
+    host->pixel_format_api = "GDI32";
+  }
   if (!host->wgl_choose_pixel_format || !host->wgl_create_context ||
       !host->wgl_delete_context ||
       !host->wgl_get_current_context || !host->wgl_get_proc_address ||
@@ -1195,6 +1211,7 @@ napi_value Diagnostics(napi_env env, napi_callback_info info) {
                host->renderer_healthy.load(std::memory_order_acquire));
   SetNamedString(env, result, "renderer", "libghostty/OpenGL/WGL");
   SetNamedString(env, result, "glVersion", host->gl_version);
+  SetNamedString(env, result, "pixelFormatApi", host->pixel_format_api);
   napi_value swaps;
   napi_create_bigint_uint64(env, host->swaps.load(std::memory_order_relaxed),
                             &swaps);

--- a/example/electron-embed-windows/src/libghostty_embed_win.cc
+++ b/example/electron-embed-windows/src/libghostty_embed_win.cc
@@ -1,0 +1,1245 @@
+#define WIN32_LEAN_AND_MEAN
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#include <windowsx.h>
+#include <GL/gl.h>
+
+#include <atomic>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include <node_api.h>
+
+#include "ghostty.h"
+
+namespace {
+
+constexpr wchar_t kTerminalWindowClass[] =
+    L"GhosttyElectronNativeTerminalWindow";
+constexpr UINT kWakeupMessage = WM_APP + 0x317;
+constexpr UINT kCopyCommand = 1;
+constexpr UINT kPasteCommand = 2;
+
+constexpr int kWglContextMajorVersionArb = 0x2091;
+constexpr int kWglContextMinorVersionArb = 0x2092;
+constexpr int kWglContextProfileMaskArb = 0x9126;
+constexpr int kWglContextCoreProfileBitArb = 0x00000001;
+constexpr int kWglContextCompatibilityProfileBitArb = 0x00000002;
+
+using WglCreateContextAttribsArb = HGLRC(WINAPI*)(HDC, HGLRC, const int*);
+using WglChoosePixelFormatFn = int(WINAPI*)(HDC, const PIXELFORMATDESCRIPTOR*);
+using WglCreateContextFn = HGLRC(WINAPI*)(HDC);
+using WglDeleteContextFn = BOOL(WINAPI*)(HGLRC);
+using WglGetCurrentContextFn = HGLRC(WINAPI*)();
+using WglGetProcAddressFn = PROC(WINAPI*)(LPCSTR);
+using WglMakeCurrentFn = BOOL(WINAPI*)(HDC, HGLRC);
+using WglSetPixelFormatFn = BOOL(WINAPI*)(HDC,
+                                         int,
+                                         const PIXELFORMATDESCRIPTOR*);
+using WglSwapBuffersFn = BOOL(WINAPI*)(HDC);
+using GlGetStringFn = const GLubyte*(APIENTRY*)(GLenum);
+
+void Trace(const char* message) {
+  char trace_path[MAX_PATH] = {};
+  if (GetEnvironmentVariableA("GHOSTTY_EMBED_TRACE", trace_path,
+                              std::size(trace_path)) != 0) {
+    HANDLE trace = CreateFileA(trace_path, FILE_APPEND_DATA,
+                               FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr,
+                               OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr);
+    if (trace != INVALID_HANDLE_VALUE) {
+      const char prefix[] = "[ghostty-embed] ";
+      const char newline[] = "\r\n";
+      DWORD written = 0;
+      WriteFile(trace, prefix, sizeof(prefix) - 1, &written, nullptr);
+      WriteFile(trace, message, static_cast<DWORD>(std::strlen(message)),
+                &written, nullptr);
+      WriteFile(trace, newline, sizeof(newline) - 1, &written, nullptr);
+      CloseHandle(trace);
+    }
+  }
+}
+
+struct GhosttyHost {
+  ghostty_config_t config = nullptr;
+  ghostty_app_t app = nullptr;
+  ghostty_surface_t surface = nullptr;
+  HWND parent = nullptr;
+  HWND child = nullptr;
+  HDC device_context = nullptr;
+  HGLRC render_context = nullptr;
+  HMODULE opengl_module = nullptr;
+  WglChoosePixelFormatFn wgl_choose_pixel_format = nullptr;
+  WglCreateContextFn wgl_create_context = nullptr;
+  WglDeleteContextFn wgl_delete_context = nullptr;
+  WglGetCurrentContextFn wgl_get_current_context = nullptr;
+  WglGetProcAddressFn wgl_get_proc_address = nullptr;
+  WglMakeCurrentFn wgl_make_current = nullptr;
+  WglSetPixelFormatFn wgl_set_pixel_format = nullptr;
+  WglSwapBuffersFn wgl_swap_buffers = nullptr;
+  GlGetStringFn gl_get_string = nullptr;
+  CRITICAL_SECTION context_lock = {};
+  bool context_lock_initialized = false;
+  std::atomic<bool> closing = false;
+  std::atomic<bool> renderer_healthy = true;
+  std::atomic<uint64_t> swaps = 0;
+  bool left_captured = false;
+  bool right_captured = false;
+  wchar_t pending_high_surrogate = 0;
+  int modifier_latch = GHOSTTY_MODS_NONE;
+  std::string gl_version;
+};
+
+void Throw(napi_env env, const char* message) {
+  napi_throw_error(env, "ERR_GHOSTTY_EMBED", message);
+}
+
+bool GetNamedDouble(napi_env env,
+                    napi_value object,
+                    const char* name,
+                    double* result) {
+  napi_value value;
+  if (napi_get_named_property(env, object, name, &value) != napi_ok)
+    return false;
+  return napi_get_value_double(env, value, result) == napi_ok;
+}
+
+std::string GetNamedString(napi_env env, napi_value object, const char* name) {
+  napi_value value;
+  if (napi_get_named_property(env, object, name, &value) != napi_ok)
+    return {};
+
+  size_t length = 0;
+  if (napi_get_value_string_utf8(env, value, nullptr, 0, &length) != napi_ok)
+    return {};
+
+  std::string result(length + 1, '\0');
+  if (napi_get_value_string_utf8(env, value, result.data(), result.size(),
+                                 &length) != napi_ok) {
+    return {};
+  }
+  result.resize(length);
+  return result;
+}
+
+std::string WideToUtf8(const wchar_t* value, int length = -1) {
+  if (!value)
+    return {};
+  const int output_length =
+      WideCharToMultiByte(CP_UTF8, 0, value, length, nullptr, 0, nullptr,
+                          nullptr);
+  if (output_length <= 0)
+    return {};
+  std::string result(output_length, '\0');
+  WideCharToMultiByte(CP_UTF8, 0, value, length, result.data(), output_length,
+                      nullptr, nullptr);
+  if (length == -1 && !result.empty() && result.back() == '\0')
+    result.pop_back();
+  return result;
+}
+
+std::wstring Utf8ToWide(const char* value) {
+  if (!value)
+    return {};
+  const int output_length =
+      MultiByteToWideChar(CP_UTF8, 0, value, -1, nullptr, 0);
+  if (output_length <= 0)
+    return {};
+  std::wstring result(output_length, L'\0');
+  MultiByteToWideChar(CP_UTF8, 0, value, -1, result.data(), output_length);
+  return result;
+}
+
+ghostty_input_mods_e CurrentModifiers(const GhosttyHost* host) {
+  int mods = host ? host->modifier_latch : GHOSTTY_MODS_NONE;
+  if (GetKeyState(VK_CAPITAL) & 1)
+    mods |= GHOSTTY_MODS_CAPS;
+  if (GetKeyState(VK_NUMLOCK) & 1)
+    mods |= GHOSTTY_MODS_NUM;
+  return static_cast<ghostty_input_mods_e>(mods);
+}
+
+void UpdateModifierLatch(GhosttyHost* host,
+                         WPARAM virtual_key,
+                         LPARAM lparam,
+                         bool down) {
+  if (!host)
+    return;
+  int bits = 0;
+  switch (virtual_key) {
+    case VK_SHIFT:
+    case VK_LSHIFT:
+    case VK_RSHIFT: {
+      bits = GHOSTTY_MODS_SHIFT;
+      const UINT scan_code = static_cast<UINT>((lparam >> 16) & 0xff);
+      const UINT resolved = virtual_key == VK_SHIFT
+                                ? MapVirtualKeyW(scan_code, MAPVK_VSC_TO_VK_EX)
+                                : static_cast<UINT>(virtual_key);
+      if (resolved == VK_RSHIFT)
+        bits |= GHOSTTY_MODS_SHIFT_RIGHT;
+      break;
+    }
+    case VK_CONTROL:
+    case VK_LCONTROL:
+    case VK_RCONTROL:
+      bits = GHOSTTY_MODS_CTRL;
+      if (virtual_key == VK_RCONTROL || (lparam & (1LL << 24)))
+        bits |= GHOSTTY_MODS_CTRL_RIGHT;
+      break;
+    case VK_MENU:
+    case VK_LMENU:
+    case VK_RMENU:
+      bits = GHOSTTY_MODS_ALT;
+      if (virtual_key == VK_RMENU || (lparam & (1LL << 24)))
+        bits |= GHOSTTY_MODS_ALT_RIGHT;
+      break;
+    case VK_LWIN:
+    case VK_RWIN:
+      bits = GHOSTTY_MODS_SUPER;
+      if (virtual_key == VK_RWIN)
+        bits |= GHOSTTY_MODS_SUPER_RIGHT;
+      break;
+    default:
+      return;
+  }
+  if (down)
+    host->modifier_latch |= bits;
+  else
+    host->modifier_latch &= ~bits;
+}
+
+uint32_t NativeScanCode(LPARAM lparam) {
+  uint32_t scan_code = static_cast<uint32_t>((lparam >> 16) & 0xff);
+  if ((lparam & (1LL << 24)) != 0)
+    scan_code |= 0xe000;
+  return scan_code;
+}
+
+uint32_t UnshiftedCodepoint(WPARAM virtual_key) {
+  if (virtual_key >= 'A' && virtual_key <= 'Z')
+    return static_cast<uint32_t>('a' + (virtual_key - 'A'));
+  if (virtual_key >= '0' && virtual_key <= '9')
+    return static_cast<uint32_t>(virtual_key);
+  return 0;
+}
+
+bool IsTextProducingKey(WPARAM virtual_key) {
+  return virtual_key == VK_SPACE ||
+         (virtual_key >= '0' && virtual_key <= '9') ||
+         (virtual_key >= 'A' && virtual_key <= 'Z') ||
+         (virtual_key >= VK_NUMPAD0 && virtual_key <= VK_DIVIDE) ||
+         (virtual_key >= VK_OEM_1 && virtual_key <= VK_OEM_8) ||
+         virtual_key == VK_OEM_102;
+}
+
+bool HasCommandModifier(const GhosttyHost* host) {
+  return host &&
+         (host->modifier_latch &
+          (GHOSTTY_MODS_CTRL | GHOSTTY_MODS_ALT | GHOSTTY_MODS_SUPER));
+}
+
+int DipToPixel(HWND window, double value) {
+  const UINT dpi = window ? GetDpiForWindow(window) : 96;
+  const double scale = dpi > 0 ? static_cast<double>(dpi) / 96.0 : 1.0;
+  return static_cast<int>(std::lround(value * scale));
+}
+
+void SendMousePosition(GhosttyHost* host, LPARAM lparam) {
+  if (!host || !host->surface)
+    return;
+  ghostty_surface_mouse_pos(host->surface, GET_X_LPARAM(lparam),
+                            GET_Y_LPARAM(lparam), CurrentModifiers(host));
+}
+
+void UpdateSurfaceMetrics(GhosttyHost* host) {
+  if (!host || !host->surface || !host->child)
+    return;
+  RECT bounds = {};
+  if (!GetClientRect(host->child, &bounds))
+    return;
+  const UINT dpi = GetDpiForWindow(host->child);
+  const double scale = dpi > 0 ? static_cast<double>(dpi) / 96.0 : 1.0;
+  ghostty_surface_set_content_scale(host->surface, scale, scale);
+  ghostty_surface_set_size(
+      host->surface, static_cast<uint32_t>(bounds.right - bounds.left),
+      static_cast<uint32_t>(bounds.bottom - bounds.top));
+}
+
+void* WglGetProcAddress(void* userdata, const char* name) {
+  auto* host = static_cast<GhosttyHost*>(userdata);
+  if (!host || !name || !host->wgl_get_proc_address)
+    return nullptr;
+  PROC proc = host->wgl_get_proc_address(name);
+  if (proc && proc != reinterpret_cast<PROC>(1) &&
+      proc != reinterpret_cast<PROC>(2) &&
+      proc != reinterpret_cast<PROC>(3) &&
+      proc != reinterpret_cast<PROC>(-1)) {
+    return reinterpret_cast<void*>(proc);
+  }
+  return host->opengl_module
+             ? reinterpret_cast<void*>(GetProcAddress(host->opengl_module, name))
+             : nullptr;
+}
+
+bool WglMakeCurrent(void* userdata) {
+  auto* host = static_cast<GhosttyHost*>(userdata);
+  if (!host || !host->device_context || !host->render_context)
+    return false;
+  EnterCriticalSection(&host->context_lock);
+  if (!host->wgl_make_current(host->device_context, host->render_context)) {
+    LeaveCriticalSection(&host->context_lock);
+    return false;
+  }
+  return true;
+}
+
+void WglClearCurrent(void* userdata) {
+  auto* host = static_cast<GhosttyHost*>(userdata);
+  if (!host)
+    return;
+  host->wgl_make_current(nullptr, nullptr);
+  LeaveCriticalSection(&host->context_lock);
+}
+
+void WglSwapBuffers(void* userdata) {
+  auto* host = static_cast<GhosttyHost*>(userdata);
+  if (!host || !host->device_context)
+    return;
+  if (host->wgl_swap_buffers(host->device_context))
+    host->swaps.fetch_add(1, std::memory_order_relaxed);
+  else
+    host->renderer_healthy.store(false, std::memory_order_release);
+}
+
+bool VersionAtLeast43(const char* version) {
+  if (!version)
+    return false;
+  int major = 0;
+  int minor = 0;
+  if (sscanf_s(version, "%d.%d", &major, &minor) != 2)
+    return false;
+  return major > 4 || (major == 4 && minor >= 3);
+}
+
+bool LoadWglApi(GhosttyHost* host, std::string* error) {
+  wchar_t override_path[MAX_PATH] = {};
+  const DWORD override_length = GetEnvironmentVariableW(
+      L"GHOSTTY_MESA_OPENGL_PATH", override_path, std::size(override_path));
+  if (override_length > 0 && override_length < std::size(override_path)) {
+    host->opengl_module = LoadLibraryExW(
+        override_path, nullptr, LOAD_WITH_ALTERED_SEARCH_PATH);
+  } else {
+    host->opengl_module = LoadLibraryW(L"opengl32.dll");
+  }
+  if (!host->opengl_module) {
+    *error = "Unable to load the requested OpenGL implementation";
+    return false;
+  }
+
+  const auto load = [host](const char* name) {
+    return GetProcAddress(host->opengl_module, name);
+  };
+  host->wgl_create_context =
+      reinterpret_cast<WglCreateContextFn>(load("wglCreateContext"));
+  host->wgl_choose_pixel_format = reinterpret_cast<WglChoosePixelFormatFn>(
+      load("wglChoosePixelFormat"));
+  host->wgl_delete_context =
+      reinterpret_cast<WglDeleteContextFn>(load("wglDeleteContext"));
+  host->wgl_get_current_context = reinterpret_cast<WglGetCurrentContextFn>(
+      load("wglGetCurrentContext"));
+  host->wgl_get_proc_address =
+      reinterpret_cast<WglGetProcAddressFn>(load("wglGetProcAddress"));
+  host->wgl_make_current =
+      reinterpret_cast<WglMakeCurrentFn>(load("wglMakeCurrent"));
+  host->wgl_set_pixel_format = reinterpret_cast<WglSetPixelFormatFn>(
+      load("wglSetPixelFormat"));
+  host->wgl_swap_buffers =
+      reinterpret_cast<WglSwapBuffersFn>(load("wglSwapBuffers"));
+  host->gl_get_string =
+      reinterpret_cast<GlGetStringFn>(load("glGetString"));
+  if (!host->wgl_choose_pixel_format || !host->wgl_create_context ||
+      !host->wgl_delete_context ||
+      !host->wgl_get_current_context || !host->wgl_get_proc_address ||
+      !host->wgl_make_current || !host->wgl_set_pixel_format ||
+      !host->wgl_swap_buffers || !host->gl_get_string) {
+    *error = "The requested OpenGL DLL is missing required WGL exports";
+    return false;
+  }
+  return true;
+}
+
+bool InitializeWgl(GhosttyHost* host, std::string* error) {
+  if (!LoadWglApi(host, error))
+    return false;
+  host->device_context = GetDC(host->child);
+  if (!host->device_context) {
+    *error = "GetDC failed for the native terminal child HWND";
+    return false;
+  }
+
+  PIXELFORMATDESCRIPTOR format = {};
+  format.nSize = sizeof(format);
+  format.nVersion = 1;
+  format.dwFlags =
+      PFD_DRAW_TO_WINDOW | PFD_SUPPORT_OPENGL | PFD_DOUBLEBUFFER;
+  format.iPixelType = PFD_TYPE_RGBA;
+  format.cColorBits = 32;
+  format.cAlphaBits = 8;
+  format.cDepthBits = 24;
+  format.cStencilBits = 8;
+  format.iLayerType = PFD_MAIN_PLANE;
+
+  const int pixel_format =
+      host->wgl_choose_pixel_format(host->device_context, &format);
+  if (pixel_format == 0 ||
+      !host->wgl_set_pixel_format(host->device_context, pixel_format,
+                                  &format)) {
+    *error = "Unable to set a double-buffered WGL pixel format";
+    return false;
+  }
+
+  HGLRC legacy = host->wgl_create_context(host->device_context);
+  if (!legacy || !host->wgl_make_current(host->device_context, legacy)) {
+    *error = "Unable to create the WGL bootstrap context";
+    if (legacy)
+      host->wgl_delete_context(legacy);
+    return false;
+  }
+
+  auto create_context = reinterpret_cast<WglCreateContextAttribsArb>(
+      host->wgl_get_proc_address("wglCreateContextAttribsARB"));
+  HGLRC modern = nullptr;
+  if (create_context) {
+    const int profiles[] = {kWglContextCoreProfileBitArb,
+                            kWglContextCompatibilityProfileBitArb};
+    const int versions[][2] = {{4, 5}, {4, 3}};
+    for (const auto& version : versions) {
+      for (const int profile : profiles) {
+        const int attributes[] = {
+            kWglContextMajorVersionArb,
+            version[0],
+            kWglContextMinorVersionArb,
+            version[1],
+            kWglContextProfileMaskArb,
+            profile,
+            0,
+        };
+        modern = create_context(host->device_context, nullptr, attributes);
+        if (modern)
+          break;
+      }
+      if (modern)
+        break;
+    }
+  }
+
+  if (modern) {
+    host->wgl_make_current(nullptr, nullptr);
+    host->wgl_delete_context(legacy);
+    host->render_context = modern;
+    if (!host->wgl_make_current(host->device_context,
+                                host->render_context)) {
+      *error = "Unable to activate the OpenGL 4.3 WGL context";
+      return false;
+    }
+  } else {
+    host->render_context = legacy;
+  }
+
+  const char* version =
+      reinterpret_cast<const char*>(host->gl_get_string(GL_VERSION));
+  host->gl_version = version ? version : "unknown";
+  if (!VersionAtLeast43(version)) {
+    *error = "Ghostty requires OpenGL 4.3; WGL reported " + host->gl_version;
+    host->wgl_make_current(nullptr, nullptr);
+    return false;
+  }
+  host->wgl_make_current(nullptr, nullptr);
+  return true;
+}
+
+void DestroyWgl(GhosttyHost* host) {
+  if (!host)
+    return;
+  // Surface.deinit joins the renderer thread and then enters the renderer
+  // once on the caller thread so GPU resources can be freed. Balance that
+  // final make_current before taking the lock for context destruction.
+  if (host->render_context && host->wgl_get_current_context &&
+      host->wgl_get_current_context() == host->render_context) {
+    host->wgl_make_current(nullptr, nullptr);
+    LeaveCriticalSection(&host->context_lock);
+  }
+  if (host->context_lock_initialized)
+    EnterCriticalSection(&host->context_lock);
+  if (host->render_context) {
+    host->wgl_delete_context(host->render_context);
+    host->render_context = nullptr;
+  }
+  if (host->device_context && host->child) {
+    ReleaseDC(host->child, host->device_context);
+    host->device_context = nullptr;
+  }
+  if (host->context_lock_initialized) {
+    LeaveCriticalSection(&host->context_lock);
+    DeleteCriticalSection(&host->context_lock);
+    host->context_lock_initialized = false;
+  }
+  if (host->opengl_module) {
+    FreeLibrary(host->opengl_module);
+    host->opengl_module = nullptr;
+  }
+}
+
+bool ReadClipboard(void* userdata, ghostty_clipboard_e type, void* state) {
+  Trace("clipboard: read requested");
+  auto* host = static_cast<GhosttyHost*>(userdata);
+  if (!host || !host->surface || type != GHOSTTY_CLIPBOARD_STANDARD)
+    return false;
+  if (!OpenClipboard(host->child))
+    return false;
+  HANDLE value_handle = GetClipboardData(CF_UNICODETEXT);
+  const wchar_t* value = value_handle
+                             ? static_cast<const wchar_t*>(GlobalLock(value_handle))
+                             : nullptr;
+  const std::string utf8 = value ? WideToUtf8(value) : std::string();
+  if (value)
+    GlobalUnlock(value_handle);
+  CloseClipboard();
+  if (utf8.empty())
+    return false;
+  Trace("clipboard: read completed");
+  ghostty_surface_complete_clipboard_request(host->surface, utf8.c_str(), state,
+                                             false);
+  return true;
+}
+
+void ConfirmReadClipboard(void* userdata,
+                          const char* value,
+                          void* state,
+                          ghostty_clipboard_request_e) {
+  Trace("clipboard: read confirmed");
+  auto* host = static_cast<GhosttyHost*>(userdata);
+  if (host && host->surface)
+    ghostty_surface_complete_clipboard_request(host->surface, value, state,
+                                               true);
+}
+
+void WriteClipboard(void* userdata,
+                    ghostty_clipboard_e type,
+                    const ghostty_clipboard_content_s* content,
+                    size_t length,
+                    bool) {
+  Trace("clipboard: write requested");
+  auto* host = static_cast<GhosttyHost*>(userdata);
+  if (!host || type != GHOSTTY_CLIPBOARD_STANDARD || !content)
+    return;
+  for (size_t index = 0; index < length; ++index) {
+    if (!content[index].mime || !content[index].data ||
+        std::strcmp(content[index].mime, "text/plain") != 0) {
+      continue;
+    }
+    const std::wstring wide = Utf8ToWide(content[index].data);
+    if (wide.empty() || !OpenClipboard(host->child))
+      return;
+    EmptyClipboard();
+    const SIZE_T bytes = wide.size() * sizeof(wchar_t);
+    HGLOBAL allocation = GlobalAlloc(GMEM_MOVEABLE, bytes);
+    if (allocation) {
+      void* destination = GlobalLock(allocation);
+      if (destination) {
+        std::memcpy(destination, wide.data(), bytes);
+        GlobalUnlock(allocation);
+        if (!SetClipboardData(CF_UNICODETEXT, allocation))
+          GlobalFree(allocation);
+        else
+          Trace("clipboard: write completed");
+      } else {
+        GlobalFree(allocation);
+      }
+    }
+    CloseClipboard();
+    return;
+  }
+}
+
+void Wakeup(void* userdata) {
+  auto* host = static_cast<GhosttyHost*>(userdata);
+  if (host && !host->closing.load(std::memory_order_acquire) && host->child)
+    PostMessageW(host->child, kWakeupMessage, 0, 0);
+}
+
+bool Action(ghostty_app_t app,
+            ghostty_target_s,
+            ghostty_action_s action) {
+  auto* host = static_cast<GhosttyHost*>(ghostty_app_userdata(app));
+  if (!host)
+    return false;
+  if (host->closing.load(std::memory_order_acquire)) {
+    return action.tag == GHOSTTY_ACTION_RENDER ||
+           action.tag == GHOSTTY_ACTION_RENDERER_HEALTH;
+  }
+  switch (action.tag) {
+    case GHOSTTY_ACTION_RENDER:
+      if (host->surface)
+        ghostty_surface_refresh(host->surface);
+      return true;
+    case GHOSTTY_ACTION_RENDERER_HEALTH:
+      host->renderer_healthy.store(
+          action.action.renderer_health == GHOSTTY_RENDERER_HEALTH_HEALTHY,
+          std::memory_order_release);
+      return true;
+    default:
+      return false;
+  }
+}
+
+void CloseSurface(void*, bool) {}
+
+bool EnsureGhosttyInitialized() {
+  static std::once_flag once;
+  static int result = -1;
+  std::call_once(once, [] {
+    char process_name[] = "electron-libghostty-windows";
+    char* argv[] = {process_name};
+    result = ghostty_init(1, argv);
+  });
+  return result == GHOSTTY_SUCCESS;
+}
+
+void SendKey(GhosttyHost* host,
+             ghostty_input_action_e action,
+             WPARAM virtual_key,
+             LPARAM lparam) {
+  if (!host || !host->surface)
+    return;
+  ghostty_input_key_s key = {};
+  key.action = action;
+  key.mods = CurrentModifiers(host);
+  key.consumed_mods = GHOSTTY_MODS_NONE;
+  key.keycode = NativeScanCode(lparam);
+  key.unshifted_codepoint = UnshiftedCodepoint(virtual_key);
+  key.text = nullptr;
+  ghostty_surface_key(host->surface, key);
+}
+
+void SendUtf16Character(GhosttyHost* host, wchar_t character) {
+  if (!host || !host->surface)
+    return;
+  if (character >= 0xd800 && character <= 0xdbff) {
+    host->pending_high_surrogate = character;
+    return;
+  }
+  wchar_t utf16[3] = {};
+  int length = 1;
+  if (character >= 0xdc00 && character <= 0xdfff &&
+      host->pending_high_surrogate) {
+    utf16[0] = host->pending_high_surrogate;
+    utf16[1] = character;
+    length = 2;
+  } else {
+    utf16[0] = character;
+  }
+  host->pending_high_surrogate = 0;
+  const std::string utf8 = WideToUtf8(utf16, length);
+  if (!utf8.empty())
+    ghostty_surface_text_input(host->surface, utf8.data(), utf8.size());
+}
+
+void InvokeBinding(GhosttyHost* host, const char* action) {
+  if (!host || !host->surface || !action)
+    return;
+  if (ghostty_surface_binding_action(host->surface, action,
+                                    std::strlen(action))) {
+    Trace("binding: action handled");
+  } else {
+    Trace("binding: action rejected");
+  }
+}
+
+void ShowContextMenu(GhosttyHost* host, LPARAM lparam) {
+  if (!host || !host->child)
+    return;
+  HMENU menu = CreatePopupMenu();
+  if (!menu)
+    return;
+  const bool has_selection =
+      host->surface && ghostty_surface_has_selection(host->surface);
+  AppendMenuW(menu, MF_STRING | (has_selection ? MF_ENABLED : MF_GRAYED),
+              kCopyCommand, L"Copy");
+  AppendMenuW(menu,
+              MF_STRING | (IsClipboardFormatAvailable(CF_UNICODETEXT)
+                               ? MF_ENABLED
+                               : MF_GRAYED),
+              kPasteCommand, L"Paste");
+  POINT point = {GET_X_LPARAM(lparam), GET_Y_LPARAM(lparam)};
+  ClientToScreen(host->child, &point);
+  const UINT command = TrackPopupMenu(
+      menu, TPM_RETURNCMD | TPM_RIGHTBUTTON | TPM_NONOTIFY, point.x, point.y, 0,
+      host->child, nullptr);
+  DestroyMenu(menu);
+  if (command == kCopyCommand)
+    InvokeBinding(host, "copy_to_clipboard");
+  else if (command == kPasteCommand)
+    InvokeBinding(host, "paste_from_clipboard");
+}
+
+LRESULT CALLBACK TerminalWindowProc(HWND window,
+                                    UINT message,
+                                    WPARAM wparam,
+                                    LPARAM lparam) {
+  GhosttyHost* host = reinterpret_cast<GhosttyHost*>(
+      GetWindowLongPtrW(window, GWLP_USERDATA));
+  if (message == WM_NCCREATE) {
+    const auto* create = reinterpret_cast<CREATESTRUCTW*>(lparam);
+    host = static_cast<GhosttyHost*>(create->lpCreateParams);
+    SetWindowLongPtrW(window, GWLP_USERDATA,
+                      reinterpret_cast<LONG_PTR>(host));
+  }
+
+  if (!host)
+    return DefWindowProcW(window, message, wparam, lparam);
+
+  switch (message) {
+    case kWakeupMessage:
+      if (!host->closing.load(std::memory_order_acquire) && host->app)
+        ghostty_app_tick(host->app);
+      return 0;
+    case WM_SIZE:
+    case WM_DPICHANGED_AFTERPARENT:
+      UpdateSurfaceMetrics(host);
+      if (host->surface)
+        ghostty_surface_refresh(host->surface);
+      return 0;
+    case WM_SHOWWINDOW:
+      if (host->surface)
+        ghostty_surface_set_occlusion(host->surface, wparam != 0);
+      return 0;
+    case WM_SETFOCUS:
+      if (host->app)
+        ghostty_app_set_focus(host->app, true);
+      if (host->surface)
+        ghostty_surface_set_focus(host->surface, true);
+      return 0;
+    case WM_KILLFOCUS:
+      host->modifier_latch = GHOSTTY_MODS_NONE;
+      if (host->surface)
+        ghostty_surface_set_focus(host->surface, false);
+      if (host->app)
+        ghostty_app_set_focus(host->app, false);
+      return 0;
+    case WM_LBUTTONDOWN:
+      SetFocus(window);
+      SetCapture(window);
+      host->left_captured = true;
+      SendMousePosition(host, lparam);
+      if (host->surface)
+        ghostty_surface_mouse_button(host->surface, GHOSTTY_MOUSE_PRESS,
+                                     GHOSTTY_MOUSE_LEFT,
+                                     CurrentModifiers(host));
+      return 0;
+    case WM_LBUTTONUP:
+      SendMousePosition(host, lparam);
+      if (host->surface)
+        ghostty_surface_mouse_button(host->surface, GHOSTTY_MOUSE_RELEASE,
+                                     GHOSTTY_MOUSE_LEFT,
+                                     CurrentModifiers(host));
+      if (host->left_captured) {
+        ReleaseCapture();
+        host->left_captured = false;
+      }
+      return 0;
+    case WM_RBUTTONDOWN:
+      SetFocus(window);
+      SendMousePosition(host, lparam);
+      host->right_captured =
+          host->surface && ghostty_surface_mouse_captured(host->surface);
+      if (host->right_captured) {
+        SetCapture(window);
+        ghostty_surface_mouse_button(host->surface, GHOSTTY_MOUSE_PRESS,
+                                     GHOSTTY_MOUSE_RIGHT,
+                                     CurrentModifiers(host));
+      } else {
+        ShowContextMenu(host, lparam);
+      }
+      return 0;
+    case WM_RBUTTONUP:
+      if (host->right_captured && host->surface) {
+        SendMousePosition(host, lparam);
+        ghostty_surface_mouse_button(host->surface, GHOSTTY_MOUSE_RELEASE,
+                                     GHOSTTY_MOUSE_RIGHT,
+                                     CurrentModifiers(host));
+        ReleaseCapture();
+        host->right_captured = false;
+      }
+      return 0;
+    case WM_MOUSEMOVE:
+      SendMousePosition(host, lparam);
+      return 0;
+    case WM_MOUSEWHEEL:
+    case WM_MOUSEHWHEEL:
+      if (host->surface) {
+        const double delta =
+            static_cast<double>(GET_WHEEL_DELTA_WPARAM(wparam)) / WHEEL_DELTA;
+        ghostty_surface_mouse_scroll(
+            host->surface, message == WM_MOUSEHWHEEL ? delta : 0.0,
+            message == WM_MOUSEWHEEL ? delta : 0.0, 0);
+      }
+      return 0;
+    case WM_KEYDOWN:
+    case WM_SYSKEYDOWN:
+      // Alt+Tab belongs to Windows. Do not leak the Tab press into the shell
+      // if the system sends the child HWND a system-key message first.
+      if (message == WM_SYSKEYDOWN && wparam == VK_TAB)
+        return 0;
+      UpdateModifierLatch(host, wparam, lparam, true);
+      // Windows delivers committed printable text through WM_CHAR. Sending
+      // the physical key as well would duplicate unshifted digits for OEM
+      // punctuation (for example '%' becoming '5'). Command chords still go
+      // through Ghostty's key binding path.
+      if (IsTextProducingKey(wparam) && !HasCommandModifier(host))
+        return 0;
+      SendKey(host, (lparam & (1LL << 30)) ? GHOSTTY_ACTION_REPEAT
+                                          : GHOSTTY_ACTION_PRESS,
+              wparam, lparam);
+      return 0;
+    case WM_KEYUP:
+    case WM_SYSKEYUP:
+      if (message == WM_SYSKEYUP && wparam == VK_TAB)
+        return 0;
+      if (IsTextProducingKey(wparam) && !HasCommandModifier(host)) {
+        UpdateModifierLatch(host, wparam, lparam, false);
+        return 0;
+      }
+      SendKey(host, GHOSTTY_ACTION_RELEASE, wparam, lparam);
+      UpdateModifierLatch(host, wparam, lparam, false);
+      return 0;
+    case WM_CHAR:
+      if (wparam >= 0x20 && wparam != 0x7f)
+        SendUtf16Character(host, static_cast<wchar_t>(wparam));
+      return 0;
+    case WM_UNICHAR:
+      if (wparam == UNICODE_NOCHAR)
+        return TRUE;
+      if (wparam <= 0xffff) {
+        SendUtf16Character(host, static_cast<wchar_t>(wparam));
+      } else if (wparam <= 0x10ffff) {
+        const uint32_t codepoint = static_cast<uint32_t>(wparam) - 0x10000;
+        SendUtf16Character(host,
+                           static_cast<wchar_t>(0xd800 + (codepoint >> 10)));
+        SendUtf16Character(host,
+                           static_cast<wchar_t>(0xdc00 + (codepoint & 0x3ff)));
+      }
+      return 0;
+    case WM_SYSCHAR:
+      return 0;
+    case WM_SETCURSOR:
+      SetCursor(LoadCursorW(nullptr, MAKEINTRESOURCEW(32513)));
+      return TRUE;
+    case WM_ERASEBKGND:
+      return 1;
+    case WM_PAINT: {
+      PAINTSTRUCT paint = {};
+      BeginPaint(window, &paint);
+      EndPaint(window, &paint);
+      if (host->surface)
+        ghostty_surface_refresh(host->surface);
+      return 0;
+    }
+    case WM_NCDESTROY:
+      SetWindowLongPtrW(window, GWLP_USERDATA, 0);
+      return DefWindowProcW(window, message, wparam, lparam);
+    default:
+      return DefWindowProcW(window, message, wparam, lparam);
+  }
+}
+
+bool EnsureWindowClass() {
+  static std::once_flag once;
+  static bool success = false;
+  std::call_once(once, [] {
+    WNDCLASSEXW window_class = {};
+    window_class.cbSize = sizeof(window_class);
+    window_class.style = CS_OWNDC | CS_HREDRAW | CS_VREDRAW;
+    window_class.lpfnWndProc = TerminalWindowProc;
+    window_class.hInstance = GetModuleHandleW(nullptr);
+    window_class.hCursor = LoadCursorW(nullptr, MAKEINTRESOURCEW(32513));
+    window_class.hbrBackground =
+        static_cast<HBRUSH>(GetStockObject(BLACK_BRUSH));
+    window_class.lpszClassName = kTerminalWindowClass;
+    success = RegisterClassExW(&window_class) != 0 ||
+              GetLastError() == ERROR_CLASS_ALREADY_EXISTS;
+  });
+  return success;
+}
+
+void DestroyHostResources(GhosttyHost* host) {
+  if (!host || host->closing.exchange(true, std::memory_order_acq_rel))
+    return;
+  Trace("destroy: entered");
+  if (host->surface) {
+    ghostty_surface_set_focus(host->surface, false);
+    Trace("destroy: freeing surface");
+    ghostty_surface_free(host->surface);
+    Trace("destroy: surface freed");
+    host->surface = nullptr;
+  }
+  if (host->app) {
+    Trace("destroy: freeing app");
+    ghostty_app_free(host->app);
+    Trace("destroy: app freed");
+    host->app = nullptr;
+  }
+  if (host->config) {
+    Trace("destroy: freeing config");
+    ghostty_config_free(host->config);
+    Trace("destroy: config freed");
+    host->config = nullptr;
+  }
+  Trace("destroy: freeing WGL");
+  DestroyWgl(host);
+  Trace("destroy: WGL freed");
+  if (host->child) {
+    SetWindowLongPtrW(host->child, GWLP_USERDATA, 0);
+    DestroyWindow(host->child);
+    host->child = nullptr;
+  }
+  host->parent = nullptr;
+  Trace("destroy: complete");
+}
+
+void FinalizeHost(napi_env, void* data, void*) {
+  auto* host = static_cast<GhosttyHost*>(data);
+  DestroyHostResources(host);
+  delete host;
+}
+
+napi_value Create(napi_env env, napi_callback_info info) {
+  Trace("create: entered");
+  size_t argc = 2;
+  napi_value args[2];
+  if (napi_get_cb_info(env, info, &argc, args, nullptr, nullptr) != napi_ok ||
+      argc != 2) {
+    Throw(env, "create expects a native window handle and bounds/options");
+    return nullptr;
+  }
+
+  void* handle_data = nullptr;
+  size_t handle_size = 0;
+  if (napi_get_buffer_info(env, args[0], &handle_data, &handle_size) !=
+          napi_ok ||
+      handle_size != sizeof(HWND)) {
+    Throw(env,
+          "Expected BrowserWindow.getNativeWindowHandle() on 64-bit Windows");
+    return nullptr;
+  }
+  HWND parent = *static_cast<HWND*>(handle_data);
+  if (!parent || !IsWindow(parent)) {
+    Throw(env, "Electron returned an invalid parent HWND");
+    return nullptr;
+  }
+
+  double x = 0;
+  double y = 0;
+  double width = 800;
+  double height = 600;
+  if (!GetNamedDouble(env, args[1], "x", &x) ||
+      !GetNamedDouble(env, args[1], "y", &y) ||
+      !GetNamedDouble(env, args[1], "width", &width) ||
+      !GetNamedDouble(env, args[1], "height", &height)) {
+    Throw(env, "Bounds must contain numeric x, y, width, and height");
+    return nullptr;
+  }
+
+  if (!EnsureWindowClass() || !EnsureGhosttyInitialized()) {
+    Throw(env, "Unable to initialize the Ghostty Windows host");
+    return nullptr;
+  }
+  Trace("create: libghostty initialized");
+
+  Trace("create: allocating host");
+  auto* host = new GhosttyHost();
+  Trace("create: host allocated");
+  InitializeCriticalSection(&host->context_lock);
+  host->context_lock_initialized = true;
+  host->parent = parent;
+  Trace("create: creating child HWND");
+  host->child = CreateWindowExW(
+      0, kTerminalWindowClass, L"Native libghostty terminal",
+      WS_CHILD | WS_VISIBLE | WS_CLIPSIBLINGS | WS_CLIPCHILDREN,
+      DipToPixel(parent, x), DipToPixel(parent, y),
+      DipToPixel(parent, width), DipToPixel(parent, height), parent, nullptr,
+      GetModuleHandleW(nullptr), host);
+  if (!host->child) {
+    DestroyHostResources(host);
+    delete host;
+    Throw(env, "CreateWindowEx failed for the terminal child HWND");
+    return nullptr;
+  }
+  Trace("create: child HWND created");
+
+  std::string wgl_error;
+  if (!InitializeWgl(host, &wgl_error)) {
+    DestroyHostResources(host);
+    delete host;
+    Throw(env, wgl_error.c_str());
+    return nullptr;
+  }
+  Trace("create: WGL context created");
+
+  host->config = ghostty_config_new();
+  if (!host->config) {
+    DestroyHostResources(host);
+    delete host;
+    Throw(env, "ghostty_config_new failed");
+    return nullptr;
+  }
+  ghostty_config_load_default_files(host->config);
+  ghostty_config_finalize(host->config);
+  Trace("create: config finalized");
+
+  ghostty_runtime_config_s runtime = {};
+  runtime.userdata = host;
+  runtime.supports_selection_clipboard = false;
+  runtime.wakeup_cb = Wakeup;
+  runtime.action_cb = Action;
+  runtime.read_clipboard_cb = ReadClipboard;
+  runtime.confirm_read_clipboard_cb = ConfirmReadClipboard;
+  runtime.write_clipboard_cb = WriteClipboard;
+  runtime.close_surface_cb = CloseSurface;
+  host->app = ghostty_app_new(&runtime, host->config);
+  if (!host->app) {
+    DestroyHostResources(host);
+    delete host;
+    Throw(env, "ghostty_app_new failed");
+    return nullptr;
+  }
+  Trace("create: app created");
+
+  const std::string working_directory =
+      GetNamedString(env, args[1], "workingDirectory");
+  const std::string command = GetNamedString(env, args[1], "command");
+  ghostty_surface_config_s surface = ghostty_surface_config_new();
+  surface.platform_tag = GHOSTTY_PLATFORM_OPENGL;
+  surface.platform.opengl.userdata = host;
+  surface.platform.opengl.make_current = WglMakeCurrent;
+  surface.platform.opengl.clear_current = WglClearCurrent;
+  surface.platform.opengl.get_proc_address = WglGetProcAddress;
+  surface.platform.opengl.swap_buffers = WglSwapBuffers;
+  surface.userdata = host;
+  const UINT dpi = GetDpiForWindow(host->child);
+  surface.scale_factor = dpi > 0 ? static_cast<double>(dpi) / 96.0 : 1.0;
+  surface.working_directory =
+      working_directory.empty() ? nullptr : working_directory.c_str();
+  surface.command = command.empty() ? nullptr : command.c_str();
+  host->surface = ghostty_surface_new(host->app, &surface);
+  if (!host->surface) {
+    DestroyHostResources(host);
+    delete host;
+    Throw(env, "ghostty_surface_new failed for the WGL surface");
+    return nullptr;
+  }
+  Trace("create: surface created");
+
+  host->closing.store(false, std::memory_order_release);
+  ghostty_app_set_focus(host->app, true);
+  ghostty_surface_set_focus(host->surface, true);
+  UpdateSurfaceMetrics(host);
+  SetWindowPos(host->child, HWND_TOP, DipToPixel(parent, x),
+               DipToPixel(parent, y), DipToPixel(parent, width),
+               DipToPixel(parent, height),
+               SWP_SHOWWINDOW | SWP_NOACTIVATE);
+
+  napi_value external;
+  napi_create_external(env, host, FinalizeHost, nullptr, &external);
+  Trace("create: complete");
+  return external;
+}
+
+GhosttyHost* GetHost(napi_env env, napi_value value) {
+  GhosttyHost* host = nullptr;
+  if (napi_get_value_external(env, value, reinterpret_cast<void**>(&host)) !=
+          napi_ok ||
+      !host) {
+    return nullptr;
+  }
+  return host;
+}
+
+napi_value SetBounds(napi_env env, napi_callback_info info) {
+  size_t argc = 2;
+  napi_value args[2];
+  if (napi_get_cb_info(env, info, &argc, args, nullptr, nullptr) != napi_ok ||
+      argc != 2) {
+    Throw(env, "setBounds expects a terminal handle and bounds");
+    return nullptr;
+  }
+  GhosttyHost* host = GetHost(env, args[0]);
+  if (!host || host->closing.load(std::memory_order_acquire) || !host->child) {
+    Throw(env, "Invalid terminal handle");
+    return nullptr;
+  }
+  double x = 0;
+  double y = 0;
+  double width = 0;
+  double height = 0;
+  if (!GetNamedDouble(env, args[1], "x", &x) ||
+      !GetNamedDouble(env, args[1], "y", &y) ||
+      !GetNamedDouble(env, args[1], "width", &width) ||
+      !GetNamedDouble(env, args[1], "height", &height)) {
+    Throw(env, "Bounds must contain numeric x, y, width, and height");
+    return nullptr;
+  }
+  SetWindowPos(host->child, HWND_TOP, DipToPixel(host->parent, x),
+               DipToPixel(host->parent, y), DipToPixel(host->parent, width),
+               DipToPixel(host->parent, height),
+               SWP_SHOWWINDOW | SWP_NOACTIVATE);
+  UpdateSurfaceMetrics(host);
+  napi_value undefined;
+  napi_get_undefined(env, &undefined);
+  return undefined;
+}
+
+napi_value SendText(napi_env env, napi_callback_info info) {
+  size_t argc = 2;
+  napi_value args[2];
+  if (napi_get_cb_info(env, info, &argc, args, nullptr, nullptr) != napi_ok ||
+      argc != 2) {
+    Throw(env, "sendText expects a terminal handle and UTF-8 text");
+    return nullptr;
+  }
+  GhosttyHost* host = GetHost(env, args[0]);
+  if (!host || host->closing.load(std::memory_order_acquire) ||
+      !host->surface) {
+    Throw(env, "Invalid terminal handle");
+    return nullptr;
+  }
+  size_t length = 0;
+  if (napi_get_value_string_utf8(env, args[1], nullptr, 0, &length) !=
+      napi_ok) {
+    Throw(env, "sendText text must be a string");
+    return nullptr;
+  }
+  std::string text(length + 1, '\0');
+  if (napi_get_value_string_utf8(env, args[1], text.data(), text.size(),
+                                 &length) != napi_ok) {
+    Throw(env, "Unable to read sendText text");
+    return nullptr;
+  }
+  text.resize(length);
+  ghostty_surface_text_input(host->surface, text.data(), text.size());
+  napi_value undefined;
+  napi_get_undefined(env, &undefined);
+  return undefined;
+}
+
+napi_value Focus(napi_env env, napi_callback_info info) {
+  size_t argc = 1;
+  napi_value args[1];
+  if (napi_get_cb_info(env, info, &argc, args, nullptr, nullptr) != napi_ok ||
+      argc != 1) {
+    Throw(env, "focus expects a terminal handle");
+    return nullptr;
+  }
+  GhosttyHost* host = GetHost(env, args[0]);
+  if (!host || host->closing.load(std::memory_order_acquire) || !host->child) {
+    Throw(env, "Invalid terminal handle");
+    return nullptr;
+  }
+  SetFocus(host->child);
+  napi_value undefined;
+  napi_get_undefined(env, &undefined);
+  return undefined;
+}
+
+void SetNamedString(napi_env env,
+                    napi_value object,
+                    const char* name,
+                    const std::string& value) {
+  napi_value result;
+  napi_create_string_utf8(env, value.c_str(), value.size(), &result);
+  napi_set_named_property(env, object, name, result);
+}
+
+void SetNamedBool(napi_env env,
+                  napi_value object,
+                  const char* name,
+                  bool value) {
+  napi_value result;
+  napi_get_boolean(env, value, &result);
+  napi_set_named_property(env, object, name, result);
+}
+
+napi_value Diagnostics(napi_env env, napi_callback_info info) {
+  size_t argc = 1;
+  napi_value args[1];
+  if (napi_get_cb_info(env, info, &argc, args, nullptr, nullptr) != napi_ok ||
+      argc != 1) {
+    Throw(env, "diagnostics expects a terminal handle");
+    return nullptr;
+  }
+  GhosttyHost* host = GetHost(env, args[0]);
+  if (!host) {
+    Throw(env, "Invalid terminal handle");
+    return nullptr;
+  }
+  napi_value result;
+  napi_create_object(env, &result);
+  SetNamedBool(env, result, "realLibghostty", host->surface != nullptr);
+  SetNamedBool(env, result, "rendererHealthy",
+               host->renderer_healthy.load(std::memory_order_acquire));
+  SetNamedString(env, result, "renderer", "libghostty/OpenGL/WGL");
+  SetNamedString(env, result, "glVersion", host->gl_version);
+  napi_value swaps;
+  napi_create_bigint_uint64(env, host->swaps.load(std::memory_order_relaxed),
+                            &swaps);
+  napi_set_named_property(env, result, "swaps", swaps);
+  return result;
+}
+
+napi_value Destroy(napi_env env, napi_callback_info info) {
+  size_t argc = 1;
+  napi_value args[1];
+  if (napi_get_cb_info(env, info, &argc, args, nullptr, nullptr) != napi_ok ||
+      argc != 1) {
+    Throw(env, "destroy expects a terminal handle");
+    return nullptr;
+  }
+  GhosttyHost* host = GetHost(env, args[0]);
+  if (!host) {
+    Throw(env, "Invalid terminal handle");
+    return nullptr;
+  }
+  DestroyHostResources(host);
+  napi_value undefined;
+  napi_get_undefined(env, &undefined);
+  return undefined;
+}
+
+napi_value Init(napi_env env, napi_value exports) {
+  napi_property_descriptor properties[] = {
+      {"create", nullptr, Create, nullptr, nullptr, nullptr, napi_default,
+       nullptr},
+      {"setBounds", nullptr, SetBounds, nullptr, nullptr, nullptr,
+       napi_default, nullptr},
+      {"sendText", nullptr, SendText, nullptr, nullptr, nullptr, napi_default,
+       nullptr},
+      {"focus", nullptr, Focus, nullptr, nullptr, nullptr, napi_default,
+       nullptr},
+      {"diagnostics", nullptr, Diagnostics, nullptr, nullptr, nullptr,
+       napi_default, nullptr},
+      {"destroy", nullptr, Destroy, nullptr, nullptr, nullptr, napi_default,
+       nullptr},
+  };
+  napi_define_properties(env, exports, std::size(properties), properties);
+  return exports;
+}
+
+}  // namespace
+
+NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -66,6 +66,7 @@ typedef enum {
   GHOSTTY_PLATFORM_INVALID,
   GHOSTTY_PLATFORM_MACOS,
   GHOSTTY_PLATFORM_IOS,
+  GHOSTTY_PLATFORM_OPENGL,
 } ghostty_platform_e;
 
 typedef enum {
@@ -453,9 +454,23 @@ typedef struct {
   void* uiview;
 } ghostty_platform_ios_s;
 
+typedef bool (*ghostty_opengl_make_current_cb)(void*);
+typedef void (*ghostty_opengl_clear_current_cb)(void*);
+typedef void* (*ghostty_opengl_get_proc_address_cb)(void*, const char*);
+typedef void (*ghostty_opengl_swap_buffers_cb)(void*);
+
+typedef struct {
+  void* userdata;
+  ghostty_opengl_make_current_cb make_current;
+  ghostty_opengl_clear_current_cb clear_current;
+  ghostty_opengl_get_proc_address_cb get_proc_address;
+  ghostty_opengl_swap_buffers_cb swap_buffers;
+} ghostty_platform_opengl_s;
+
 typedef union {
   ghostty_platform_macos_s macos;
   ghostty_platform_ios_s ios;
+  ghostty_platform_opengl_s opengl;
 } ghostty_platform_u;
 
 typedef enum {

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -469,6 +469,10 @@ typedef enum {
 typedef enum {
   GHOSTTY_SURFACE_IO_EXEC = 0,
   GHOSTTY_SURFACE_IO_MANUAL = 1,
+  // The embedder owns the PTY and terminal protocol while Ghostty mirrors
+  // output for rendering and encodes user input. Parser-generated terminal
+  // replies are suppressed so the owning terminal core replies only once.
+  GHOSTTY_SURFACE_IO_MANUAL_MIRROR = 2,
 } ghostty_surface_io_mode_e;
 
 typedef void (*ghostty_io_write_cb)(void*, const char*, uintptr_t);

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -66,6 +66,7 @@ typedef enum {
   GHOSTTY_PLATFORM_INVALID,
   GHOSTTY_PLATFORM_MACOS,
   GHOSTTY_PLATFORM_IOS,
+  GHOSTTY_PLATFORM_METAL_EXTERNAL,
 } ghostty_platform_e;
 
 typedef enum {
@@ -453,9 +454,29 @@ typedef struct {
   void* uiview;
 } ghostty_platform_ios_s;
 
+/**
+ * Called after Metal finishes rendering a frame into an IOSurface.
+ *
+ * This callback runs on a Metal command-buffer completion thread and must be
+ * thread-safe and non-blocking. `iosurface` is a borrowed IOSurfaceRef that is
+ * valid only for the duration of the callback. The embedder must retain it or
+ * create its transport handle before returning if it needs a longer lifetime.
+ * `width_px` and `height_px` are the IOSurface dimensions in pixels.
+ */
+typedef void (*ghostty_metal_external_present_cb)(void* userdata,
+                                                  void* iosurface,
+                                                  uint32_t width_px,
+                                                  uint32_t height_px);
+
+typedef struct {
+  void* userdata;
+  ghostty_metal_external_present_cb present;
+} ghostty_platform_metal_external_s;
+
 typedef union {
   ghostty_platform_macos_s macos;
   ghostty_platform_ios_s ios;
+  ghostty_platform_metal_external_s metal_external;
 } ghostty_platform_u;
 
 typedef enum {
@@ -472,6 +493,9 @@ typedef enum {
 } ghostty_surface_io_mode_e;
 
 typedef void (*ghostty_io_write_cb)(void*, const char*, uintptr_t);
+typedef void (*ghostty_pty_tee_cb)(void* userdata,
+                                  const char* bytes,
+                                  uintptr_t len);
 
 // Content-free renderer activity events emitted only when a surface installs
 // ghostty_renderer_event_cb. Begin/end pairs run on the renderer thread.
@@ -504,6 +528,10 @@ typedef struct {
   ghostty_io_write_cb io_write_cb;
   void* io_write_userdata;
   ghostty_renderer_event_cb renderer_event_cb;
+  // Optional initial tee installed before the IO thread starts. This prevents
+  // embedders from missing startup bytes while racing the post-create setter.
+  ghostty_pty_tee_cb pty_tee_cb;
+  void* pty_tee_userdata;
 } ghostty_surface_config_s;
 
 typedef struct {
@@ -1247,7 +1275,6 @@ GHOSTTY_API void ghostty_surface_process_output(ghostty_surface_t, const char*, 
 // broadcast raw bytes to a paired iPhone. Set cb=NULL to clear. Callback
 // runs on the IO read thread; embedder owns cross-thread hand-off. Upstream
 // candidate.
-typedef void (*ghostty_pty_tee_cb)(void* userdata, const char* bytes, uintptr_t len);
 GHOSTTY_API void ghostty_surface_set_pty_tee_cb(ghostty_surface_t,
                                                 ghostty_pty_tee_cb,
                                                 void* userdata);

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1152,6 +1152,10 @@ GHOSTTY_API void ghostty_string_free(ghostty_string_s);
 GHOSTTY_API ghostty_config_t ghostty_config_new();
 GHOSTTY_API void ghostty_config_free(ghostty_config_t);
 GHOSTTY_API ghostty_config_t ghostty_config_clone(ghostty_config_t);
+// Serialize the effective configuration as valid Ghostty config-file syntax.
+// The returned bytes include all public values and must be released with
+// ghostty_string_free.
+GHOSTTY_API ghostty_string_s ghostty_config_serialize(ghostty_config_t);
 GHOSTTY_API void ghostty_config_load_cli_args(ghostty_config_t);
 GHOSTTY_API void ghostty_config_load_file(ghostty_config_t, const char*);
 GHOSTTY_API void ghostty_config_load_string(ghostty_config_t, const char*, uintptr_t, const char*);
@@ -1343,6 +1347,16 @@ GHOSTTY_API bool ghostty_surface_read_screen_tail_vt(ghostty_surface_t,
                                                      uintptr_t,
                                                      uintptr_t,
                                                      ghostty_text_s*);
+// Atomically capture the same VT tail plus the modulo-uint64 position of the
+// next PTY-output byte. The position advances only after output has been
+// applied to the terminal, so bytes at or after it can be replayed following a
+// worker restart. The sequence wraps on uint64 overflow.
+GHOSTTY_API bool ghostty_surface_read_screen_tail_vt_with_output_sequence(
+    ghostty_surface_t,
+    uintptr_t,
+    uintptr_t,
+    ghostty_text_s*,
+    uint64_t* next_sequence);
 GHOSTTY_API void ghostty_surface_free_text(ghostty_surface_t, ghostty_text_s*);
 
 #ifdef __APPLE__

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -68,6 +68,7 @@ typedef enum {
   GHOSTTY_PLATFORM_IOS = 2,
   GHOSTTY_PLATFORM_OPENGL = 3,
   GHOSTTY_PLATFORM_METAL_EXTERNAL = 4,
+  GHOSTTY_PLATFORM_METAL_EXTERNAL_LEASED = 5,
 } ghostty_platform_e;
 
 typedef enum {
@@ -474,6 +475,51 @@ typedef struct {
   ghostty_metal_external_present_cb present;
 } ghostty_platform_metal_external_s;
 
+typedef enum {
+  // Ghostty may immediately reuse the frame's exact swap-chain slot.
+  GHOSTTY_METAL_EXTERNAL_FRAME_DROP = 0,
+  // The embedder owns a lease until it releases frame_token.
+  GHOSTTY_METAL_EXTERNAL_FRAME_ACQUIRE = 1,
+} ghostty_metal_external_frame_disposition_e;
+
+typedef enum {
+  GHOSTTY_METAL_EXTERNAL_COLOR_SPACE_DISPLAY_P3 = 0,
+} ghostty_metal_external_color_space_e;
+
+typedef struct {
+  // Borrowed for the callback, and kept alive by Ghostty after ACQUIRE until
+  // the matching frame_token is released.
+  void* iosurface;
+  // Nonzero identity for this exact acquisition of this swap-chain slot.
+  uint64_t frame_token;
+  // Opaque value captured when Ghostty began drawing this frame.
+  uint64_t host_context;
+  uint32_t width_px;
+  uint32_t height_px;
+  ghostty_metal_external_color_space_e color_space;
+} ghostty_metal_external_frame_s;
+
+/**
+ * Called after Metal finishes rendering a leased external frame.
+ *
+ * This callback runs on a Metal command-buffer completion thread and must be
+ * thread-safe and non-blocking. Returning ACQUIRE keeps this exact IOSurface
+ * swap-chain slot alive until ghostty_surface_release_external_frame is called
+ * with frame_token. Returning DROP permits immediate reuse. Releases may occur
+ * on any thread and in any order while the surface remains alive. Every
+ * acquired frame must be released before ghostty_surface_free; surface teardown
+ * may wait for outstanding leases so it cannot free an IOSurface in use.
+ */
+typedef ghostty_metal_external_frame_disposition_e
+    (*ghostty_metal_external_present_leased_cb)(
+        void* userdata,
+        const ghostty_metal_external_frame_s* frame);
+
+typedef struct {
+  void* userdata;
+  ghostty_metal_external_present_leased_cb present;
+} ghostty_platform_metal_external_leased_s;
+
 typedef bool (*ghostty_opengl_make_current_cb)(void*);
 typedef void (*ghostty_opengl_clear_current_cb)(void*);
 typedef void* (*ghostty_opengl_get_proc_address_cb)(void*, const char*);
@@ -492,6 +538,7 @@ typedef union {
   ghostty_platform_ios_s ios;
   ghostty_platform_opengl_s opengl;
   ghostty_platform_metal_external_s metal_external;
+  ghostty_platform_metal_external_leased_s metal_external_leased;
 } ghostty_platform_u;
 
 typedef enum {
@@ -1247,6 +1294,22 @@ GHOSTTY_API void ghostty_surface_set_focus(ghostty_surface_t, bool);
 GHOSTTY_API void ghostty_surface_set_occlusion(ghostty_surface_t, bool);
 GHOSTTY_API void ghostty_surface_set_size(ghostty_surface_t, uint32_t, uint32_t);
 GHOSTTY_API ghostty_surface_size_s ghostty_surface_size(ghostty_surface_t);
+// Set an authoritative logical terminal grid. Ghostty derives the exact pixel
+// dimensions from the current cell metrics and padding, applies the resize,
+// and optionally writes the resolved dimensions. Zero or overflowing sizes
+// fail without changing the surface.
+GHOSTTY_API bool ghostty_surface_set_grid_size(ghostty_surface_t,
+                                               uint16_t columns,
+                                               uint16_t rows,
+                                               ghostty_surface_size_s* resolved);
+// Set an opaque value captured into subsequently submitted leased frames.
+GHOSTTY_API void ghostty_surface_set_external_frame_context(ghostty_surface_t,
+                                                            uint64_t context);
+// Release a frame returned as ACQUIRE by the leased Metal callback. Releases
+// are thread-safe and may arrive out of order. False means the token was zero,
+// unknown, stale, duplicated, or not owned by the host.
+GHOSTTY_API bool ghostty_surface_release_external_frame(ghostty_surface_t,
+                                                        uint64_t frame_token);
 GHOSTTY_API bool ghostty_surface_scrollbar(ghostty_surface_t,
                                           ghostty_surface_scrollbar_s*);
 // Atomically validates the row-space identity and scrolls to an absolute row.

--- a/include/ghostty/vt/terminal.h
+++ b/include/ghostty/vt/terminal.h
@@ -1095,6 +1095,22 @@ typedef enum GHOSTTY_ENUM_TYPED {
    * Output type: uint64_t *
    */
   GHOSTTY_TERMINAL_DATA_SCREEN_ACTIVITY = 35,
+
+  /**
+   * An opaque activity token for cursor-semantic continuity.
+   *
+   * The token changes whenever Ghostty processes an operation that can affect
+   * cursor replay semantics, even when the resolved cursor shape and blink
+   * values remain unchanged. This includes DECSCUSR, DEC mode 12, alternate
+   * screen mode dispatches, full reset, and configured cursor-default changes.
+   * Multiple such operations within one ghostty_terminal_vt_write() call each
+   * advance the token. The token may also produce false-positive changes.
+   * Consumers must treat it as opaque and compare it only for inequality; its
+   * magnitude and ordering have no meaning.
+   *
+   * Output type: uint64_t *
+   */
+  GHOSTTY_TERMINAL_DATA_CURSOR_ACTIVITY = 36,
   GHOSTTY_TERMINAL_DATA_MAX_VALUE = GHOSTTY_ENUM_MAX_VALUE,
 } GhosttyTerminalData;
 

--- a/include/ghostty/vt/terminal.h
+++ b/include/ghostty/vt/terminal.h
@@ -1063,6 +1063,24 @@ typedef enum GHOSTTY_ENUM_TYPED {
    * Output type: bool *
    */
   GHOSTTY_TERMINAL_DATA_VIEWPORT_ACTIVE = 32,
+
+  /**
+   * The active screen's effective cursor visual style.
+   *
+   * This is the visual shape selected by DECSCUSR or the configured terminal
+   * default. It is distinct from GHOSTTY_TERMINAL_DATA_CURSOR_STYLE, which is
+   * the SGR style applied to newly printed cells.
+   *
+   * Output type: GhosttyTerminalCursorStyle *
+   */
+  GHOSTTY_TERMINAL_DATA_CURSOR_VISUAL_STYLE = 33,
+
+  /**
+   * Whether the effective cursor visual is blinking (DEC mode 12).
+   *
+   * Output type: bool *
+   */
+  GHOSTTY_TERMINAL_DATA_CURSOR_BLINKING = 34,
   GHOSTTY_TERMINAL_DATA_MAX_VALUE = GHOSTTY_ENUM_MAX_VALUE,
 } GhosttyTerminalData;
 

--- a/include/ghostty/vt/terminal.h
+++ b/include/ghostty/vt/terminal.h
@@ -1081,6 +1081,20 @@ typedef enum GHOSTTY_ENUM_TYPED {
    * Output type: bool *
    */
   GHOSTTY_TERMINAL_DATA_CURSOR_BLINKING = 34,
+
+  /**
+   * An opaque activity token for active-screen continuity.
+   *
+   * The token is guaranteed to change on every actual active-screen switch,
+   * including multiple switches processed by one ghostty_terminal_vt_write()
+   * call. It may also change for other screen activity, such as selection
+   * changes. Consumers must treat the value as opaque and compare it only for
+   * inequality; its magnitude and ordering have no meaning. A request to
+   * switch to the already-active screen need not change the token.
+   *
+   * Output type: uint64_t *
+   */
+  GHOSTTY_TERMINAL_DATA_SCREEN_ACTIVITY = 35,
   GHOSTTY_TERMINAL_DATA_MAX_VALUE = GHOSTTY_ENUM_MAX_VALUE,
 } GhosttyTerminalData;
 

--- a/pkg/opengl/glad.zig
+++ b/pkg/opengl/glad.zig
@@ -17,6 +17,13 @@ pub fn load(getProcAddress: anytype) !c_int {
     const GlfwFnValue = fn ([*:0]const u8) callconv(.c) ?GlProc;
     const GlfwFn = *const fn ([*:0]const u8) callconv(.c) ?GlProc;
 
+    // gladLoadGLContext only fills the function table. It does not initialize
+    // glad_loader_handle, which is consumed by gladLoaderUnloadGLContext.
+    // Embedded surfaces can move one GL context across threads and reload this
+    // thread-local value during teardown, so carrying Zig's undefined-memory
+    // poison into that field would make unload attempt to close a bogus handle.
+    context = std.mem.zeroes(Context);
+
     const res = switch (@TypeOf(getProcAddress)) {
         // glfw
         GlfwFn => c.gladLoadGLContext(&context, @ptrCast(getProcAddress)),

--- a/pkg/opengl/glad.zig
+++ b/pkg/opengl/glad.zig
@@ -14,11 +14,17 @@ pub threadlocal var context: Context = undefined;
 /// forms of the function depending on what we're interfacing with.
 pub fn load(getProcAddress: anytype) !c_int {
     const GlProc = *const fn () callconv(.c) void;
+    const GlfwFnValue = fn ([*:0]const u8) callconv(.c) ?GlProc;
     const GlfwFn = *const fn ([*:0]const u8) callconv(.c) ?GlProc;
 
     const res = switch (@TypeOf(getProcAddress)) {
         // glfw
         GlfwFn => c.gladLoadGLContext(&context, @ptrCast(getProcAddress)),
+
+        // A bare function declaration needs its address taken before it can
+        // be passed through C's function-pointer ABI. This is the form used
+        // by the embedded renderer's callback trampoline.
+        GlfwFnValue => c.gladLoadGLContext(&context, @ptrCast(&getProcAddress)),
 
         // null proc address means that we are just loading the globally
         // pointed gl functions

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -663,8 +663,8 @@ pub fn init(
         // application owns the PTY/session and Ghostty only renders bytes and
         // encodes input. Delete this branch when upstream exposes an
         // embedder-owned IO backend.
-        const use_manual_io = if (comptime @hasDecl(apprt.runtime.Surface, "ioMode"))
-            rt_surface.ioMode() == .manual
+        const use_manual_io = if (comptime @hasDecl(apprt.runtime.Surface, "usesManualIo"))
+            rt_surface.usesManualIo()
         else
             false;
         var io_backend: termio.Backend = if (use_manual_io) manual: {
@@ -727,6 +727,10 @@ pub fn init(
             .full_config = config,
             .config = try termio.Termio.DerivedConfig.init(alloc, config),
             .backend = io_backend,
+            .suppress_terminal_responses = if (comptime @hasDecl(apprt.runtime.Surface, "suppressTerminalResponses"))
+                rt_surface.suppressTerminalResponses()
+            else
+                false,
             .mailbox = io_mailbox,
             .renderer_state = &self.renderer_state,
             .renderer_wakeup = render_thread.wakeup,

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -780,6 +780,12 @@ pub fn init(
     );
     self.renderer_thr.setName("renderer") catch {};
 
+    // libghostty allows the embedder to free a surface as soon as creation
+    // returns. Wait until the renderer's stop watcher is armed so that teardown
+    // cannot race thread startup and lose the stop notification.
+    if (comptime apprt.runtime == apprt.embedded)
+        self.renderer_thread.started.wait();
+
     // Start our IO thread
     self.io_thr = try std.Thread.spawn(
         .{},
@@ -787,6 +793,9 @@ pub fn init(
         .{ &self.io_thread, &self.io },
     );
     self.io_thr.setName("io") catch {};
+
+    if (comptime apprt.runtime == apprt.embedded)
+        self.io_thread.started.wait();
 
     // Determine our initial window size if configured. We need to do this
     // quite late in the process because our height/width are in grid dimensions,

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -732,6 +732,14 @@ pub fn init(
             .renderer_wakeup = render_thread.wakeup,
             .renderer_mailbox = render_thread.mailbox,
             .surface_mailbox = .{ .surface = self, .app = app_mailbox },
+            .pty_tee_cb = if (comptime @hasDecl(apprt.runtime.Surface, "ptyTeeCallback"))
+                rt_surface.ptyTeeCallback()
+            else
+                null,
+            .pty_tee_userdata = if (comptime @hasDecl(apprt.runtime.Surface, "ptyTeeUserdata"))
+                rt_surface.ptyTeeUserdata()
+            else
+                null,
         });
     }
     // Outside the block, IO has now taken ownership of our temporary state

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -360,6 +360,7 @@ pub const App = struct {
 pub const Platform = union(PlatformTag) {
     macos: MacOS,
     ios: IOS,
+    opengl: OpenGL,
 
     // If our build target for libghostty is not darwin then we do
     // not include macos support at all.
@@ -373,6 +374,16 @@ pub const Platform = union(PlatformTag) {
         uiview: objc.Object,
     } else void;
 
+    /// An embedder-owned OpenGL context and presentation surface. The
+    /// callbacks may be invoked from Ghostty's renderer thread.
+    pub const OpenGL = struct {
+        userdata: ?*anyopaque,
+        make_current: *const fn (?*anyopaque) callconv(.c) bool,
+        clear_current: *const fn (?*anyopaque) callconv(.c) void,
+        get_proc_address: *const fn (?*anyopaque, [*:0]const u8) callconv(.c) ?*anyopaque,
+        swap_buffers: *const fn (?*anyopaque) callconv(.c) void,
+    };
+
     // The C ABI compatible version of this union. The tag is expected
     // to be stored elsewhere.
     pub const C = extern union {
@@ -382,6 +393,14 @@ pub const Platform = union(PlatformTag) {
 
         ios: extern struct {
             uiview: ?*anyopaque,
+        },
+
+        opengl: extern struct {
+            userdata: ?*anyopaque,
+            make_current: ?*const fn (?*anyopaque) callconv(.c) bool,
+            clear_current: ?*const fn (?*anyopaque) callconv(.c) void,
+            get_proc_address: ?*const fn (?*anyopaque, [*:0]const u8) callconv(.c) ?*anyopaque,
+            swap_buffers: ?*const fn (?*anyopaque) callconv(.c) void,
         },
     };
 
@@ -402,6 +421,21 @@ pub const Platform = union(PlatformTag) {
                     break :ios error.UIViewMustBeSet);
                 break :ios .{ .ios = .{ .uiview = uiview } };
             } else error.UnsupportedPlatform,
+
+            .opengl => opengl: {
+                const config = c_platform.opengl;
+                break :opengl .{ .opengl = .{
+                    .userdata = config.userdata,
+                    .make_current = config.make_current orelse
+                        return error.OpenGLMakeCurrentMustBeSet,
+                    .clear_current = config.clear_current orelse
+                        return error.OpenGLClearCurrentMustBeSet,
+                    .get_proc_address = config.get_proc_address orelse
+                        return error.OpenGLGetProcAddressMustBeSet,
+                    .swap_buffers = config.swap_buffers orelse
+                        return error.OpenGLSwapBuffersMustBeSet,
+                } };
+            },
         };
     }
 };
@@ -412,6 +446,7 @@ pub const PlatformTag = enum(c_int) {
 
     macos = 1,
     ios = 2,
+    opengl = 3,
 };
 
 pub const EnvVar = extern struct {

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1180,9 +1180,14 @@ pub const Surface = struct {
     }
 };
 
-test "manual mirror IO mode preserves surface config ABI" {
+const surface_config_abi_size = 152;
+
+test "embedded surface config ABI is pinned" {
     const defaults: Surface.Options = .{};
-    try std.testing.expectEqual(@as(usize, 120), @sizeOf(Surface.Options));
+    try std.testing.expectEqual(
+        @as(usize, surface_config_abi_size),
+        @sizeOf(Surface.Options),
+    );
     try std.testing.expectEqual(IoMode.exec, defaults.io_mode);
     try std.testing.expectEqual(@as(c_int, 2), @intFromEnum(IoMode.manual_mirror));
     try std.testing.expect(!IoMode.exec.usesManualIo());
@@ -1194,8 +1199,8 @@ test "manual mirror IO mode preserves surface config ABI" {
 
 comptime {
     const defaults: Surface.Options = .{};
-    if (@sizeOf(Surface.Options) != 120)
-        @compileError("manual mirror IO mode must not change the surface config ABI");
+    if (@sizeOf(Surface.Options) != surface_config_abi_size)
+        @compileError("embedded surface config ABI changed; update all pinned consumers");
     if (defaults.io_mode != .exec)
         @compileError("surface IO must default to exec mode");
     if (@intFromEnum(IoMode.manual_mirror) != 2)

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -427,6 +427,18 @@ pub const EnvVar = extern struct {
 pub const IoMode = enum(c_int) {
     exec = 0,
     manual = 1,
+    manual_mirror = 2,
+
+    pub fn usesManualIo(self: IoMode) bool {
+        return switch (self) {
+            .exec => false,
+            .manual, .manual_mirror => true,
+        };
+    }
+
+    pub fn suppressesTerminalResponses(self: IoMode) bool {
+        return self == .manual_mirror;
+    }
 };
 
 pub const IoWriteCallback = *const fn (?*anyopaque, [*]const u8, usize) callconv(.c) void;
@@ -758,12 +770,20 @@ pub const Surface = struct {
         return self.io_mode;
     }
 
+    pub fn usesManualIo(self: *const Surface) bool {
+        return self.io_mode.usesManualIo();
+    }
+
     pub fn ioWriteCallback(self: *const Surface) ?IoWriteCallback {
         return self.io_write_cb;
     }
 
     pub fn ioWriteUserdata(self: *const Surface) ?*anyopaque {
         return self.io_write_userdata;
+    }
+
+    pub fn suppressTerminalResponses(self: *const Surface) bool {
+        return self.io_mode.suppressesTerminalResponses();
     }
 
     pub fn rendererInstrumentation(self: *const Surface) renderer.Instrumentation {
@@ -1124,6 +1144,33 @@ pub const Surface = struct {
         return .{ .x = pos.x * scale.x, .y = pos.y * scale.y };
     }
 };
+
+test "manual mirror IO mode preserves surface config ABI" {
+    const defaults: Surface.Options = .{};
+    try std.testing.expectEqual(@as(usize, 120), @sizeOf(Surface.Options));
+    try std.testing.expectEqual(IoMode.exec, defaults.io_mode);
+    try std.testing.expectEqual(@as(c_int, 2), @intFromEnum(IoMode.manual_mirror));
+    try std.testing.expect(!IoMode.exec.usesManualIo());
+    try std.testing.expect(IoMode.manual.usesManualIo());
+    try std.testing.expect(IoMode.manual_mirror.usesManualIo());
+    try std.testing.expect(!IoMode.manual.suppressesTerminalResponses());
+    try std.testing.expect(IoMode.manual_mirror.suppressesTerminalResponses());
+}
+
+comptime {
+    const defaults: Surface.Options = .{};
+    if (@sizeOf(Surface.Options) != 120)
+        @compileError("manual mirror IO mode must not change the surface config ABI");
+    if (defaults.io_mode != .exec)
+        @compileError("surface IO must default to exec mode");
+    if (@intFromEnum(IoMode.manual_mirror) != 2)
+        @compileError("manual mirror IO mode must preserve its C ABI value");
+    if (!IoMode.manual.usesManualIo() or !IoMode.manual_mirror.usesManualIo())
+        @compileError("both manual IO modes must use the embedder backend");
+    if (IoMode.manual.suppressesTerminalResponses() or
+        !IoMode.manual_mirror.suppressesTerminalResponses())
+        @compileError("only manual mirror mode may suppress terminal responses");
+}
 
 /// Inspector is the state required for the terminal inspector. A terminal
 /// inspector is 1:1 with a Surface.

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -2027,6 +2027,40 @@ pub const CAPI = struct {
         surface.core_surface.renderer_state.mutex.lock();
         defer surface.core_surface.renderer_state.mutex.unlock();
 
+        return readScreenTailVTLocked(surface, max_rows, max_bytes, result);
+    }
+
+    /// Atomically capture a VT tail and the modulo-u64 position immediately
+    /// after every PTY-output byte represented by that terminal snapshot.
+    export fn ghostty_surface_read_screen_tail_vt_with_output_sequence(
+        surface: *Surface,
+        max_rows: usize,
+        max_bytes: usize,
+        result: *Text,
+        next_sequence: *u64,
+    ) bool {
+        surface.core_surface.renderer_state.mutex.lock();
+        defer surface.core_surface.renderer_state.mutex.unlock();
+
+        const snapshot_succeeded = readScreenTailVTLocked(
+            surface,
+            max_rows,
+            max_bytes,
+            result,
+        );
+        return publishOutputSnapshotSequenceLocked(
+            snapshot_succeeded,
+            surface.core_surface.io.processed_output_bytes,
+            next_sequence,
+        );
+    }
+
+    fn readScreenTailVTLocked(
+        surface: *Surface,
+        max_rows: usize,
+        max_bytes: usize,
+        result: *Text,
+    ) bool {
         if (max_rows == 0 or max_bytes == 0) return false;
         const core_surface = &surface.core_surface;
         const opts: terminal.formatter.Options = .{
@@ -2065,6 +2099,16 @@ pub const CAPI = struct {
             .text = owned.ptr,
             .text_len = owned.len,
         };
+        return true;
+    }
+
+    fn publishOutputSnapshotSequenceLocked(
+        snapshot_succeeded: bool,
+        processed_output_bytes: u64,
+        next_sequence: *u64,
+    ) bool {
+        if (!snapshot_succeeded) return false;
+        next_sequence.* = processed_output_bytes;
         return true;
     }
 
@@ -3679,6 +3723,23 @@ pub const CAPI = struct {
         }
     };
 };
+
+test "output sequence publishes only with successful VT tail snapshot" {
+    var next_sequence: u64 = 99;
+    try std.testing.expect(!CAPI.publishOutputSnapshotSequenceLocked(
+        false,
+        42,
+        &next_sequence,
+    ));
+    try std.testing.expectEqual(@as(u64, 99), next_sequence);
+
+    try std.testing.expect(CAPI.publishOutputSnapshotSequenceLocked(
+        true,
+        42,
+        &next_sequence,
+    ));
+    try std.testing.expectEqual(@as(u64, 42), next_sequence);
+}
 
 test "render grid preserves terminal color semantics" {
     const default_color = CAPI.renderGridColorSemantics(.none);

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1287,7 +1287,10 @@ pub const Surface = struct {
     }
 };
 
-const surface_config_abi_size = 152;
+// The cmux integration combines the OpenGL platform payload (the largest
+// Platform.C variant) with the startup PTY tee fields. Keep the resulting C
+// layout pinned so every exact-revision consumer fails loudly on drift.
+const surface_config_abi_size = 168;
 
 test "embedded surface config ABI is pinned" {
     const defaults: Surface.Options = .{};

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -360,6 +360,7 @@ pub const App = struct {
 pub const Platform = union(PlatformTag) {
     macos: MacOS,
     ios: IOS,
+    metal_external: MetalExternal,
 
     // If our build target for libghostty is not darwin then we do
     // not include macos support at all.
@@ -373,6 +374,24 @@ pub const Platform = union(PlatformTag) {
         uiview: objc.Object,
     } else void;
 
+    /// An embedder-owned presenter for Metal IOSurfaces. This platform never
+    /// accesses an NSView, UIView, or CALayer. The callback runs on a Metal
+    /// command-buffer completion thread after the GPU finishes the frame.
+    pub const MetalExternal = if (builtin.target.os.tag.isDarwin()) struct {
+        userdata: ?*anyopaque,
+
+        /// `iosurface` is borrowed and valid only for the callback duration.
+        /// Retain it or create its transport handle before returning if the
+        /// embedder needs to extend its lifetime. The callback must be
+        /// thread-safe and must not block the renderer thread.
+        present: *const fn (
+            userdata: ?*anyopaque,
+            iosurface: *anyopaque,
+            width_px: u32,
+            height_px: u32,
+        ) callconv(.c) void,
+    } else void;
+
     // The C ABI compatible version of this union. The tag is expected
     // to be stored elsewhere.
     pub const C = extern union {
@@ -382,6 +401,16 @@ pub const Platform = union(PlatformTag) {
 
         ios: extern struct {
             uiview: ?*anyopaque,
+        },
+
+        metal_external: extern struct {
+            userdata: ?*anyopaque,
+            present: ?*const fn (
+                userdata: ?*anyopaque,
+                iosurface: *anyopaque,
+                width_px: u32,
+                height_px: u32,
+            ) callconv(.c) void,
         },
     };
 
@@ -402,6 +431,15 @@ pub const Platform = union(PlatformTag) {
                     break :ios error.UIViewMustBeSet);
                 break :ios .{ .ios = .{ .uiview = uiview } };
             } else error.UnsupportedPlatform,
+
+            .metal_external => if (MetalExternal != void) metal_external: {
+                const config = c_platform.metal_external;
+                break :metal_external .{ .metal_external = .{
+                    .userdata = config.userdata,
+                    .present = config.present orelse
+                        return error.MetalExternalPresentMustBeSet,
+                } };
+            } else error.UnsupportedPlatform,
         };
     }
 };
@@ -412,7 +450,45 @@ pub const PlatformTag = enum(c_int) {
 
     macos = 1,
     ios = 2,
+    metal_external = 3,
 };
+
+test "embedded metal external platform validates presentation callback" {
+    if (Platform.MetalExternal == void) return error.SkipZigTest;
+
+    var c_platform: Platform.C = undefined;
+    c_platform.metal_external = .{
+        .userdata = null,
+        .present = null,
+    };
+    try std.testing.expectError(
+        error.MetalExternalPresentMustBeSet,
+        Platform.init(@intFromEnum(PlatformTag.metal_external), c_platform),
+    );
+
+    const Callback = struct {
+        fn present(
+            _: ?*anyopaque,
+            _: *anyopaque,
+            _: u32,
+            _: u32,
+        ) callconv(.c) void {}
+    };
+    c_platform.metal_external.present = &Callback.present;
+
+    const platform = try Platform.init(
+        @intFromEnum(PlatformTag.metal_external),
+        c_platform,
+    );
+    try std.testing.expectEqual(
+        PlatformTag.metal_external,
+        std.meta.activeTag(platform),
+    );
+    try std.testing.expectEqual(
+        @as(c_int, 3),
+        @intFromEnum(PlatformTag.metal_external),
+    );
+}
 
 pub const EnvVar = extern struct {
     /// The name of the environment variable.
@@ -430,6 +506,7 @@ pub const IoMode = enum(c_int) {
 };
 
 pub const IoWriteCallback = *const fn (?*anyopaque, [*]const u8, usize) callconv(.c) void;
+pub const PtyTeeCallback = *const fn (?*anyopaque, [*]const u8, usize) callconv(.c) void;
 pub const RendererEventCallback = renderer.InstrumentationCallback;
 
 pub const Surface = struct {
@@ -445,6 +522,8 @@ pub const Surface = struct {
     io_mode: IoMode = .exec,
     io_write_cb: ?IoWriteCallback = null,
     io_write_userdata: ?*anyopaque = null,
+    pty_tee_cb: ?PtyTeeCallback = null,
+    pty_tee_userdata: ?*anyopaque = null,
     renderer_event_cb: ?RendererEventCallback = null,
     scrollback_limit_bytes: usize = 0,
 
@@ -506,6 +585,14 @@ pub const Surface = struct {
         /// Optional content-free renderer activity callback. This receives the
         /// surface `userdata` and runs synchronously on the renderer thread.
         renderer_event_cb: ?RendererEventCallback = null,
+
+        /// Optional tee for every PTY-output byte slice before parsing. Unlike
+        /// the post-create setter, this is installed before the IO thread can
+        /// emit startup bytes.
+        pty_tee_cb: ?PtyTeeCallback = null,
+
+        /// Userdata passed to pty_tee_cb.
+        pty_tee_userdata: ?*anyopaque = null,
     };
 
     pub fn init(
@@ -529,6 +616,8 @@ pub const Surface = struct {
             .io_mode = opts.io_mode,
             .io_write_cb = opts.io_write_cb,
             .io_write_userdata = opts.io_write_userdata,
+            .pty_tee_cb = opts.pty_tee_cb,
+            .pty_tee_userdata = opts.pty_tee_userdata,
             .renderer_event_cb = opts.renderer_event_cb,
             .scrollback_limit_bytes = scrollback_limit_bytes,
         };
@@ -661,10 +750,20 @@ pub const Surface = struct {
     }
 
     test "embedded surface scrollback cap inherits when unset" {
-        try std.testing.expectEqual(@as(usize, 120), @sizeOf(Options));
+        try std.testing.expectEqual(@as(usize, 144), @sizeOf(Options));
         try std.testing.expectEqual(
             @as(usize, 50_000_000),
             effectiveScrollbackLimit(50_000_000, 0),
+        );
+    }
+
+    test "embedded surface options include initial PTY tee" {
+        const options: Options = .{};
+        try std.testing.expect(options.pty_tee_cb == null);
+        try std.testing.expect(options.pty_tee_userdata == null);
+        try std.testing.expect(
+            @offsetOf(Options, "pty_tee_cb") <
+                @offsetOf(Options, "pty_tee_userdata"),
         );
     }
 
@@ -764,6 +863,14 @@ pub const Surface = struct {
 
     pub fn ioWriteUserdata(self: *const Surface) ?*anyopaque {
         return self.io_write_userdata;
+    }
+
+    pub fn ptyTeeCallback(self: *const Surface) ?PtyTeeCallback {
+        return self.pty_tee_cb;
+    }
+
+    pub fn ptyTeeUserdata(self: *const Surface) ?*anyopaque {
+        return self.pty_tee_userdata;
     }
 
     pub fn rendererInstrumentation(self: *const Surface) renderer.Instrumentation {

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -28,6 +28,16 @@ const log = std.log.scoped(.embedded_window);
 
 pub const resourcesDir = internal_os.resourcesDir;
 
+/// The external presenter either drops its borrowed frame immediately or
+/// acquires a Ghostty-owned lease that must later be released by token.
+pub const ExternalFrameDisposition = renderer.external_frame.Disposition;
+
+/// The color space attached to the exported IOSurface.
+pub const ExternalFrameColorSpace = renderer.external_frame.ColorSpace;
+
+/// One completed Metal frame offered to an external compositor.
+pub const ExternalFrame = renderer.external_frame.Frame;
+
 pub const App = struct {
     /// Because we only expect the embedding API to be used in embedded
     /// environments, the options are extern so that we can expose it
@@ -362,6 +372,7 @@ pub const Platform = union(PlatformTag) {
     ios: IOS,
     opengl: OpenGL,
     metal_external: MetalExternal,
+    metal_external_leased: MetalExternalLeased,
 
     // If our build target for libghostty is not darwin then we do
     // not include macos support at all.
@@ -393,6 +404,17 @@ pub const Platform = union(PlatformTag) {
         ) callconv(.c) void,
     } else void;
 
+    /// An embedder-owned IOSurface presenter with explicit, token-addressed
+    /// ownership. Returning `.acquire` keeps the exact swap-chain slot alive
+    /// until `ghostty_surface_release_external_frame` releases its token.
+    pub const MetalExternalLeased = if (builtin.target.os.tag.isDarwin()) struct {
+        userdata: ?*anyopaque,
+        present: *const fn (
+            userdata: ?*anyopaque,
+            frame: *const ExternalFrame,
+        ) callconv(.c) ExternalFrameDisposition,
+    } else void;
+
     /// An embedder-owned OpenGL context and presentation surface. The
     /// callbacks may be invoked from Ghostty's renderer thread.
     pub const OpenGL = struct {
@@ -422,6 +444,14 @@ pub const Platform = union(PlatformTag) {
                 width_px: u32,
                 height_px: u32,
             ) callconv(.c) void,
+        },
+
+        metal_external_leased: extern struct {
+            userdata: ?*anyopaque,
+            present: ?*const fn (
+                userdata: ?*anyopaque,
+                frame: *const ExternalFrame,
+            ) callconv(.c) ExternalFrameDisposition,
         },
 
         opengl: extern struct {
@@ -460,6 +490,15 @@ pub const Platform = union(PlatformTag) {
                 } };
             } else error.UnsupportedPlatform,
 
+            .metal_external_leased => if (MetalExternalLeased != void) leased: {
+                const config = c_platform.metal_external_leased;
+                break :leased .{ .metal_external_leased = .{
+                    .userdata = config.userdata,
+                    .present = config.present orelse
+                        return error.MetalExternalLeasedPresentMustBeSet,
+                } };
+            } else error.UnsupportedPlatform,
+
             .opengl => opengl: {
                 const config = c_platform.opengl;
                 break :opengl .{ .opengl = .{
@@ -486,7 +525,20 @@ pub const PlatformTag = enum(c_int) {
     ios = 2,
     opengl = 3,
     metal_external = 4,
+    metal_external_leased = 5,
 };
+
+comptime {
+    if (@intFromEnum(PlatformTag.metal_external) != 4 or
+        @intFromEnum(PlatformTag.metal_external_leased) != 5)
+        @compileError("external Metal platform tags changed ABI");
+    if (@sizeOf(ExternalFrame) != 40)
+        @compileError("external Metal frame changed ABI");
+    // OpenGL remains the largest platform variant, so adding the leased
+    // presenter must not change ghostty_surface_config_s.
+    if (@sizeOf(Platform.C) != 40)
+        @compileError("embedded platform union changed ABI");
+}
 
 test "embedded metal external platform validates presentation callback" {
     if (Platform.MetalExternal == void) return error.SkipZigTest;
@@ -522,6 +574,62 @@ test "embedded metal external platform validates presentation callback" {
     try std.testing.expectEqual(
         @as(c_int, 4),
         @intFromEnum(PlatformTag.metal_external),
+    );
+}
+
+test "embedded leased metal platform preserves ABI and validates callback" {
+    if (Platform.MetalExternalLeased == void) return error.SkipZigTest;
+
+    var c_platform: Platform.C = undefined;
+    c_platform.metal_external_leased = .{
+        .userdata = null,
+        .present = null,
+    };
+    try std.testing.expectError(
+        error.MetalExternalLeasedPresentMustBeSet,
+        Platform.init(
+            @intFromEnum(PlatformTag.metal_external_leased),
+            c_platform,
+        ),
+    );
+
+    const Callback = struct {
+        fn present(
+            _: ?*anyopaque,
+            _: *const ExternalFrame,
+        ) callconv(.c) ExternalFrameDisposition {
+            return .drop;
+        }
+    };
+    c_platform.metal_external_leased.present = &Callback.present;
+
+    const platform = try Platform.init(
+        @intFromEnum(PlatformTag.metal_external_leased),
+        c_platform,
+    );
+    try std.testing.expectEqual(
+        PlatformTag.metal_external_leased,
+        std.meta.activeTag(platform),
+    );
+    try std.testing.expectEqual(
+        @as(c_int, 5),
+        @intFromEnum(PlatformTag.metal_external_leased),
+    );
+    try std.testing.expectEqual(@as(usize, 40), @sizeOf(ExternalFrame));
+    try std.testing.expectEqual(@as(usize, 40), @sizeOf(Platform.C));
+
+    const c = @import("ghostty.h");
+    try std.testing.expectEqual(
+        @as(c_int, @intFromEnum(ExternalFrameDisposition.drop)),
+        @as(c_int, c.GHOSTTY_METAL_EXTERNAL_FRAME_DROP),
+    );
+    try std.testing.expectEqual(
+        @as(c_int, @intFromEnum(ExternalFrameDisposition.acquire)),
+        @as(c_int, c.GHOSTTY_METAL_EXTERNAL_FRAME_ACQUIRE),
+    );
+    try std.testing.expectEqual(
+        @sizeOf(ExternalFrame),
+        @sizeOf(c.ghostty_metal_external_frame_s),
     );
 }
 
@@ -573,6 +681,8 @@ pub const Surface = struct {
     pty_tee_userdata: ?*anyopaque = null,
     renderer_event_cb: ?RendererEventCallback = null,
     scrollback_limit_bytes: usize = 0,
+    /// Opaque embedder value captured into each leased frame at draw time.
+    external_frame_context: std.atomic.Value(u64) = .{ .raw = 0 },
 
     /// The current title of the surface. The embedded apprt saves this so
     /// that getTitle works without the implementer needing to save it.
@@ -667,6 +777,7 @@ pub const Surface = struct {
             .pty_tee_userdata = opts.pty_tee_userdata,
             .renderer_event_cb = opts.renderer_event_cb,
             .scrollback_limit_bytes = scrollback_limit_bytes,
+            .external_frame_context = .{ .raw = 0 },
         };
 
         // Add ourselves to the list of surfaces on the app.
@@ -900,6 +1011,14 @@ pub const Surface = struct {
         return self.size;
     }
 
+    pub fn externalFrameContext(self: *const Surface) u64 {
+        return self.external_frame_context.load(.acquire);
+    }
+
+    pub fn setExternalFrameContext(self: *Surface, value: u64) void {
+        self.external_frame_context.store(value, .release);
+    }
+
     pub fn ioMode(self: *const Surface) IoMode {
         return self.io_mode;
     }
@@ -1095,6 +1214,29 @@ pub const Surface = struct {
             log.err("error in size callback err={}", .{err});
             return;
         };
+    }
+
+    /// Set an authoritative logical grid by resolving its exact pixel size
+    /// from the live cell metrics and padding. The renderer and PTY still flow
+    /// through the normal resize path, so all existing ordering is preserved.
+    pub fn updateGridSize(self: *Surface, columns: u16, rows: u16) bool {
+        const requested: renderer.GridSize = .{
+            .columns = columns,
+            .rows = rows,
+        };
+        const screen = self.core_surface.size.screenForGrid(requested) orelse
+            return false;
+        self.updateSize(screen.width, screen.height);
+
+        // Padding balancing may be recomputed by the core resize. Re-resolve
+        // once with that authoritative padding if necessary.
+        if (!self.core_surface.size.grid().equals(requested)) {
+            const adjusted = self.core_surface.size.screenForGrid(requested) orelse
+                return false;
+            self.updateSize(adjusted.width, adjusted.height);
+        }
+
+        return self.core_surface.size.grid().equals(requested);
     }
 
     pub fn colorSchemeCallback(self: *Surface, scheme: apprt.ColorScheme) void {
@@ -2314,8 +2456,7 @@ pub const CAPI = struct {
         surface.updateSize(w, h);
     }
 
-    /// Return the size information a surface has.
-    export fn ghostty_surface_size(surface: *Surface) SurfaceSize {
+    fn surfaceSize(surface: *Surface) SurfaceSize {
         const grid_size = surface.core_surface.size.grid();
         return .{
             .columns = grid_size.columns,
@@ -2325,6 +2466,43 @@ pub const CAPI = struct {
             .cell_width_px = surface.core_surface.size.cell.width,
             .cell_height_px = surface.core_surface.size.cell.height,
         };
+    }
+
+    /// Return the size information a surface has.
+    export fn ghostty_surface_size(surface: *Surface) SurfaceSize {
+        return surfaceSize(surface);
+    }
+
+    /// Set an authoritative grid and return the pixel size Ghostty resolved.
+    export fn ghostty_surface_set_grid_size(
+        surface: *Surface,
+        columns: u16,
+        rows: u16,
+        resolved: ?*SurfaceSize,
+    ) bool {
+        if (!surface.updateGridSize(columns, rows)) return false;
+        if (resolved) |result| result.* = surfaceSize(surface);
+        return true;
+    }
+
+    /// Set an opaque context captured into subsequently submitted frames.
+    export fn ghostty_surface_set_external_frame_context(
+        surface: *Surface,
+        context: u64,
+    ) void {
+        surface.setExternalFrameContext(context);
+    }
+
+    /// Release one exact IOSurface slot acquired by the leased callback.
+    export fn ghostty_surface_release_external_frame(
+        surface: *Surface,
+        frame_token: u64,
+    ) bool {
+        switch (surface.platform) {
+            .metal_external_leased => {},
+            else => return false,
+        }
+        return surface.core_surface.renderer.releaseExternalFrame(frame_token);
     }
 
     const RenderGridColorSource = enum {

--- a/src/build/GhosttyLib.zig
+++ b/src/build/GhosttyLib.zig
@@ -73,7 +73,7 @@ pub fn initShared(
     deps: *const SharedDeps,
 ) !GhosttyLib {
     const lib = b.addLibrary(.{
-        .name = "ghostty",
+        .name = "ghostty-internal",
         .linkage = .dynamic,
         .root_module = b.createModule(.{
             .root_source_file = b.path("src/main_c.zig"),
@@ -269,7 +269,7 @@ fn sharedLibraryName(os_tag: std.Target.Os.Tag) []const u8 {
     return if (os_tag == .windows)
         "ghostty-internal.dll"
     else
-        "ghostty-internal.so";
+        "libghostty-internal.so";
 }
 
 fn staticLibraryName(os_tag: std.Target.Os.Tag) []const u8 {

--- a/src/build/GhosttyLib.zig
+++ b/src/build/GhosttyLib.zig
@@ -12,6 +12,7 @@ step: *std.Build.Step,
 
 /// The final static library file
 output: std.Build.LazyPath,
+implib: ?std.Build.LazyPath,
 dsym: ?std.Build.LazyPath,
 pkg_config: ?std.Build.LazyPath,
 pkg_config_static: ?std.Build.LazyPath,
@@ -60,6 +61,7 @@ pub fn initStatic(
     return .{
         .step = combined.step,
         .output = combined.output,
+        .implib = null,
 
         // Static libraries cannot have dSYMs because they aren't linked.
         .dsym = null,
@@ -73,6 +75,9 @@ pub fn initShared(
     deps: *const SharedDeps,
 ) !GhosttyLib {
     const lib = b.addLibrary(.{
+        // Keep the emitted basename identical to the installed embedder
+        // library on every platform. Windows import libraries record this
+        // name, and Linux derives the shared-object SONAME from it.
         .name = "ghostty-internal",
         .linkage = .dynamic,
         .root_module = b.createModule(.{
@@ -152,6 +157,10 @@ pub fn initShared(
     return .{
         .step = &lib.step,
         .output = lib.getEmittedBin(),
+        .implib = if (deps.config.target.result.os.tag == .windows)
+            lib.getEmittedImplib()
+        else
+            null,
         .dsym = dsymutil,
         .pkg_config = pcs.shared,
         .pkg_config_static = pcs.static,
@@ -181,6 +190,7 @@ pub fn initMacOSUniversal(
     return .{
         .step = universal.step,
         .output = universal.output,
+        .implib = null,
 
         // You can't run dsymutil on a universal binary, you have to
         // do it on the individual binaries.
@@ -195,6 +205,17 @@ pub fn install(self: *const GhosttyLib, name: []const u8) void {
     const step = b.getInstallStep();
     const lib_install = b.addInstallLibFile(self.output, name);
     step.dependOn(&lib_install.step);
+
+    // A Windows DLL is not directly linkable by MSVC consumers. Zig emits
+    // the matching COFF import library, so install it beside the DLL instead
+    // of forcing every embedder to find an unstable cache path.
+    if (self.implib) |implib| {
+        const implib_install = b.addInstallLibFile(
+            implib,
+            "ghostty-internal.lib",
+        );
+        step.dependOn(&implib_install.step);
+    }
 
     if (self.pkg_config) |pc| {
         step.dependOn(&b.addInstallFileWithDir(

--- a/src/build/SharedDeps.zig
+++ b/src/build/SharedDeps.zig
@@ -596,15 +596,19 @@ pub fn add(
         }
     }
 
-    // If we're building an exe then we have additional dependencies.
-    if (step.kind != .lib) {
-        // We always statically compile glad
+    // GLAD provides the OpenGL loader implementation used by the renderer.
+    // Embedded libraries need it just as executables do, otherwise loader
+    // calls compile but remain unresolved when the shared library is loaded.
+    if (self.config.renderer == .opengl) {
         step.addIncludePath(b.path("vendor/glad/include/"));
         step.addCSourceFile(.{
             .file = b.path("vendor/glad/src/gl.c"),
             .flags = &.{},
         });
+    }
 
+    // If we're building an exe then we have additional dependencies.
+    if (step.kind != .lib) {
         // When we're targeting flatpak we ALWAYS link GTK so we
         // get access to glib for dbus.
         if (self.config.flatpak) step.linkSystemLibrary2("gtk4", dynamic_link_opts);

--- a/src/config/CApi.zig
+++ b/src/config/CApi.zig
@@ -5,6 +5,7 @@ const state = &@import("../global.zig").state;
 const String = @import("../main_c.zig").String;
 
 const Config = @import("Config.zig");
+const FileFormatter = @import("formatter_file.zig").FileFormatter;
 const c_get = @import("c_get.zig");
 const edit = @import("edit.zig");
 const Key = @import("key.zig").Key;
@@ -48,6 +49,36 @@ export fn ghostty_config_clone(self: *Config) ?*Config {
     };
 
     return result;
+}
+
+/// Serialize every public effective configuration value using Ghostty's
+/// config-file formatter. The returned allocation is owned by the caller and
+/// is released by ghostty_string_free.
+export fn ghostty_config_serialize(self: *const Config) String {
+    const serialized = serializeConfig(state.alloc, self) catch |err| {
+        log.err("error serializing config err={}", .{err});
+        return .empty;
+    };
+    return .fromSlice(serialized);
+}
+
+fn serializeConfig(alloc: std.mem.Allocator, self: *const Config) ![]u8 {
+    var output: std.Io.Writer.Allocating = .init(alloc);
+    defer output.deinit();
+
+    // Config.default preloads command-palette entries, while parsing that key
+    // appends. Clear it before the all-values formatter emits the effective
+    // entries so loading this snapshot into a fresh config is lossless.
+    try output.writer.writeAll("command-palette-entry = clear\n");
+
+    const formatter: FileFormatter = .{
+        .alloc = alloc,
+        .config = self,
+        .docs = false,
+        .changed = false,
+    };
+    try formatter.format(&output.writer);
+    return try output.toOwnedSlice();
 }
 
 /// Load the configuration from the CLI args.
@@ -174,6 +205,39 @@ test "ghostty_config_get: bool" {
     const key = "maximize";
     try testing.expect(ghostty_config_get(&cfg, &out, key, key.len));
     try testing.expect(out);
+}
+
+test "ghostty_config_serialize round trips effective values" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var source = try Config.default(alloc);
+    defer source.deinit();
+    source.@"font-size" = 23.5;
+    source.@"window-theme" = .dark;
+    source.@"cursor-opacity" = 0.375;
+
+    const serialized = try serializeConfig(alloc, &source);
+    defer alloc.free(serialized);
+    try testing.expect(std.mem.indexOf(u8, serialized, "font-size = 23.5") != null);
+    try testing.expect(std.mem.indexOf(u8, serialized, "window-theme = dark") != null);
+
+    var restored = try Config.default(alloc);
+    defer restored.deinit();
+    try restored.loadString(
+        alloc,
+        serialized,
+        "/tmp/ghostty-effective-config",
+    );
+    try restored.finalize();
+
+    try testing.expectEqual(source.@"font-size", restored.@"font-size");
+    try testing.expectEqual(source.@"window-theme", restored.@"window-theme");
+    try testing.expectEqual(source.@"cursor-opacity", restored.@"cursor-opacity");
+    try testing.expect(source.@"command-palette-entry".equal(
+        restored.@"command-palette-entry",
+    ));
+    try testing.expectEqual(@as(usize, 0), restored._diagnostics.items().len);
 }
 
 test "ghostty_config_get: enum" {

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -1324,6 +1324,18 @@ pub const Action = union(enum) {
         return Error.InvalidAction;
     }
 
+    /// Bridge the generic config struct parser to the action grammar. This is
+    /// required for command-palette entries whose action parameters contain
+    /// commas, such as `write_screen_file:copy,vt`.
+    pub fn parseCLI(
+        self: *Action,
+        alloc: Allocator,
+        input: ?[]const u8,
+    ) !void {
+        const parsed = try parse(input orelse return Error.InvalidFormat);
+        self.* = try parsed.clone(alloc);
+    }
+
     /// The scope of an action. The scope is the context in which an action
     /// must be executed.
     pub const Scope = enum {

--- a/src/os/windows.zig
+++ b/src/os/windows.zig
@@ -14,12 +14,15 @@ pub const FILE_ATTRIBUTE_NORMAL = windows.FILE_ATTRIBUTE_NORMAL;
 pub const FILE_FLAG_OVERLAPPED = windows.FILE_FLAG_OVERLAPPED;
 pub const FILE_SHARE_READ = windows.FILE_SHARE_READ;
 pub const GENERIC_READ = windows.GENERIC_READ;
+pub const GENERIC_WRITE = windows.GENERIC_WRITE;
 pub const HANDLE = windows.HANDLE;
 pub const HANDLE_FLAG_INHERIT = windows.HANDLE_FLAG_INHERIT;
 pub const INFINITE = windows.INFINITE;
 pub const INVALID_HANDLE_VALUE = windows.INVALID_HANDLE_VALUE;
 pub const MAX_PATH = windows.MAX_PATH;
 pub const OPEN_EXISTING = windows.OPEN_EXISTING;
+pub const OVERLAPPED = windows.OVERLAPPED;
+pub const PIPE_ACCESS_INBOUND = windows.PIPE_ACCESS_INBOUND;
 pub const PIPE_ACCESS_OUTBOUND = windows.PIPE_ACCESS_OUTBOUND;
 pub const PIPE_TYPE_BYTE = windows.PIPE_TYPE_BYTE;
 pub const PROCESS_INFORMATION = windows.PROCESS_INFORMATION;
@@ -29,6 +32,8 @@ pub const STARTUPINFOW = windows.STARTUPINFOW;
 pub const STARTF_USESTDHANDLES = windows.STARTF_USESTDHANDLES;
 pub const SYNCHRONIZE = windows.SYNCHRONIZE;
 pub const WAIT_FAILED = windows.WAIT_FAILED;
+pub const CREATE_EVENT_MANUAL_RESET = windows.CREATE_EVENT_MANUAL_RESET;
+pub const EVENT_ALL_ACCESS = windows.EVENT_ALL_ACCESS;
 pub const FALSE = windows.FALSE;
 pub const TRUE = windows.TRUE;
 
@@ -86,6 +91,9 @@ pub const exp = struct {
             lpBytesRead: ?*windows.DWORD,
             lpTotalBytesAvail: ?*windows.DWORD,
             lpBytesLeftThisMessage: ?*windows.DWORD,
+        ) callconv(.winapi) windows.BOOL;
+        pub extern "kernel32" fn ResetEvent(
+            hEvent: windows.HANDLE,
         ) callconv(.winapi) windows.BOOL;
         // Duplicated here because lpCommandLine is not marked optional in zig std
         pub extern "kernel32" fn CreateProcessW(

--- a/src/pty.zig
+++ b/src/pty.zig
@@ -471,10 +471,11 @@ const WindowsPty = struct {
 
     pub fn deinit(self: *Pty) void {
         // Older Windows versions wait indefinitely in ClosePseudoConsole if
-        // output remains open. Closing input or the ConPTY-side output handle
-        // first can also make conhost enter two teardown paths concurrently.
-        // Keep every other endpoint valid until the app-side output is closed
-        // and the pseudoconsole has finished its single owner teardown.
+        // output remains open. The ConPTY-side setup handles are normally
+        // released immediately after the child starts, but error cleanup can
+        // reach this point before that ownership transition. Close the
+        // app-side output first, let the pseudoconsole finish teardown, then
+        // idempotently release any setup handles still owned here.
         // https://learn.microsoft.com/en-us/windows/console/closepseudoconsole
         closeOwnedHandle(&self.out_pipe);
         if (self.pseudo_console) |pseudo_console| {
@@ -482,9 +483,18 @@ const WindowsPty = struct {
             self.pseudo_console = null;
         }
 
+        self.releasePseudoConsolePipeHandles();
+        closeOwnedHandle(&self.in_pipe);
+    }
+
+    /// Release the synchronous handles supplied to CreatePseudoConsole. The
+    /// pseudoconsole duplicates these handles, so the host must release its
+    /// copies after the attached child has started. Keeping them open prevents
+    /// broken-channel detection and makes teardown ownership ambiguous.
+    /// https://learn.microsoft.com/en-us/windows/console/creating-a-pseudoconsole-session#creating-the-pseudoconsole
+    pub fn releasePseudoConsolePipeHandles(self: *Pty) void {
         closeOwnedHandle(&self.out_pipe_pty);
         closeOwnedHandle(&self.in_pipe_pty);
-        closeOwnedHandle(&self.in_pipe);
     }
 
     /// Close a PTY endpoint at most once. This also makes cleanup safe when
@@ -548,6 +558,15 @@ test {
         .freebsd => try testing.expect(std.mem.startsWith(u8, pty.getProcessInfo(.tty_name).?, "/dev/")),
         .linux => try testing.expect(std.mem.startsWith(u8, pty.getProcessInfo(.tty_name).?, "/dev/pts/")),
         .macos => try testing.expect(std.mem.startsWith(u8, pty.getProcessInfo(.tty_name).?, "/dev/")),
+        .windows => {
+            // The host-side copies passed to CreatePseudoConsole are released
+            // after child creation. Releasing them repeatedly and then running
+            // the deferred full teardown must remain safe.
+            pty.releasePseudoConsolePipeHandles();
+            try testing.expectEqual(windows.INVALID_HANDLE_VALUE, pty.out_pipe_pty);
+            try testing.expectEqual(windows.INVALID_HANDLE_VALUE, pty.in_pipe_pty);
+            pty.releasePseudoConsolePipeHandles();
+        },
         else => try testing.expect(pty.getProcessInfo(.tty_name) == null),
     }
 }

--- a/src/pty.zig
+++ b/src/pty.zig
@@ -343,23 +343,43 @@ const WindowsPty = struct {
     pub fn open(size: winsize) OpenError!Pty {
         var pty: Pty = undefined;
 
-        var pipe_path_buf: [128]u8 = undefined;
-        var pipe_path_buf_w: [128]u16 = undefined;
-        const pipe_path = std.fmt.bufPrintZ(
-            &pipe_path_buf,
-            "\\\\.\\pipe\\LOCAL\\ghostty-pty-{d}-{d}",
+        const pipe_id = pipe_name_counter.fetchAdd(1, .monotonic);
+
+        var in_pipe_path_buf: [128]u8 = undefined;
+        var in_pipe_path_buf_w: [128]u16 = undefined;
+        const in_pipe_path = std.fmt.bufPrintZ(
+            &in_pipe_path_buf,
+            "\\\\.\\pipe\\LOCAL\\ghostty-pty-{d}-{d}-in",
             .{
                 windows.GetCurrentProcessId(),
-                pipe_name_counter.fetchAdd(1, .monotonic),
+                pipe_id,
             },
         ) catch unreachable;
 
-        const pipe_path_w_len = std.unicode.utf8ToUtf16Le(
-            &pipe_path_buf_w,
-            pipe_path,
+        const in_pipe_path_w_len = std.unicode.utf8ToUtf16Le(
+            &in_pipe_path_buf_w,
+            in_pipe_path,
         ) catch unreachable;
-        pipe_path_buf_w[pipe_path_w_len] = 0;
-        const pipe_path_w = pipe_path_buf_w[0..pipe_path_w_len :0];
+        in_pipe_path_buf_w[in_pipe_path_w_len] = 0;
+        const in_pipe_path_w = in_pipe_path_buf_w[0..in_pipe_path_w_len :0];
+
+        var out_pipe_path_buf: [128]u8 = undefined;
+        var out_pipe_path_buf_w: [128]u16 = undefined;
+        const out_pipe_path = std.fmt.bufPrintZ(
+            &out_pipe_path_buf,
+            "\\\\.\\pipe\\LOCAL\\ghostty-pty-{d}-{d}-out",
+            .{
+                windows.GetCurrentProcessId(),
+                pipe_id,
+            },
+        ) catch unreachable;
+
+        const out_pipe_path_w_len = std.unicode.utf8ToUtf16Le(
+            &out_pipe_path_buf_w,
+            out_pipe_path,
+        ) catch unreachable;
+        out_pipe_path_buf_w[out_pipe_path_w_len] = 0;
+        const out_pipe_path_w = out_pipe_path_buf_w[0..out_pipe_path_w_len :0];
 
         const security_attributes = windows.SECURITY_ATTRIBUTES{
             .nLength = @sizeOf(windows.SECURITY_ATTRIBUTES),
@@ -368,7 +388,7 @@ const WindowsPty = struct {
         };
 
         pty.in_pipe = windows.kernel32.CreateNamedPipeW(
-            pipe_path_w.ptr,
+            in_pipe_path_w.ptr,
             windows.PIPE_ACCESS_OUTBOUND |
                 windows.exp.FILE_FLAG_FIRST_PIPE_INSTANCE |
                 windows.FILE_FLAG_OVERLAPPED,
@@ -386,7 +406,7 @@ const WindowsPty = struct {
 
         var security_attributes_read = security_attributes;
         pty.in_pipe_pty = windows.kernel32.CreateFileW(
-            pipe_path_w.ptr,
+            in_pipe_path_w.ptr,
             windows.GENERIC_READ,
             0,
             &security_attributes_read,
@@ -399,28 +419,39 @@ const WindowsPty = struct {
         }
         errdefer _ = windows.CloseHandle(pty.in_pipe_pty);
 
-        // The in_pipe needs to be created as a named pipe, since anonymous
-        // pipes created with CreatePipe do not support overlapped operations,
-        // and the IOCP backend of libxev only uses overlapped operations on files.
-        //
-        // It would be ideal to use CreatePipe here, so that our pipe isn't
-        // visible to any other processes.
-
-        // if (windows.exp.kernel32.CreatePipe(&pty.in_pipe_pty, &pty.in_pipe, null, 0) == 0) {
-        //     return windows.unexpectedError(windows.kernel32.GetLastError());
-        // }
-        // errdefer {
-        //     _ = windows.CloseHandle(pty.in_pipe_pty);
-        //     _ = windows.CloseHandle(pty.in_pipe);
-        // }
-
-        if (windows.exp.kernel32.CreatePipe(&pty.out_pipe, &pty.out_pipe_pty, null, 0) == 0) {
+        // Both app-side handles use overlapped I/O. ConPTY requires the client
+        // handles passed to CreatePseudoConsole to remain synchronous.
+        pty.out_pipe = windows.kernel32.CreateNamedPipeW(
+            out_pipe_path_w.ptr,
+            windows.PIPE_ACCESS_INBOUND |
+                windows.exp.FILE_FLAG_FIRST_PIPE_INSTANCE |
+                windows.FILE_FLAG_OVERLAPPED,
+            windows.PIPE_TYPE_BYTE,
+            1,
+            4096,
+            4096,
+            0,
+            &security_attributes,
+        );
+        if (pty.out_pipe == windows.INVALID_HANDLE_VALUE) {
             return windows.unexpectedError(windows.kernel32.GetLastError());
         }
-        errdefer {
-            _ = windows.CloseHandle(pty.out_pipe);
-            _ = windows.CloseHandle(pty.out_pipe_pty);
+        errdefer _ = windows.CloseHandle(pty.out_pipe);
+
+        var security_attributes_write = security_attributes;
+        pty.out_pipe_pty = windows.kernel32.CreateFileW(
+            out_pipe_path_w.ptr,
+            windows.GENERIC_WRITE,
+            0,
+            &security_attributes_write,
+            windows.OPEN_EXISTING,
+            windows.FILE_ATTRIBUTE_NORMAL,
+            null,
+        );
+        if (pty.out_pipe_pty == windows.INVALID_HANDLE_VALUE) {
+            return windows.unexpectedError(windows.kernel32.GetLastError());
         }
+        errdefer _ = windows.CloseHandle(pty.out_pipe_pty);
 
         try windows.SetHandleInformation(pty.in_pipe, windows.HANDLE_FLAG_INHERIT, 0);
         try windows.SetHandleInformation(pty.in_pipe_pty, windows.HANDLE_FLAG_INHERIT, 0);

--- a/src/pty.zig
+++ b/src/pty.zig
@@ -330,18 +330,19 @@ const WindowsPty = struct {
     // Process-wide counter for pipe names
     var pipe_name_counter = std.atomic.Value(u32).init(1);
 
-    out_pipe: windows.HANDLE,
-    in_pipe: windows.HANDLE,
-    out_pipe_pty: windows.HANDLE,
-    in_pipe_pty: windows.HANDLE,
-    pseudo_console: windows.exp.HPCON,
+    out_pipe: windows.HANDLE = windows.INVALID_HANDLE_VALUE,
+    in_pipe: windows.HANDLE = windows.INVALID_HANDLE_VALUE,
+    out_pipe_pty: windows.HANDLE = windows.INVALID_HANDLE_VALUE,
+    in_pipe_pty: windows.HANDLE = windows.INVALID_HANDLE_VALUE,
+    pseudo_console: ?windows.exp.HPCON = null,
     size: winsize,
 
     pub const OpenError = error{Unexpected};
 
     /// Open a new PTY with the given initial size.
     pub fn open(size: winsize) OpenError!Pty {
-        var pty: Pty = undefined;
+        var pty: Pty = .{ .size = size };
+        errdefer pty.deinit();
 
         const pipe_id = pipe_name_counter.fetchAdd(1, .monotonic);
 
@@ -402,7 +403,6 @@ const WindowsPty = struct {
         if (pty.in_pipe == windows.INVALID_HANDLE_VALUE) {
             return windows.unexpectedError(windows.kernel32.GetLastError());
         }
-        errdefer _ = windows.CloseHandle(pty.in_pipe);
 
         var security_attributes_read = security_attributes;
         pty.in_pipe_pty = windows.kernel32.CreateFileW(
@@ -417,7 +417,6 @@ const WindowsPty = struct {
         if (pty.in_pipe_pty == windows.INVALID_HANDLE_VALUE) {
             return windows.unexpectedError(windows.kernel32.GetLastError());
         }
-        errdefer _ = windows.CloseHandle(pty.in_pipe_pty);
 
         // Both app-side handles use overlapped I/O. ConPTY requires the client
         // handles passed to CreatePseudoConsole to remain synchronous.
@@ -436,7 +435,6 @@ const WindowsPty = struct {
         if (pty.out_pipe == windows.INVALID_HANDLE_VALUE) {
             return windows.unexpectedError(windows.kernel32.GetLastError());
         }
-        errdefer _ = windows.CloseHandle(pty.out_pipe);
 
         var security_attributes_write = security_attributes;
         pty.out_pipe_pty = windows.kernel32.CreateFileW(
@@ -451,33 +449,50 @@ const WindowsPty = struct {
         if (pty.out_pipe_pty == windows.INVALID_HANDLE_VALUE) {
             return windows.unexpectedError(windows.kernel32.GetLastError());
         }
-        errdefer _ = windows.CloseHandle(pty.out_pipe_pty);
 
         try windows.SetHandleInformation(pty.in_pipe, windows.HANDLE_FLAG_INHERIT, 0);
         try windows.SetHandleInformation(pty.in_pipe_pty, windows.HANDLE_FLAG_INHERIT, 0);
         try windows.SetHandleInformation(pty.out_pipe, windows.HANDLE_FLAG_INHERIT, 0);
         try windows.SetHandleInformation(pty.out_pipe_pty, windows.HANDLE_FLAG_INHERIT, 0);
 
+        var pseudo_console: windows.exp.HPCON = undefined;
         const result = windows.exp.kernel32.CreatePseudoConsole(
             .{ .X = @intCast(size.ws_col), .Y = @intCast(size.ws_row) },
             pty.in_pipe_pty,
             pty.out_pipe_pty,
             0,
-            &pty.pseudo_console,
+            &pseudo_console,
         );
         if (result != windows.S_OK) return error.Unexpected;
+        pty.pseudo_console = pseudo_console;
 
-        pty.size = size;
         return pty;
     }
 
     pub fn deinit(self: *Pty) void {
-        _ = windows.CloseHandle(self.in_pipe_pty);
-        _ = windows.CloseHandle(self.in_pipe);
-        _ = windows.CloseHandle(self.out_pipe_pty);
-        _ = windows.CloseHandle(self.out_pipe);
-        _ = windows.exp.kernel32.ClosePseudoConsole(self.pseudo_console);
-        self.* = undefined;
+        // Older Windows versions wait indefinitely in ClosePseudoConsole if
+        // output remains open. Closing input or the ConPTY-side output handle
+        // first can also make conhost enter two teardown paths concurrently.
+        // Keep every other endpoint valid until the app-side output is closed
+        // and the pseudoconsole has finished its single owner teardown.
+        // https://learn.microsoft.com/en-us/windows/console/closepseudoconsole
+        closeOwnedHandle(&self.out_pipe);
+        if (self.pseudo_console) |pseudo_console| {
+            windows.exp.kernel32.ClosePseudoConsole(pseudo_console);
+            self.pseudo_console = null;
+        }
+
+        closeOwnedHandle(&self.out_pipe_pty);
+        closeOwnedHandle(&self.in_pipe_pty);
+        closeOwnedHandle(&self.in_pipe);
+    }
+
+    /// Close a PTY endpoint at most once. This also makes cleanup safe when
+    /// open fails after acquiring only a prefix of the owned handles.
+    fn closeOwnedHandle(handle: *windows.HANDLE) void {
+        if (handle.* == windows.INVALID_HANDLE_VALUE) return;
+        _ = windows.CloseHandle(handle.*);
+        handle.* = windows.INVALID_HANDLE_VALUE;
     }
 
     pub const GetSizeError = error{};
@@ -491,8 +506,9 @@ const WindowsPty = struct {
 
     /// Set the size of the pty.
     pub fn setSize(self: *Pty, size: winsize) SetSizeError!void {
+        const pseudo_console = self.pseudo_console orelse return error.ResizeFailed;
         const result = windows.exp.kernel32.ResizePseudoConsole(
-            self.pseudo_console,
+            pseudo_console,
             .{ .X = @intCast(size.ws_col), .Y = @intCast(size.ws_row) },
         );
 

--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -13,6 +13,8 @@ const cursor = @import("renderer/cursor.zig");
 const instrumentation = @import("renderer/instrumentation.zig");
 const message = @import("renderer/message.zig");
 const size = @import("renderer/size.zig");
+pub const frame_lease = @import("renderer/frame_lease.zig");
+pub const external_frame = @import("renderer/external_frame.zig");
 pub const shadertoy = @import("renderer/shadertoy.zig");
 pub const Backend = @import("renderer/backend.zig").Backend;
 pub const GenericRenderer = @import("renderer/generic.zig").Renderer;
@@ -64,6 +66,8 @@ test {
     _ = cursor;
     _ = instrumentation;
     _ = message;
+    _ = frame_lease;
+    _ = external_frame;
     _ = shadertoy;
     _ = size;
     _ = Thread;

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -49,13 +49,28 @@ const ExternalPresenter = struct {
     ) callconv(.c) void,
 };
 
+const ExternalLeasedPresenter = struct {
+    surface: *apprt.Surface,
+    userdata: ?*anyopaque,
+    present_callback: *const fn (
+        userdata: ?*anyopaque,
+        frame: *const rendererpkg.external_frame.Frame,
+    ) callconv(.c) rendererpkg.external_frame.Disposition,
+};
+
 const Presenter = union(enum) {
     layer: IOSurfaceLayer,
     external: ExternalPresenter,
+    external_leased: ExternalLeasedPresenter,
 
     fn init(opts: rendererpkg.Options) !Presenter {
         switch (opts.rt_surface.platform) {
             .metal_external => |config| return .{ .external = .{
+                .surface = opts.rt_surface,
+                .userdata = config.userdata,
+                .present_callback = config.present,
+            } },
+            .metal_external_leased => |config| return .{ .external_leased = .{
                 .surface = opts.rt_surface,
                 .userdata = config.userdata,
                 .present_callback = config.present,
@@ -75,6 +90,7 @@ const Presenter = union(enum) {
                 .macos => |value| value.nsview,
                 .ios => |value| value.uiview,
                 .metal_external => unreachable,
+                .metal_external_leased => unreachable,
                 .opengl => unreachable,
             },
         };
@@ -126,6 +142,7 @@ const Presenter = union(enum) {
         switch (self.*) {
             .layer => |*layer| layer.release(),
             .external => {},
+            .external_leased => {},
         }
     }
 };
@@ -209,7 +226,7 @@ pub fn prepareDeinit(self: *Metal) void {
         .ios => {
             const layer = switch (self.presenter) {
                 .layer => |*value| value,
-                .external => return,
+                .external, .external_leased => return,
             };
             const renderer: *align(1) Renderer = @fieldParentPtr("api", self);
             layer.detachFromHostIfDisplayCallbackOwned(
@@ -227,7 +244,7 @@ pub fn loopEnter(self: *Metal) void {
         .layer => |*value| value,
         // The external presenter is driven by Ghostty's existing renderer
         // loop. It deliberately installs no AppKit display callback.
-        .external => return,
+        .external, .external_leased => return,
     };
     const renderer: *align(1) Renderer = @fieldParentPtr("api", self);
     layer.setDisplayCallback(
@@ -297,6 +314,13 @@ pub fn surfaceSize(self: *const Metal) !struct { width: u32, height: u32 } {
                 .height = value.height,
             };
         },
+        .external_leased => |external| external_size: {
+            const value = try external.surface.getSize();
+            break :external_size .{
+                .width = value.width,
+                .height = value.height,
+            };
+        },
     };
 
     // We need to clamp our runtime surface size to the maximum
@@ -325,8 +349,16 @@ pub fn initTarget(self: *const Metal, width: usize, height: usize) !Target {
     });
 }
 
-/// Present the provided target.
-pub inline fn present(self: *Metal, target: Target, sync: bool) !void {
+/// Present the provided target. The return value reports whether a leased
+/// external presenter acquired the exact swap-chain slot.
+pub inline fn present(
+    self: *Metal,
+    renderer: *Renderer,
+    target: Target,
+    sync: bool,
+    frame_token: rendererpkg.frame_lease.Token,
+    host_context: u64,
+) !bool {
     switch (self.presenter) {
         .layer => |*layer| {
             if (sync) {
@@ -334,14 +366,40 @@ pub inline fn present(self: *Metal, target: Target, sync: bool) !void {
             } else {
                 try layer.setSurface(target.surface);
             }
+            return false;
         },
-        .external => |external| external.present_callback(
-            external.userdata,
-            @ptrCast(target.surface),
-            @intCast(target.width),
-            @intCast(target.height),
-        ),
+        .external => |external| {
+            external.present_callback(
+                external.userdata,
+                @ptrCast(target.surface),
+                @intCast(target.width),
+                @intCast(target.height),
+            );
+            return false;
+        },
+        .external_leased => |external| {
+            if (!renderer.beginExternalFramePresentation(frame_token))
+                return error.InvalidExternalFrameToken;
+
+            const frame: rendererpkg.external_frame.Frame = .{
+                .iosurface = @ptrCast(target.surface),
+                .frame_token = frame_token,
+                .host_context = host_context,
+                .width_px = @intCast(target.width),
+                .height_px = @intCast(target.height),
+                .color_space = .display_p3,
+            };
+            return external.present_callback(external.userdata, &frame) == .acquire;
+        },
     }
+}
+
+/// Capture the embedder's opaque frame context at draw submission time.
+pub fn externalFrameContext(self: *const Metal) u64 {
+    return switch (self.presenter) {
+        .external_leased => |external| external.surface.externalFrameContext(),
+        else => 0,
+    };
 }
 
 /// Present the last presented target again. (noop for Metal)
@@ -489,8 +547,16 @@ pub inline fn beginFrame(
     renderer: *Renderer,
     /// The target is presented via the provided renderer's API when completed.
     target: *Target,
+    frame_token: rendererpkg.frame_lease.Token,
+    host_context: u64,
 ) !Frame {
-    return try Frame.begin(.{ .queue = self.queue }, renderer, target);
+    return try Frame.begin(
+        .{ .queue = self.queue },
+        renderer,
+        target,
+        frame_token,
+        host_context,
+    );
 }
 
 fn chooseDevice() error{NoMetalDevice}!objc.Object {

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -38,7 +38,97 @@ pub const swap_chain_count = 3;
 
 const log = std.log.scoped(.metal);
 
-layer: IOSurfaceLayer,
+const ExternalPresenter = struct {
+    surface: *apprt.Surface,
+    userdata: ?*anyopaque,
+    present_callback: *const fn (
+        userdata: ?*anyopaque,
+        iosurface: *anyopaque,
+        width_px: u32,
+        height_px: u32,
+    ) callconv(.c) void,
+};
+
+const Presenter = union(enum) {
+    layer: IOSurfaceLayer,
+    external: ExternalPresenter,
+
+    fn init(opts: rendererpkg.Options) !Presenter {
+        switch (opts.rt_surface.platform) {
+            .metal_external => |config| return .{ .external = .{
+                .surface = opts.rt_surface,
+                .userdata = config.userdata,
+                .present_callback = config.present,
+            } },
+            .macos, .ios => {},
+        }
+
+        const ViewInfo = struct {
+            view: objc.Object,
+            scale_factor: f64,
+        };
+
+        const info: ViewInfo = .{
+            .scale_factor = @floatCast(opts.rt_surface.content_scale.x),
+            .view = switch (opts.rt_surface.platform) {
+                .macos => |value| value.nsview,
+                .ios => |value| value.uiview,
+                .metal_external => unreachable,
+            },
+        };
+
+        // Create an IOSurfaceLayer which we can assign to the view to make
+        // it in to a "layer-hosting view", so that we can manually control
+        // the layer contents.
+        var layer = try IOSurfaceLayer.init();
+        errdefer layer.release();
+
+        // Add our layer to the view.
+        //
+        // On macOS we do this by making the view "layer-hosting"
+        // by assigning it to the view's `layer` property BEFORE
+        // setting `wantsLayer` to `true`.
+        //
+        // On iOS, views are always layer-backed, and `layer`
+        // is readonly, so instead we add it as a sublayer.
+        switch (comptime builtin.os.tag) {
+            .macos => {
+                info.view.setProperty("layer", layer.layer.value);
+                info.view.setProperty("wantsLayer", true);
+            },
+
+            .ios => {
+                const view_layer = objc.Object.fromId(info.view.getProperty(?*anyopaque, "layer"));
+                view_layer.msgSend(void, objc.sel("addSublayer:"), .{layer.layer.value});
+            },
+
+            else => @compileError("unsupported target for Metal"),
+        }
+
+        // Ensure that if our layer is oversized it
+        // does not overflow the bounds of the view.
+        info.view.setProperty("clipsToBounds", true);
+
+        // Ensure that our layer has a content scale set to
+        // match the scale factor of the window. This avoids
+        // magnification issues leading to blurry rendering.
+        layer.layer.setProperty("contentsScale", info.scale_factor);
+
+        // This makes it so that our display callback will actually be called.
+        layer.layer.setProperty("needsDisplayOnBoundsChange", true);
+
+        return .{ .layer = layer };
+    }
+
+    fn deinit(self: *Presenter) void {
+        switch (self.*) {
+            .layer => |*layer| layer.release(),
+            .external => {},
+        }
+    }
+};
+
+presenter: Presenter,
 
 /// MTLDevice
 device: objc.Object,
@@ -87,66 +177,17 @@ pub fn init(alloc: Allocator, opts: rendererpkg.Options) !Metal {
         .{ default_storage_mode, max_texture_size },
     );
 
-    const ViewInfo = struct {
-        view: objc.Object,
-        scaleFactor: f64,
-    };
-
-    // Get the metadata about our underlying view that we'll be rendering to.
-    const info: ViewInfo = switch (apprt.runtime) {
-        apprt.embedded => .{
-            .scaleFactor = @floatCast(opts.rt_surface.content_scale.x),
-            .view = switch (opts.rt_surface.platform) {
-                .macos => |v| v.nsview,
-                .ios => |v| v.uiview,
-            },
-        },
-
+    const presenter = switch (apprt.runtime) {
+        apprt.embedded => try Presenter.init(opts),
         else => @compileError("unsupported apprt for metal"),
     };
-
-    // Create an IOSurfaceLayer which we can assign to the view to make
-    // it in to a "layer-hosting view", so that we can manually control
-    // the layer contents.
-    var layer = try IOSurfaceLayer.init();
-    errdefer layer.release();
-
-    // Add our layer to the view.
-    //
-    // On macOS we do this by making the view "layer-hosting"
-    // by assigning it to the view's `layer` property BEFORE
-    // setting `wantsLayer` to `true`.
-    //
-    // On iOS, views are always layer-backed, and `layer`
-    // is readonly, so instead we add it as a sublayer.
-    switch (comptime builtin.os.tag) {
-        .macos => {
-            info.view.setProperty("layer", layer.layer.value);
-            info.view.setProperty("wantsLayer", true);
-        },
-
-        .ios => {
-            const view_layer = objc.Object.fromId(info.view.getProperty(?*anyopaque, "layer"));
-            view_layer.msgSend(void, objc.sel("addSublayer:"), .{layer.layer.value});
-        },
-
-        else => @compileError("unsupported target for Metal"),
+    errdefer {
+        var value = presenter;
+        value.deinit();
     }
 
-    // Ensure that if our layer is oversized it
-    // does not overflow the bounds of the view.
-    info.view.setProperty("clipsToBounds", true);
-
-    // Ensure that our layer has a content scale set to
-    // match the scale factor of the window. This avoids
-    // magnification issues leading to blurry rendering.
-    layer.layer.setProperty("contentsScale", info.scaleFactor);
-
-    // This makes it so that our display callback will actually be called.
-    layer.layer.setProperty("needsDisplayOnBoundsChange", true);
-
     return .{
-        .layer = layer,
+        .presenter = presenter,
         .device = device,
         .queue = queue,
         .blending = opts.config.blending,
@@ -158,14 +199,18 @@ pub fn init(alloc: Allocator, opts: rendererpkg.Options) !Metal {
 pub fn deinit(self: *Metal) void {
     self.queue.release();
     self.device.release();
-    self.layer.release();
+    self.presenter.deinit();
 }
 
 pub fn prepareDeinit(self: *Metal) void {
     switch (comptime builtin.os.tag) {
         .ios => {
+            const layer = switch (self.presenter) {
+                .layer => |*value| value,
+                .external => return,
+            };
             const renderer: *align(1) Renderer = @fieldParentPtr("api", self);
-            self.layer.detachFromHostIfDisplayCallbackOwned(
+            layer.detachFromHostIfDisplayCallbackOwned(
                 @ptrCast(&displayCallback),
                 @ptrCast(renderer),
             );
@@ -176,8 +221,14 @@ pub fn prepareDeinit(self: *Metal) void {
 }
 
 pub fn loopEnter(self: *Metal) void {
+    const layer = switch (self.presenter) {
+        .layer => |*value| value,
+        // The external presenter is driven by Ghostty's existing renderer
+        // loop. It deliberately installs no AppKit display callback.
+        .external => return,
+    };
     const renderer: *align(1) Renderer = @fieldParentPtr("api", self);
-    self.layer.setDisplayCallback(
+    layer.setDisplayCallback(
         @ptrCast(&displayCallback),
         @ptrCast(renderer),
     );
@@ -228,21 +279,30 @@ pub fn initShaders(
 
 /// Get the current size of the runtime surface.
 pub fn surfaceSize(self: *const Metal) !struct { width: u32, height: u32 } {
-    const bounds = self.layer.layer.getProperty(graphics.Rect, "bounds");
-    const scale = self.layer.layer.getProperty(f64, "contentsScale");
+    const size: struct { width: u32, height: u32 } = switch (self.presenter) {
+        .layer => |layer| layer_size: {
+            const bounds = layer.layer.getProperty(graphics.Rect, "bounds");
+            const scale = layer.layer.getProperty(f64, "contentsScale");
+            break :layer_size .{
+                .width = @intFromFloat(bounds.size.width * scale),
+                .height = @intFromFloat(bounds.size.height * scale),
+            };
+        },
+        .external => |external| external_size: {
+            const value = try external.surface.getSize();
+            break :external_size .{
+                .width = value.width,
+                .height = value.height,
+            };
+        },
+    };
 
     // We need to clamp our runtime surface size to the maximum
     // possible texture size since we can't create a screen buffer (texture)
     // larger than that.
     return .{
-        .width = @min(
-            @as(u32, @intFromFloat(bounds.size.width * scale)),
-            self.max_texture_size,
-        ),
-        .height = @min(
-            @as(u32, @intFromFloat(bounds.size.height * scale)),
-            self.max_texture_size,
-        ),
+        .width = @min(size.width, self.max_texture_size),
+        .height = @min(size.height, self.max_texture_size),
     };
 }
 
@@ -265,10 +325,20 @@ pub fn initTarget(self: *const Metal, width: usize, height: usize) !Target {
 
 /// Present the provided target.
 pub inline fn present(self: *Metal, target: Target, sync: bool) !void {
-    if (sync) {
-        self.layer.setSurfaceSync(target.surface);
-    } else {
-        try self.layer.setSurface(target.surface);
+    switch (self.presenter) {
+        .layer => |*layer| {
+            if (sync) {
+                layer.setSurfaceSync(target.surface);
+            } else {
+                try layer.setSurface(target.surface);
+            }
+        },
+        .external => |external| external.present_callback(
+            external.userdata,
+            @ptrCast(target.surface),
+            @intCast(target.width),
+            @intCast(target.height),
+        ),
     }
 }
 

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -99,6 +99,7 @@ pub fn init(alloc: Allocator, opts: rendererpkg.Options) !Metal {
             .view = switch (opts.rt_surface.platform) {
                 .macos => |v| v.nsview,
                 .ios => |v| v.uiview,
+                .opengl => return error.OpenGLPlatformNotSupportedByMetal,
             },
         },
 

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -281,8 +281,9 @@ pub fn displayRealized(self: *const OpenGL) void {
         },
 
         // Embedded contexts are prepared by surfaceInit and threadEnter. The
-        // generic renderer still references this hook, so it must compile as a
-        // no-op even though an embedder never calls it.
+        // embedder owns one context for the surface lifetime and never enters
+        // GTK's realize cycle, but the generic renderer still instantiates
+        // this method for every OpenGL runtime.
         apprt.embedded => {},
 
         else => @compileError("unsupported app runtime for OpenGL"),

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -245,7 +245,11 @@ pub fn displayRealized(self: *const OpenGL) void {
             );
         },
 
-        else => @compileError("only GTK should be calling displayRealized"),
+        // Embedded surfaces never participate in GTK's realize cycle, but
+        // the generic renderer still instantiates this method for OpenGL.
+        apprt.embedded => {},
+
+        else => @compileError("unsupported app runtime for OpenGL"),
     }
 }
 

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -4,6 +4,7 @@ pub const OpenGL = @This();
 const std = @import("std");
 const Allocator = std.mem.Allocator;
 const builtin = @import("builtin");
+const build_config = @import("../build_config.zig");
 const gl = @import("opengl");
 const shadertoy = @import("shadertoy.zig");
 const apprt = @import("../apprt.zig");
@@ -33,6 +34,41 @@ pub const swap_chain_count = 1;
 
 const log = std.log.scoped(.opengl);
 
+const is_embedded = build_config.artifact == .lib;
+const GlProc = *const fn () callconv(.c) void;
+const EmbeddedState = if (is_embedded) struct {
+    surface: *apprt.Surface,
+    platform: *const apprt.embedded.Platform.OpenGL,
+} else void;
+threadlocal var embedded_state: if (is_embedded) ?EmbeddedState else void =
+    if (is_embedded) null else {};
+
+fn embeddedGetProcAddress(name: [*:0]const u8) callconv(.c) ?GlProc {
+    const state = embedded_state orelse return null;
+    const ptr = state.platform.get_proc_address(
+        state.platform.userdata,
+        name,
+    ) orelse return null;
+    return @ptrCast(@alignCast(ptr));
+}
+
+fn enterEmbedded(surface: *apprt.Surface) !void {
+    const platform = switch (surface.platform) {
+        .opengl => |*value| value,
+        else => return error.OpenGLPlatformRequired,
+    };
+    if (!platform.make_current(platform.userdata))
+        return error.OpenGLMakeCurrentFailed;
+    embedded_state = .{ .surface = surface, .platform = platform };
+}
+
+fn leaveEmbedded() void {
+    const state = embedded_state orelse return;
+    gl.glad.unload();
+    state.platform.clear_current(state.platform.userdata);
+    embedded_state = null;
+}
+
 /// We require at least OpenGL 4.3
 pub const MIN_VERSION_MAJOR = 4;
 pub const MIN_VERSION_MINOR = 3;
@@ -56,6 +92,7 @@ pub fn init(alloc: Allocator, opts: rendererpkg.Options) error{}!OpenGL {
 }
 
 pub fn deinit(self: *OpenGL) void {
+    if (comptime is_embedded) leaveEmbedded();
     self.* = undefined;
 }
 
@@ -160,8 +197,6 @@ fn prepareContext(getProcAddress: anytype) !void {
 
 /// This is called early right after surface creation.
 pub fn surfaceInit(surface: *apprt.Surface) !void {
-    _ = surface;
-
     switch (apprt.runtime) {
         else => @compileError("unsupported app runtime for OpenGL"),
 
@@ -170,9 +205,9 @@ pub fn surfaceInit(surface: *apprt.Surface) !void {
         => try prepareContext(null),
 
         apprt.embedded => {
-            // TODO(mitchellh): this does nothing today to allow libghostty
-            // to compile for OpenGL targets but libghostty is strictly
-            // broken for rendering on this platforms.
+            try enterEmbedded(surface);
+            errdefer leaveEmbedded();
+            try prepareContext(embeddedGetProcAddress);
         },
     }
 
@@ -191,12 +226,12 @@ pub fn surfaceInit(surface: *apprt.Surface) !void {
 pub fn finalizeSurfaceInit(self: *const OpenGL, surface: *apprt.Surface) !void {
     _ = self;
     _ = surface;
+    if (comptime is_embedded) leaveEmbedded();
 }
 
 /// Callback called by renderer.Thread when it begins.
 pub fn threadEnter(self: *const OpenGL, surface: *apprt.Surface) !void {
     _ = self;
-    _ = surface;
 
     switch (apprt.runtime) {
         else => @compileError("unsupported app runtime for OpenGL"),
@@ -209,9 +244,9 @@ pub fn threadEnter(self: *const OpenGL, surface: *apprt.Surface) !void {
         },
 
         apprt.embedded => {
-            // TODO(mitchellh): this does nothing today to allow libghostty
-            // to compile for OpenGL targets but libghostty is strictly
-            // broken for rendering on this platforms.
+            try enterEmbedded(surface);
+            errdefer leaveEmbedded();
+            try prepareContext(embeddedGetProcAddress);
         },
     }
 }
@@ -229,7 +264,7 @@ pub fn threadExit(self: *const OpenGL) void {
         },
 
         apprt.embedded => {
-            // TODO: see threadEnter
+            leaveEmbedded();
         },
     }
 }
@@ -282,6 +317,11 @@ pub fn initShaders(
 /// Get the current size of the runtime surface.
 pub fn surfaceSize(self: *const OpenGL) !struct { width: u32, height: u32 } {
     _ = self;
+    if (comptime is_embedded) {
+        const state = embedded_state orelse return error.OpenGLContextNotCurrent;
+        const size = try state.surface.getSize();
+        return .{ .width = size.width, .height = size.height };
+    }
     var viewport: [4]gl.c.GLint = undefined;
     gl.glad.context.GetIntegerv.?(gl.c.GL_VIEWPORT, &viewport);
     return .{
@@ -332,6 +372,11 @@ pub fn present(self: *OpenGL, target: Target) !void {
 
     // Keep track of this target in case we need to repeat it.
     self.last_target = target;
+
+    if (comptime is_embedded) {
+        const state = embedded_state orelse return error.OpenGLContextNotCurrent;
+        state.platform.swap_buffers(state.platform.userdata);
+    }
 }
 
 /// Present the last presented target again.

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -207,7 +207,7 @@ pub fn surfaceInit(surface: *apprt.Surface) !void {
         apprt.embedded => {
             try enterEmbedded(surface);
             errdefer leaveEmbedded();
-            try prepareContext(embeddedGetProcAddress);
+            try prepareContext(&embeddedGetProcAddress);
         },
     }
 
@@ -246,7 +246,7 @@ pub fn threadEnter(self: *const OpenGL, surface: *apprt.Surface) !void {
         apprt.embedded => {
             try enterEmbedded(surface);
             errdefer leaveEmbedded();
-            try prepareContext(embeddedGetProcAddress);
+            try prepareContext(&embeddedGetProcAddress);
         },
     }
 }
@@ -280,8 +280,9 @@ pub fn displayRealized(self: *const OpenGL) void {
             );
         },
 
-        // Embedded surfaces never participate in GTK's realize cycle, but
-        // the generic renderer still instantiates this method for OpenGL.
+        // Embedded contexts are prepared by surfaceInit and threadEnter. The
+        // generic renderer still references this hook, so it must compile as a
+        // no-op even though an embedder never calls it.
         apprt.embedded => {},
 
         else => @compileError("unsupported app runtime for OpenGL"),

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -521,7 +521,10 @@ pub inline fn beginFrame(
     renderer: *Renderer,
     /// The target is presented via the provided renderer's API when completed.
     target: *Target,
+    frame_token: rendererpkg.frame_lease.Token,
+    external_context: u64,
 ) !Frame {
     _ = self;
-    return try Frame.begin(.{}, renderer, target);
+    _ = external_context;
+    return try Frame.begin(.{}, renderer, target, frame_token);
 }

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -292,9 +292,24 @@ pub fn displayRealized(self: *const OpenGL) void {
 
 /// Actions taken before doing anything in `drawFrame`.
 ///
-/// Right now there's nothing we need to do for OpenGL.
+/// Embedded hosts own the default framebuffer and can resize it independently
+/// of the long-lived renderer context. OpenGL does not update the viewport
+/// when a drawable changes size, so synchronize it before every frame.
 pub fn drawFrameStart(self: *OpenGL) void {
     _ = self;
+    if (comptime is_embedded) {
+        const state = embedded_state orelse return;
+        const size = state.surface.getSize() catch |err| {
+            log.err("error querying embedded OpenGL surface size err={}", .{err});
+            return;
+        };
+        gl.glad.context.Viewport.?(
+            0,
+            0,
+            @intCast(size.width),
+            @intCast(size.height),
+        );
+    }
 }
 
 /// Actions taken after `drawFrame` is done.

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -231,6 +231,11 @@ wakeup_c: xev.Completion = .{},
 stop: xev.Async,
 stop_c: xev.Completion = .{},
 
+/// Set after the stop watcher is armed. Embedded callers can destroy a
+/// surface immediately after creation, so Surface.init must not return while
+/// a stop notification could still be lost during thread startup.
+started: std.Thread.ResetEvent = .{},
+
 /// The timer used for rendering
 render_h: xev.Timer,
 render_c: xev.Completion = .{},
@@ -549,6 +554,11 @@ fn threadMain_(self: *Thread) !void {
     // Setup our thread QoS
     self.setQosClass();
 
+    // Arm stop before any fallible renderer setup. Surface.init waits for
+    // this signal in embedded builds, making an immediate free deterministic.
+    self.stop.wait(&self.loop, &self.stop_c, Thread, self, stopCallback);
+    self.started.set();
+
     // Run our loop start/end callbacks if the renderer cares.
     const has_loop = @hasDecl(rendererpkg.Renderer, "loopEnter");
     if (has_loop) try self.renderer.loopEnter(self);
@@ -562,7 +572,6 @@ fn threadMain_(self: *Thread) !void {
 
     // Start the async handlers
     self.wakeup.wait(&self.loop, &self.wakeup_c, Thread, self, wakeupCallback);
-    self.stop.wait(&self.loop, &self.stop_c, Thread, self, stopCallback);
     self.draw_now.wait(&self.loop, &self.draw_now_c, Thread, self, drawNowCallback);
     self.visibility_retry.wait(
         &self.loop,

--- a/src/renderer/external_frame.zig
+++ b/src/renderer/external_frame.zig
@@ -1,0 +1,53 @@
+/// The external presenter either drops its borrowed frame immediately or
+/// acquires a Ghostty-owned lease that must later be released by token.
+pub const Disposition = enum(c_int) {
+    drop = 0,
+    acquire = 1,
+};
+
+/// The color space attached to the exported IOSurface.
+pub const ColorSpace = enum(c_int) {
+    display_p3 = 0,
+};
+
+/// One completed Metal frame offered to an external compositor.
+pub const Frame = extern struct {
+    iosurface: *anyopaque,
+    frame_token: u64,
+    host_context: u64,
+    width_px: u32,
+    height_px: u32,
+    color_space: ColorSpace,
+};
+
+test "external Metal frame C ABI" {
+    const std = @import("std");
+    const lib = @import("../lib/main.zig");
+    const c = @import("ghostty.h");
+
+    try lib.checkGhosttyHEnum(
+        Disposition,
+        "GHOSTTY_METAL_EXTERNAL_FRAME_",
+    );
+    try lib.checkGhosttyHEnum(
+        ColorSpace,
+        "GHOSTTY_METAL_EXTERNAL_COLOR_SPACE_",
+    );
+    try std.testing.expectEqual(
+        @sizeOf(Frame),
+        @sizeOf(c.ghostty_metal_external_frame_s),
+    );
+    inline for (.{
+        "iosurface",
+        "frame_token",
+        "host_context",
+        "width_px",
+        "height_px",
+        "color_space",
+    }) |field| {
+        try std.testing.expectEqual(
+            @offsetOf(Frame, field),
+            @offsetOf(c.ghostty_metal_external_frame_s, field),
+        );
+    }
+}

--- a/src/renderer/frame_lease.zig
+++ b/src/renderer/frame_lease.zig
@@ -1,0 +1,299 @@
+const std = @import("std");
+
+/// A token identifies one exact swap-chain slot for one acquisition of that
+/// slot. Tokens are never zero, and a token becomes invalid as soon as its
+/// slot is returned to the pool.
+pub const Token = u64;
+
+/// Thread-safe ownership tracking for a fixed-size renderer swap chain.
+///
+/// GPU completion callbacks and external compositors can finish frames in a
+/// different order than the renderer submitted them. A counting semaphore by
+/// itself only tracks how many slots are free; this pool additionally tracks
+/// which exact slot is free so an out-of-order host release cannot cause the
+/// renderer to reuse an IOSurface that is still being displayed.
+pub fn Pool(comptime slot_count: usize) type {
+    if (slot_count == 0) @compileError("a frame lease pool needs at least one slot");
+
+    return struct {
+        const Self = @This();
+
+        pub const Lease = struct {
+            slot: std.math.IntFittingRange(0, slot_count - 1),
+            token: Token,
+        };
+
+        const SlotState = enum {
+            free,
+            gpu,
+            presenting,
+            host,
+            deinit,
+        };
+
+        const Slot = struct {
+            state: SlotState = .free,
+            token: Token = 0,
+
+            /// A host can release on another thread before its presentation
+            /// callback has returned. Remember that release until the callback
+            /// disposition is known so the permit is posted exactly once.
+            release_pending: bool = false,
+        };
+
+        mutex: std.Thread.Mutex = .{},
+        available: std.Thread.Semaphore = .{ .permits = slot_count },
+        slots: [slot_count]Slot = [_]Slot{.{}} ** slot_count,
+        next_token: Token = 0,
+        defunct: bool = false,
+
+        /// Acquire one exact free slot. A null timeout waits indefinitely.
+        pub fn acquire(
+            self: *Self,
+            timeout_ns: ?u64,
+        ) error{ Defunct, Timeout }!Lease {
+            if (timeout_ns) |timeout| {
+                try self.available.timedWait(timeout);
+            } else {
+                self.available.wait();
+            }
+            errdefer self.available.post();
+
+            self.mutex.lock();
+            defer self.mutex.unlock();
+
+            if (self.defunct) return error.Defunct;
+
+            for (&self.slots, 0..) |*slot, index| {
+                if (slot.state != .free) continue;
+
+                const token = self.freshTokenLocked();
+                slot.* = .{
+                    .state = .gpu,
+                    .token = token,
+                };
+                return .{
+                    .slot = @intCast(index),
+                    .token = token,
+                };
+            }
+
+            // Every permit corresponds to exactly one `.free` slot.
+            unreachable;
+        }
+
+        /// Transition a GPU-complete frame before invoking a leased external
+        /// presentation callback. This must happen before the callback because
+        /// another process may release the token while the callback is running.
+        pub fn beginPresentation(self: *Self, token: Token) bool {
+            self.mutex.lock();
+            defer self.mutex.unlock();
+
+            const slot = self.findLocked(token) orelse return false;
+            if (slot.state != .gpu) return false;
+            slot.state = .presenting;
+            return true;
+        }
+
+        /// Finish GPU completion and callback dispatch. `host_acquired` is the
+        /// callback disposition. Returns false for an unknown token or invalid
+        /// transition; successful calls either transfer the exact slot to the
+        /// host or return its permit to the renderer.
+        pub fn finish(self: *Self, token: Token, host_acquired: bool) bool {
+            var post = false;
+
+            self.mutex.lock();
+            const slot = self.findLocked(token) orelse {
+                self.mutex.unlock();
+                return false;
+            };
+            switch (slot.state) {
+                .gpu => {
+                    if (host_acquired) {
+                        self.mutex.unlock();
+                        return false;
+                    }
+                    slot.* = .{};
+                    post = true;
+                },
+                .presenting => {
+                    if (host_acquired and !slot.release_pending) {
+                        slot.state = .host;
+                    } else {
+                        slot.* = .{};
+                        post = true;
+                    }
+                },
+                else => {
+                    self.mutex.unlock();
+                    return false;
+                },
+            }
+            self.mutex.unlock();
+
+            if (post) self.available.post();
+            return true;
+        }
+
+        /// Release a frame acquired by an external presentation callback.
+        /// Duplicate, stale, unknown, and not-yet-presented tokens return false.
+        pub fn releaseHost(self: *Self, token: Token) bool {
+            var post = false;
+
+            self.mutex.lock();
+            const slot = self.findLocked(token) orelse {
+                self.mutex.unlock();
+                return false;
+            };
+            switch (slot.state) {
+                .presenting => {
+                    if (slot.release_pending) {
+                        self.mutex.unlock();
+                        return false;
+                    }
+                    slot.release_pending = true;
+                },
+                .host => {
+                    slot.* = .{};
+                    post = true;
+                },
+                else => {
+                    self.mutex.unlock();
+                    return false;
+                },
+            }
+            self.mutex.unlock();
+
+            if (post) self.available.post();
+            return true;
+        }
+
+        /// Prevent new acquisitions. Existing GPU and host owners may still
+        /// finish so teardown can safely wait for their exact slots.
+        pub fn beginDeinit(self: *Self) void {
+            self.mutex.lock();
+            defer self.mutex.unlock();
+            self.defunct = true;
+        }
+
+        /// Consume one free slot for teardown and return its exact index.
+        pub fn takeForDeinit(
+            self: *Self,
+            timeout_ns: ?u64,
+        ) error{Timeout}!std.math.IntFittingRange(0, slot_count - 1) {
+            if (timeout_ns) |timeout| {
+                try self.available.timedWait(timeout);
+            } else {
+                self.available.wait();
+            }
+
+            self.mutex.lock();
+            defer self.mutex.unlock();
+            for (&self.slots, 0..) |*slot, index| {
+                if (slot.state != .free) continue;
+                slot.state = .deinit;
+                return @intCast(index);
+            }
+
+            // Every permit corresponds to exactly one `.free` slot.
+            unreachable;
+        }
+
+        fn findLocked(self: *Self, token: Token) ?*Slot {
+            if (token == 0) return null;
+            for (&self.slots) |*slot| {
+                if (slot.token == token and slot.state != .free and
+                    slot.state != .deinit) return slot;
+            }
+            return null;
+        }
+
+        fn freshTokenLocked(self: *Self) Token {
+            while (true) {
+                self.next_token +%= 1;
+                if (self.next_token == 0) continue;
+                if (self.findLocked(self.next_token) == null) return self.next_token;
+            }
+        }
+    };
+}
+
+test "frame lease pool reuses the exact out-of-order released slot" {
+    const LeasePool = Pool(3);
+    var pool: LeasePool = .{};
+
+    const first = try pool.acquire(null);
+    const second = try pool.acquire(null);
+    const third = try pool.acquire(null);
+
+    try std.testing.expect(pool.beginPresentation(first.token));
+    try std.testing.expect(pool.finish(first.token, true));
+    try std.testing.expect(pool.beginPresentation(second.token));
+    try std.testing.expect(pool.finish(second.token, true));
+    try std.testing.expect(pool.beginPresentation(third.token));
+    try std.testing.expect(pool.finish(third.token, true));
+
+    try std.testing.expect(pool.releaseHost(second.token));
+    try std.testing.expect(!pool.releaseHost(second.token));
+
+    const replacement = try pool.acquire(null);
+    try std.testing.expectEqual(second.slot, replacement.slot);
+    try std.testing.expect(replacement.token != second.token);
+
+    try std.testing.expect(pool.finish(replacement.token, false));
+    try std.testing.expect(pool.releaseHost(first.token));
+    try std.testing.expect(pool.releaseHost(third.token));
+}
+
+test "frame lease pool accepts release racing the presentation callback" {
+    const LeasePool = Pool(1);
+    var pool: LeasePool = .{};
+
+    const lease = try pool.acquire(null);
+    try std.testing.expect(pool.beginPresentation(lease.token));
+    try std.testing.expect(pool.releaseHost(lease.token));
+    try std.testing.expect(!pool.releaseHost(lease.token));
+
+    // The callback subsequently says acquire, but the early release wins and
+    // makes this exact slot immediately available once callback dispatch ends.
+    try std.testing.expect(pool.finish(lease.token, true));
+    const replacement = try pool.acquire(null);
+    try std.testing.expectEqual(lease.slot, replacement.slot);
+    try std.testing.expect(replacement.token != lease.token);
+    try std.testing.expect(!pool.releaseHost(lease.token));
+    try std.testing.expect(pool.finish(replacement.token, false));
+}
+
+test "frame lease pool rejects host release before presentation" {
+    const LeasePool = Pool(1);
+    var pool: LeasePool = .{};
+    const lease = try pool.acquire(null);
+
+    try std.testing.expect(!pool.releaseHost(lease.token));
+    try std.testing.expect(!pool.releaseHost(0));
+    try std.testing.expect(!pool.releaseHost(999));
+    try std.testing.expect(pool.finish(lease.token, false));
+}
+
+test "frame lease pool teardown consumes exact slots" {
+    const LeasePool = Pool(2);
+    var pool: LeasePool = .{};
+
+    const gpu_done = try pool.acquire(null);
+    const host_owned = try pool.acquire(null);
+    try std.testing.expect(pool.finish(gpu_done.token, false));
+    try std.testing.expect(pool.beginPresentation(host_owned.token));
+    try std.testing.expect(pool.finish(host_owned.token, true));
+
+    pool.beginDeinit();
+    try std.testing.expectEqual(
+        gpu_done.slot,
+        try pool.takeForDeinit(null),
+    );
+    try std.testing.expect(pool.releaseHost(host_owned.token));
+    try std.testing.expectEqual(
+        host_owned.slot,
+        try pool.takeForDeinit(null),
+    );
+    try std.testing.expect(!pool.releaseHost(host_owned.token));
+}

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -280,6 +280,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             // This is comptime because there isn't a good reason to change
             // this at runtime and there is a lot of complexity to support it.
             const buf_count = GraphicsAPI.swap_chain_count;
+            const LeasePool = renderer.frame_lease.Pool(buf_count);
 
             // cmux iOS fork: bounded acquire deadline for `nextFrame`. On iOS
             // `render_now` produces frames synchronously on a single serial
@@ -297,11 +298,10 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             /// `buf_count` structs that can hold the
             /// data needed by the GPU to draw a frame.
             frames: [buf_count]FrameState,
-            /// Index of the most recently used frame state struct.
-            frame_index: std.math.IntFittingRange(0, buf_count) = 0,
-            /// Semaphore that we wait on to make sure we have an available
-            /// frame state struct so we can start working on a new frame.
-            frame_sema: std.Thread.Semaphore = .{ .permits = buf_count },
+            /// Exact-slot ownership and generation tokens for the swap chain.
+            /// The GPU and an external compositor may release frames out of
+            /// submission order, so a bare counting semaphore is insufficient.
+            leases: LeasePool = .{},
 
             /// Set to true when deinited, if you try to deinit a defunct
             /// swap chain it will just be ignored, to prevent double-free.
@@ -325,6 +325,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             pub fn deinit(self: *SwapChain) void {
                 if (self.defunct) return;
                 self.defunct = true;
+                self.leases.beginDeinit();
 
                 // Wait for all of our inflight draws to complete so that we can
                 // cleanly deinit our GPU state. cmux iOS fork: bound each wait
@@ -338,19 +339,28 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 if (comptime builtin.os.tag == .ios) {
                     var acquired: usize = 0;
                     while (acquired < buf_count) : (acquired += 1) {
-                        self.frame_sema.timedWait(frame_acquire_timeout_ns) catch break;
+                        const index = self.leases.takeForDeinit(
+                            frame_acquire_timeout_ns,
+                        ) catch break;
+                        self.frames[index].deinit();
                     }
-                    for (self.frames[0..acquired]) |*frame| frame.deinit();
                 } else {
-                    for (0..buf_count) |_| self.frame_sema.wait();
-                    for (&self.frames) |*frame| frame.deinit();
+                    for (0..buf_count) |_| {
+                        const index = self.leases.takeForDeinit(null) catch unreachable;
+                        self.frames[index].deinit();
+                    }
                 }
             }
 
+            const AcquiredFrame = struct {
+                state: *FrameState,
+                token: renderer.frame_lease.Token,
+            };
+
             /// Get the next frame state to draw to. This will wait on the
             /// semaphore to ensure that the frame is available. This must
-            /// always be paired with a call to releaseFrame.
-            pub fn nextFrame(self: *SwapChain) error{ Defunct, Timeout }!*FrameState {
+            /// always be paired with a call to finishFrame.
+            pub fn nextFrame(self: *SwapChain) error{ Defunct, Timeout }!AcquiredFrame {
                 if (self.defunct) return error.Defunct;
 
                 // cmux iOS fork: bound the acquire so a stalled GPU completion
@@ -361,19 +371,41 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 // macOS/OpenGL keep the proven unbounded wait (they drive
                 // frames from the renderer-thread vsync loop where this is
                 // legitimate backpressure, never a serial-queue wedge).
-                if (comptime builtin.os.tag == .ios) {
-                    try self.frame_sema.timedWait(frame_acquire_timeout_ns);
-                } else {
-                    self.frame_sema.wait();
-                }
-                errdefer self.frame_sema.post();
-                self.frame_index = (self.frame_index + 1) % buf_count;
-                return &self.frames[self.frame_index];
+                const lease = try self.leases.acquire(if (comptime builtin.os.tag == .ios)
+                    frame_acquire_timeout_ns
+                else
+                    null);
+                return .{
+                    .state = &self.frames[lease.slot],
+                    .token = lease.token,
+                };
             }
 
-            /// This should be called when the frame has completed drawing.
-            pub fn releaseFrame(self: *SwapChain) void {
-                self.frame_sema.post();
+            /// Mark a GPU-complete frame as entering the external presentation
+            /// callback. Host releases are accepted after this transition.
+            pub fn beginExternalPresentation(
+                self: *SwapChain,
+                token: renderer.frame_lease.Token,
+            ) bool {
+                return self.leases.beginPresentation(token);
+            }
+
+            /// This should be called exactly once when GPU completion and any
+            /// external presentation callback have both finished.
+            pub fn finishFrame(
+                self: *SwapChain,
+                token: renderer.frame_lease.Token,
+                host_acquired: bool,
+            ) bool {
+                return self.leases.finish(token, host_acquired);
+            }
+
+            /// Release a frame previously acquired by the external host.
+            pub fn releaseExternalFrame(
+                self: *SwapChain,
+                token: renderer.frame_lease.Token,
+            ) bool {
+                return self.leases.releaseHost(token);
             }
         };
 
@@ -1601,9 +1633,10 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             defer damage.deinit();
 
             // Wait for a frame to be available.
-            const frame = try self.swap_chain.nextFrame();
-            errdefer self.swap_chain.releaseFrame();
-            // log.debug("drawing frame index={}", .{self.swap_chain.frame_index});
+            const acquired = try self.swap_chain.nextFrame();
+            const frame = acquired.state;
+            errdefer assert(self.swap_chain.finishFrame(acquired.token, false));
+            // log.debug("drawing frame token={}", .{acquired.token});
 
             // If we need to reinitialize our shaders, do so.
             if (self.reinitialize_shaders) {
@@ -1697,7 +1730,16 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             }
 
             // Get a frame context from the graphics API.
-            var frame_ctx = try self.api.beginFrame(self, &frame.target);
+            const external_context = if (@hasDecl(GraphicsAPI, "externalFrameContext"))
+                self.api.externalFrameContext()
+            else
+                0;
+            var frame_ctx = try self.api.beginFrame(
+                self,
+                &frame.target,
+                acquired.token,
+                external_context,
+            );
             defer frame_ctx.complete(sync);
 
             {
@@ -1848,6 +1890,8 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
         pub fn frameCompleted(
             self: *Self,
             health: Health,
+            token: renderer.frame_lease.Token,
+            host_acquired: bool,
         ) void {
             // If our health value hasn't changed, then we do nothing. We don't
             // do a cmpxchg here because strict atomicity isn't important.
@@ -1873,8 +1917,29 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 if (pushed > 0) self.health.store(health, .seq_cst);
             }
 
-            // Always release our semaphore
-            self.swap_chain.releaseFrame();
+            // Return this exact slot, or transfer it to the external host.
+            // Completion callbacks are allowed to arrive out of order.
+            assert(self.swap_chain.finishFrame(token, host_acquired));
+        }
+
+        /// Mark an exact GPU-complete slot as entering a leased external
+        /// presentation callback. This is thread-safe and intentionally occurs
+        /// before invoking the callback so an immediate cross-process release
+        /// cannot race ownership establishment.
+        pub fn beginExternalFramePresentation(
+            self: *Self,
+            token: renderer.frame_lease.Token,
+        ) bool {
+            return self.swap_chain.beginExternalPresentation(token);
+        }
+
+        /// Release a leased external frame. This may be called from any host
+        /// thread while the surface remains alive.
+        pub fn releaseExternalFrame(
+            self: *Self,
+            token: renderer.frame_lease.Token,
+        ) bool {
+            return self.swap_chain.releaseExternalFrame(token);
         }
 
         /// Call this any time the background image path changes.

--- a/src/renderer/metal/Frame.zig
+++ b/src/renderer/metal/Frame.zig
@@ -13,6 +13,7 @@ const Target = @import("Target.zig");
 const RenderPass = @import("RenderPass.zig");
 
 const Health = @import("../../renderer.zig").Health;
+const FrameToken = @import("../../renderer.zig").frame_lease.Token;
 
 const log = std.log.scoped(.metal);
 
@@ -35,6 +36,8 @@ pub fn begin(
     renderer: *Renderer,
     /// The target is presented via the provided renderer's API when completed.
     target: *Target,
+    frame_token: FrameToken,
+    host_context: u64,
 ) !Self {
     const buffer = opts.queue.msgSend(
         objc.Object,
@@ -49,6 +52,8 @@ pub fn begin(
             .renderer = renderer,
             .target = target,
             .sync = false,
+            .frame_token = frame_token,
+            .host_context = host_context,
         },
         &bufferCompleted,
     );
@@ -61,6 +66,8 @@ const CompletionBlock = objc.Block(struct {
     renderer: *Renderer,
     target: *Target,
     sync: bool,
+    frame_token: FrameToken,
+    host_context: u64,
 }, .{
     objc.c.id, // MTLCommandBuffer
 }, void);
@@ -79,16 +86,21 @@ fn bufferCompleted(
     };
 
     // If the frame is healthy, present it.
+    var host_acquired = false;
     if (health == .healthy) {
-        block.renderer.api.present(
+        host_acquired = block.renderer.api.present(
+            block.renderer,
             block.target.*,
             block.sync,
-        ) catch |err| {
+            block.frame_token,
+            block.host_context,
+        ) catch |err| failed: {
             log.err("Failed to present render target: err={}", .{err});
+            break :failed false;
         };
     }
 
-    block.renderer.frameCompleted(health);
+    block.renderer.frameCompleted(health, block.frame_token, host_acquired);
 }
 
 /// Add a render pass to this frame with the provided attachments.
@@ -112,13 +124,13 @@ pub inline fn complete(self: *Self, sync: bool) void {
     // blocking `waitUntilCompleted` here would park that queue forever if the
     // GPU present stalls during a foreground resize storm. Force async
     // completion on iOS so the queue thread returns right after `commit`; the
-    // completion handler (bufferCompleted -> frameCompleted -> releaseFrame)
-    // still reposts the frame_sema permit. Today the iOS `render_now` path
+    // completion handler (bufferCompleted -> frameCompleted -> finishFrame)
+    // still returns the exact swap-chain permit. Today the iOS `render_now` path
     // already passes sync=false, so this is a no-op for the current build and
     // unchanged for macOS (use_sync == sync); it is a structural guarantee that
     // no future sync=true path can reintroduce the freeze on iOS. `use_sync` is
     // the SINGLE source of truth for both branches so exactly one completion
-    // path runs per committed buffer (net-zero frame_sema balance).
+    // path runs per committed buffer (net-zero swap-chain permit balance).
     const use_sync = sync and builtin.os.tag != .ios;
 
     // If we don't complete synchronously, add our block as a completion

--- a/src/renderer/opengl/Frame.zig
+++ b/src/renderer/opengl/Frame.zig
@@ -11,6 +11,7 @@ const Target = @import("Target.zig");
 const RenderPass = @import("RenderPass.zig");
 
 const Health = @import("../../renderer.zig").Health;
+const FrameToken = @import("../../renderer.zig").frame_lease.Token;
 
 const log = std.log.scoped(.opengl);
 
@@ -19,6 +20,7 @@ pub const Options = struct {};
 
 renderer: *Renderer,
 target: *Target,
+frame_token: FrameToken,
 
 /// Begin encoding a frame.
 pub fn begin(
@@ -28,12 +30,14 @@ pub fn begin(
     renderer: *Renderer,
     /// The target is presented via the provided renderer's API when completed.
     target: *Target,
+    frame_token: FrameToken,
 ) !Self {
     _ = opts;
 
     return .{
         .renderer = renderer,
         .target = target,
+        .frame_token = frame_token,
     };
 }
 
@@ -67,5 +71,5 @@ pub fn complete(self: *const Self, sync: bool) void {
     }
 
     // Report the health to the renderer.
-    self.renderer.frameCompleted(health);
+    self.renderer.frameCompleted(health, self.frame_token, false);
 }

--- a/src/renderer/size.zig
+++ b/src/renderer/size.zig
@@ -43,6 +43,30 @@ pub const Size = struct {
         return self.screen.subPadding(self.padding);
     }
 
+    /// Resolve the exact surface pixel dimensions for an authoritative grid
+    /// using the current cell metrics and padding. Invalid or overflowing
+    /// dimensions return null without truncation.
+    pub fn screenForGrid(self: Size, requested: GridSize) ?ScreenSize {
+        if (requested.columns == 0 or requested.rows == 0 or
+            self.cell.width == 0 or self.cell.height == 0) return null;
+
+        const width = @as(u64, requested.columns) * self.cell.width +
+            self.padding.left + self.padding.right;
+        const height = @as(u64, requested.rows) * self.cell.height +
+            self.padding.top + self.padding.bottom;
+        if (width > std.math.maxInt(u32) or height > std.math.maxInt(u32))
+            return null;
+
+        const screen: ScreenSize = .{
+            .width = @intCast(width),
+            .height = @intCast(height),
+        };
+        var resolved = self;
+        resolved.screen = screen;
+        if (!resolved.grid().equals(requested)) return null;
+        return screen;
+    }
+
     /// Set the padding to be balanced around the grid. The balanced
     /// padding is calculated AFTER the explicit padding is taken
     /// into account.
@@ -404,6 +428,48 @@ test "GridSize update rounding" {
 
     try testing.expectEqual(@as(GridSize.Unit, 3), grid.columns);
     try testing.expectEqual(@as(GridSize.Unit, 2), grid.rows);
+}
+
+test "Size.screenForGrid resolves exact logical dimensions" {
+    const size: Size = .{
+        .screen = .{ .width = 1, .height = 1 },
+        .cell = .{ .width = 9, .height = 17 },
+        .padding = .{ .left = 3, .right = 5, .top = 7, .bottom = 11 },
+    };
+
+    const screen = size.screenForGrid(.{
+        .columns = 120,
+        .rows = 40,
+    }).?;
+    try std.testing.expectEqual(@as(u32, 1088), screen.width);
+    try std.testing.expectEqual(@as(u32, 698), screen.height);
+
+    var resolved = size;
+    resolved.screen = screen;
+    try std.testing.expectEqual(
+        GridSize{ .columns = 120, .rows = 40 },
+        resolved.grid(),
+    );
+}
+
+test "Size.screenForGrid rejects zero and overflow" {
+    const normal: Size = .{
+        .screen = .{ .width = 0, .height = 0 },
+        .cell = .{ .width = 8, .height = 16 },
+        .padding = .{},
+    };
+    try std.testing.expect(normal.screenForGrid(.{ .columns = 0, .rows = 1 }) == null);
+    try std.testing.expect(normal.screenForGrid(.{ .columns = 1, .rows = 0 }) == null);
+
+    const overflowing: Size = .{
+        .screen = .{ .width = 0, .height = 0 },
+        .cell = .{ .width = std.math.maxInt(u32), .height = 1 },
+        .padding = .{ .left = 1 },
+    };
+    try std.testing.expect(overflowing.screenForGrid(.{
+        .columns = 2,
+        .rows = 1,
+    }) == null);
 }
 
 test "coordinate conversion" {

--- a/src/terminal/c/render.zig
+++ b/src/terminal/c/render.zig
@@ -1613,6 +1613,126 @@ test "render: colors get" {
     }
 }
 
+test "render: OSC dynamic color resets follow later C API defaults" {
+    var terminal: terminal_c.Terminal = null;
+    try testing.expectEqual(Result.success, terminal_c.new(
+        &lib.alloc.test_allocator,
+        &terminal,
+        .{
+            .cols = 80,
+            .rows = 24,
+            .max_scrollback = 10_000,
+        },
+    ));
+    defer terminal_c.free(terminal);
+
+    const Channels = struct {
+        const Spec = struct {
+            option: terminal_c.Option,
+            terminal_data: terminal_c.TerminalData,
+            render_data: Data,
+            default_a: colorpkg.RGB.C,
+            override_b: colorpkg.RGB.C,
+            default_c: colorpkg.RGB.C,
+        };
+
+        const all = [_]Spec{
+            .{
+                .option = .color_foreground,
+                .terminal_data = .color_foreground,
+                .render_data = .color_foreground,
+                .default_a = .{ .r = 0x11, .g = 0x12, .b = 0x13 },
+                .override_b = .{ .r = 0x41, .g = 0x42, .b = 0x43 },
+                .default_c = .{ .r = 0x71, .g = 0x72, .b = 0x73 },
+            },
+            .{
+                .option = .color_background,
+                .terminal_data = .color_background,
+                .render_data = .color_background,
+                .default_a = .{ .r = 0x21, .g = 0x22, .b = 0x23 },
+                .override_b = .{ .r = 0x51, .g = 0x52, .b = 0x53 },
+                .default_c = .{ .r = 0x81, .g = 0x82, .b = 0x83 },
+            },
+            .{
+                .option = .color_cursor,
+                .terminal_data = .color_cursor,
+                .render_data = .color_cursor,
+                .default_a = .{ .r = 0x31, .g = 0x32, .b = 0x33 },
+                .override_b = .{ .r = 0x61, .g = 0x62, .b = 0x63 },
+                .default_c = .{ .r = 0x91, .g = 0x92, .b = 0x93 },
+            },
+        };
+
+        fn setDefaults(t: terminal_c.Terminal, comptime field: []const u8) !void {
+            inline for (all) |channel| {
+                const value = @field(channel, field);
+                try testing.expectEqual(
+                    Result.success,
+                    terminal_c.set(t, channel.option, @ptrCast(&value)),
+                );
+            }
+        }
+
+        fn expectEffective(t: terminal_c.Terminal, comptime field: []const u8) !void {
+            inline for (all) |channel| {
+                var actual: colorpkg.RGB.C = undefined;
+                try testing.expectEqual(
+                    Result.success,
+                    terminal_c.get(t, channel.terminal_data, @ptrCast(&actual)),
+                );
+                try testing.expectEqual(@field(channel, field), actual);
+            }
+        }
+
+        fn expectRendered(state: RenderState, comptime field: []const u8) !void {
+            inline for (all) |channel| {
+                var actual: colorpkg.RGB.C = undefined;
+                try testing.expectEqual(
+                    Result.success,
+                    get(state, channel.render_data, @ptrCast(&actual)),
+                );
+                try testing.expectEqual(@field(channel, field), actual);
+            }
+        }
+    };
+
+    try Channels.setDefaults(terminal, "default_a");
+
+    var state: RenderState = null;
+    try testing.expectEqual(Result.success, new(
+        &lib.alloc.test_allocator,
+        &state,
+    ));
+    defer free(state);
+
+    try testing.expectEqual(Result.success, update(state, terminal));
+    try Channels.expectRendered(state, "default_a");
+
+    const set_override =
+        "\x1b]10;rgb:41/42/43\x1b\\" ++
+        "\x1b]11;rgb:51/52/53\x1b\\" ++
+        "\x1b]12;rgb:61/62/63\x1b\\";
+    terminal_c.vt_write(terminal, set_override, set_override.len);
+    try testing.expectEqual(Result.success, update(state, terminal));
+    try Channels.expectRendered(state, "override_b");
+
+    const reset_override =
+        "\x1b]110\x1b\\" ++
+        "\x1b]111\x1b\\" ++
+        "\x1b]112\x1b\\";
+    terminal_c.vt_write(terminal, reset_override, reset_override.len);
+    try testing.expectEqual(Result.success, update(state, terminal));
+    try Channels.expectRendered(state, "default_a");
+
+    try Channels.setDefaults(terminal, "default_c");
+    try Channels.expectEffective(terminal, "default_c");
+
+    // Reusing an already-populated render state must pick up the mutable
+    // embedder default after the application override has been reset.
+    try testing.expectEqual(Result.success, update(state, terminal));
+    try Channels.expectRendered(state, "default_c");
+}
+
 test "render: row cells bg_color no background" {
     var terminal: terminal_c.Terminal = null;
     try testing.expectEqual(Result.success, terminal_c.new(

--- a/src/terminal/c/terminal.zig
+++ b/src/terminal/c/terminal.zig
@@ -556,6 +556,15 @@ pub const TerminalCursorStyle = enum(c_int) {
             _ => null,
         };
     }
+
+    fn fromZig(style: Screen.CursorStyle) TerminalCursorStyle {
+        return switch (style) {
+            .bar => .bar,
+            .block => .block,
+            .underline => .underline,
+            .block_hollow => .block_hollow,
+        };
+    }
 };
 
 /// C: GhosttyDeviceAttributes
@@ -690,17 +699,25 @@ pub const TerminalData = enum(c_int) {
     kitty_graphics = 30,
     selection = 31,
     viewport_active = 32,
+    cursor_visual_style = 33,
+    cursor_blinking = 34,
 
     /// Output type expected for querying the data of the given kind.
     pub fn OutType(comptime self: TerminalData) type {
         return switch (self) {
             .invalid => void,
             .cols, .rows, .cursor_x, .cursor_y => size.CellCountInt,
-            .cursor_pending_wrap, .cursor_visible, .mouse_tracking, .viewport_active => bool,
+            .cursor_pending_wrap,
+            .cursor_visible,
+            .mouse_tracking,
+            .viewport_active,
+            .cursor_blinking,
+            => bool,
             .active_screen => TerminalScreen,
             .kitty_keyboard_flags => u8,
             .scrollbar => TerminalScrollbar,
             .cursor_style => style_c.Style,
+            .cursor_visual_style => TerminalCursorStyle,
             .title, .pwd => lib.String,
             .total_rows, .scrollback_rows => usize,
             .width_px, .height_px => u32,
@@ -832,6 +849,8 @@ fn getTyped(
             t.screens.active.selection orelse return .no_value,
         ),
         .viewport_active => out.* = t.screens.active.pages.viewport == .active,
+        .cursor_visual_style => out.* = .fromZig(t.screens.active.cursor.cursor_style),
+        .cursor_blinking => out.* = t.modes.get(.cursor_blinking),
     }
 
     return .success;
@@ -1732,6 +1751,138 @@ test "set default cursor style and blink" {
     vt_write(t, "\x1b[0 q", 5);
     try testing.expectEqual(Screen.CursorStyle.underline, t.?.terminal.screens.active.cursor.cursor_style);
     try testing.expect(t.?.terminal.modes.get(.cursor_blinking));
+}
+
+fn expectCursorVisual(
+    t: Terminal,
+    expected_style: TerminalCursorStyle,
+    expected_blinking: bool,
+) !void {
+    var style: TerminalCursorStyle = undefined;
+    var blinking: bool = undefined;
+    try testing.expectEqual(Result.success, get(t, .cursor_visual_style, @ptrCast(&style)));
+    try testing.expectEqual(Result.success, get(t, .cursor_blinking, @ptrCast(&blinking)));
+    try testing.expectEqual(expected_style, style);
+    try testing.expectEqual(expected_blinking, blinking);
+}
+
+test "get cursor visual configured defaults and DECSCUSR reset" {
+    var t: Terminal = null;
+    try testing.expectEqual(Result.success, new(
+        &lib.alloc.test_allocator,
+        &t,
+        .{ .cols = 80, .rows = 24, .max_scrollback = 0 },
+    ));
+    defer free(t);
+
+    try expectCursorVisual(t, .block, false);
+
+    const default_style: TerminalCursorStyle = .bar;
+    const default_blink = true;
+    try testing.expectEqual(Result.success, set(t, .default_cursor_style, @ptrCast(&default_style)));
+    try testing.expectEqual(Result.success, set(t, .default_cursor_blink, @ptrCast(&default_blink)));
+    try expectCursorVisual(t, .bar, true);
+
+    const explicit = "\x1b[4 q";
+    vt_write(t, explicit, explicit.len);
+    try expectCursorVisual(t, .underline, false);
+
+    const reset_to_default = "\x1b[0 q";
+    vt_write(t, reset_to_default, reset_to_default.len);
+    try expectCursorVisual(t, .bar, true);
+}
+
+test "get cursor visual covers every DECSCUSR shape and blink pair" {
+    var t: Terminal = null;
+    try testing.expectEqual(Result.success, new(
+        &lib.alloc.test_allocator,
+        &t,
+        .{ .cols = 80, .rows = 24, .max_scrollback = 0 },
+    ));
+    defer free(t);
+
+    const cases = [_]struct {
+        sequence: []const u8,
+        style: TerminalCursorStyle,
+        blinking: bool,
+    }{
+        .{ .sequence = "\x1b[1 q", .style = .block, .blinking = true },
+        .{ .sequence = "\x1b[2 q", .style = .block, .blinking = false },
+        .{ .sequence = "\x1b[3 q", .style = .underline, .blinking = true },
+        .{ .sequence = "\x1b[4 q", .style = .underline, .blinking = false },
+        .{ .sequence = "\x1b[5 q", .style = .bar, .blinking = true },
+        .{ .sequence = "\x1b[6 q", .style = .bar, .blinking = false },
+    };
+
+    for (cases) |case| {
+        vt_write(t, case.sequence.ptr, case.sequence.len);
+        try expectCursorVisual(t, case.style, case.blinking);
+    }
+
+    // DEC mode 12 controls blink independently of the DECSCUSR shape.
+    const blink_on = "\x1b[?12h";
+    vt_write(t, blink_on, blink_on.len);
+    try expectCursorVisual(t, .bar, true);
+
+    const blink_off = "\x1b[?12l";
+    vt_write(t, blink_off, blink_off.len);
+    try expectCursorVisual(t, .bar, false);
+}
+
+test "get cursor visual follows active screen shape and terminal blink mode" {
+    var t: Terminal = null;
+    try testing.expectEqual(Result.success, new(
+        &lib.alloc.test_allocator,
+        &t,
+        .{ .cols = 80, .rows = 24, .max_scrollback = 0 },
+    ));
+    defer free(t);
+
+    const primary_bar = "\x1b[5 q";
+    vt_write(t, primary_bar, primary_bar.len);
+    try expectCursorVisual(t, .bar, true);
+
+    // Mode 1049 copies the primary cursor into the alternate screen.
+    const enter_alt = "\x1b[?1049h";
+    vt_write(t, enter_alt, enter_alt.len);
+    try expectCursorVisual(t, .bar, true);
+
+    const alt_underline = "\x1b[3 q";
+    vt_write(t, alt_underline, alt_underline.len);
+    try expectCursorVisual(t, .underline, true);
+
+    const blink_off = "\x1b[?12l";
+    vt_write(t, blink_off, blink_off.len);
+    try expectCursorVisual(t, .underline, false);
+
+    // Returning restores the primary screen's shape. Blink remains steady
+    // because DEC mode 12 belongs to the terminal, not an individual screen.
+    const leave_alt = "\x1b[?1049l";
+    vt_write(t, leave_alt, leave_alt.len);
+    try expectCursorVisual(t, .bar, false);
+}
+
+test "get cursor visual RIS restores configured defaults" {
+    var t: Terminal = null;
+    try testing.expectEqual(Result.success, new(
+        &lib.alloc.test_allocator,
+        &t,
+        .{ .cols = 80, .rows = 24, .max_scrollback = 0 },
+    ));
+    defer free(t);
+
+    const default_style: TerminalCursorStyle = .bar;
+    const default_blink = true;
+    try testing.expectEqual(Result.success, set(t, .default_cursor_style, @ptrCast(&default_style)));
+    try testing.expectEqual(Result.success, set(t, .default_cursor_blink, @ptrCast(&default_blink)));
+
+    const explicit = "\x1b[4 q";
+    vt_write(t, explicit, explicit.len);
+    try expectCursorVisual(t, .underline, false);
+
+    const ris = "\x1bc";
+    vt_write(t, ris, ris.len);
+    try expectCursorVisual(t, .bar, true);
 }
 
 test "set and get selection" {

--- a/src/terminal/c/terminal.zig
+++ b/src/terminal/c/terminal.zig
@@ -701,6 +701,7 @@ pub const TerminalData = enum(c_int) {
     viewport_active = 32,
     cursor_visual_style = 33,
     cursor_blinking = 34,
+    screen_activity = 35,
 
     /// Output type expected for querying the data of the given kind.
     pub fn OutType(comptime self: TerminalData) type {
@@ -721,6 +722,7 @@ pub const TerminalData = enum(c_int) {
             .title, .pwd => lib.String,
             .total_rows, .scrollback_rows => usize,
             .width_px, .height_px => u32,
+            .screen_activity => u64,
             .color_foreground,
             .color_background,
             .color_cursor,
@@ -851,6 +853,7 @@ fn getTyped(
         .viewport_active => out.* = t.screens.active.pages.viewport == .active,
         .cursor_visual_style => out.* = .fromZig(t.screens.active.cursor.cursor_style),
         .cursor_blinking => out.* = t.modes.get(.cursor_blinking),
+        .screen_activity => out.* = t.selectionActivity(),
     }
 
     return .success;
@@ -1883,6 +1886,50 @@ test "get cursor visual RIS restores configured defaults" {
     const ris = "\x1bc";
     vt_write(t, ris, ris.len);
     try expectCursorVisual(t, .bar, true);
+}
+
+test "get screen activity tracks active screen switches" {
+    var t: Terminal = null;
+    try testing.expectEqual(Result.success, new(
+        &lib.alloc.test_allocator,
+        &t,
+        .{ .cols = 80, .rows = 24, .max_scrollback = 0 },
+    ));
+    defer free(t);
+
+    var initial: u64 = undefined;
+    try testing.expectEqual(Result.success, get(t, .screen_activity, @ptrCast(&initial)));
+
+    const text = "screen activity is not text activity";
+    vt_write(t, text, text.len);
+    var after_text: u64 = undefined;
+    try testing.expectEqual(Result.success, get(t, .screen_activity, @ptrCast(&after_text)));
+    try testing.expectEqual(initial, after_text);
+
+    const enter_alt = "\x1b[?1049h";
+    vt_write(t, enter_alt, enter_alt.len);
+    var after_enter: u64 = undefined;
+    try testing.expectEqual(Result.success, get(t, .screen_activity, @ptrCast(&after_enter)));
+    try testing.expect(after_enter != after_text);
+
+    // A repeated request for the active screen is not an actual switch.
+    vt_write(t, enter_alt, enter_alt.len);
+    var after_noop_enter: u64 = undefined;
+    try testing.expectEqual(Result.success, get(t, .screen_activity, @ptrCast(&after_noop_enter)));
+    try testing.expectEqual(after_enter, after_noop_enter);
+
+    const leave_alt = "\x1b[?1049l";
+    vt_write(t, leave_alt, leave_alt.len);
+    var after_leave: u64 = undefined;
+    try testing.expectEqual(Result.success, get(t, .screen_activity, @ptrCast(&after_leave)));
+    try testing.expect(after_leave != after_noop_enter);
+
+    // Both actual switches must survive batching in a single VT write.
+    const enter_and_leave = "\x1b[?1049h\x1b[?1049l";
+    vt_write(t, enter_and_leave, enter_and_leave.len);
+    var after_batched_switches: u64 = undefined;
+    try testing.expectEqual(Result.success, get(t, .screen_activity, @ptrCast(&after_batched_switches)));
+    try testing.expect(after_batched_switches != after_leave);
 }
 
 test "set and get selection" {

--- a/src/terminal/c/terminal.zig
+++ b/src/terminal/c/terminal.zig
@@ -523,6 +523,7 @@ fn setTyped(
         },
         .default_cursor_style => {
             const style = (if (value) |ptr| ptr.* else TerminalCursorStyle.block).toZig() orelse return .invalid_value;
+            wrapper.stream.handler.recordCursorActivity();
             wrapper.stream.handler.default_cursor_style = style;
             if (wrapper.stream.handler.default_cursor) {
                 wrapper.terminal.screens.active.cursor.cursor_style = style;
@@ -530,6 +531,7 @@ fn setTyped(
         },
         .default_cursor_blink => {
             const blink = if (value) |ptr| ptr.* else false;
+            wrapper.stream.handler.recordCursorActivity();
             wrapper.stream.handler.default_cursor_blink = blink;
             if (wrapper.stream.handler.default_cursor) {
                 wrapper.terminal.modes.set(.cursor_blinking, blink);
@@ -627,8 +629,8 @@ pub fn resize(
 }
 
 pub fn reset(terminal_: Terminal) callconv(lib.calling_conv) void {
-    const t: *ZigTerminal = (terminal_ orelse return).terminal;
-    t.fullReset();
+    const wrapper = terminal_ orelse return;
+    wrapper.stream.handler.fullReset();
 }
 
 pub fn mode_get(
@@ -702,6 +704,7 @@ pub const TerminalData = enum(c_int) {
     cursor_visual_style = 33,
     cursor_blinking = 34,
     screen_activity = 35,
+    cursor_activity = 36,
 
     /// Output type expected for querying the data of the given kind.
     pub fn OutType(comptime self: TerminalData) type {
@@ -722,7 +725,7 @@ pub const TerminalData = enum(c_int) {
             .title, .pwd => lib.String,
             .total_rows, .scrollback_rows => usize,
             .width_px, .height_px => u32,
-            .screen_activity => u64,
+            .screen_activity, .cursor_activity => u64,
             .color_foreground,
             .color_background,
             .color_cursor,
@@ -790,7 +793,8 @@ fn getTyped(
     comptime data: TerminalData,
     out: *data.OutType(),
 ) Result {
-    const t: *ZigTerminal = (terminal_ orelse return .invalid_value).terminal;
+    const wrapper = terminal_ orelse return .invalid_value;
+    const t: *ZigTerminal = wrapper.terminal;
     switch (data) {
         .invalid => return .invalid_value,
         .cols => out.* = t.cols,
@@ -854,6 +858,7 @@ fn getTyped(
         .cursor_visual_style => out.* = .fromZig(t.screens.active.cursor.cursor_style),
         .cursor_blinking => out.* = t.modes.get(.cursor_blinking),
         .screen_activity => out.* = t.selectionActivity(),
+        .cursor_activity => out.* = wrapper.stream.handler.cursorActivity(),
     }
 
     return .success;
@@ -1930,6 +1935,153 @@ test "get screen activity tracks active screen switches" {
     var after_batched_switches: u64 = undefined;
     try testing.expectEqual(Result.success, get(t, .screen_activity, @ptrCast(&after_batched_switches)));
     try testing.expect(after_batched_switches != after_leave);
+}
+
+fn getCursorActivity(t: Terminal) !u64 {
+    var activity: u64 = undefined;
+    try testing.expectEqual(Result.success, get(t, .cursor_activity, @ptrCast(&activity)));
+    return activity;
+}
+
+test "get cursor activity tracks replay semantics independent of resolved visual" {
+    var t: Terminal = null;
+    try testing.expectEqual(Result.success, new(
+        &lib.alloc.test_allocator,
+        &t,
+        .{ .cols = 80, .rows = 24, .max_scrollback = 0 },
+    ));
+    defer free(t);
+
+    var activity = try getCursorActivity(t);
+
+    const text = "cursor activity is not text activity";
+    vt_write(t, text, text.len);
+    try testing.expectEqual(activity, try getCursorActivity(t));
+
+    // Both operations resolve to the configured block/steady visual, but each
+    // changes whether replay should use an explicit or default cursor.
+    const explicit_same_visual = "\x1b[2 q";
+    vt_write(t, explicit_same_visual, explicit_same_visual.len);
+    var next = try getCursorActivity(t);
+    try testing.expect(next != activity);
+    activity = next;
+    try expectCursorVisual(t, .block, false);
+
+    const reset_same_visual = "\x1b[0 q";
+    vt_write(t, reset_same_visual, reset_same_visual.len);
+    next = try getCursorActivity(t);
+    try testing.expect(next != activity);
+    activity = next;
+    try expectCursorVisual(t, .block, false);
+
+    // A repeated reset is still a cursor-semantic dispatch.
+    vt_write(t, reset_same_visual, reset_same_visual.len);
+    next = try getCursorActivity(t);
+    try testing.expect(next != activity);
+    activity = next;
+
+    // DEC mode 12 advances on every set/reset dispatch.
+    const blink_dispatches = [_][]const u8{
+        "\x1b[?12h",
+        "\x1b[?12h",
+        "\x1b[?12l",
+    };
+    for (blink_dispatches) |sequence| {
+        vt_write(t, sequence.ptr, sequence.len);
+        next = try getCursorActivity(t);
+        try testing.expect(next != activity);
+        activity = next;
+    }
+
+    // Restoring saved DEC mode 12 is dispatched through the same semantic
+    // path and must be observable as well.
+    const save_blink = "\x1b[?12s";
+    vt_write(t, save_blink, save_blink.len);
+    activity = try getCursorActivity(t);
+    const enable_blink = "\x1b[?12h";
+    vt_write(t, enable_blink, enable_blink.len);
+    next = try getCursorActivity(t);
+    try testing.expect(next != activity);
+    activity = next;
+    const restore_blink = "\x1b[?12r";
+    vt_write(t, restore_blink, restore_blink.len);
+    next = try getCursorActivity(t);
+    try testing.expect(next != activity);
+    activity = next;
+
+    // All supported alternate-screen mode dispatches affect cursor replay.
+    const screen_dispatches = [_][]const u8{
+        "\x1b[?47h",
+        "\x1b[?47l",
+        "\x1b[?1047h",
+        "\x1b[?1047l",
+        "\x1b[?1049h",
+        "\x1b[?1049h",
+        "\x1b[?1049l",
+    };
+    for (screen_dispatches) |sequence| {
+        vt_write(t, sequence.ptr, sequence.len);
+        next = try getCursorActivity(t);
+        try testing.expect(next != activity);
+        activity = next;
+    }
+
+    // A same-pair alternate-screen round trip in one write must not disappear
+    // merely because the final resolved visual equals the initial visual.
+    const same_pair_roundtrip = "\x1b[?1049h\x1b[?1049l";
+    vt_write(t, same_pair_roundtrip, same_pair_roundtrip.len);
+    next = try getCursorActivity(t);
+    try testing.expect(next != activity);
+    activity = next;
+    try expectCursorVisual(t, .block, false);
+
+    // RIS advances even when it restores the already-resolved default pair.
+    const ris = "\x1bc";
+    vt_write(t, ris, ris.len);
+    next = try getCursorActivity(t);
+    try testing.expect(next != activity);
+    activity = next;
+    try expectCursorVisual(t, .block, false);
+
+    const default_style: TerminalCursorStyle = .block;
+    const default_blink = false;
+    try testing.expectEqual(Result.success, set(t, .default_cursor_style, @ptrCast(&default_style)));
+    next = try getCursorActivity(t);
+    try testing.expect(next != activity);
+    activity = next;
+
+    try testing.expectEqual(Result.success, set(t, .default_cursor_blink, @ptrCast(&default_blink)));
+    next = try getCursorActivity(t);
+    try testing.expect(next != activity);
+    activity = next;
+
+    reset(t);
+    next = try getCursorActivity(t);
+    try testing.expect(next != activity);
+    activity = next;
+
+    // A batch that resets cursor provenance, switches screens, and performs
+    // RIS ends on the same visual pair but must still be observable.
+    const batched_reset_switch = "\x1b[0 q\x1b[?1049h\x1bc";
+    vt_write(t, batched_reset_switch, batched_reset_switch.len);
+    next = try getCursorActivity(t);
+    try testing.expect(next != activity);
+    try expectCursorVisual(t, .block, false);
+}
+
+test "cursor activity wraps" {
+    var t: Terminal = null;
+    try testing.expectEqual(Result.success, new(
+        &lib.alloc.test_allocator,
+        &t,
+        .{ .cols = 80, .rows = 24, .max_scrollback = 0 },
+    ));
+    defer free(t);
+
+    t.?.stream.handler.cursor_activity = std.math.maxInt(u64);
+    const reset_cursor = "\x1b[0 q";
+    vt_write(t, reset_cursor, reset_cursor.len);
+    try testing.expectEqual(@as(u64, 0), try getCursorActivity(t));
 }
 
 test "set and get selection" {

--- a/src/terminal/color.zig
+++ b/src/terminal/color.zig
@@ -350,7 +350,7 @@ pub const DynamicRGB = struct {
     }
 
     pub fn reset(self: *DynamicRGB) void {
-        self.override = self.default;
+        self.override = null;
     }
 };
 

--- a/src/terminal/stream_terminal.zig
+++ b/src/terminal/stream_terminal.zig
@@ -50,6 +50,9 @@ pub const Handler = struct {
     default_cursor_style: Screen.CursorStyle = .block,
     default_cursor_blink: bool = false,
 
+    /// Opaque epoch for operations that can affect cursor replay semantics.
+    cursor_activity: u64 = 0,
+
     pub const Effects = struct {
         /// Called when the terminal needs to write data back to the pty,
         /// e.g. in response to a DECRQM query. The data is only valid
@@ -122,6 +125,27 @@ pub const Handler = struct {
         self.apc_handler.deinit();
     }
 
+    /// Return the opaque cursor-semantic activity token. Consumers must only
+    /// compare this value for inequality.
+    pub fn cursorActivity(self: *const Handler) u64 {
+        return self.cursor_activity;
+    }
+
+    /// Record an operation that can affect cursor replay semantics.
+    pub fn recordCursorActivity(self: *Handler) void {
+        self.cursor_activity +%= 1;
+    }
+
+    /// Perform a full terminal reset while preserving configured cursor
+    /// defaults and advancing cursor-semantic activity.
+    pub fn fullReset(self: *Handler) void {
+        self.recordCursorActivity();
+        self.terminal.fullReset();
+        self.default_cursor = true;
+        self.terminal.modes.set(.cursor_blinking, self.default_cursor_blink);
+        self.terminal.screens.active.cursor.cursor_style = self.default_cursor_style;
+    }
+
     pub fn vt(
         self: *Handler,
         comptime action: Action.Tag,
@@ -166,6 +190,7 @@ pub const Handler = struct {
                 self.terminal.screens.active.cursor.x + 1,
             ),
             .cursor_style => {
+                self.recordCursorActivity();
                 self.default_cursor = false;
 
                 const blink = switch (value) {
@@ -249,12 +274,7 @@ pub const Handler = struct {
             },
             .active_status_display => self.terminal.status_display = value,
             .decaln => try self.terminal.decaln(),
-            .full_reset => {
-                self.terminal.fullReset();
-                self.default_cursor = true;
-                self.terminal.modes.set(.cursor_blinking, self.default_cursor_blink);
-                self.terminal.screens.active.cursor.cursor_style = self.default_cursor_style;
-            },
+            .full_reset => self.fullReset(),
             .start_hyperlink => try self.terminal.screens.active.startHyperlink(value.uri, value.id),
             .end_hyperlink => self.terminal.screens.active.endHyperlink(),
             .semantic_prompt => try self.terminal.semanticPrompt(value),
@@ -521,6 +541,15 @@ pub const Handler = struct {
     }
 
     fn setMode(self: *Handler, mode: modes.Mode, enabled: bool) !void {
+        switch (mode) {
+            .cursor_blinking,
+            .alt_screen_legacy,
+            .alt_screen,
+            .alt_screen_save_cursor_clear_enter,
+            => self.recordCursorActivity(),
+            else => {},
+        }
+
         // Set the mode on the terminal
         self.terminal.modes.set(mode, enabled);
 

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -1819,43 +1819,119 @@ pub const ReadThread = struct {
         };
         defer crash.sentry.thread_state = null;
 
+        const read_event = windows.kernel32.CreateEventExW(
+            null,
+            null,
+            windows.CREATE_EVENT_MANUAL_RESET,
+            windows.EVENT_ALL_ACCESS,
+        ) orelse {
+            log.err("error creating read event err={}", .{windows.kernel32.GetLastError()});
+            return;
+        };
+        defer _ = windows.CloseHandle(read_event);
+
         var buf: [1024]u8 = undefined;
         while (true) {
-            while (true) {
-                var n: windows.DWORD = 0;
-                if (windows.kernel32.ReadFile(fd, &buf, buf.len, &n, null) == 0) {
-                    const err = windows.kernel32.GetLastError();
-                    switch (err) {
-                        // Check for a quit signal
-                        .OPERATION_ABORTED => break,
+            // Checking both before and immediately after submission closes the
+            // race where teardown cancels before ReadFile becomes pending.
+            if (windowsQuitRequested(quit)) return;
 
-                        else => {
-                            log.err("io reader error err={}", .{err});
-                            unreachable;
-                        },
-                    }
-                }
-
-                @call(.always_inline, termio.Termio.processOutput, .{ io, buf[0..n] });
-
-                // See threadMainPosix: hand the renderer state mutex
-                // off if the renderer is waiting, since this loop
-                // would otherwise starve it under heavy output.
-                io.renderer_state.yieldToDemand();
-            }
-
-            var quit_bytes: windows.DWORD = 0;
-            if (windows.exp.kernel32.PeekNamedPipe(quit, null, 0, null, &quit_bytes, null) == 0) {
-                const err = windows.kernel32.GetLastError();
-                log.err("quit pipe reader error err={}", .{err});
-                unreachable;
-            }
-
-            if (quit_bytes > 0) {
-                log.info("read thread got quit signal", .{});
+            if (windows.exp.kernel32.ResetEvent(read_event) == 0) {
+                log.err("error resetting read event err={}", .{windows.kernel32.GetLastError()});
                 return;
             }
+
+            var overlapped = std.mem.zeroes(windows.OVERLAPPED);
+            overlapped.hEvent = read_event;
+
+            if (windows.kernel32.ReadFile(fd, &buf, buf.len, null, &overlapped) == 0) {
+                const err = windows.kernel32.GetLastError();
+                switch (err) {
+                    .IO_PENDING => {},
+                    .HANDLE_EOF, .BROKEN_PIPE, .NO_DATA => return,
+                    .OPERATION_ABORTED => {
+                        if (!windowsQuitRequested(quit)) {
+                            log.err("io reader operation aborted without quit signal", .{});
+                        }
+                        return;
+                    },
+                    else => {
+                        log.err("io reader submission error err={}", .{err});
+                        return;
+                    },
+                }
+            }
+
+            const quitting = windowsQuitRequested(quit);
+            if (quitting) {
+                // Cancel this exact request. The main IO thread also cancels
+                // all requests, but it may have done so before this ReadFile
+                // was submitted.
+                if (windows.kernel32.CancelIoEx(fd, &overlapped) == 0) {
+                    switch (windows.kernel32.GetLastError()) {
+                        .NOT_FOUND => {},
+                        else => |err| log.warn("error cancelling submitted read err={}", .{err}),
+                    }
+                }
+            }
+
+            const n = windowsCompleteRead(fd, quit, &overlapped, quitting) orelse return;
+            if (quitting) return;
+
+            @call(.always_inline, termio.Termio.processOutput, .{ io, buf[0..n] });
+
+            // See threadMainPosix: hand the renderer state mutex
+            // off if the renderer is waiting, since this loop
+            // would otherwise starve it under heavy output.
+            io.renderer_state.yieldToDemand();
         }
+    }
+
+    /// Returns true when teardown requested the Windows reader to stop. A
+    /// broken quit pipe also stops the reader so teardown cannot deadlock.
+    fn windowsQuitRequested(quit: posix.fd_t) bool {
+        var quit_bytes: windows.DWORD = 0;
+        if (windows.exp.kernel32.PeekNamedPipe(quit, null, 0, null, &quit_bytes, null) == 0) {
+            log.err("quit pipe reader error err={}", .{windows.kernel32.GetLastError()});
+            return true;
+        }
+
+        if (quit_bytes == 0) return false;
+        log.info("read thread got quit signal", .{});
+        return true;
+    }
+
+    /// Waits until an overlapped read is fully complete before its buffer,
+    /// OVERLAPPED state, or event can be reused. Returns null for clean EOF,
+    /// cancellation during teardown, or an error that was already logged.
+    fn windowsCompleteRead(
+        fd: posix.fd_t,
+        quit: posix.fd_t,
+        overlapped: *windows.OVERLAPPED,
+        quitting: bool,
+    ) ?usize {
+        var n: windows.DWORD = 0;
+        if (windows.kernel32.GetOverlappedResult(
+            fd,
+            overlapped,
+            &n,
+            windows.TRUE,
+        ) == 0) {
+            const err = windows.kernel32.GetLastError();
+            switch (err) {
+                .OPERATION_ABORTED => {
+                    if (!quitting and !windowsQuitRequested(quit)) {
+                        log.err("io reader completion aborted without quit signal", .{});
+                    }
+                },
+                .HANDLE_EOF, .BROKEN_PIPE, .NO_DATA => {},
+                else => log.err("io reader completion error err={}", .{err}),
+            }
+            return null;
+        }
+
+        if (n == 0) return null;
+        return @intCast(n);
     }
 };
 

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -1061,6 +1061,18 @@ const Subprocess = struct {
                 else => return err,
             }
         };
+
+        if (comptime builtin.os.tag == .windows) {
+            // CreatePseudoConsole duplicates its synchronous pipe handles. Once
+            // CreateProcess succeeds, release our setup copies so channel
+            // closure is observable and only HPCON owns the ConPTY lifetime.
+            // `pty` and `self.pty` are value copies, so invalidate both after
+            // the long-lived copy performs the idempotent close.
+            self.pty.?.releasePseudoConsolePipeHandles();
+            pty.out_pipe_pty = self.pty.?.out_pipe_pty;
+            pty.in_pipe_pty = self.pty.?.in_pipe_pty;
+        }
+
         errdefer killCommand(&cmd) catch |err| {
             log.warn("error killing command during cleanup err={}", .{err});
         };

--- a/src/termio/Manual.zig
+++ b/src/termio/Manual.zig
@@ -113,3 +113,38 @@ test "manual queueWrite linefeed conversion" {
     try manual.queueWrite(testing.allocator, &td, "a\rb", true);
     try testing.expectEqualStrings("a\r\nb", out.items);
 }
+
+test "manual queueWrite preserves encoded user input" {
+    const testing = std.testing;
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(testing.allocator);
+
+    const cb = struct {
+        fn write(ud: ?*anyopaque, ptr: [*]const u8, len: usize) callconv(.c) void {
+            const list: *std.ArrayList(u8) = @ptrCast(@alignCast(ud.?));
+            _ = list.appendSlice(testing.allocator, ptr[0..len]) catch {};
+        }
+    }.write;
+
+    var manual = try Manual.init(testing.allocator, .{ .write_cb = cb, .write_userdata = &out });
+    defer manual.deinit();
+
+    var td: termio.Termio.ThreadData = undefined;
+    const inputs = [_][]const u8{
+        // Keyboard, committed UTF-8 text, SGR mouse, and bracketed paste all
+        // share this backend path after their surface-level encoding.
+        "\x1b[1;5A",
+        "\xce\xbb",
+        "\x1b[<0;10;5M",
+        "\x1b[200~hello\x1b[201~",
+    };
+    for (inputs) |input| {
+        try manual.queueWrite(testing.allocator, &td, input, false);
+    }
+
+    try testing.expectEqualSlices(
+        u8,
+        "\x1b[1;5A\xce\xbb\x1b[<0;10;5M\x1b[200~hello\x1b[201~",
+        out.items,
+    );
+}

--- a/src/termio/Options.zig
+++ b/src/termio/Options.zig
@@ -39,3 +39,9 @@ renderer_mailbox: *renderer.Thread.Mailbox,
 
 /// The mailbox for sending the surface messages.
 surface_mailbox: apprt.surface.Mailbox,
+
+/// Optional PTY-output tee installed before the IO thread starts.
+pty_tee_cb: ?termio.Termio.PtyTeeCallback = null,
+
+/// Userdata passed to pty_tee_cb.
+pty_tee_userdata: ?*anyopaque = null,

--- a/src/termio/Options.zig
+++ b/src/termio/Options.zig
@@ -20,6 +20,10 @@ config: termio.Termio.DerivedConfig,
 /// The backend for termio that implements where reads/writes are sourced.
 backend: termio.Backend,
 
+/// Drop replies generated while parsing terminal output. This is used by
+/// mirror renderers when another terminal core owns the PTY protocol.
+suppress_terminal_responses: bool = false,
+
 /// The mailbox for the terminal. This is how messages are delivered.
 /// If you're using termio.Thread this MUST be "mailbox".
 mailbox: termio.Mailbox,

--- a/src/termio/Termio.zig
+++ b/src/termio/Termio.zig
@@ -24,6 +24,12 @@ const ProcessInfo = @import("../pty.zig").ProcessInfo;
 
 const log = std.log.scoped(.io_exec);
 
+pub const PtyTeeCallback = *const fn (
+    ?*anyopaque,
+    [*]const u8,
+    usize,
+) callconv(.c) void;
+
 /// Mutex state argument for queueMessage.
 pub const MutexState = enum { locked, unlocked };
 
@@ -70,9 +76,9 @@ manual_linefeed_mode: std.atomic.Value(bool) = .{ .raw = false },
 /// this to broadcast raw bytes to a paired iPhone so the phone can feed
 /// the same bytes through its own libghostty surface, producing an
 /// identical grid by construction. Both fields are read on the IO read
-/// thread; install once from `apprt.embedded` after surface create and
-/// leave alone for the surface's lifetime.
-pty_tee_cb: ?*const fn (?*anyopaque, [*]const u8, usize) callconv(.c) void = null,
+/// thread. The embedded runtime installs initial values before starting that
+/// thread; the compatibility setter may replace them after surface creation.
+pty_tee_cb: ?PtyTeeCallback = null,
 pty_tee_userdata: ?*anyopaque = null,
 
 /// The stream parser. This parses the stream of escape codes and so on
@@ -322,6 +328,8 @@ pub fn init(self: *Termio, alloc: Allocator, opts: termio.Options) !void {
         .size = opts.size,
         .backend = backend,
         .mailbox = opts.mailbox,
+        .pty_tee_cb = opts.pty_tee_cb,
+        .pty_tee_userdata = opts.pty_tee_userdata,
         .terminal_stream = .initAlloc(alloc, handler),
         .thread_enter_state = thread_enter_state,
     };

--- a/src/termio/Termio.zig
+++ b/src/termio/Termio.zig
@@ -81,6 +81,11 @@ manual_linefeed_mode: std.atomic.Value(bool) = .{ .raw = false },
 pty_tee_cb: ?PtyTeeCallback = null,
 pty_tee_userdata: ?*anyopaque = null,
 
+/// Number of PTY-output bytes fully applied to terminal state. This is read
+/// and updated only while renderer_state.mutex is held. Addition wraps so the
+/// value remains a stable modulo-u64 stream position across long sessions.
+processed_output_bytes: u64 = 0,
+
 /// The stream parser. This parses the stream of escape codes and so on
 /// from the child process and calls callbacks in the stream handler.
 terminal_stream: StreamHandler.Stream,
@@ -804,7 +809,15 @@ pub fn processOutput(self: *Termio, buf: []const u8) void {
     // the lock to grab our read data.
     self.renderer_state.mutex.lock();
     defer self.renderer_state.mutex.unlock();
-    self.processOutputLocked(buf);
+    processOutputAndAdvanceLocked(self, buf);
+}
+
+/// Apply output and publish its byte position as one renderer-mutex critical
+/// section. Keeping the sequence update after the parser is the recovery
+/// contract: observers never see bytes as processed before terminal state does.
+fn processOutputAndAdvanceLocked(context: anytype, buf: []const u8) void {
+    context.processOutputLocked(buf);
+    context.processed_output_bytes +%= @intCast(buf.len);
 }
 
 /// Process output from readdata but the lock is already held.
@@ -857,6 +870,31 @@ fn processOutputLocked(self: *Termio, buf: []const u8) void {
         self.terminal_stream.handler.termio_messaged = false;
         self.mailbox.notify();
     }
+}
+
+test "processed output sequence advances after output is applied" {
+    const FakeTermio = struct {
+        processed_output_bytes: u64,
+        sequence_during_apply: u64 = 0,
+        applied_bytes: usize = 0,
+
+        fn processOutputLocked(self: *@This(), buf: []const u8) void {
+            self.sequence_during_apply = self.processed_output_bytes;
+            self.applied_bytes = buf.len;
+        }
+    };
+
+    var fake: FakeTermio = .{
+        .processed_output_bytes = std.math.maxInt(u64) - 1,
+    };
+    processOutputAndAdvanceLocked(&fake, "abc");
+
+    try std.testing.expectEqual(
+        std.math.maxInt(u64) - 1,
+        fake.sequence_during_apply,
+    );
+    try std.testing.expectEqual(@as(usize, 3), fake.applied_bytes);
+    try std.testing.expectEqual(@as(u64, 1), fake.processed_output_bytes);
 }
 
 /// Sends a DSR response for the current color scheme to the pty.

--- a/src/termio/Termio.zig
+++ b/src/termio/Termio.zig
@@ -79,6 +79,9 @@ pty_tee_userdata: ?*anyopaque = null,
 /// from the child process and calls callbacks in the stream handler.
 terminal_stream: StreamHandler.Stream,
 
+/// True when another terminal core owns protocol replies for this PTY.
+suppress_terminal_responses: bool,
+
 /// Last time the cursor was reset. This is used to prevent message
 /// flooding with cursor resets.
 last_cursor_reset: ?std.time.Instant = null,
@@ -302,6 +305,7 @@ pub fn init(self: *Termio, alloc: Allocator, opts: termio.Options) !void {
         .osc_color_report_format = opts.config.osc_color_report_format,
         .clipboard_write = opts.config.clipboard_write,
         .enquiry_response = opts.config.enquiry_response,
+        .suppress_terminal_responses = opts.suppress_terminal_responses,
         .default_cursor_style = opts.config.cursor_style,
         .default_cursor_blink = opts.config.cursor_blink,
     };
@@ -323,6 +327,7 @@ pub fn init(self: *Termio, alloc: Allocator, opts: termio.Options) !void {
         .backend = backend,
         .mailbox = opts.mailbox,
         .terminal_stream = .initAlloc(alloc, handler),
+        .suppress_terminal_responses = opts.suppress_terminal_responses,
         .thread_enter_state = thread_enter_state,
     };
 }
@@ -653,6 +658,7 @@ pub fn sizeReport(self: *Termio, td: *ThreadData, style: termio.Message.SizeRepo
 }
 
 fn sizeReportLocked(self: *Termio, td: *ThreadData, style: termio.Message.SizeReport) !void {
+    if (self.suppress_terminal_responses) return;
     const grid_size = self.size.grid();
     const report_size: terminalpkg.size_report.Size = .{
         .rows = grid_size.rows,
@@ -766,7 +772,7 @@ pub fn focusGained(self: *Termio, td: *ThreadData, focused: bool) !void {
     self.renderer_state.mutex.unlock();
 
     // If we have focus events enabled, we send the focus event.
-    if (focus_event) {
+    if (focus_event and !self.suppress_terminal_responses) {
         var buf: [terminalpkg.focus.max_encode_size]u8 = undefined;
         var writer: std.Io.Writer = .fixed(&buf);
         terminalpkg.focus.encode(&writer, if (focused) .gained else .lost) catch |err| {
@@ -860,6 +866,7 @@ pub fn colorSchemeReport(self: *Termio, td: *ThreadData, force: bool) !void {
 }
 
 pub fn colorSchemeReportLocked(self: *Termio, td: *ThreadData, force: bool) !void {
+    if (self.suppress_terminal_responses) return;
     if (!force and !self.renderer_state.terminal.modes.get(.report_color_scheme)) {
         return;
     }

--- a/src/termio/Thread.zig
+++ b/src/termio/Thread.zig
@@ -55,6 +55,9 @@ wakeup_c: xev.Completion = .{},
 stop: xev.Async,
 stop_c: xev.Completion = .{},
 
+/// Set after the stop watcher is armed. See renderer.Thread.started.
+started: std.Thread.ResetEvent = .{},
+
 /// This is used for timer-based selection scrolling.
 scroll: xev.Timer,
 scroll_c: xev.Completion = .{},
@@ -260,6 +263,11 @@ fn threadMain_(self: *Thread, io: *termio.Termio) !void {
     // ourselves and the thread data so we can thread that through (pun intended).
     var cb: CallbackData = .{ .self = self, .io = io };
 
+    // Arm stop before fallible backend setup so an immediate surface free
+    // cannot lose its notification and strand Surface.deinit in join().
+    self.stop.wait(&self.loop, &self.stop_c, CallbackData, &cb, stopCallback);
+    self.started.set();
+
     // Run our thread start/end callbacks. This allows the implementation
     // to hook into the event loop as needed. The thread data is created
     // on the stack here so that it has a stable pointer throughout the
@@ -270,7 +278,6 @@ fn threadMain_(self: *Thread, io: *termio.Termio) !void {
 
     // Start the async handlers.
     mailbox.wakeup.wait(&self.loop, &self.wakeup_c, CallbackData, &cb, wakeupCallback);
-    self.stop.wait(&self.loop, &self.stop_c, CallbackData, &cb, stopCallback);
 
     // Run
     log.debug("starting IO thread", .{});

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -16,6 +16,70 @@ const posix = std.posix;
 const log = std.log.scoped(.io_handler);
 const max_tmux_control_pane_output_bytes: usize = 65_536;
 
+fn suppressTerminalResponse(enabled: bool, msg: termio.Message) bool {
+    if (!enabled) return false;
+    switch (msg) {
+        .write_small,
+        .write_stable,
+        .color_scheme_report,
+        .size_report,
+        .focused,
+        => return true,
+        .write_alloc => |req| {
+            req.alloc.free(req.data);
+            return true;
+        },
+        else => return false,
+    }
+}
+
+test "terminal response suppression drops every parser reply class" {
+    const testing = std.testing;
+
+    // Device attributes and status reports use the stable and small write
+    // variants respectively.
+    try testing.expect(suppressTerminalResponse(
+        true,
+        .{ .write_stable = "\x1b[?62;22c" },
+    ));
+
+    var dsr: termio.Message = .{ .write_small = .{} };
+    const dsr_bytes = "\x1b[12;34R";
+    @memcpy(dsr.write_small.data[0..dsr_bytes.len], dsr_bytes);
+    dsr.write_small.len = dsr_bytes.len;
+    try testing.expect(suppressTerminalResponse(true, dsr));
+
+    // OSC and DCS replies can exceed the inline message storage and therefore
+    // exercise the allocating variant. The suppression path owns and frees it.
+    const long_osc_reply: []const u8 = "\x1b]4;0;rgb:00/00/00;1;rgb:ff/ff/ff;2;rgb:00/00/00;3;rgb:ff/ff/ff\x1b\\";
+    const osc = try termio.Message.writeReq(testing.allocator, long_osc_reply);
+    try testing.expect(suppressTerminalResponse(true, osc));
+
+    try testing.expect(!suppressTerminalResponse(
+        false,
+        .{ .write_stable = "reply" },
+    ));
+    try testing.expect(suppressTerminalResponse(
+        true,
+        .{ .size_report = .csi_18_t },
+    ));
+    try testing.expect(suppressTerminalResponse(
+        true,
+        .{ .color_scheme_report = .{ .force = true } },
+    ));
+    try testing.expect(suppressTerminalResponse(
+        true,
+        .{ .focused = true },
+    ));
+
+    // State-changing parser messages are never terminal replies and must
+    // continue to reach the Termio side in mirror mode.
+    try testing.expect(!suppressTerminalResponse(
+        true,
+        .{ .linefeed_mode = true },
+    ));
+}
+
 /// This is used as the handler for the terminal.Stream type. This is
 /// stateful and is expected to live for the entire lifetime of the terminal.
 /// It is NOT VALID to stop a stream handler, create a new one, and use that
@@ -56,6 +120,10 @@ pub const StreamHandler = struct {
 
     /// The clipboard write access configuration.
     clipboard_write: configpkg.ClipboardAccess,
+
+    /// When another terminal core owns the PTY protocol, Ghostty is only a
+    /// render/input mirror and must not emit a second copy of protocol replies.
+    suppress_terminal_responses: bool = false,
 
     //---------------------------------------------------------------
     // Internal state
@@ -137,6 +205,8 @@ pub const StreamHandler = struct {
     }
 
     inline fn messageWriter(self: *StreamHandler, msg: termio.Message) void {
+        if (suppressTerminalResponse(self.suppress_terminal_responses, msg))
+            return;
         self.termio_mailbox.send(msg, self.renderer_state.mutex);
         self.termio_messaged = true;
     }


### PR DESCRIPTION
## Summary

This is the cumulative landing PR for the cmux Ghostty fork stack. It preserves the commits and APIs from #122, #123, and #127, plus the dynamic-color fix originally reviewed here, and reconciles them with current `main`.

- add viewless and leased external Metal presenters with exact frame-token ownership
- preserve the embedded OpenGL/manual-mirror path, PTY tee, config serialization, and VT recovery APIs
- expose cursor visual/activity state for process-separated frontends
- make OSC 110/111/112 resets follow mutable embedder defaults
- combine external frame leases with current main's completion-lifetime and tokened-presentation fencing
- retain current main's renderer/link changes and fix the stale PageList row-space revision assertions

## Integration invariants

- each swap-chain slot has exact ownership through GPU completion and optional host release
- late Metal callbacks are lifetime-fenced during teardown
- tokened layer presentation acknowledges only the exact IOSurface assigned on the main thread
- external presenters do not install an AppKit display callback
- the public C and Zig embedded surface layouts remain identical

## Validation

- `zig build -Demit-xcframework=true -Dxcframework-target=universal -Doptimize=ReleaseFast`
- `zig build test-lib-vt` (4,759 passed, 34 skipped)
- focused Metal/OpenGL presentation, frame-lease pool, and embedded ABI tests
- focused cursor visual/activity and OSC mutable-default coverage (included in full lib-vt suite)
- `zig fmt --check src build.zig`
- `git diff --check`

Supersedes #122, #123, and #127 as the cumulative landing point.