### PR TITLE
Preserve Kitty text produced by consumed Alt

### DIFF
--- a/src/input/key_encode.zig
+++ b/src/input/key_encode.zig
@@ -292,10 +292,12 @@ fn kitty(
         if (opts.kitty_flags.report_associated and
             seq.event != .release)
         associated: {
-            // Determine if the Alt modifier should be treated as an actual
-            // modifier (in which case it prevents associated text) or as
-            // the macOS Option key, which does not prevent associated text.
-            const alt_prevents_text = if (comptime builtin.os.tag == .macos)
+            // Alt consumed to produce this event's text is not an effective
+            // text-preventing modifier. Otherwise retain the platform's
+            // configured Alt-versus-Option behavior.
+            const alt_prevents_text = if (event.consumed_mods.alt)
+                false
+            else if (comptime builtin.os.tag == .macos)
                 switch (opts.macos_option_as_alt) {
                     .left => all_mods.sides.alt == .left,
                     .right => all_mods.sides.alt == .right,

--- a/src/input/key_encode.zig
+++ b/src/input/key_encode.zig
@@ -1722,6 +1722,27 @@ test "kitty: report associated with alt text on macOS with option" {
     try testing.expectEqualStrings("\x1b[119;3;8721u", writer.buffered());
 }
 
+test "kitty: report associated text produced by consumed alt" {
+    var buf: [128]u8 = undefined;
+    var writer: std.Io.Writer = .fixed(&buf);
+    try kitty(&writer, .{
+        .key = .key_w,
+        .mods = .{ .alt = true },
+        .consumed_mods = .{ .alt = true },
+        .utf8 = "∑",
+        .unshifted_codepoint = 119,
+    }, .{
+        .kitty_flags = .{
+            .disambiguate = true,
+            .report_all = true,
+            .report_alternates = true,
+            .report_associated = true,
+        },
+        .macos_option_as_alt = .true,
+    });
+    try testing.expectEqualStrings("\x1b[119;3;8721u", writer.buffered());
+}
+
 test "kitty: report associated with alt text on macOS with alt" {
     if (comptime !builtin.target.os.tag.isDarwin()) return error.SkipZigTest;
 


### PR DESCRIPTION
Honor per-event consumed Alt modifiers when deciding whether Kitty associated text is allowed. The encoded modifier remains Alt, while Option-generated text is preserved on every target OS.

Regression: a cross-platform encoder test expects Alt-W with consumed Alt and `∑` text to encode as `ESC[119;3;8721u`.

Required by https://github.com/manaflow-ai/cmux/pull/8698.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/131"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787411111&installation_model_id=21920&pr_number=131&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F131&signature=5d32fac407dedefa973536e5c2150a85be7ed697a7bd922139fa997fc600da22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves Kitty associated text when Alt is consumed to produce the character, while still encoding Alt as a modifier. Unblocks `cmux` PR #8698 and ensures Option-generated text (e.g., ∑ from Alt-W) is reported across OSes.

- **Bug Fixes**
  - Do not suppress associated text when Alt was consumed; otherwise keep platform Alt/Option behavior.
  - Added test for Alt-W producing ∑: ESC[119;3;8721u.

<sup>Written for commit 130463c38f14f951a3e9913a691745146d079ec5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/131?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

