### PR TITLE
fix: publish renderer lifecycle state without blocking

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -3718,22 +3718,10 @@ pub fn occlusionCallback(self: *Surface, visible: bool) !void {
     crash.sentry.thread_state = self.crashThreadState();
     defer crash.sentry.thread_state = null;
 
-    // cmux iOS fork: this runs on the MAIN thread (the iOS embedder calls
-    // `set_occlusion` from `@MainActor` lifecycle code). A `.forever` push here
-    // blocks main until `render_now` drains the renderer mailbox, while a
-    // serial-queue `surface_mailbox` `.forever` push blocks the serial queue
-    // until the main-thread app tick drains it: main waits for serial, serial
-    // waits for main = permanent deadlock. Invariant: nothing reachable from the
-    // iOS render serial queue (here: via the renderer mailbox it shares) may
-    // block unboundedly. `.visible` is an idempotent bool and `Message.deinit`
-    // frees nothing for it, so an instant drop leaks nothing. The companion gate
-    // in `renderer/Thread.zig:drawFrame` keeps iOS rendering even if a
-    // `.visible=true` is dropped (Swift owns occlusion via `renderingSuspended`).
-    if (comptime builtin.os.tag == .ios) {
-        _ = self.renderer_thread.mailbox.push(.{ .visible = visible }, .{ .instant = {} });
-    } else {
-        _ = self.renderer_thread.mailbox.push(.{ .visible = visible }, .{ .forever = {} });
-    }
+    // Surface lifecycle callbacks run on the embedder's UI executor. Publish
+    // idempotent state through the renderer thread's coalesced latest-value
+    // path so a full mailbox or wedged renderer can never park that executor.
+    self.renderer_thread.publishVisible(visible);
     try self.queueRender();
 }
 
