### PR TITLE
fix: consume the newline delimiter in open stderr logging loop

### DIFF
--- a/src/os/main.zig
+++ b/src/os/main.zig
@@ -70,6 +70,7 @@ pub const getKernelInfo = kernel_info.getKernelInfo;
 test {
     _ = file;
     _ = i18n;
+    _ = openpkg;
     _ = path;
     _ = uri;
     _ = shell;

--- a/src/os/main.zig
+++ b/src/os/main.zig
@@ -70,10 +70,16 @@ pub const getKernelInfo = kernel_info.getKernelInfo;
 test {
     _ = file;
     _ = i18n;
-    _ = openpkg;
     _ = path;
     _ = uri;
     _ = shell;
+
+    // open.zig is implemented for a fixed set of OSes; import its tests
+    // only on those targets so unsupported test targets never analyze it.
+    switch (comptime builtin.os.tag) {
+        .linux, .freebsd, .windows, .macos, .ios => _ = openpkg,
+        else => {},
+    }
 
     if (comptime builtin.os.tag == .linux) {
         _ = kernel_info;

--- a/src/os/open.zig
+++ b/src/os/open.zig
@@ -80,18 +80,31 @@ fn openThread(exe_: std.process.Child) void {
     if (exe.stderr) |stderr| {
         var buffer: [256]u8 = undefined;
         var stream = stderr.readerStreaming(&buffer);
-        const reader = &stream.interface;
-        while (true) {
-            const line = reader.takeDelimiterExclusive('\n') catch |outer| switch (outer) {
-                error.EndOfStream => break,
-                error.ReadFailed => break,
-                error.StreamTooLong => reader.take(buffer.len) catch |inner| switch (inner) {
-                    error.ReadFailed => break,
-                    error.EndOfStream => break,
-                },
-            };
-            log.warn("open stderr={s}", .{line});
-        }
+        logStderrLines(&stream.interface);
     }
     _ = exe.wait() catch {};
+}
+
+/// Log each newline-delimited line from the reader until the stream ends
+/// or a read fails. Lines longer than the reader's buffer are logged in
+/// buffer-sized chunks.
+fn logStderrLines(reader: *std.Io.Reader) void {
+    while (true) {
+        // takeDelimiter (unlike takeDelimiterExclusive) consumes the
+        // delimiter, so this loop can't spin on a buffered newline.
+        const line = (reader.takeDelimiter('\n') catch |err| switch (err) {
+            error.ReadFailed => return,
+            error.StreamTooLong => reader.take(reader.buffer.len) catch return,
+        }) orelse return;
+        if (line.len > 0) log.warn("open stderr={s}", .{line});
+    }
+}
+
+test "logStderrLines terminates and consumes a delimited stream" {
+    // Regression test: takeDelimiterExclusive does not consume the
+    // delimiter byte, so a loop around it spins forever once the first
+    // newline arrives, logging an empty line at unbounded rate.
+    var reader: std.Io.Reader = .fixed("warning: foo\n\nbar\n");
+    logStderrLines(&reader);
+    try std.testing.expectEqual(@as(usize, 0), reader.buffered().len);
 }


### PR DESCRIPTION
## Problem

`openThread` in `src/os/open.zig` logs each stderr line from the spawned `open`/`xdg-open` command using `std.Io.Reader.takeDelimiterExclusive`, which returns the line but does not advance past the delimiter byte. Once the child writes a single newline to stderr, every subsequent iteration peeks the same buffered newline, returns an empty slice, and logs it — an infinite busy loop.

Observed in production (cmux 0.64.20, macOS): two leaked threads pinned at ~85% CPU each for days, emitting ~44,000 `os-open: open stderr=` messages/second until logd throttled the whole process (`__FIREHOSE_CLIENT_THROTTLED_DUE_TO_HEAVY_LOGGING__` on-stack), which in turn made unrelated `os_log` calls block and the UI jank.

The same loop exists in upstream ghostty-org/ghostty (introduced in `bb375a2f`, "deal with large outputs from xdg-open/rundll32/open"), so this is upstreamable.

## Fix

- Switch to `takeDelimiter`, which consumes the delimiter and returns `null` at end of stream.
- Skip logging empty lines.
- Extract the loop into `logStderrLines` and add a regression test. On the old code the test spins forever at ~93% CPU (reproducing the production hang); on the new code it passes in seconds and asserts the stream is fully consumed.
- Wire `open.zig` into the `src/os/main.zig` test block — its tests were not previously part of `zig build test`.

Verified with `zig build test -Dtest-filter=logStderrLines` on zig 0.15.2, plus a full ReleaseFast universal GhosttyKit.xcframework build and a cmux Debug app build on top of it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/129"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787330960&installation_model_id=21920&pr_number=129&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F129&signature=9c6a4e2abd673fc80e0d893dada2665d7c3e41fb72574634cc39997027a92662"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consume the newline delimiter when reading `open`/`xdg-open` stderr to stop an infinite loop that spiked CPU and flooded logs.

- **Bug Fixes**
  - Switch to `takeDelimiter` to consume newlines and stop on EOF.
  - Skip empty lines; chunk long lines to the buffer size.
  - Extract `logStderrLines` and add a regression test; import `open.zig` tests only on supported OSes in `src/os/main.zig`.

<sup>Written for commit 7bf51a5db54d48c8b2412d0cba8942ea11bfa596. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/129?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved process output handling so consecutive blank lines no longer cause logging to stall.
  * Ensured error output is fully consumed and handled reliably, including oversized or interrupted streams.

* **Tests**
  * Added regression coverage verifying that delimited error output completes successfully without leaving unread data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->