### PR TITLE
fix: bound renderer mailbox drain turns

### DIFF
--- a/src/datastruct/blocking_queue.zig
+++ b/src/datastruct/blocking_queue.zig
@@ -156,6 +156,18 @@ pub fn BlockingQueue(
             return self.data[n];
         }
 
+        /// Return the number of values currently queued.
+        ///
+        /// Consumers can use this to bound one processing turn to a snapshot
+        /// of the queue. Producers may add more values after this returns, but
+        /// a single-consumer queue retains at least this many values until that
+        /// consumer pops them.
+        pub fn count(self: *Self) Size {
+            self.mutex.lock();
+            defer self.mutex.unlock();
+            return self.len;
+        }
+
         /// Pop all values from the queue. This will hold the big mutex
         /// until `deinit` is called on the return value. This is used if
         /// you know you're going to "pop" and utilize all the values
@@ -229,6 +241,25 @@ test "basic push and pop" {
 
     // Verify we can still push
     try testing.expectEqual(@as(Q.Size, 1), q.push(1, .{ .instant = {} }));
+}
+
+test "count snapshots one bounded consumer turn" {
+    const testing = std.testing;
+    const Q = BlockingQueue(u64, 4);
+    const q = try Q.create(testing.allocator);
+    defer q.destroy(testing.allocator);
+
+    try testing.expectEqual(@as(Q.Size, 1), q.push(1, .{ .instant = {} }));
+    try testing.expectEqual(@as(Q.Size, 2), q.push(2, .{ .instant = {} }));
+
+    var remaining = q.count();
+    try testing.expectEqual(@as(Q.Size, 3), q.push(3, .{ .instant = {} }));
+    while (remaining > 0) : (remaining -= 1) {
+        _ = q.pop().?;
+    }
+
+    try testing.expectEqual(@as(u64, 3), q.pop().?);
+    try testing.expectEqual(@as(Q.Size, 0), q.count());
 }
 
 test "timed push" {

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -809,7 +809,22 @@ fn drainMailbox(self: *Thread) !MailboxDrainResult {
     const external_drain = self.externalDrainActive();
     var visibility = VisibilityDrainState.init(self.flags.visible);
 
-    while (self.mailbox.pop()) |message| {
+    // Process only the messages present at the start of this renderer turn.
+    // Producers can refill the queue as we pop. Draining until a transient
+    // empty state lets sustained terminal output monopolize the renderer loop,
+    // delaying lifecycle state below and the render that follows this drain.
+    // A snapshot gives both bounded latency while preserving FIFO ordering.
+    var remaining = self.mailbox.count();
+    defer if (!external_drain and self.mailbox.count() > 0) {
+        // Producer notifications can coalesce with the wake currently being
+        // handled, so explicitly retain another turn for work added mid-drain.
+        self.wakeup.notify() catch |err| {
+            log.warn("failed to continue renderer mailbox drain err={}", .{err});
+        };
+    };
+
+    while (remaining > 0) : (remaining -= 1) {
+        const message = self.mailbox.pop() orelse break;
         log.debug("mailbox message={}", .{message});
         switch (message) {
             .crash => @panic("crash request, crashing intentionally"),
@@ -893,9 +908,9 @@ fn drainMailbox(self: *Thread) !MailboxDrainResult {
     }
 
     // Lifecycle state is latest-value rather than ordered work. Apply it after
-    // the ordinary mailbox so an older compatibility message cannot overwrite
-    // a newer request. A publication racing this take remains pending and its
-    // own wakeup drives the next drain.
+    // this bounded ordinary-mailbox snapshot so an older compatibility message
+    // cannot overwrite a newer request, without waiting for a producer-refilled
+    // queue to become transiently empty.
     const surface_state = self.surface_state_requests.take();
     if (surface_state.visible) |value| self.applyVisible(&visibility, value);
     if (surface_state.focused) |value| try self.applyFocused(value, external_drain);


### PR DESCRIPTION
## Summary

- bound each renderer wake to the ordinary mailbox depth present at the start of the turn
- consume coalesced lifecycle state and render before processing work that arrived during that batch
- explicitly re-wake when producers added work during the drain, since their notifications may coalesce with the active callback

## Root cause

https://github.com/manaflow-ai/ghostty/commit/ca21db1bb8361bf5b58a848dd823b6ee24a5d9fa moved visibility/focus/display ID to latest-value slots consumed after the ordinary mailbox. The mailbox loop could consume producer refills indefinitely, starving both the lifecycle take and the render step under continuous terminal echo. This caused https://github.com/manaflow-ai/cmux/issues/8808.

## Validation

- `zig build test -Dtest-filter="count snapshots one bounded consumer turn"`
- `zig build test -Dtest-filter="surface lifecycle state bypasses"`
- `zig build test -Dtest-filter="visibility drain"`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/135"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787468596&installation_model_id=21920&pr_number=135&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F135&signature=125e627bba116d38697c98479a585e626d284f2484075a87a077347d8616b7e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound the renderer mailbox drain to a per-turn snapshot to prevent starvation and keep lifecycle updates and rendering responsive under sustained input. Fixes visible typing lag during heavy terminal echo.

- **Bug Fixes**
  - Added `count()` to the blocking queue to snapshot length for a bounded consumer turn.
  - Mailbox drain now processes only messages present at turn start; applies latest lifecycle state right after.
  - If producers add work mid-drain, explicitly re-wakes the renderer to avoid coalesced notification loss.
  - Added a unit test to verify bounded-turn behavior.

<sup>Written for commit b81ddb139baafaf40d1bb4b97221957989d67bd9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/135?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

