### PR TITLE
Prompt before terminal clipboard writes by default

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1153,6 +1153,8 @@ typedef void (*ghostty_runtime_confirm_read_clipboard_cb)(
     const char*,
     void*,
     ghostty_clipboard_request_e);
+// When the final argument is true, the embedder must obtain explicit approval
+// before writing and leave the clipboard unchanged when approval is denied.
 typedef void (*ghostty_runtime_write_clipboard_cb)(void*,
                                                    ghostty_clipboard_e,
                                                    const ghostty_clipboard_content_s*,

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -79,7 +79,9 @@ pub const App = struct {
             apprt.ClipboardRequestType,
         ) callconv(.c) void,
 
-        /// Write the clipboard value.
+        /// Write the clipboard value. When `confirm` is true, the embedder must
+        /// obtain explicit approval before writing and must leave the clipboard
+        /// unchanged when approval is denied.
         write_clipboard: *const fn (
             SurfaceUD,
             c_int,

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -11009,3 +11009,14 @@ test "compatibility: window new-window" {
         );
     }
 }
+
+test "clipboard access defaults require confirmation" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var cfg = try Config.default(alloc);
+    defer cfg.deinit();
+
+    try testing.expectEqual(ClipboardAccess.ask, cfg.@"clipboard-read");
+    try testing.expectEqual(ClipboardAccess.ask, cfg.@"clipboard-write");
+}

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -2387,8 +2387,8 @@ keybind: Keybinds = .{},
 @"focus-follows-mouse": bool = false,
 
 /// Whether to allow programs running in the terminal to read/write to the
-/// system clipboard (OSC 52, for googling). The default is to allow clipboard
-/// reading after prompting the user and allow writing unconditionally.
+/// system clipboard (OSC 52, for googling). The default is to prompt before
+/// reading or writing.
 ///
 /// Valid values are:
 ///
@@ -2397,7 +2397,7 @@ keybind: Keybinds = .{},
 ///   * `deny`
 ///
 @"clipboard-read": ClipboardAccess = .ask,
-@"clipboard-write": ClipboardAccess = .allow,
+@"clipboard-write": ClipboardAccess = .ask,
 
 /// Trims trailing whitespace on data that is copied to the clipboard. This does
 /// not affect data sent to the clipboard via `clipboard-write`. This only


### PR DESCRIPTION
## Summary
- default terminal clipboard reads and writes to `ask`
- clarify that callback confirmation flags must be honored before access completes

## Testing
- added the default-setting regression test in the first commit
- passed focused and broader clipboard tests with Zig 0.15.2