@@ -3750,19 +3738,9 @@ pub fn focusCallback(self: *Surface, focused: bool) !void {
     if (self.focused == focused) return;
     self.focused = focused;
 
-    // Notify our render thread of the new state.
-    //
-    // cmux iOS fork: runs on the MAIN thread (the iOS embedder calls `set_focus`
-    // from `@MainActor` code). Same main↔serial renderer-mailbox deadlock as
-    // `.visible` above; gate to a non-blocking instant push. `.focus` is an
-    // idempotent bool that `drawFrame` re-reads each frame and `Message.deinit`
-    // frees nothing for it, so a drop at worst shows a hollow cursor until the
-    // next focus change. macOS keeps the proven blocking path.
-    if (comptime builtin.os.tag == .ios) {
-        _ = self.renderer_thread.mailbox.push(.{ .focus = focused }, .{ .instant = {} });
-    } else {
-        _ = self.renderer_thread.mailbox.push(.{ .focus = focused }, .{ .forever = {} });
-    }
+    // Focus is latest-value lifecycle state. Publishing it cannot wait for the
+    // renderer mailbox that the renderer itself must drain.
+    self.renderer_thread.publishFocused(focused);
 
     if (!focused) unfocused: {
         // If we lost focus and we have a keypress, then we want to send a key

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -3472,10 +3472,7 @@ pub const CAPI = struct {
     const Darwin = struct {
         export fn ghostty_surface_set_display_id(ptr: *Surface, display_id: u32) void {
             const surface = &ptr.core_surface;
-            _ = surface.renderer_thread.mailbox.push(
-                .{ .macos_display_id = display_id },
-                .{ .forever = {} },
-            );
+            surface.renderer_thread.publishDisplayID(display_id);
             surface.renderer_thread.wakeup.notify() catch {};
         }
 

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -1181,6 +1181,38 @@ test "visibility drain coalesces rapid hide show ordering" {
     try std.testing.expectEqual(null, canceled.rendererTransition());
 }
 
+test "surface lifecycle state bypasses a full renderer mailbox and keeps latest values" {
+    const mailbox = try Mailbox.create(std.testing.allocator);
+    defer mailbox.destroy(std.testing.allocator);
+
+    for (0..64) |_| {
+        try std.testing.expect(mailbox.push(
+            .{ .visible = false },
+            .{ .instant = {} },
+        ) != 0);
+    }
+    try std.testing.expectEqual(
+        @as(Mailbox.Size, 0),
+        mailbox.push(.{ .visible = false }, .{ .instant = {} }),
+    );
+
+    var state: SurfaceStateRequests = .{};
+    state.publishVisible(false);
+    state.publishVisible(true);
+    state.publishFocused(false);
+    state.publishDisplayID(7);
+    state.publishDisplayID(42);
+
+    const update = state.take();
+    try std.testing.expectEqual(true, update.visible);
+    try std.testing.expectEqual(false, update.focused);
+    try std.testing.expectEqual(@as(u32, 42), update.display_id);
+    try std.testing.expectEqual(
+        @as(Mailbox.Size, 0),
+        mailbox.push(.{ .visible = false }, .{ .instant = {} }),
+    );
+}
+
 test "synchronous presentation is delivered after thread draw cleanup" {
     const Event = enum { begin, renderer_cleanup, end, callback };
     const State = struct {

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -43,6 +43,59 @@ const VisibilityDrainState = struct {
     }
 };
 
+/// Latest-value publication for surface lifecycle state. These values are
+/// idempotent and have no owned payloads, so producers can replace an unread
+/// request instead of waiting for space in the ordered renderer mailbox.
+///
+/// Each property has its own atomic slot. Zero means no pending request;
+/// booleans use one/ two for false/true, and display ids are offset by one so
+/// every u32 value remains representable. A producer that races `take` either
+/// lands in the returned update or remains pending for the next renderer wake.
+const SurfaceStateRequests = struct {
+    const Update = struct {
+        visible: ?bool = null,
+        focused: ?bool = null,
+        display_id: ?u32 = null,
+    };
+
+    visible: std.atomic.Value(u8) = std.atomic.Value(u8).init(0),
+    focused: std.atomic.Value(u8) = std.atomic.Value(u8).init(0),
+    display_id: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
+
+    fn publishVisible(self: *SurfaceStateRequests, value: bool) void {
+        self.visible.store(if (value) 2 else 1, .release);
+    }
+
+    fn publishFocused(self: *SurfaceStateRequests, value: bool) void {
+        self.focused.store(if (value) 2 else 1, .release);
+    }
+
+    fn publishDisplayID(self: *SurfaceStateRequests, value: u32) void {
+        self.display_id.store(@as(u64, value) + 1, .release);
+    }
+
+    fn take(self: *SurfaceStateRequests) Update {
+        return .{
+            .visible = decodeBool(self.visible.swap(0, .acq_rel)),
+            .focused = decodeBool(self.focused.swap(0, .acq_rel)),
+            .display_id = decodeDisplayID(self.display_id.swap(0, .acq_rel)),
+        };
+    }
+
+    fn decodeBool(value: u8) ?bool {
+        return switch (value) {
+            0 => null,
+            1 => false,
+            2 => true,
+            else => unreachable,
+        };
+    }
+
+    fn decodeDisplayID(value: u64) ?u32 {
+        return if (value == 0) null else @intCast(value - 1);
+    }
+};
+
 const DrawFrameResult = enum {
     skipped_invisible,
     deferred_to_vsync,
@@ -288,6 +341,9 @@ instrumentation: instrumentationpkg.Instrumentation,
 /// Retained until a visibility-regain frame is actually submitted.
 visibility_regain: VisibilityRegainState = .{},
 
+/// Coalesced surface state published without entering the bounded mailbox.
+surface_state_requests: SurfaceStateRequests = .{},
+
 /// Last visibility state forwarded to the renderer. Renderer-thread owned.
 /// This can temporarily differ from `flags.visible` only when a later
 /// mailbox handler aborts a drain before its coalesced transition commits.
@@ -524,6 +580,20 @@ pub fn drainMailboxNow(self: *Thread) void {
     };
 }
 
+/// Publish latest-value surface lifecycle state without waiting for renderer
+/// mailbox capacity. Callers must notify `wakeup` after publishing.
+pub fn publishVisible(self: *Thread, value: bool) void {
+    self.surface_state_requests.publishVisible(value);
+}
+
+pub fn publishFocused(self: *Thread, value: bool) void {
+    self.surface_state_requests.publishFocused(value);
+}
+
+pub fn publishDisplayID(self: *Thread, value: u32) void {
+    self.surface_state_requests.publishDisplayID(value);
+}
+
 /// The app thread calls this after draining its mailbox. A failed
 /// `redraw_surface` push wakes that thread even though no message was queued,
 /// so mailbox capacity becoming available is the readiness signal for one
@@ -735,75 +805,9 @@ fn drainMailbox(self: *Thread) !MailboxDrainResult {
         switch (message) {
             .crash => @panic("crash request, crashing intentionally"),
 
-            .visible => |v| visible: {
-                // If our state didn't change we do nothing.
-                if (!visibility.apply(v)) break :visible;
+            .visible => |v| self.applyVisible(&visibility, v),
 
-                // Set our visible state
-                self.flags.visible = v;
-
-                // Visibility affects our QoS class
-                self.setQosClass();
-
-                // Note that we're explicitly today not stopping any
-                // cursor timers, draw timers, etc. These things have very
-                // little resource cost and properly maintaining their active
-                // state across different transitions is going to be bug-prone,
-                // so its easier to just let them keep firing and have them
-                // check the visible state themselves to control their behavior.
-            },
-
-            .focus => |v| focus: {
-                // If our state didn't change we do nothing.
-                if (self.flags.focused == v) break :focus;
-
-                // Set our state
-                self.flags.focused = v;
-
-                // Focus affects our QoS class
-                self.setQosClass();
-
-                // Set it on the renderer
-                try self.renderer.setFocus(v);
-
-                if (external_drain) {
-                    if (v) self.resetExternalCursorBlink();
-                    break :focus;
-                }
-
-                // We always resync our draw timer (may disable it)
-                self.syncDrawTimer();
-
-                if (!v) {
-                    // If we're not focused, then we stop the cursor blink
-                    if (self.cursor_c.state() == .active and
-                        self.cursor_c_cancel.state() == .dead)
-                    {
-                        self.cursor_h.cancel(
-                            &self.loop,
-                            &self.cursor_c,
-                            &self.cursor_c_cancel,
-                            void,
-                            null,
-                            cursorCancelCallback,
-                        );
-                    }
-                } else {
-                    // If we're focused, we immediately show the cursor again
-                    // and then restart the timer.
-                    if (self.cursor_c.state() != .active) {
-                        self.flags.cursor_blink_visible = true;
-                        self.cursor_h.run(
-                            &self.loop,
-                            &self.cursor_c,
-                            cursorBlinkInterval(),
-                            Thread,
-                            self,
-                            cursorTimerCallback,
-                        );
-                    }
-                }
-            },
+            .focus => |v| try self.applyFocused(v, external_drain),
 
             .reset_cursor_blink => {
                 self.flags.cursor_blink_visible = true;
@@ -862,11 +866,7 @@ fn drainMailbox(self: *Thread) !MailboxDrainResult {
                 self.flags.has_inspector = v;
             },
 
-            .macos_display_id => |v| {
-                if (@hasDecl(rendererpkg.Renderer, "setMacOSDisplayID")) {
-                    try self.renderer.setMacOSDisplayID(v);
-                }
-            },
+            .macos_display_id => |v| try self.applyDisplayID(v),
 
             // cmux fork: release/recreate the renderer's GPU resources (swap
             // chain / IOSurface) without freeing the surface. Safe here because
@@ -883,6 +883,15 @@ fn drainMailbox(self: *Thread) !MailboxDrainResult {
         }
     }
 
+    // Lifecycle state is latest-value rather than ordered work. Apply it after
+    // the ordinary mailbox so an older compatibility message cannot overwrite
+    // a newer request. A publication racing this take remains pending and its
+    // own wakeup drives the next drain.
+    const surface_state = self.surface_state_requests.take();
+    if (surface_state.visible) |value| self.applyVisible(&visibility, value);
+    if (surface_state.focused) |value| try self.applyFocused(value, external_drain);
+    if (surface_state.display_id) |value| try self.applyDisplayID(value);
+
     if (external_drain) return .{};
 
     // Hidden wakeups leave terminal dirty flags untouched. Rebuild exactly
@@ -894,6 +903,66 @@ fn drainMailbox(self: *Thread) !MailboxDrainResult {
         &self.visibility_regain,
         visibility.rendererTransition(),
     );
+}
+
+fn applyVisible(
+    self: *Thread,
+    visibility: *VisibilityDrainState,
+    value: bool,
+) void {
+    if (!visibility.apply(value)) return;
+    self.flags.visible = value;
+    self.setQosClass();
+
+    // Timers are intentionally left armed across visibility changes. Their
+    // callbacks already consult this renderer-owned flag.
+}
+
+fn applyFocused(self: *Thread, value: bool, external_drain: bool) !void {
+    if (self.flags.focused == value) return;
+    self.flags.focused = value;
+    self.setQosClass();
+    try self.renderer.setFocus(value);
+
+    if (external_drain) {
+        if (value) self.resetExternalCursorBlink();
+        return;
+    }
+
+    self.syncDrawTimer();
+    if (!value) {
+        if (self.cursor_c.state() == .active and
+            self.cursor_c_cancel.state() == .dead)
+        {
+            self.cursor_h.cancel(
+                &self.loop,
+                &self.cursor_c,
+                &self.cursor_c_cancel,
+                void,
+                null,
+                cursorCancelCallback,
+            );
+        }
+        return;
+    }
+
+    if (self.cursor_c.state() != .active) {
+        self.flags.cursor_blink_visible = true;
+        self.cursor_h.run(
+            &self.loop,
+            &self.cursor_c,
+            cursorBlinkInterval(),
+            Thread,
+            self,
+            cursorTimerCallback,
+        );
+    }
+}
+
+fn applyDisplayID(self: *Thread, value: u32) !void {
+    if (@hasDecl(rendererpkg.Renderer, "setMacOSDisplayID")) {
+        try self.renderer.setMacOSDisplayID(value);
+    }
 }
 
 fn changeConfig(self: *Thread, config: *const DerivedConfig) !void {


### PR DESCRIPTION
## Summary

- publish visibility, focus, and macOS display-ID lifecycle state through independent atomic latest-value slots
- apply those values on the renderer thread after its ordered mailbox drain
- keep UI/embedder lifecycle callbacks out of the renderer's bounded mailbox

## Why

cmux issue manaflow-ai/cmux#8759 reproduced an app-wide main-thread freeze while switching workspaces. A live LLDB capture showed the main thread parked in `ghostty_surface_set_occlusion` waiting for renderer mailbox capacity while the renderer was wedged. Focus and display-ID used the same synchronous path.

## Tests

- red commit: `2d99010ff` fills the renderer mailbox and requires lifecycle publication to retain the latest values without entering it
- fix commit: `ca21db1bb`
- `zig build test -Dtest-filter='surface lifecycle state bypasses'`
- universal ReleaseFast GhosttyKit: `zig build -Demit-macos-app=false -Demit-xcframework=true -Dxcframework-target=universal -Doptimize=ReleaseFast`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/132"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787441955&installation_model_id=21920&pr_number=132&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F132&signature=b3418e309f2cedd56f45901ac88a8c8eed1a901880e1da145269fcdf0898955a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make renderer lifecycle updates non-blocking by publishing visibility, focus, and macOS display ID via coalesced latest-value slots and applying them after the mailbox drain. This prevents UI/main thread stalls and resolves the freeze during workspace switches (cmux#8759).

- **Bug Fixes**
  - Replaced mailbox pushes with non-blocking `publishVisible`, `publishFocused`, and `publishDisplayID` that use per-field atomic slots.
  - Renderer applies these updates after draining the ordered mailbox to coalesce and keep the latest values.
  - UI/embedder callbacks no longer wait on the bounded renderer mailbox, avoiding deadlocks in occlusion/focus/display-ID paths.
  - Added a test to ensure lifecycle state bypasses a full mailbox and retains the newest values.

<sup>Written for commit ade1de1f4213bdf34a387b255906ce2aae0c4da2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/132?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

