### PR TITLE
Support unindented hard-wrapped links

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -7002,6 +7002,140 @@ test "Surface: path link selection spans an indented hard newline" {
     )) == null);
 }
 
+test "Surface: markdown path spans unindented hard newlines" {
+    if (comptime !@import("terminal_options").oniguruma) return error.SkipZigTest;
+
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const prefix = "##  ";
+    const first = "/Users/austinwang/Library/Developer/Xcode/DerivedData/";
+    const second = "cmux-fix-split-resize/Build/Products/Debug/cmux DEV fix-";
+    const third = "split-resize.app";
+    const value = first ++ second ++ third;
+
+    try oni.testing.ensureInit();
+    var config = try configpkg.Config.default(alloc);
+    defer config.deinit();
+    var derived = try DerivedConfig.init(alloc, &config);
+    defer derived.deinit();
+
+    var screen = try terminal.Screen.init(alloc, .{
+        .cols = 80,
+        .rows = 4,
+        .max_scrollback = 0,
+    });
+    defer screen.deinit();
+
+    screen.cursorSetSemanticContent(.output);
+    try screen.testWriteString(
+        prefix ++ first ++ "\r\n" ++ second ++ "\r\n" ++ third,
+    );
+
+    for ([_]terminal.point.Coordinate{
+        .{ .x = prefix.len + 10, .y = 0 },
+        .{ .x = 12, .y = 1 },
+        .{ .x = 6, .y = 2 },
+    }) |point| {
+        const pin = screen.pages.pin(.{ .active = point }).?;
+        var link = (try linkAtScreenPin(
+            alloc,
+            &screen,
+            derived.links,
+            pin,
+            input.ctrlOrSuper(.{}),
+        )) orelse return error.TestExpectedEqual;
+        defer link.deinit(alloc);
+        try testing.expectEqualStrings(value, linkActionTarget(link));
+    }
+}
+
+test "Surface: URL spans unindented hard newlines" {
+    if (comptime !@import("terminal_options").oniguruma) return error.SkipZigTest;
+
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const first = "https://github.com/manaflow-ai/cmux/issues/8583#issuecomment-";
+    const second = "0123456789-";
+    const third = "abcdefghijklmnopqrstuvwxyz";
+    const value = first ++ second ++ third;
+
+    try oni.testing.ensureInit();
+    var config = try configpkg.Config.default(alloc);
+    defer config.deinit();
+    var derived = try DerivedConfig.init(alloc, &config);
+    defer derived.deinit();
+
+    var screen = try terminal.Screen.init(alloc, .{
+        .cols = 96,
+        .rows = 4,
+        .max_scrollback = 0,
+    });
+    defer screen.deinit();
+    screen.cursorSetSemanticContent(.output);
+    try screen.testWriteString(first ++ "\r\n" ++ second ++ "\r\n" ++ third);
+
+    for ([_]terminal.point.Coordinate{
+        .{ .x = 20, .y = 0 },
+        .{ .x = 5, .y = 1 },
+        .{ .x = 10, .y = 2 },
+    }) |point| {
+        const pin = screen.pages.pin(.{ .active = point }).?;
+        var link = (try linkAtScreenPin(
+            alloc,
+            &screen,
+            derived.links,
+            pin,
+            input.ctrlOrSuper(.{}),
+        )) orelse return error.TestExpectedEqual;
+        defer link.deinit(alloc);
+        try testing.expectEqualStrings(value, linkActionTarget(link));
+    }
+}
+
+test "Surface: file URL spans soft-wrapped rows" {
+    if (comptime !@import("terminal_options").oniguruma) return error.SkipZigTest;
+
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const value = "file:///Users/admin/berkshire-vault/raw/product/strategy/buyer-decision-model.html";
+    const cols = 32;
+    const last_index = value.len - 1;
+
+    try oni.testing.ensureInit();
+    var config = try configpkg.Config.default(alloc);
+    defer config.deinit();
+    var derived = try DerivedConfig.init(alloc, &config);
+    defer derived.deinit();
+
+    var screen = try terminal.Screen.init(alloc, .{
+        .cols = cols,
+        .rows = 4,
+        .max_scrollback = 0,
+    });
+    defer screen.deinit();
+    screen.cursorSetSemanticContent(.output);
+    try screen.testWriteString(value);
+
+    for ([_]terminal.point.Coordinate{
+        .{ .x = 5, .y = 0 },
+        .{
+            .x = @intCast(last_index % cols),
+            .y = @intCast(last_index / cols),
+        },
+    }) |point| {
+        const pin = screen.pages.pin(.{ .active = point }).?;
+        var link = (try linkAtScreenPin(
+            alloc,
+            &screen,
+            derived.links,
+            pin,
+            input.ctrlOrSuper(.{}),
+        )) orelse return error.TestExpectedEqual;
+        defer link.deinit(alloc);
+        try testing.expectEqualStrings(value, linkActionTarget(link));
+    }
+}
+
 test "Surface: wrapped path preserves mapped trailing spaces for copy policy" {
     if (comptime !@import("terminal_options").oniguruma) return error.SkipZigTest;
 

--- a/src/link.zig
+++ b/src/link.zig
@@ -1352,7 +1352,11 @@ fn hardWrapBoundary(
             indentation += 1;
             continue;
         }
-        if (!link_wrap.canJoinCodepoints(before, indentation, cp)) return false;
+        const continuation = link_wrap.continuationKind(
+            before,
+            indentation,
+            cp,
+        ) orelse return false;
 
         // Probe a bounded UTF-8 prefix without allocating under the terminal
         // lock. Filling the probe is ambiguous, so fail closed rather than
@@ -1382,6 +1386,7 @@ fn hardWrapBoundary(
         return !link_wrap.startsIndependentLink(
             prefix[0..prefix_len],
             before,
+            continuation,
         );
     }
     return false;

--- a/src/link_wrap.zig
+++ b/src/link_wrap.zig
@@ -76,23 +76,26 @@ pub fn normalize(
                 next += 1;
             }
 
-            if (boundary > 0 and
-                next < input.len and
-                canJoinCodepoints(
-                    string.items[boundary - 1],
-                    next - (i + 1),
+            if (boundary > 0 and next < input.len) {
+                const before = string.items[boundary - 1];
+                const indentation = next - (i + 1);
+                if (continuationKind(
+                    before,
+                    indentation,
                     input[next],
-                ) and
-                !startsIndependentLink(
-                    input[next..],
-                    string.items[boundary - 1],
-                ))
-            {
-                string.shrinkRetainingCapacity(boundary);
-                map.shrinkRetainingCapacity(boundary);
-                joined = true;
-                i = next;
-                continue;
+                )) |kind| {
+                    if (!startsIndependentLink(
+                        input[next..],
+                        before,
+                        kind,
+                    )) {
+                        string.shrinkRetainingCapacity(boundary);
+                        map.shrinkRetainingCapacity(boundary);
+                        joined = true;
+                        i = next;
+                        continue;
+                    }
+                }
             }
         }
 
@@ -128,11 +131,21 @@ fn isBreakPunctuation(byte: u8) bool {
 
 pub const max_continuation_indentation = 16;
 
+pub const ContinuationKind = enum {
+    unindented,
+    indented,
+};
+
 /// Return whether the first token should own its row instead of continuing
 /// the preceding token. Explicit roots and schemes always qualify. A bare
-/// relative path qualifies only after `/`, where joining two complete
-/// path-shaped rows would silently produce a different target.
-pub fn startsIndependentLink(input: []const u8, before: u21) bool {
+/// relative path qualifies only at an indented boundary after `/`, where the
+/// indentation is evidence that the formatter may have started a nested list
+/// item rather than continued one unbroken token.
+pub fn startsIndependentLink(
+    input: []const u8,
+    before: u21,
+    continuation: ContinuationKind,
+) bool {
     if (input.len == 0) return false;
     if (input[0] == '/') return true;
     if (std.mem.startsWith(u8, input, "./") or
@@ -161,7 +174,9 @@ pub fn startsIndependentLink(input: []const u8, before: u21) bool {
     var index: usize = if (input[0] == '.' and
         input.len > 1 and isWordByte(input[1]))
         2
-    else if (before == '/' and isWordByte(input[0]))
+    else if (continuation == .indented and
+        before == '/' and
+        isWordByte(input[0]))
         1
     else
         return false;
@@ -189,20 +204,22 @@ fn isBareSegmentByte(byte: u8) bool {
     return isWordByte(byte) or byte == '-' or byte == '.';
 }
 
-/// Return whether two terminal rows form a recognized prose hard-wrap
-/// boundary. Keeping this predicate shared with grid expansion prevents the
-/// selected candidate and normalized bytes from disagreeing.
-pub fn canJoinCodepoints(
+/// Classify whether two terminal rows form a recognized prose hard-wrap
+/// boundary. Keeping this classifier shared with grid expansion prevents the
+/// selected candidate and normalized bytes from disagreeing. Indentation is
+/// common but not required: terminal UIs also hard-wrap an unbroken token at a
+/// punctuation boundary without adding continuation padding.
+pub fn continuationKind(
     before: u21,
     indentation: usize,
     after: u21,
-) bool {
-    if (indentation == 0 or
-        indentation > max_continuation_indentation or
-        before > std.math.maxInt(u8)) return false;
-    if (!isBreakPunctuation(@intCast(before))) return false;
-    if (after > std.math.maxInt(u8)) return true;
-    return isLinkByte(@intCast(after));
+) ?ContinuationKind {
+    if (indentation > max_continuation_indentation or
+        before > std.math.maxInt(u8)) return null;
+    if (!isBreakPunctuation(@intCast(before))) return null;
+    if (after <= std.math.maxInt(u8) and
+        !isLinkByte(@intCast(after))) return null;
+    return if (indentation == 0) .unindented else .indented;
 }
 
 fn isLinkByte(byte: u8) bool {
@@ -270,22 +287,35 @@ test "normalize joins a CRLF link continuation" {
     try testing.expectEqualStrings("/tmp/build-warm.app", normalized.string);
 }
 
-test "normalize does not join unindented or unpunctuated lines" {
+test "normalize joins unindented continuation but not unpunctuated lines" {
     const testing = std.testing;
     const alloc = testing.allocator;
 
-    for ([_][]const u8{
-        "/tmp/build-\nwarm.app",
-        "/tmp/build\n    warm.app",
-    }) |input| {
-        const input_map = try alloc.alloc(usize, input.len);
-        defer alloc.free(input_map);
-        for (input_map, 0..) |*item, index| item.* = index;
+    const joined = "/tmp/build-\nwarm.app";
+    var joined_map: [joined.len]usize = undefined;
+    for (&joined_map, 0..) |*item, index| item.* = index;
+    const normalized_joined = try normalize(
+        usize,
+        alloc,
+        joined,
+        &joined_map,
+        .{},
+    );
+    defer normalized_joined.deinit(alloc);
+    try testing.expectEqualStrings("/tmp/build-warm.app", normalized_joined.string);
 
-        const normalized = try normalize(usize, alloc, input, input_map, .{});
-        defer normalized.deinit(alloc);
-        try testing.expectEqualStrings(input, normalized.string);
-    }
+    const separate = "/tmp/build\n    warm.app";
+    var separate_map: [separate.len]usize = undefined;
+    for (&separate_map, 0..) |*item, index| item.* = index;
+    const normalized_separate = try normalize(
+        usize,
+        alloc,
+        separate,
+        &separate_map,
+        .{},
+    );
+    defer normalized_separate.deinit(alloc);
+    try testing.expectEqualStrings(separate, normalized_separate.string);
 }
 
 test "startsIndependentLink recognizes independent URL and path prefixes" {
@@ -299,11 +329,15 @@ test "startsIndependentLink recognizes independent URL and path prefixes" {
         "$HOME/foo",
         "https://example.com",
         "file:///tmp/foo",
-    }) |input| try testing.expect(startsIndependentLink(input, '-'));
+    }) |input| try testing.expect(startsIndependentLink(
+        input,
+        '-',
+        .indented,
+    ));
 
-    try testing.expect(startsIndependentLink(".config/foo", '-'));
-    try testing.expect(startsIndependentLink("src/foo", '/'));
-    try testing.expect(startsIndependentLink("日本語/foo", '/'));
+    try testing.expect(startsIndependentLink(".config/foo", '-', .indented));
+    try testing.expect(startsIndependentLink("src/foo", '/', .indented));
+    try testing.expect(startsIndependentLink("日本語/foo", '/', .indented));
 
     for ([_][]const u8{
         "20260716-warm.app",
@@ -311,9 +345,14 @@ test "startsIndependentLink recognizes independent URL and path prefixes" {
         "(video_game)",
         "日本語",
         "continuation",
-    }) |input| try testing.expect(!startsIndependentLink(input, '-'));
+    }) |input| try testing.expect(!startsIndependentLink(
+        input,
+        '-',
+        .indented,
+    ));
 
-    try testing.expect(!startsIndependentLink("src/foo", '-'));
+    try testing.expect(!startsIndependentLink("src/foo", '-', .indented));
+    try testing.expect(!startsIndependentLink("src/foo", '/', .unindented));
 }
 
 test "normalize keeps adjacent independent links separate" {


### PR DESCRIPTION
## Summary

- extend the canonical terminal-grid link resolver to recognize real-newline continuations without indentation when they break after link punctuation
- keep grid expansion and newline normalization on one shared `ContinuationKind` classifier, so hover, copy, preview, and open use the same complete target
- retain the existing guards for explicit schemes/roots, semantic prompt transitions, unrelated indentation, and sentence punctuation

Fixes the Ghostty layer of https://github.com/manaflow-ai/cmux/issues/8810 and covers the remaining hard-wrap shapes in https://github.com/manaflow-ai/cmux/issues/8583. The soft-wrapped `file://` regression from https://github.com/manaflow-ai/cmux/issues/4675 remains covered.

## Root cause

The indented hard-wrap fix only expanded a candidate when the next physical row had at least one indentation cell. Agent TUIs can emit a real newline at a punctuation boundary with zero indentation, so the canonical candidate stopped at the clicked physical row before regex matching. The embedding app receives only that already-truncated target and has no grid metadata with which to repair it.

## Tests

- test-only commit `bde834169` fails the exact three-row markdown-prefixed `.app` path and an unindented long URL while the soft-wrapped `file://` guard passes
- fix commit `823641e23` passes those cases from every row
- focused indented-wrap, punctuation, normalization, independence, and soft-wrap regressions
- full `zig build test -Dapp-runtime=none -Demit-macos-app=false -Demit-xcframework=false`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/134"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787460430&installation_model_id=21920&pr_number=134&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F134&signature=f9e6f20bc44eb45c801282f8057cdb33bd47ff9c1ef761046812a03baa2f7248"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Join unindented hard-wrapped links split at punctuation, so link targets aren’t truncated across rows. This makes hover, copy, preview, and open work for these cases and addresses `manaflow-ai/cmux#8810` (Ghostty side) and the remaining cases in `#8583`.

- Bug Fixes
  - Introduced a shared `continuationKind` classifier to detect indented and unindented continuations and keep selection and normalization in sync.
  - Updated independence checks to respect continuation type while preserving guards for explicit schemes/roots, prompt boundaries, unrelated indentation, and sentence punctuation.
  - Added tests for markdown paths and long URLs broken by real newlines; confirmed soft-wrapped `file://` remains correct.

<sup>Written for commit 823641e234c3c6bf4bc5badb72261d8a6fc37232. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

