### PR TITLE
renderer: harden bounded drains for external rendering

### DIFF
--- a/src/datastruct/blocking_queue.zig
+++ b/src/datastruct/blocking_queue.zig
@@ -156,6 +156,13 @@ pub fn BlockingQueue(
             return self.data[n];
         }
 
+        /// Return the number of unread items at one instant.
+        pub fn count(self: *Self) Size {
+            self.mutex.lock();
+            defer self.mutex.unlock();
+            return self.len;
+        }
+
         /// Pop all values from the queue. This will hold the big mutex
         /// until `deinit` is called on the return value. This is used if
         /// you know you're going to "pop" and utilize all the values

--- a/src/datastruct/blocking_queue.zig
+++ b/src/datastruct/blocking_queue.zig
@@ -214,10 +214,12 @@ test "basic push and pop" {
 
     // Should have no values
     try testing.expect(q.pop() == null);
+    try testing.expectEqual(@as(Q.Size, 0), q.count());
 
     // Push until we're full
     try testing.expectEqual(@as(Q.Size, 1), q.push(1, .{ .instant = {} }));
     try testing.expectEqual(@as(Q.Size, 2), q.push(2, .{ .instant = {} }));
+    try testing.expectEqual(@as(Q.Size, 2), q.count());
     try testing.expectEqual(@as(Q.Size, 3), q.push(3, .{ .instant = {} }));
     try testing.expectEqual(@as(Q.Size, 4), q.push(4, .{ .instant = {} }));
     try testing.expectEqual(@as(Q.Size, 0), q.push(5, .{ .instant = {} }));

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -232,6 +232,18 @@ fn drainMessageBatch(context: anytype) !bool {
     return context.pendingMessageCount() > 0;
 }
 
+/// External rendering permanently disables the xev renderer callback, so it
+/// must consume continuation batches itself. On iOS the terminal-output
+/// producer and render call share one serial queue; looping here restores the
+/// exhaustive drain contract without exposing normal renderer wakes to
+/// unbounded producer replenishment.
+fn drainMailboxUntilQuiescent(context: anytype) !void {
+    while (true) {
+        const result = try context.drainMailbox();
+        if (!result.wake_pending) return;
+    }
+}
+
 /// Apply the one renderer visibility transition left after mailbox
 /// coalescing. The context seam keeps the wake behavior directly testable
 /// without constructing a platform renderer.
@@ -547,9 +559,8 @@ pub fn deinit(self: *Thread) void {
 /// when upstream exposes a synchronous embedder render tick.
 pub fn renderNow(self: *Thread) void {
     self.enterExternalDrainMode();
-    _ = self.drainMailbox() catch |err| fallback: {
+    self.drainMailboxUntilQuiescent() catch |err| {
         log.err("renderNow: error draining mailbox err={}", .{err});
-        break :fallback MailboxDrainResult{};
     };
 
     self.notifySelectionChanged();
@@ -570,9 +581,8 @@ pub fn renderNowWithPresentation(
     presentation: rendererpkg.FramePresentation,
 ) void {
     self.enterExternalDrainMode();
-    _ = self.drainMailbox() catch |err| fallback: {
+    self.drainMailboxUntilQuiescent() catch |err| {
         log.err("renderNowWithPresentation: error draining mailbox err={}", .{err});
-        break :fallback MailboxDrainResult{};
     };
 
     self.notifySelectionChanged();
@@ -612,7 +622,7 @@ fn finishRenderNowWithPresentation(
     value.deliver();
 }
 
-/// Drain one finite snapshot of the renderer mailbox.
+/// Drain the external renderer mailbox until no continuation work remains.
 ///
 /// cmux iOS fork: a public seam over the private `drainMailbox` so a producer
 /// running on the iOS render serial queue (where `render_now` is the mailbox's
@@ -620,15 +630,14 @@ fn finishRenderNowWithPresentation(
 /// message that must NOT be dropped (e.g. `.font_grid`, whose handler derefs the
 /// old grid). Safe to call from that queue for the same reason `render_now` is:
 /// `render_now` already calls `drainMailbox` on this serial queue every frame
-/// (see `renderNow`). The snapshot includes every message queued when this call
-/// starts, so a full mailbox is made available for the caller's retry without
-/// admitting unbounded work from concurrent producers. `drainMailbox` and its
-/// handlers take no `renderer_state.mutex`, so it cannot self-deadlock against
-/// a caller that holds it. Delete when upstream exposes a synchronous embedder
-/// render tick.
+/// (see `renderNow`). Terminal-output producers cannot refill between batches
+/// because they share that queue; continuation batches also consume work from
+/// other threads before returning. `drainMailbox` and its handlers take no
+/// `renderer_state.mutex`, so it cannot self-deadlock against a caller that
+/// holds it. Delete when upstream exposes a synchronous embedder render tick.
 pub fn drainMailboxNow(self: *Thread) void {
     self.enterExternalDrainMode();
-    _ = self.drainMailbox() catch |err| {
+    self.drainMailboxUntilQuiescent() catch |err| {
         log.err("drainMailboxNow: error draining mailbox err={}", .{err});
         return;
     };
@@ -868,8 +877,12 @@ fn drainMailbox(self: *Thread) !MailboxDrainResult {
     // Lifecycle state is latest-value rather than ordered work. Apply it after
     // the ordinary mailbox so an older compatibility message cannot overwrite
     // a newer request. A publication racing this take remains pending and its
-    // own wakeup drives the next drain.
+    // own normal wakeup or the external continuation loop drives the next drain.
     const surface_state = self.surface_state_requests.take();
+    // Visibility application cannot fail. If a later lifecycle operation
+    // fails, renderAfterMailboxDrain reconciles this updated thread flag with
+    // renderer visibility, so only the failed and not-yet-applied values need
+    // to be restored below.
     if (surface_state.visible) |value| self.applyVisible(&visibility, value);
     if (surface_state.focused) |value| {
         self.applyFocused(value, external_drain) catch |err| {
@@ -1406,6 +1419,21 @@ test "renderer mailbox wake excludes messages added while draining" {
     try std.testing.expect(try drainMessageBatch(&context));
     try std.testing.expectEqual(@as(usize, 1), context.handled);
     try std.testing.expectEqual(@as(usize, 1), context.pending);
+}
+
+test "external renderer consumes every continuation batch" {
+    const Context = struct {
+        drains: usize = 0,
+
+        fn drainMailbox(self: *@This()) !MailboxDrainResult {
+            self.drains += 1;
+            return .{ .wake_pending = self.drains < 3 };
+        }
+    };
+
+    var context: Context = .{};
+    try drainMailboxUntilQuiescent(&context);
+    try std.testing.expectEqual(@as(usize, 3), context.drains);
 }
 
 test "surface lifecycle state bypasses a full renderer mailbox and keeps latest values" {

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -185,6 +185,17 @@ const MailboxDrainResult = struct {
     rendered_visibility_regain: bool = false,
 };
 
+/// Process ordinary renderer messages and report whether work remains.
+///
+/// The context seam keeps the wake batching policy deterministic in tests
+/// without constructing a platform renderer.
+fn drainMessageBatch(context: anytype) !bool {
+    while (context.popMessage()) |message| {
+        try context.handleMessage(message);
+    }
+    return context.pendingMessageCount() > 0;
+}
+
 /// Apply the one renderer visibility transition left after mailbox
 /// coalescing. The context seam keeps the wake behavior directly testable
 /// without constructing a platform renderer.
@@ -809,88 +820,12 @@ fn drainMailbox(self: *Thread) !MailboxDrainResult {
     const external_drain = self.externalDrainActive();
     var visibility = VisibilityDrainState.init(self.flags.visible);
 
-    while (self.mailbox.pop()) |message| {
-        log.debug("mailbox message={}", .{message});
-        switch (message) {
-            .crash => @panic("crash request, crashing intentionally"),
-
-            .visible => |v| self.applyVisible(&visibility, v),
-
-            .focus => |v| try self.applyFocused(v, external_drain),
-
-            .reset_cursor_blink => {
-                self.flags.cursor_blink_visible = true;
-                if (external_drain) {
-                    self.resetExternalCursorBlink();
-                    continue;
-                }
-                if (self.cursor_c.state() == .active) {
-                    self.cursor_h.reset(
-                        &self.loop,
-                        &self.cursor_c,
-                        &self.cursor_c_cancel,
-                        cursorBlinkInterval(),
-                        Thread,
-                        self,
-                        cursorTimerCallback,
-                    );
-                }
-            },
-
-            .font_grid => |grid| {
-                self.renderer.setFontGrid(grid.grid);
-                grid.set.deref(grid.old_key);
-            },
-
-            .resize => |v| self.renderer.setScreenSize(v),
-
-            .change_config => |config| {
-                defer config.alloc.destroy(config.thread);
-                defer config.alloc.destroy(config.impl);
-                try self.changeConfig(config.thread);
-                try self.renderer.changeConfig(config.impl);
-
-                // Stop and start the draw timer to capture the new
-                // hasAnimations value.
-                if (!external_drain) self.syncDrawTimer();
-            },
-
-            .search_viewport_matches => |v| {
-                // Note we don't free the new value because we expect our
-                // allocators to match.
-                if (self.renderer.search_matches) |*m| m.arena.deinit();
-                self.renderer.search_matches = v;
-                self.renderer.search_matches_dirty = true;
-            },
-
-            .search_selected_match => |v| {
-                // Note we don't free the new value because we expect our
-                // allocators to match.
-                if (self.renderer.search_selected_match) |*m| m.arena.deinit();
-                self.renderer.search_selected_match = v;
-                self.renderer.search_matches_dirty = true;
-            },
-
-            .inspector => |v| {
-                self.flags.has_inspector = v;
-            },
-
-            .macos_display_id => |v| try self.applyDisplayID(v),
-
-            // cmux fork: release/recreate the renderer's GPU resources (swap
-            // chain / IOSurface) without freeing the surface. Safe here because
-            // this runs on the renderer thread (so it never races a draw), the
-            // surface is occluded when this is sent (macOS `drawFrame` early-
-            // returns on `!flags.visible`), and both calls take `draw_mutex`.
-            .display_realized => |v| {
-                if (v) {
-                    try self.renderer.displayRealized();
-                } else {
-                    self.renderer.displayUnrealized();
-                }
-            },
-        }
-    }
+    var message_drain: MailboxMessageDrainContext = .{
+        .thread = self,
+        .visibility = &visibility,
+        .external_drain = external_drain,
+    };
+    _ = try drainMessageBatch(&message_drain);
 
     // Lifecycle state is latest-value rather than ordered work. Apply it after
     // the ordinary mailbox so an older compatibility message cannot overwrite
@@ -912,6 +847,119 @@ fn drainMailbox(self: *Thread) !MailboxDrainResult {
         &self.visibility_regain,
         visibility.rendererTransition(),
     );
+}
+
+const MailboxMessageDrainContext = struct {
+    thread: *Thread,
+    visibility: *VisibilityDrainState,
+    external_drain: bool,
+
+    fn pendingMessageCount(self: *@This()) Mailbox.Size {
+        return self.thread.mailbox.count();
+    }
+
+    fn popMessage(self: *@This()) ?rendererpkg.Message {
+        return self.thread.mailbox.pop();
+    }
+
+    fn handleMessage(
+        self: *@This(),
+        message: rendererpkg.Message,
+    ) !void {
+        try self.thread.handleMailboxMessage(
+            message,
+            self.visibility,
+            self.external_drain,
+        );
+    }
+};
+
+fn handleMailboxMessage(
+    self: *Thread,
+    message: rendererpkg.Message,
+    visibility: *VisibilityDrainState,
+    external_drain: bool,
+) !void {
+    log.debug("mailbox message={}", .{message});
+    switch (message) {
+        .crash => @panic("crash request, crashing intentionally"),
+
+        .visible => |v| self.applyVisible(visibility, v),
+
+        .focus => |v| try self.applyFocused(v, external_drain),
+
+        .reset_cursor_blink => {
+            self.flags.cursor_blink_visible = true;
+            if (external_drain) {
+                self.resetExternalCursorBlink();
+                return;
+            }
+            if (self.cursor_c.state() == .active) {
+                self.cursor_h.reset(
+                    &self.loop,
+                    &self.cursor_c,
+                    &self.cursor_c_cancel,
+                    cursorBlinkInterval(),
+                    Thread,
+                    self,
+                    cursorTimerCallback,
+                );
+            }
+        },
+
+        .font_grid => |grid| {
+            self.renderer.setFontGrid(grid.grid);
+            grid.set.deref(grid.old_key);
+        },
+
+        .resize => |v| self.renderer.setScreenSize(v),
+
+        .change_config => |config| {
+            defer config.alloc.destroy(config.thread);
+            defer config.alloc.destroy(config.impl);
+            try self.changeConfig(config.thread);
+            try self.renderer.changeConfig(config.impl);
+
+            // Stop and start the draw timer to capture the new
+            // hasAnimations value.
+            if (!external_drain) self.syncDrawTimer();
+        },
+
+        .search_viewport_matches => |v| {
+            // Note we don't free the new value because we expect our
+            // allocators to match.
+            if (self.renderer.search_matches) |*m| m.arena.deinit();
+            self.renderer.search_matches = v;
+            self.renderer.search_matches_dirty = true;
+        },
+
+        .search_selected_match => |v| {
+            // Note we don't free the new value because we expect our
+            // allocators to match.
+            if (self.renderer.search_selected_match) |*m| m.arena.deinit();
+            self.renderer.search_selected_match = v;
+            self.renderer.search_matches_dirty = true;
+        },
+
+        .inspector => |v| {
+            self.flags.has_inspector = v;
+        },
+
+        .macos_display_id => |v| try self.applyDisplayID(v),
+
+        // cmux fork: release/recreate the renderer's GPU resources (swap
+        // chain / IOSurface) without freeing the surface. Safe here because
+        // this runs on the renderer thread (so it never races a draw), the
+        // surface is occluded when this is sent (macOS `drawFrame` early-
+        // returns on `!flags.visible`), and both calls take `draw_mutex`.
+        .display_realized => |v| {
+            if (v) {
+                try self.renderer.displayRealized();
+            } else {
+                self.renderer.displayUnrealized();
+            }
+        },
+    }
 }
 
 fn applyVisible(
@@ -1257,6 +1305,33 @@ test "visibility drain coalesces rapid hide show ordering" {
     try std.testing.expect(canceled.apply(false));
     try std.testing.expect(canceled.apply(true));
     try std.testing.expectEqual(null, canceled.rendererTransition());
+}
+
+test "renderer mailbox wake excludes messages added while draining" {
+    const Context = struct {
+        pending: usize = 1,
+        handled: usize = 0,
+
+        fn pendingMessageCount(self: *@This()) usize {
+            return self.pending;
+        }
+
+        fn popMessage(self: *@This()) ?u8 {
+            if (self.pending == 0) return null;
+            self.pending -= 1;
+            return 1;
+        }
+
+        fn handleMessage(self: *@This(), _: u8) !void {
+            self.handled += 1;
+            if (self.handled < 4) self.pending += 1;
+        }
+    };
+
+    var context: Context = .{};
+    try std.testing.expect(try drainMessageBatch(&context));
+    try std.testing.expectEqual(@as(usize, 1), context.handled);
+    try std.testing.expectEqual(@as(usize, 1), context.pending);
 }
 
 test "surface lifecycle state bypasses a full renderer mailbox and keeps latest values" {

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -216,15 +216,12 @@ const MailboxDrainResult = struct {
     wake_pending: bool = false,
 };
 
-/// External rendering permanently disables the xev renderer callback, so its
-/// callers must consume finite continuation batches themselves. The primary
-/// iOS terminal-output producer shares this serial render queue and therefore
-/// cannot keep replenishing it between batches.
-fn drainMailboxUntilQuiescent(context: anytype) !void {
-    while (true) {
-        const result = try context.drainMailbox();
-        if (!result.wake_pending) return;
-    }
+/// Service one finite mailbox turn for a synchronous renderer and retain a
+/// follow-up turn on both success and failure. The caller renders after this
+/// returns, so a continuously replenished queue cannot postpone the frame.
+fn drainSynchronousMailbox(context: anytype) !void {
+    defer context.scheduleRendererContinuationIfNeeded();
+    _ = try context.drainMailbox();
 }
 
 /// Apply the one renderer visibility transition left after mailbox
@@ -542,7 +539,7 @@ pub fn deinit(self: *Thread) void {
 /// when upstream exposes a synchronous embedder render tick.
 pub fn renderNow(self: *Thread) void {
     self.enterExternalDrainMode();
-    self.drainMailboxUntilQuiescent() catch |err| {
+    drainSynchronousMailbox(self) catch |err| {
         log.err("renderNow: error draining mailbox err={}", .{err});
     };
 
@@ -564,7 +561,7 @@ pub fn renderNowWithPresentation(
     presentation: rendererpkg.FramePresentation,
 ) void {
     self.enterExternalDrainMode();
-    self.drainMailboxUntilQuiescent() catch |err| {
+    drainSynchronousMailbox(self) catch |err| {
         log.err("renderNowWithPresentation: error draining mailbox err={}", .{err});
     };
 
@@ -605,7 +602,7 @@ fn finishRenderNowWithPresentation(
     value.deliver();
 }
 
-/// Drain the external renderer mailbox until no continuation work remains.
+/// Drain one finite external renderer mailbox turn.
 ///
 /// cmux iOS fork: a public seam over the private `drainMailbox` so a producer
 /// running on the iOS render serial queue (where `render_now` is the mailbox's
@@ -613,14 +610,14 @@ fn finishRenderNowWithPresentation(
 /// message that must NOT be dropped (e.g. `.font_grid`, whose handler derefs the
 /// old grid). Safe to call from that queue for the same reason `render_now` is:
 /// `render_now` already calls `drainMailbox` on this serial queue every frame
-/// (see `renderNow`). Each batch stays finite, and the serial terminal-output
-/// producer cannot replenish work between batches. `drainMailbox` and its
-/// handlers take no `renderer_state.mutex`, so it cannot self-deadlock against
-/// a caller that holds it. Delete when upstream exposes a synchronous embedder
-/// render tick.
+/// (see `renderNow`). Any remainder schedules another embedder render through
+/// the existing `.render` action, so this call stays bounded even if another
+/// producer is active. `drainMailbox` and its handlers take no
+/// `renderer_state.mutex`, so it cannot self-deadlock against a caller that
+/// holds it. Delete when upstream exposes a synchronous embedder render tick.
 pub fn drainMailboxNow(self: *Thread) void {
     self.enterExternalDrainMode();
-    self.drainMailboxUntilQuiescent() catch |err| {
+    drainSynchronousMailbox(self) catch |err| {
         log.err("drainMailboxNow: error draining mailbox err={}", .{err});
         return;
     };
@@ -645,6 +642,13 @@ pub fn publishDisplayID(self: *Thread, value: u32) void {
 /// so mailbox capacity becoming available is the readiness signal for one
 /// retained reveal retry.
 pub fn appMailboxDrained(self: *Thread) void {
+    // A rejected external continuation uses the app mailbox's existing
+    // retained-redraw signal. Once capacity returns, enqueue it again if the
+    // renderer still has work.
+    if (self.externalDrainActive()) {
+        self.scheduleRendererContinuationIfNeeded();
+    }
+
     const generation = self.visibility_regain.pendingGeneration() orelse return;
     self.visibility_retry_generation.store(generation, .release);
     self.visibility_retry.notify() catch |err| {
@@ -664,6 +668,35 @@ fn enterExternalDrainMode(self: *Thread) void {
 fn externalDrainActive(self: *const Thread) bool {
     if (comptime builtin.os.tag != .ios) return false;
     return self.external_drain.load(.seq_cst);
+}
+
+fn hasPendingRendererWork(self: *const Thread) bool {
+    return self.mailbox.count() > 0 or
+        self.surface_state_requests.hasPending();
+}
+
+fn scheduleExternalRendererContinuation(self: *Thread) void {
+    _ = self.app_mailbox.push(
+        .{ .redraw_surface = self.surface },
+        .{ .instant = {} },
+    );
+}
+
+/// Retain a finite follow-up turn without draining renderer state from the
+/// wrong thread. Normal rendering re-notifies xev. External iOS rendering uses
+/// the app mailbox's established `.render` action, whose embedder callback
+/// schedules the next `render_now` invocation.
+fn scheduleRendererContinuationIfNeeded(self: *Thread) void {
+    if (!self.hasPendingRendererWork()) return;
+
+    if (self.externalDrainActive()) {
+        self.scheduleExternalRendererContinuation();
+        return;
+    }
+
+    self.wakeup.notify() catch |err| {
+        log.warn("failed to continue pending renderer work err={}", .{err});
+    };
 }
 
 fn resetExternalCursorBlink(self: *Thread) void {
@@ -1174,7 +1207,14 @@ fn wakeupCallback(
     };
 
     const t = self_.?;
-    if (t.externalDrainActive()) return .rearm;
+    if (t.externalDrainActive()) {
+        // External mode owns renderer state on its serial queue. Convert the
+        // coalesced xev wake into an unconditional embedder render request.
+        // Unconditional scheduling closes the race where a producer publishes
+        // after a pending-work check while this callback is still active.
+        t.scheduleExternalRendererContinuation();
+        return .rearm;
+    }
     const regain_was_pending = t.visibility_regain.isPending();
 
     // When we wake up, we check the mailbox. Mailbox producers should
@@ -1349,19 +1389,46 @@ test "visibility drain coalesces rapid hide show ordering" {
     try std.testing.expectEqual(null, canceled.rendererTransition());
 }
 
-test "external renderer consumes every continuation batch" {
+test "synchronous renderer drains one finite batch and retains continuation" {
     const Context = struct {
         drains: usize = 0,
+        continuations: usize = 0,
 
         fn drainMailbox(self: *@This()) !MailboxDrainResult {
             self.drains += 1;
-            return .{ .wake_pending = self.drains < 3 };
+            return .{ .wake_pending = true };
+        }
+
+        fn scheduleRendererContinuationIfNeeded(self: *@This()) void {
+            self.continuations += 1;
         }
     };
 
     var context: Context = .{};
-    try drainMailboxUntilQuiescent(&context);
-    try std.testing.expectEqual(@as(usize, 3), context.drains);
+    try drainSynchronousMailbox(&context);
+    try std.testing.expectEqual(@as(usize, 1), context.drains);
+    try std.testing.expectEqual(@as(usize, 1), context.continuations);
+}
+
+test "synchronous renderer retains continuation after drain error" {
+    const Context = struct {
+        continuations: usize = 0,
+
+        fn drainMailbox(_: *@This()) !MailboxDrainResult {
+            return error.DrainFailed;
+        }
+
+        fn scheduleRendererContinuationIfNeeded(self: *@This()) void {
+            self.continuations += 1;
+        }
+    };
+
+    var context: Context = .{};
+    try std.testing.expectError(
+        error.DrainFailed,
+        drainSynchronousMailbox(&context),
+    );
+    try std.testing.expectEqual(@as(usize, 1), context.continuations);
 }
 
 test "surface lifecycle state bypasses a full renderer mailbox and keeps latest values" {

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -74,12 +74,42 @@ const SurfaceStateRequests = struct {
         self.display_id.store(@as(u64, value) + 1, .release);
     }
 
+    fn restoreFocusedIfEmpty(
+        self: *SurfaceStateRequests,
+        value: bool,
+    ) void {
+        _ = self.focused.cmpxchgStrong(
+            0,
+            if (value) 2 else 1,
+            .release,
+            .monotonic,
+        );
+    }
+
+    fn restoreDisplayIDIfEmpty(
+        self: *SurfaceStateRequests,
+        value: u32,
+    ) void {
+        _ = self.display_id.cmpxchgStrong(
+            0,
+            @as(u64, value) + 1,
+            .release,
+            .monotonic,
+        );
+    }
+
     fn take(self: *SurfaceStateRequests) Update {
         return .{
             .visible = decodeBool(self.visible.swap(0, .acq_rel)),
             .focused = decodeBool(self.focused.swap(0, .acq_rel)),
             .display_id = decodeDisplayID(self.display_id.swap(0, .acq_rel)),
         };
+    }
+
+    fn hasPending(self: *const SurfaceStateRequests) bool {
+        return self.visible.load(.acquire) != 0 or
+            self.focused.load(.acquire) != 0 or
+            self.display_id.load(.acquire) != 0;
     }
 
     fn decodeBool(value: u8) ?bool {
@@ -183,7 +213,7 @@ const VisibilityRegainState = struct {
 const MailboxDrainResult = struct {
     visibility_regain_started: bool = false,
     rendered_visibility_regain: bool = false,
-    mailbox_pending: bool = false,
+    wake_pending: bool = false,
 };
 
 /// Process ordinary renderer messages and report whether work remains.
@@ -191,6 +221,9 @@ const MailboxDrainResult = struct {
 /// The context seam keeps the wake batching policy deterministic in tests
 /// without constructing a platform renderer.
 fn drainMessageBatch(context: anytype) !bool {
+    // Capture the limit before the first pop. Producers may append while
+    // handlers run, but those later messages stay in FIFO order for the next
+    // wake instead of extending this wake indefinitely.
     const limit = context.pendingMessageCount();
     for (0..limit) |_| {
         const message = context.popMessage() orelse break;
@@ -579,7 +612,7 @@ fn finishRenderNowWithPresentation(
     value.deliver();
 }
 
-/// Drain the renderer mailbox once, applying every queued message.
+/// Drain one finite snapshot of the renderer mailbox.
 ///
 /// cmux iOS fork: a public seam over the private `drainMailbox` so a producer
 /// running on the iOS render serial queue (where `render_now` is the mailbox's
@@ -587,10 +620,12 @@ fn finishRenderNowWithPresentation(
 /// message that must NOT be dropped (e.g. `.font_grid`, whose handler derefs the
 /// old grid). Safe to call from that queue for the same reason `render_now` is:
 /// `render_now` already calls `drainMailbox` on this serial queue every frame
-/// (see `renderNow`), so this is byte-identical drain behavior and adds no new
-/// concurrency. `drainMailbox` and its handlers take no `renderer_state.mutex`,
-/// so it cannot self-deadlock against a caller that holds it. Delete when
-/// upstream exposes a synchronous embedder render tick.
+/// (see `renderNow`). The snapshot includes every message queued when this call
+/// starts, so a full mailbox is made available for the caller's retry without
+/// admitting unbounded work from concurrent producers. `drainMailbox` and its
+/// handlers take no `renderer_state.mutex`, so it cannot self-deadlock against
+/// a caller that holds it. Delete when upstream exposes a synchronous embedder
+/// render tick.
 pub fn drainMailboxNow(self: *Thread) void {
     self.enterExternalDrainMode();
     _ = self.drainMailbox() catch |err| {
@@ -836,10 +871,28 @@ fn drainMailbox(self: *Thread) !MailboxDrainResult {
     // own wakeup drives the next drain.
     const surface_state = self.surface_state_requests.take();
     if (surface_state.visible) |value| self.applyVisible(&visibility, value);
-    if (surface_state.focused) |value| try self.applyFocused(value, external_drain);
-    if (surface_state.display_id) |value| try self.applyDisplayID(value);
+    if (surface_state.focused) |value| {
+        self.applyFocused(value, external_drain) catch |err| {
+            // Preserve the failed value only when no newer publication won
+            // the slot. A display update taken in the same batch has not run
+            // yet, so preserve it under the same latest-value rule.
+            self.surface_state_requests.restoreFocusedIfEmpty(value);
+            if (surface_state.display_id) |display_id| {
+                self.surface_state_requests.restoreDisplayIDIfEmpty(display_id);
+            }
+            return err;
+        };
+    }
+    if (surface_state.display_id) |value| {
+        self.applyDisplayID(value) catch |err| {
+            self.surface_state_requests.restoreDisplayIDIfEmpty(value);
+            return err;
+        };
+    }
 
-    if (external_drain) return .{ .mailbox_pending = mailbox_pending };
+    const wake_pending =
+        mailbox_pending or self.surface_state_requests.hasPending();
+    if (external_drain) return .{ .wake_pending = wake_pending };
 
     // Hidden wakeups leave terminal dirty flags untouched. Rebuild exactly
     // once from their union before making the renderer visible again, then
@@ -850,7 +903,7 @@ fn drainMailbox(self: *Thread) !MailboxDrainResult {
         &self.visibility_regain,
         visibility.rendererTransition(),
     );
-    result.mailbox_pending = mailbox_pending;
+    result.wake_pending = wake_pending;
     return result;
 }
 
@@ -982,9 +1035,13 @@ fn applyVisible(
 
 fn applyFocused(self: *Thread, value: bool, external_drain: bool) !void {
     if (self.flags.focused == value) return;
+
+    // Keep thread and renderer focus state transactional. If a future
+    // renderer implementation returns an error, the caller can retry the
+    // latest-value request without the thread flags suppressing that retry.
+    try self.renderer.setFocus(value);
     self.flags.focused = value;
     self.setQosClass();
-    try self.renderer.setFocus(value);
 
     if (external_drain) {
         if (value) self.resetExternalCursorBlink();
@@ -1160,7 +1217,8 @@ fn wakeupCallback(
     const drain_result = t.drainMailbox() catch |err| fallback: {
         log.err("error draining mailbox err={}", .{err});
         break :fallback MailboxDrainResult{
-            .mailbox_pending = t.mailbox.count() > 0,
+            .wake_pending = t.mailbox.count() > 0 or
+                t.surface_state_requests.hasPending(),
         };
     };
 
@@ -1173,9 +1231,9 @@ fn wakeupCallback(
     // A producer can refill the queue while this wake consumes its initial
     // snapshot. Render that snapshot before explicitly scheduling the next
     // batch so continuous output cannot starve lifecycle state or frames.
-    if (drain_result.mailbox_pending) {
+    if (drain_result.wake_pending) {
         t.wakeup.notify() catch |err| {
-            log.warn("error scheduling pending renderer mailbox err={}", .{err});
+            log.warn("error scheduling pending renderer work err={}", .{err});
         };
     }
 
@@ -1376,6 +1434,27 @@ test "surface lifecycle state bypasses a full renderer mailbox and keeps latest 
     try std.testing.expectEqual(true, update.visible);
     try std.testing.expectEqual(false, update.focused);
     try std.testing.expectEqual(@as(u32, 42), update.display_id);
+    try std.testing.expect(!state.hasPending());
+
+    state.publishFocused(true);
+    try std.testing.expect(state.hasPending());
+    const retained = state.take();
+    try std.testing.expectEqual(true, retained.focused);
+    try std.testing.expect(!state.hasPending());
+
+    state.restoreFocusedIfEmpty(false);
+    state.restoreDisplayIDIfEmpty(7);
+    const restored = state.take();
+    try std.testing.expectEqual(false, restored.focused);
+    try std.testing.expectEqual(@as(u32, 7), restored.display_id);
+
+    state.publishFocused(true);
+    state.publishDisplayID(42);
+    state.restoreFocusedIfEmpty(false);
+    state.restoreDisplayIDIfEmpty(7);
+    const newer = state.take();
+    try std.testing.expectEqual(true, newer.focused);
+    try std.testing.expectEqual(@as(u32, 42), newer.display_id);
     try std.testing.expectEqual(
         @as(Mailbox.Size, 0),
         mailbox.push(.{ .visible = false }, .{ .instant = {} }),

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -183,6 +183,7 @@ const VisibilityRegainState = struct {
 const MailboxDrainResult = struct {
     visibility_regain_started: bool = false,
     rendered_visibility_regain: bool = false,
+    mailbox_pending: bool = false,
 };
 
 /// Process ordinary renderer messages and report whether work remains.
@@ -190,7 +191,9 @@ const MailboxDrainResult = struct {
 /// The context seam keeps the wake batching policy deterministic in tests
 /// without constructing a platform renderer.
 fn drainMessageBatch(context: anytype) !bool {
-    while (context.popMessage()) |message| {
+    const limit = context.pendingMessageCount();
+    for (0..limit) |_| {
+        const message = context.popMessage() orelse break;
         try context.handleMessage(message);
     }
     return context.pendingMessageCount() > 0;
@@ -825,7 +828,7 @@ fn drainMailbox(self: *Thread) !MailboxDrainResult {
         .visibility = &visibility,
         .external_drain = external_drain,
     };
-    _ = try drainMessageBatch(&message_drain);
+    const mailbox_pending = try drainMessageBatch(&message_drain);
 
     // Lifecycle state is latest-value rather than ordered work. Apply it after
     // the ordinary mailbox so an older compatibility message cannot overwrite
@@ -836,17 +839,19 @@ fn drainMailbox(self: *Thread) !MailboxDrainResult {
     if (surface_state.focused) |value| try self.applyFocused(value, external_drain);
     if (surface_state.display_id) |value| try self.applyDisplayID(value);
 
-    if (external_drain) return .{};
+    if (external_drain) return .{ .mailbox_pending = mailbox_pending };
 
     // Hidden wakeups leave terminal dirty flags untouched. Rebuild exactly
     // once from their union before making the renderer visible again, then
     // present immediately. A full-redraw dirty bit remains authoritative
     // inside RenderState.update.
-    return applyRendererVisibilityTransition(
+    var result = applyRendererVisibilityTransition(
         self,
         &self.visibility_regain,
         visibility.rendererTransition(),
     );
+    result.mailbox_pending = mailbox_pending;
+    return result;
 }
 
 const MailboxMessageDrainContext = struct {
@@ -1154,13 +1159,24 @@ fn wakeupCallback(
     // wake up our thread after publishing.
     const drain_result = t.drainMailbox() catch |err| fallback: {
         log.err("error draining mailbox err={}", .{err});
-        break :fallback MailboxDrainResult{};
+        break :fallback MailboxDrainResult{
+            .mailbox_pending = t.mailbox.count() > 0,
+        };
     };
 
     // Render immediately unless a successful visibility regain already did.
     renderAfterMailboxDrain(t, &t.visibility_regain, drain_result);
     if (regain_was_pending and !t.visibility_regain.isPending()) {
         t.syncDrawTimer();
+    }
+
+    // A producer can refill the queue while this wake consumes its initial
+    // snapshot. Render that snapshot before explicitly scheduling the next
+    // batch so continuous output cannot starve lifecycle state or frames.
+    if (drain_result.mailbox_pending) {
+        t.wakeup.notify() catch |err| {
+            log.warn("error scheduling pending renderer mailbox err={}", .{err});
+        };
     }
 
     // PageList mutations maintain their own compression dirty state. Checking


### PR DESCRIPTION
## Summary

Austin Wang's https://github.com/manaflow-ai/ghostty/pull/135 bounds normal renderer mailbox turns and fixes the continuous-output latency regression from https://github.com/manaflow-ai/cmux/issues/8808.

This follow-up closes the external-rendering and error-path gaps found during review:

- drain one finite mailbox snapshot per synchronous render, then render immediately
- retain remaining work through the existing app-mailbox `.render` action instead of spinning until empty
- convert external xev wakeups into unconditional embedder render requests so coalescing cannot drop work
- preserve failed lifecycle requests without overwriting newer publications
- recheck work published during normal rendering before deciding whether to notify again
- make focus application transactional so a retry is not suppressed

The normal mailbox batching implementation from https://github.com/manaflow-ai/ghostty/pull/135 remains unchanged.

## Tests

On the exact PR head with Zig 0.15.2:

- `synchronous renderer drains one finite batch and retains continuation`
- `synchronous renderer retains continuation after drain error`
- `surface lifecycle retry restoration preserves newer publications`
- `surface lifecycle state bypasses a full renderer mailbox and keeps latest values`
- `visibility regain` suite

The focused suite passes on `cmuxs-mac-mini-3.1`, a 48 GB fleet Mac running macOS 26.5.

Fixes the remaining external-render correctness gap exposed while investigating https://github.com/manaflow-ai/cmux/issues/8808.
