### PR TITLE
renderer: retain rejected external redraw requests

### DIFF
--- a/src/App.zig
+++ b/src/App.zig
@@ -352,7 +352,7 @@ fn drainMailbox(self: *App, rt_app: *apprt.App) !void {
             .new_window => |msg| try self.newWindow(rt_app, msg),
             .close => |surface| self.closeSurface(surface),
             .surface_message => |msg| try self.surfaceMessage(msg.surface, msg.message),
-            .redraw_surface => |surface| try self.redrawSurface(rt_app, surface),
+            .redraw_surface => |redraw| try self.redrawSurface(rt_app, redraw),
 
             // If we're quitting, then we set the quit flag and stop
             // draining the mailbox immediately. This lets us defer
@@ -395,8 +395,9 @@ pub fn focusSurface(self: *App, surface: *Surface) void {
 fn redrawSurface(
     self: *App,
     rt_app: *apprt.App,
-    surface: *apprt.Surface,
+    redraw: Message.RedrawSurface,
 ) !void {
+    const surface = redraw.surface;
     if (!self.hasRtSurface(surface)) return;
 
     const accepted = rt_app.performAction(
@@ -404,21 +405,34 @@ fn redrawSurface(
         .render,
         {},
     ) catch |err| {
-        self.externalRenderActionCompleted(surface, false);
+        if (redraw.external_generation) |generation| {
+            self.externalRenderActionCompleted(
+                surface,
+                generation,
+                false,
+            );
+        }
         return err;
     };
-    self.externalRenderActionCompleted(surface, accepted);
+    if (redraw.external_generation) |generation| {
+        self.externalRenderActionCompleted(
+            surface,
+            generation,
+            accepted,
+        );
+    }
 }
 
 fn externalRenderActionCompleted(
     self: *App,
     surface: *apprt.Surface,
+    generation: u64,
     accepted: bool,
 ) void {
     self.lockSurfaceRegistry();
     defer self.unlockSurfaceRegistry();
     if (!self.hasRtSurfaceLocked(surface)) return;
-    surface.core().externalRenderActionCompleted(accepted);
+    surface.core().externalRenderActionCompleted(generation, accepted);
 }
 
 /// Create a new window
@@ -680,7 +694,12 @@ pub const Message = union(enum) {
     /// use single-threaded draws. To redraw a surface for all runtimes,
     /// wake up the renderer thread. The renderer thread will send this
     /// message if it needs to.
-    redraw_surface: *apprt.Surface,
+    redraw_surface: RedrawSurface,
+
+    pub const RedrawSurface = struct {
+        surface: *apprt.Surface,
+        external_generation: ?u64 = null,
+    };
 
     const NewWindow = struct {
         /// The parent surface
@@ -699,8 +718,25 @@ pub const Mailbox = struct {
 
     /// Send a message to the surface.
     pub fn push(self: Mailbox, msg: Message, timeout: Queue.Timeout) Queue.Size {
+        const NoopObserver = struct {
+            fn pushCompleted(_: @This(), _: Queue.Size) void {}
+        };
+        return self.pushObserved(msg, timeout, NoopObserver{});
+    }
+
+    /// Push a message, publish its result to the caller, then publish the
+    /// shared capacity retry and wake the app. The observer closes the race
+    /// where an app drain consumes the wake before a renderer records which
+    /// surface enqueue failed.
+    pub fn pushObserved(
+        self: Mailbox,
+        msg: Message,
+        timeout: Queue.Timeout,
+        observer: anytype,
+    ) Queue.Size {
         const redraw = std.meta.activeTag(msg) == .redraw_surface;
         const result = self.mailbox.push(msg, timeout);
+        observer.pushCompleted(result);
         recordRejectedRedraw(self.redraw_retry_requested, redraw, result);
 
         // Wake up our app loop
@@ -778,7 +814,9 @@ test "full app mailbox retains redraw retry until drain" {
     }
 
     const redraw: Message = .{
-        .redraw_surface = @ptrFromInt(@alignOf(apprt.Surface)),
+        .redraw_surface = .{
+            .surface = @ptrFromInt(@alignOf(apprt.Surface)),
+        },
     };
     const rejected = queue.push(redraw, .instant);
     try std.testing.expectEqual(0, rejected);
@@ -843,8 +881,9 @@ test "observed mailbox push publishes failure before retry wake" {
     }
     const result = mailbox.pushObserved(
         .{
-            .redraw_surface =
-                @ptrFromInt(@alignOf(apprt.Surface)),
+            .redraw_surface = .{
+                .surface = @ptrFromInt(@alignOf(apprt.Surface)),
+            },
         },
         .instant,
         Observer{ .ordering = &ordering },

--- a/src/App.zig
+++ b/src/App.zig
@@ -100,6 +100,26 @@ fn hasRedrawSurfaceLocked(
     return false;
 }
 
+const RedrawSurfaceLease = struct {
+    surface: *apprt.Surface,
+
+    fn release(self: RedrawSurfaceLease) void {
+        self.surface.releaseForAppAction();
+    }
+};
+
+fn acquireRedrawSurface(
+    self: *App,
+    redraw: Message.RedrawSurface,
+) ?RedrawSurfaceLease {
+    self.lockSurfaceRegistry();
+    defer self.unlockSurfaceRegistry();
+
+    if (!self.hasRedrawSurfaceLocked(redraw)) return null;
+    redraw.surface.retainForAppAction();
+    return .{ .surface = redraw.surface };
+}
+
 /// General purpose allocator
 alloc: Allocator,
 
@@ -410,12 +430,9 @@ fn redrawSurface(
     rt_app: *apprt.App,
     redraw: Message.RedrawSurface,
 ) !void {
-    const surface = redraw.surface;
-    {
-        self.lockSurfaceRegistry();
-        defer self.unlockSurfaceRegistry();
-        if (!self.hasRedrawSurfaceLocked(redraw)) return;
-    }
+    const lease = self.acquireRedrawSurface(redraw) orelse return;
+    defer lease.release();
+    const surface = lease.surface;
 
     const accepted = rt_app.performAction(
         .{ .surface = surface.core() },

--- a/src/App.zig
+++ b/src/App.zig
@@ -885,6 +885,62 @@ test "external redraw rejects allocator-reused surface address" {
     }
 }
 
+test "redraw action lease defers reentrant embedded surface teardown" {
+    if (comptime !@hasField(apprt.App, "opts")) return error.SkipZigTest;
+    if (comptime !@hasField(apprt.Surface, "core_surface")) return error.SkipZigTest;
+
+    if (comptime @hasDecl(App, "acquireRedrawSurface") and
+        @hasField(apprt.Surface, "app_action_lifetime"))
+    {
+        var app: App = undefined;
+        try app.init(std.testing.allocator);
+        defer {
+            app.surfaces.deinit(std.testing.allocator);
+            app.font_grid_set.deinit();
+        }
+
+        var rt_app: apprt.App = undefined;
+        rt_app.core_app = &app;
+        rt_app.opts = undefined;
+        rt_app.opts.action = testAction;
+        rt_app.opts.wakeup = testWakeup;
+
+        var surface: apprt.Surface = undefined;
+        surface.app = &rt_app;
+        surface.core_surface.id = 22;
+        surface.app_action_lifetime = .{};
+        try app.surfaces.append(std.testing.allocator, &surface);
+
+        const lease = app.acquireRedrawSurface(.{
+            .surface = &surface,
+            .external_ticket = .{
+                .surface_id = 22,
+                .generation = 1,
+            },
+        }).?;
+        try std.testing.expectEqual(
+            @as(usize, 2),
+            surface.app_action_lifetime.countForTesting(),
+        );
+
+        // Models ghostty_surface_free re-entering from the host action. The
+        // owner release must unregister the surface without touching its core
+        // while the action lease is still live.
+        surface.deinit();
+        try std.testing.expect(!app.hasRtSurface(&surface));
+        try std.testing.expectEqual(
+            @as(usize, 1),
+            surface.app_action_lifetime.countForTesting(),
+        );
+
+        // Releasing this fake stack surface would intentionally run its final
+        // destructor. The lifetime state test covers that final transition.
+        _ = lease;
+    } else {
+        try std.testing.expect(false);
+    }
+}
+
 test "full app mailbox retains redraw retry until drain" {
     var queue: Mailbox.Queue = .{};
     var retry_requested = std.atomic.Value(bool).init(false);

--- a/src/App.zig
+++ b/src/App.zig
@@ -796,6 +796,65 @@ test "full app mailbox retains redraw retry until drain" {
     try std.testing.expect(!takeRedrawRetryRequest(&retry_requested));
 }
 
+test "observed mailbox push publishes failure before retry wake" {
+    if (comptime !@hasField(apprt.App, "opts")) return error.SkipZigTest;
+
+    const Ordering = struct {
+        observed: bool = false,
+        woke_after_observer: bool = false,
+        woke_after_retry_publication: bool = false,
+        retry_requested: *std.atomic.Value(bool),
+
+        fn wakeup(userdata: ?*anyopaque) callconv(.c) void {
+            const self: *@This() = @ptrCast(@alignCast(userdata.?));
+            self.woke_after_observer = self.observed;
+            self.woke_after_retry_publication =
+                self.retry_requested.load(.acquire);
+        }
+    };
+    const Observer = struct {
+        ordering: *Ordering,
+
+        fn pushCompleted(
+            self: @This(),
+            queue_size: Mailbox.Queue.Size,
+        ) void {
+            self.ordering.observed = queue_size == 0;
+        }
+    };
+
+    var queue: Mailbox.Queue = .{};
+    var retry_requested = std.atomic.Value(bool).init(false);
+    var ordering: Ordering = .{
+        .retry_requested = &retry_requested,
+    };
+    var rt_app: apprt.App = undefined;
+    rt_app.opts = undefined;
+    rt_app.opts.userdata = &ordering;
+    rt_app.opts.wakeup = Ordering.wakeup;
+    const mailbox: Mailbox = .{
+        .rt_app = &rt_app,
+        .mailbox = &queue,
+        .redraw_retry_requested = &retry_requested,
+    };
+
+    for (0..64) |_| {
+        try std.testing.expect(queue.push(.{ .open_config = {} }, .instant) > 0);
+    }
+    const result = mailbox.pushObserved(
+        .{
+            .redraw_surface =
+                @ptrFromInt(@alignOf(apprt.Surface)),
+        },
+        .instant,
+        Observer{ .ordering = &ordering },
+    );
+
+    try std.testing.expectEqual(@as(Mailbox.Queue.Size, 0), result);
+    try std.testing.expect(ordering.woke_after_observer);
+    try std.testing.expect(ordering.woke_after_retry_publication);
+}
+
 test "surface registry mutations are serialized" {
     if (comptime !@hasField(apprt.App, "opts")) return error.SkipZigTest;
     if (comptime !@hasField(apprt.Surface, "app")) return error.SkipZigTest;

--- a/src/App.zig
+++ b/src/App.zig
@@ -399,11 +399,26 @@ fn redrawSurface(
 ) !void {
     if (!self.hasRtSurface(surface)) return;
 
-    _ = try rt_app.performAction(
+    const accepted = rt_app.performAction(
         .{ .surface = surface.core() },
         .render,
         {},
-    );
+    ) catch |err| {
+        self.externalRenderActionCompleted(surface, false);
+        return err;
+    };
+    self.externalRenderActionCompleted(surface, accepted);
+}
+
+fn externalRenderActionCompleted(
+    self: *App,
+    surface: *apprt.Surface,
+    accepted: bool,
+) void {
+    self.lockSurfaceRegistry();
+    defer self.unlockSurfaceRegistry();
+    if (!self.hasRtSurfaceLocked(surface)) return;
+    surface.core().externalRenderActionCompleted(accepted);
 }
 
 /// Create a new window

--- a/src/App.zig
+++ b/src/App.zig
@@ -805,6 +805,61 @@ fn testAction(_: *apprt.App, _: apprt.Target.C, _: apprt.Action.C) callconv(.c) 
     return true;
 }
 
+test "external redraw rejects allocator-reused surface address" {
+    if (comptime !@hasField(apprt.App, "opts")) return error.SkipZigTest;
+    if (comptime !@hasField(apprt.Surface, "core_surface")) return error.SkipZigTest;
+
+    if (comptime @hasField(Message.RedrawSurface, "external_ticket")) {
+        const ActionContext = struct {
+            calls: usize = 0,
+
+            fn action(
+                rt_app: *apprt.App,
+                _: apprt.Target.C,
+                _: apprt.Action.C,
+            ) callconv(.c) bool {
+                const self: *@This() = @ptrCast(@alignCast(
+                    rt_app.opts.userdata.?,
+                ));
+                self.calls += 1;
+                return true;
+            }
+        };
+
+        var app: App = undefined;
+        try app.init(std.testing.allocator);
+        defer {
+            app.surfaces.deinit(std.testing.allocator);
+            app.font_grid_set.deinit();
+        }
+
+        var action_context: ActionContext = .{};
+        var rt_app: apprt.App = undefined;
+        rt_app.core_app = &app;
+        rt_app.opts = undefined;
+        rt_app.opts.userdata = &action_context;
+        rt_app.opts.action = ActionContext.action;
+        rt_app.opts.wakeup = testWakeup;
+
+        var surface: apprt.Surface = undefined;
+        surface.app = &rt_app;
+        surface.core_surface.id = 22;
+        try app.surfaces.append(std.testing.allocator, &surface);
+
+        try app.redrawSurface(&rt_app, .{
+            .surface = &surface,
+            .external_ticket = .{
+                .surface_id = 11,
+                .generation = 1,
+            },
+        });
+
+        try std.testing.expectEqual(@as(usize, 0), action_context.calls);
+    } else {
+        try std.testing.expect(false);
+    }
+}
+
 test "full app mailbox retains redraw retry until drain" {
     var queue: Mailbox.Queue = .{};
     var retry_requested = std.atomic.Value(bool).init(false);

--- a/src/App.zig
+++ b/src/App.zig
@@ -87,6 +87,19 @@ fn hasRtSurfaceLocked(self: *const App, surface: *apprt.Surface) bool {
     return false;
 }
 
+fn hasRedrawSurfaceLocked(
+    self: *const App,
+    redraw: Message.RedrawSurface,
+) bool {
+    for (self.surfaces.items) |surface| {
+        if (surface != redraw.surface) continue;
+        const ticket = redraw.external_ticket orelse return true;
+        return surface.core().id == ticket.surface_id;
+    }
+
+    return false;
+}
+
 /// General purpose allocator
 alloc: Allocator,
 
@@ -398,26 +411,30 @@ fn redrawSurface(
     redraw: Message.RedrawSurface,
 ) !void {
     const surface = redraw.surface;
-    if (!self.hasRtSurface(surface)) return;
+    {
+        self.lockSurfaceRegistry();
+        defer self.unlockSurfaceRegistry();
+        if (!self.hasRedrawSurfaceLocked(redraw)) return;
+    }
 
     const accepted = rt_app.performAction(
         .{ .surface = surface.core() },
         .render,
         {},
     ) catch |err| {
-        if (redraw.external_generation) |generation| {
+        if (redraw.external_ticket) |ticket| {
             self.externalRenderActionCompleted(
                 surface,
-                generation,
+                ticket,
                 false,
             );
         }
         return err;
     };
-    if (redraw.external_generation) |generation| {
+    if (redraw.external_ticket) |ticket| {
         self.externalRenderActionCompleted(
             surface,
-            generation,
+            ticket,
             accepted,
         );
     }
@@ -426,13 +443,16 @@ fn redrawSurface(
 fn externalRenderActionCompleted(
     self: *App,
     surface: *apprt.Surface,
-    generation: u64,
+    ticket: Message.ExternalRedrawTicket,
     accepted: bool,
 ) void {
     self.lockSurfaceRegistry();
     defer self.unlockSurfaceRegistry();
-    if (!self.hasRtSurfaceLocked(surface)) return;
-    surface.core().externalRenderActionCompleted(generation, accepted);
+    if (!self.hasRedrawSurfaceLocked(.{
+        .surface = surface,
+        .external_ticket = ticket,
+    })) return;
+    surface.core().externalRenderActionCompleted(ticket.generation, accepted);
 }
 
 /// Create a new window
@@ -698,7 +718,12 @@ pub const Message = union(enum) {
 
     pub const RedrawSurface = struct {
         surface: *apprt.Surface,
-        external_generation: ?u64 = null,
+        external_ticket: ?ExternalRedrawTicket = null,
+    };
+
+    pub const ExternalRedrawTicket = struct {
+        surface_id: u64,
+        generation: u64,
     };
 
     const NewWindow = struct {

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -928,6 +928,16 @@ pub fn appMailboxDrained(self: *Surface) void {
     self.renderer_thread.appMailboxDrained();
 }
 
+/// Acknowledge whether the embedder accepted an externally requested render.
+/// The renderer owns retry/coalescing state; the app thread only reports the
+/// result while this surface remains registered.
+pub fn externalRenderActionCompleted(
+    self: *Surface,
+    accepted: bool,
+) void {
+    self.renderer_thread.externalRenderActionCompleted(accepted);
+}
+
 /// Close this surface. This will trigger the runtime to start the
 /// close process, which should ultimately deinitialize this surface.
 pub fn close(self: *Surface) void {

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -933,9 +933,13 @@ pub fn appMailboxDrained(self: *Surface) void {
 /// result while this surface remains registered.
 pub fn externalRenderActionCompleted(
     self: *Surface,
+    generation: u64,
     accepted: bool,
 ) void {
-    self.renderer_thread.externalRenderActionCompleted(accepted);
+    self.renderer_thread.externalRenderActionCompleted(
+        generation,
+        accepted,
+    );
 }
 
 /// Close this surface. This will trigger the runtime to start the

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -271,15 +271,12 @@ pub const App = struct {
 
         // Create the surface
         try surface.init(self, opts, scrollback_limit_bytes);
-        errdefer surface.deinit();
-
         return surface;
     }
 
     /// Close the given surface.
-    pub fn closeSurface(self: *App, surface: *Surface) void {
+    pub fn closeSurface(_: *App, surface: *Surface) void {
         surface.deinit();
-        self.core_app.alloc.destroy(surface);
     }
 
     pub fn redrawInspector(self: *App, surface: *Surface) void {
@@ -665,11 +662,34 @@ pub const PtyTeeCallback = *const fn (?*anyopaque, [*]const u8, usize) callconv(
 pub const RendererEventCallback = renderer.InstrumentationCallback;
 pub const RenderPresentedCallback = *const fn (?*anyopaque, u64) callconv(.c) void;
 
+const SurfaceActionLifetime = struct {
+    references: std.atomic.Value(usize) = .{ .raw = 1 },
+
+    fn retain(self: *SurfaceActionLifetime) void {
+        const previous = self.references.fetchAdd(1, .seq_cst);
+        assert(previous > 0);
+        assert(previous < std.math.maxInt(usize));
+    }
+
+    /// Returns true when the caller released the final reference.
+    fn release(self: *SurfaceActionLifetime) bool {
+        const previous = self.references.fetchSub(1, .seq_cst);
+        assert(previous > 0);
+        return previous == 1;
+    }
+
+    pub fn countForTesting(self: *const SurfaceActionLifetime) usize {
+        if (!builtin.is_test) @compileError("testing only");
+        return self.references.load(.seq_cst);
+    }
+};
+
 pub const Surface = struct {
     app: *App,
     platform: Platform,
     userdata: ?*anyopaque = null,
     core_surface: CoreSurface,
+    app_action_lifetime: SurfaceActionLifetime = .{},
     content_scale: apprt.ContentScale,
     size: apprt.SurfaceSize,
     cursor_pos: apprt.CursorPos,
@@ -954,17 +974,37 @@ pub const Surface = struct {
     }
 
     pub fn deinit(self: *Surface) void {
+        // Stop new app actions before releasing the embedder's owner
+        // reference. An action already in progress retains this allocation and
+        // performs the final destruction after its reentrant host callback
+        // returns.
+        self.app.core_app.deleteSurface(self);
+        if (self.app_action_lifetime.release()) self.destroy();
+    }
+
+    /// Retain the opaque embedded surface while an app action is dispatched.
+    /// The core app calls this only while holding its surface registry lock,
+    /// so teardown cannot remove and release the owner reference first.
+    pub fn retainForAppAction(self: *Surface) void {
+        self.app_action_lifetime.retain();
+    }
+
+    pub fn releaseForAppAction(self: *Surface) void {
+        if (self.app_action_lifetime.release()) self.destroy();
+    }
+
+    fn destroy(self: *Surface) void {
+        const alloc = self.app.core_app.alloc;
+
         // Shut down our inspector
         self.freeInspector();
 
         // Free our title
-        if (self.title) |v| self.app.core_app.alloc.free(v);
-
-        // Remove ourselves from the list of known surfaces in the app.
-        self.app.core_app.deleteSurface(self);
+        if (self.title) |v| alloc.free(v);
 
         // Clean up our core surface so that all the rendering and IO stop.
         self.core_surface.deinit();
+        alloc.destroy(self);
     }
 
     /// Initialize the inspector instance. A surface can only have one

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1455,6 +1455,23 @@ pub const Surface = struct {
     }
 };
 
+test "surface action lifetime defers owner destruction until lease release" {
+    const Lifetime = if (@hasDecl(@This(), "SurfaceActionLifetime"))
+        @field(@This(), "SurfaceActionLifetime")
+    else
+        struct {
+            fn retain(_: *@This()) void {}
+            fn release(_: *@This()) bool {
+                return false;
+            }
+        };
+
+    var lifetime: Lifetime = .{};
+    lifetime.retain();
+    try std.testing.expect(!lifetime.release());
+    try std.testing.expect(lifetime.release());
+}
+
 // The cmux integration combines the OpenGL platform payload (the largest
 // Platform.C variant) with the startup PTY tee fields. Keep the resulting C
 // layout pinned so every exact-revision consumer fails loudly on drift.

--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -15,6 +15,16 @@ pub fn deinit(self: *Self) void {
     _ = self;
 }
 
+/// Keep the GObject and its embedded runtime surface alive while an app action
+/// invokes a potentially reentrant host callback.
+pub fn retainForAppAction(self: *Self) void {
+    _ = self.surface.ref();
+}
+
+pub fn releaseForAppAction(self: *Self) void {
+    self.surface.unref();
+}
+
 /// Returns the GObject surface for this apprt surface. This is a function
 /// so we can add some extra logic if we ever have to here.
 pub fn gobj(self: *Self) *Surface {

--- a/src/apprt/none.zig
+++ b/src/apprt/none.zig
@@ -16,4 +16,7 @@ pub const App = struct {
         return false;
     }
 };
-pub const Surface = struct {};
+pub const Surface = struct {
+    pub fn retainForAppAction(_: *@This()) void {}
+    pub fn releaseForAppAction(_: *@This()) void {}
+};

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -225,143 +225,144 @@ fn drainSynchronousMailbox(context: anytype) !void {
 }
 
 fn scheduleExternalRendererContinuation(context: anytype) void {
-    if (!context.requestExternalRendererContinuation()) return;
-    context.externalRendererContinuationEnqueued(
-        context.enqueueExternalRendererContinuation(),
-    );
+    const generation =
+        context.requestExternalRendererContinuation() orelse return;
+    context.enqueueExternalRendererContinuation(generation);
 }
 
 fn retryExternalRendererContinuation(context: anytype) void {
-    if (!context.retryFailedExternalRendererContinuation()) return;
-    context.externalRendererContinuationEnqueued(
-        context.enqueueExternalRendererContinuation(),
-    );
+    const generation =
+        context.retryFailedExternalRendererContinuation() orelse return;
+    context.enqueueExternalRendererContinuation(generation);
 }
 
-/// Tracks one external renderer request without conflating app-mailbox
-/// capacity, action acceptance, and a frame that has actually started.
+/// Owns one ticketed external-redraw delivery at a time.
 ///
-/// A second renderer wake behind a queued action becomes `queued_dirty`. If
-/// the host rejects that action, only the later wake is retried. A full app
-/// mailbox uses the separate `enqueue_failed` state so capacity callbacks
-/// retry only the surface whose enqueue actually failed.
-const ExternalRedrawRequest = struct {
-    const State = enum(u8) {
-        idle,
+/// The generation travels with the app-mailbox message, so a stale host
+/// acknowledgment cannot mutate a newer request. All transitions are short
+/// critical sections; mailbox pushes, host callbacks, and renderer work occur
+/// after the mutex is released.
+const ExternalRedrawDelivery = struct {
+    const Phase = enum {
         queued,
-        queued_dirty,
         enqueue_failed,
-        wake_pending,
     };
 
-    state: std.atomic.Value(u8) =
-        std.atomic.Value(u8).init(@intFromEnum(State.idle)),
+    const Request = struct {
+        generation: u64,
+        phase: Phase,
+    };
 
-    /// Claim an enqueue for a new renderer wake. A wake behind an outstanding
-    /// action is retained without adding a duplicate app-mailbox message.
-    fn request(self: *ExternalRedrawRequest) bool {
-        var current = self.state.load(.acquire);
-        while (true) {
-            const state: State = @enumFromInt(current);
-            const transition: struct { next: State, enqueue: bool } =
-                switch (state) {
-                    .idle,
-                    .enqueue_failed,
-                    .wake_pending,
-                    => .{ .next = .queued, .enqueue = true },
-                    .queued => .{ .next = .queued_dirty, .enqueue = false },
-                    .queued_dirty => return false,
-                };
+    mutex: std.Thread.Mutex = .{},
+    next_generation: u64 = 0,
+    active: ?Request = null,
+    wake_behind_active: bool = false,
 
-            if (self.state.cmpxchgWeak(
-                current,
-                @intFromEnum(transition.next),
-                .acq_rel,
-                .acquire,
-            )) |actual| {
-                current = actual;
-                continue;
+    /// Claim a ticket for a renderer wake. A wake can reuse a ticket whose
+    /// enqueue failed, because the resulting frame covers both old and new
+    /// terminal state. Wakes behind a queued host action remain coalesced.
+    fn request(self: *ExternalRedrawDelivery) ?u64 {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+
+        if (self.active) |*active| {
+            if (active.phase == .enqueue_failed) {
+                active.phase = .queued;
+                return active.generation;
             }
-            return transition.enqueue;
+            self.wake_behind_active = true;
+            return null;
         }
+        return self.startRequestLocked();
     }
 
-    /// Claim only a request rejected by a full app mailbox. This distinction
-    /// prevents one surface's capacity notification from duplicating already
-    /// queued requests for every other surface.
-    fn retryFailedEnqueue(self: *ExternalRedrawRequest) bool {
-        return self.state.cmpxchgStrong(
-            @intFromEnum(State.enqueue_failed),
-            @intFromEnum(State.queued),
-            .acq_rel,
-            .acquire,
-        ) == null;
-    }
-
-    fn enqueueCompleted(
-        self: *ExternalRedrawRequest,
-        accepted: bool,
+    /// Publish a failed enqueue for this exact ticket. `Mailbox.pushObserved`
+    /// invokes this before it publishes the shared capacity retry and wakes the
+    /// app thread.
+    fn enqueueFailed(
+        self: *ExternalRedrawDelivery,
+        generation: u64,
     ) void {
-        if (accepted) return;
+        self.mutex.lock();
+        defer self.mutex.unlock();
 
-        var current = self.state.load(.acquire);
-        while (true) {
-            const state: State = @enumFromInt(current);
-            switch (state) {
-                .queued, .queued_dirty => {},
-                .idle, .enqueue_failed, .wake_pending => return,
+        if (self.active) |*active| {
+            if (active.generation == generation) {
+                active.phase = .enqueue_failed;
             }
-
-            if (self.state.cmpxchgWeak(
-                current,
-                @intFromEnum(State.enqueue_failed),
-                .acq_rel,
-                .acquire,
-            )) |actual| {
-                current = actual;
-                continue;
-            }
-            return;
         }
     }
 
-    /// Record the host's result. A rejected action releases its own request.
-    /// If another wake arrived behind it, return true so the renderer loop can
-    /// retry that later wake once without spinning on permanent rejection.
+    /// Claim only a ticket whose own enqueue failed. A capacity callback for
+    /// one surface cannot duplicate a queued ticket for another surface.
+    fn retryFailedEnqueue(self: *ExternalRedrawDelivery) ?u64 {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+
+        if (self.active) |*active| {
+            if (active.phase == .enqueue_failed) {
+                active.phase = .queued;
+                return active.generation;
+            }
+        }
+        return null;
+    }
+
+    /// Record the host result for an exact ticket. A rejected action releases
+    /// its own request. Return true when a newer wake had coalesced behind it,
+    /// so xev schedules that later wake once without rejection spin.
     fn actionCompleted(
-        self: *ExternalRedrawRequest,
+        self: *ExternalRedrawDelivery,
+        generation: u64,
         accepted: bool,
     ) bool {
         if (accepted) return false;
 
-        var current = self.state.load(.acquire);
-        while (true) {
-            const state: State = @enumFromInt(current);
-            const transition: struct { next: State, notify: bool } =
-                switch (state) {
-                    .queued => .{ .next = .idle, .notify = false },
-                    .queued_dirty => .{
-                        .next = .wake_pending,
-                        .notify = true,
-                    },
-                    .idle, .enqueue_failed, .wake_pending => return false,
-                };
+        self.mutex.lock();
+        defer self.mutex.unlock();
 
-            if (self.state.cmpxchgWeak(
-                current,
-                @intFromEnum(transition.next),
-                .acq_rel,
-                .acquire,
-            )) |actual| {
-                current = actual;
-                continue;
-            }
-            return transition.notify;
-        }
+        const active = self.active orelse return false;
+        if (active.generation != generation) return false;
+
+        const notify = self.wake_behind_active;
+        self.active = null;
+        self.wake_behind_active = false;
+        return notify;
     }
 
-    fn renderStarted(self: *ExternalRedrawRequest) void {
-        self.state.store(@intFromEnum(State.idle), .release);
+    /// A frame start covers every request published before this critical
+    /// section. A concurrent later wake either lands before the reset and is
+    /// covered, or lands after it and receives a new ticket.
+    fn renderStarted(self: *ExternalRedrawDelivery) void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        self.active = null;
+        self.wake_behind_active = false;
+    }
+
+    /// Caller holds `mutex`.
+    fn startRequestLocked(self: *ExternalRedrawDelivery) u64 {
+        self.next_generation +%= 1;
+        if (self.next_generation == 0) self.next_generation = 1;
+        self.active = .{
+            .generation = self.next_generation,
+            .phase = .queued,
+        };
+        return self.next_generation;
+    }
+};
+
+const ExternalRedrawEnqueueObserver = struct {
+    delivery: *ExternalRedrawDelivery,
+    generation: u64,
+
+    pub fn pushCompleted(
+        self: @This(),
+        queue_size: App.Mailbox.Queue.Size,
+    ) void {
+        if (queue_size == 0) {
+            self.delivery.enqueueFailed(self.generation);
+        }
     }
 };
 
@@ -547,10 +548,10 @@ frame_acquire_timeouts: u64 = 0,
 /// mutate renderer state; the renderer OS thread only keeps async stop alive.
 external_drain: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
 
-/// External redraw state retained across app-mailbox pressure and host action
-/// dispatch. Wake-only redraws have no renderer mailbox entry that could
-/// otherwise prove a retry is needed.
-external_redraw_request: ExternalRedrawRequest = .{},
+/// Ticketed external redraw delivery retained across app-mailbox pressure and
+/// host action dispatch. Wake-only redraws have no renderer mailbox entry that
+/// could otherwise prove a retry is needed.
+external_redraw_delivery: ExternalRedrawDelivery = .{},
 
 /// Monotonic millisecond epoch used to derive cursor blink phase while
 /// `external_drain` disables the renderer-thread cursor timer.
@@ -685,7 +686,7 @@ pub fn deinit(self: *Thread) void {
 /// when upstream exposes a synchronous embedder render tick.
 pub fn renderNow(self: *Thread) void {
     self.enterExternalDrainMode();
-    self.external_redraw_request.renderStarted();
+    self.external_redraw_delivery.renderStarted();
     drainSynchronousMailbox(self) catch |err| {
         log.err("renderNow: error draining mailbox err={}", .{err});
     };
@@ -708,7 +709,7 @@ pub fn renderNowWithPresentation(
     presentation: rendererpkg.FramePresentation,
 ) void {
     self.enterExternalDrainMode();
-    self.external_redraw_request.renderStarted();
+    self.external_redraw_delivery.renderStarted();
     drainSynchronousMailbox(self) catch |err| {
         log.err("renderNowWithPresentation: error draining mailbox err={}", .{err});
     };
@@ -809,10 +810,14 @@ pub fn appMailboxDrained(self: *Thread) void {
 /// preserve that later request without retrying a permanently rejected action.
 pub fn externalRenderActionCompleted(
     self: *Thread,
+    generation: u64,
     accepted: bool,
 ) void {
     if (!self.externalDrainActive()) return;
-    if (!self.external_redraw_request.actionCompleted(accepted)) return;
+    if (!self.external_redraw_delivery.actionCompleted(
+        generation,
+        accepted,
+    )) return;
     self.wakeup.notify() catch |err| {
         log.warn("failed to retry external redraw after rejected action err={}", .{err});
     };
@@ -837,26 +842,29 @@ fn hasPendingRendererWork(self: *const Thread) bool {
         self.surface_state_requests.hasPending();
 }
 
-fn requestExternalRendererContinuation(self: *Thread) bool {
-    return self.external_redraw_request.request();
+fn requestExternalRendererContinuation(self: *Thread) ?u64 {
+    return self.external_redraw_delivery.request();
 }
 
-fn retryFailedExternalRendererContinuation(self: *Thread) bool {
-    return self.external_redraw_request.retryFailedEnqueue();
+fn retryFailedExternalRendererContinuation(self: *Thread) ?u64 {
+    return self.external_redraw_delivery.retryFailedEnqueue();
 }
 
-fn externalRendererContinuationEnqueued(
+fn enqueueExternalRendererContinuation(
     self: *Thread,
-    accepted: bool,
+    generation: u64,
 ) void {
-    self.external_redraw_request.enqueueCompleted(accepted);
-}
-
-fn enqueueExternalRendererContinuation(self: *Thread) bool {
-    return self.app_mailbox.push(
-        .{ .redraw_surface = self.surface },
+    _ = self.app_mailbox.pushObserved(
+        .{ .redraw_surface = .{
+            .surface = self.surface,
+            .external_generation = generation,
+        } },
         .{ .instant = {} },
-    ) != 0;
+        ExternalRedrawEnqueueObserver{
+            .delivery = &self.external_redraw_delivery,
+            .generation = generation,
+        },
+    );
 }
 
 /// Retain a finite follow-up turn without draining renderer state from the
@@ -1330,7 +1338,7 @@ fn drawFrame(self: *Thread, now: bool) DrawFrameResult {
 
     if (must_draw_from_app_thread) {
         const pushed = self.app_mailbox.push(
-            .{ .redraw_surface = self.surface },
+            .{ .redraw_surface = .{ .surface = self.surface } },
             .{ .instant = {} },
         );
         if (pushed == 0) return .app_mailbox_full;
@@ -1609,45 +1617,55 @@ test "synchronous renderer retains continuation after drain error" {
 }
 
 test "external redraw retries only the surface whose enqueue failed" {
-    var queued: ExternalRedrawRequest = .{};
-    var failed: ExternalRedrawRequest = .{};
+    var queued: ExternalRedrawDelivery = .{};
+    var failed: ExternalRedrawDelivery = .{};
 
-    try std.testing.expect(queued.request());
-    queued.enqueueCompleted(true);
-    try std.testing.expect(failed.request());
-    failed.enqueueCompleted(false);
+    _ = queued.request().?;
+    const failed_generation = failed.request().?;
+    failed.enqueueFailed(failed_generation);
 
-    try std.testing.expect(!queued.retryFailedEnqueue());
-    try std.testing.expect(failed.retryFailedEnqueue());
-    try std.testing.expect(!failed.retryFailedEnqueue());
+    try std.testing.expectEqual(
+        @as(?u64, null),
+        queued.retryFailedEnqueue(),
+    );
+    try std.testing.expectEqual(
+        failed_generation,
+        failed.retryFailedEnqueue().?,
+    );
+    try std.testing.expectEqual(
+        @as(?u64, null),
+        failed.retryFailedEnqueue(),
+    );
 }
 
 test "external redraw host rejection releases and preserves later wakes" {
-    var request: ExternalRedrawRequest = .{};
+    var delivery: ExternalRedrawDelivery = .{};
 
     // A rejected action without a newer wake is released. A later wake can
     // enqueue again instead of remaining latched behind the rejected action.
-    try std.testing.expect(request.request());
-    request.enqueueCompleted(true);
-    try std.testing.expect(!request.actionCompleted(false));
-    try std.testing.expect(request.request());
+    const first = delivery.request().?;
+    try std.testing.expect(!delivery.actionCompleted(first, false));
+    const second = delivery.request().?;
 
     // A wake coalesced behind an outstanding action must survive rejection.
-    request.enqueueCompleted(true);
-    try std.testing.expect(!request.request());
-    try std.testing.expect(request.actionCompleted(false));
-    try std.testing.expect(!request.retryFailedEnqueue());
-    try std.testing.expect(request.request());
+    try std.testing.expectEqual(@as(?u64, null), delivery.request());
+    try std.testing.expect(delivery.actionCompleted(second, false));
+    try std.testing.expectEqual(
+        @as(?u64, null),
+        delivery.retryFailedEnqueue(),
+    );
+    const third = delivery.request().?;
+    try std.testing.expect(third != second);
 }
 
 test "external render start consumes queued and coalesced wakes" {
-    var request: ExternalRedrawRequest = .{};
-    try std.testing.expect(request.request());
-    request.enqueueCompleted(true);
-    try std.testing.expect(!request.request());
+    var delivery: ExternalRedrawDelivery = .{};
+    const first = delivery.request().?;
+    try std.testing.expectEqual(@as(?u64, null), delivery.request());
 
-    request.renderStarted();
-    try std.testing.expect(request.request());
+    delivery.renderStarted();
+    const second = delivery.request().?;
+    try std.testing.expect(first != second);
 }
 
 test "external redraw stale acknowledgment cannot clear a newer request" {

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -225,14 +225,145 @@ fn drainSynchronousMailbox(context: anytype) !void {
 }
 
 fn scheduleExternalRendererContinuation(context: anytype) void {
-    if (!context.markExternalRendererContinuationRequested()) return;
-    context.enqueueExternalRendererContinuation();
+    if (!context.requestExternalRendererContinuation()) return;
+    context.externalRendererContinuationEnqueued(
+        context.enqueueExternalRendererContinuation(),
+    );
 }
 
 fn retryExternalRendererContinuation(context: anytype) void {
-    if (!context.externalRendererContinuationRequested()) return;
-    context.enqueueExternalRendererContinuation();
+    if (!context.retryFailedExternalRendererContinuation()) return;
+    context.externalRendererContinuationEnqueued(
+        context.enqueueExternalRendererContinuation(),
+    );
 }
+
+/// Tracks one external renderer request without conflating app-mailbox
+/// capacity, action acceptance, and a frame that has actually started.
+///
+/// A second renderer wake behind a queued action becomes `queued_dirty`. If
+/// the host rejects that action, only the later wake is retried. A full app
+/// mailbox uses the separate `enqueue_failed` state so capacity callbacks
+/// retry only the surface whose enqueue actually failed.
+const ExternalRedrawRequest = struct {
+    const State = enum(u8) {
+        idle,
+        queued,
+        queued_dirty,
+        enqueue_failed,
+        wake_pending,
+    };
+
+    state: std.atomic.Value(u8) =
+        std.atomic.Value(u8).init(@intFromEnum(State.idle)),
+
+    /// Claim an enqueue for a new renderer wake. A wake behind an outstanding
+    /// action is retained without adding a duplicate app-mailbox message.
+    fn request(self: *ExternalRedrawRequest) bool {
+        var current = self.state.load(.acquire);
+        while (true) {
+            const state: State = @enumFromInt(current);
+            const transition: struct { next: State, enqueue: bool } =
+                switch (state) {
+                    .idle,
+                    .enqueue_failed,
+                    .wake_pending,
+                    => .{ .next = .queued, .enqueue = true },
+                    .queued => .{ .next = .queued_dirty, .enqueue = false },
+                    .queued_dirty => return false,
+                };
+
+            if (self.state.cmpxchgWeak(
+                current,
+                @intFromEnum(transition.next),
+                .acq_rel,
+                .acquire,
+            )) |actual| {
+                current = actual;
+                continue;
+            }
+            return transition.enqueue;
+        }
+    }
+
+    /// Claim only a request rejected by a full app mailbox. This distinction
+    /// prevents one surface's capacity notification from duplicating already
+    /// queued requests for every other surface.
+    fn retryFailedEnqueue(self: *ExternalRedrawRequest) bool {
+        return self.state.cmpxchgStrong(
+            @intFromEnum(State.enqueue_failed),
+            @intFromEnum(State.queued),
+            .acq_rel,
+            .acquire,
+        ) == null;
+    }
+
+    fn enqueueCompleted(
+        self: *ExternalRedrawRequest,
+        accepted: bool,
+    ) void {
+        if (accepted) return;
+
+        var current = self.state.load(.acquire);
+        while (true) {
+            const state: State = @enumFromInt(current);
+            switch (state) {
+                .queued, .queued_dirty => {},
+                .idle, .enqueue_failed, .wake_pending => return,
+            }
+
+            if (self.state.cmpxchgWeak(
+                current,
+                @intFromEnum(State.enqueue_failed),
+                .acq_rel,
+                .acquire,
+            )) |actual| {
+                current = actual;
+                continue;
+            }
+            return;
+        }
+    }
+
+    /// Record the host's result. A rejected action releases its own request.
+    /// If another wake arrived behind it, return true so the renderer loop can
+    /// retry that later wake once without spinning on permanent rejection.
+    fn actionCompleted(
+        self: *ExternalRedrawRequest,
+        accepted: bool,
+    ) bool {
+        if (accepted) return false;
+
+        var current = self.state.load(.acquire);
+        while (true) {
+            const state: State = @enumFromInt(current);
+            const transition: struct { next: State, notify: bool } =
+                switch (state) {
+                    .queued => .{ .next = .idle, .notify = false },
+                    .queued_dirty => .{
+                        .next = .wake_pending,
+                        .notify = true,
+                    },
+                    .idle, .enqueue_failed, .wake_pending => return false,
+                };
+
+            if (self.state.cmpxchgWeak(
+                current,
+                @intFromEnum(transition.next),
+                .acq_rel,
+                .acquire,
+            )) |actual| {
+                current = actual;
+                continue;
+            }
+            return transition.notify;
+        }
+    }
+
+    fn renderStarted(self: *ExternalRedrawRequest) void {
+        self.state.store(@intFromEnum(State.idle), .release);
+    }
+};
 
 /// Apply the one renderer visibility transition left after mailbox
 /// coalescing. The context seam keeps the wake behavior directly testable
@@ -416,11 +547,10 @@ frame_acquire_timeouts: u64 = 0,
 /// mutate renderer state; the renderer OS thread only keeps async stop alive.
 external_drain: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
 
-/// True from the first external redraw request until an external render starts.
-/// This retains wake-only redraws across a full app mailbox; such redraws have
-/// no renderer mailbox entry that could otherwise prove a retry is needed.
-external_redraw_requested: std.atomic.Value(bool) =
-    std.atomic.Value(bool).init(false),
+/// External redraw state retained across app-mailbox pressure and host action
+/// dispatch. Wake-only redraws have no renderer mailbox entry that could
+/// otherwise prove a retry is needed.
+external_redraw_request: ExternalRedrawRequest = .{},
 
 /// Monotonic millisecond epoch used to derive cursor blink phase while
 /// `external_drain` disables the renderer-thread cursor timer.
@@ -555,7 +685,7 @@ pub fn deinit(self: *Thread) void {
 /// when upstream exposes a synchronous embedder render tick.
 pub fn renderNow(self: *Thread) void {
     self.enterExternalDrainMode();
-    self.clearExternalRendererContinuation();
+    self.external_redraw_request.renderStarted();
     drainSynchronousMailbox(self) catch |err| {
         log.err("renderNow: error draining mailbox err={}", .{err});
     };
@@ -578,7 +708,7 @@ pub fn renderNowWithPresentation(
     presentation: rendererpkg.FramePresentation,
 ) void {
     self.enterExternalDrainMode();
-    self.clearExternalRendererContinuation();
+    self.external_redraw_request.renderStarted();
     drainSynchronousMailbox(self) catch |err| {
         log.err("renderNowWithPresentation: error draining mailbox err={}", .{err});
     };
@@ -660,9 +790,8 @@ pub fn publishDisplayID(self: *Thread, value: u32) void {
 /// so mailbox capacity becoming available is the readiness signal for one
 /// retained reveal retry.
 pub fn appMailboxDrained(self: *Thread) void {
-    // A rejected external continuation uses the app mailbox's existing
-    // retained-redraw signal. Once capacity returns, enqueue it again even for
-    // a wake-only redraw with no renderer mailbox entry.
+    // Once capacity returns, retry only a continuation whose own enqueue
+    // failed. Already queued requests for other surfaces remain coalesced.
     if (self.externalDrainActive()) {
         retryExternalRendererContinuation(self);
     }
@@ -671,6 +800,21 @@ pub fn appMailboxDrained(self: *Thread) void {
     self.visibility_retry_generation.store(generation, .release);
     self.visibility_retry.notify() catch |err| {
         log.warn("failed to notify visibility-regain retry err={}", .{err});
+    };
+}
+
+/// Complete delivery of the app mailbox's `.redraw_surface` action. A rejected
+/// action releases its request so a later renderer wake can enqueue again. If
+/// a newer wake was coalesced behind the rejected action, wake xev once to
+/// preserve that later request without retrying a permanently rejected action.
+pub fn externalRenderActionCompleted(
+    self: *Thread,
+    accepted: bool,
+) void {
+    if (!self.externalDrainActive()) return;
+    if (!self.external_redraw_request.actionCompleted(accepted)) return;
+    self.wakeup.notify() catch |err| {
+        log.warn("failed to retry external redraw after rejected action err={}", .{err});
     };
 }
 
@@ -693,24 +837,26 @@ fn hasPendingRendererWork(self: *const Thread) bool {
         self.surface_state_requests.hasPending();
 }
 
-fn markExternalRendererContinuationRequested(self: *Thread) bool {
-    return !self.external_redraw_requested.swap(true, .acq_rel);
+fn requestExternalRendererContinuation(self: *Thread) bool {
+    return self.external_redraw_request.request();
 }
 
-fn externalRendererContinuationRequested(self: *const Thread) bool {
-    return self.external_redraw_requested.load(.acquire);
+fn retryFailedExternalRendererContinuation(self: *Thread) bool {
+    return self.external_redraw_request.retryFailedEnqueue();
 }
 
-fn clearExternalRendererContinuation(self: *Thread) void {
-    if (!self.externalDrainActive()) return;
-    self.external_redraw_requested.store(false, .release);
+fn externalRendererContinuationEnqueued(
+    self: *Thread,
+    accepted: bool,
+) void {
+    self.external_redraw_request.enqueueCompleted(accepted);
 }
 
-fn enqueueExternalRendererContinuation(self: *Thread) void {
-    _ = self.app_mailbox.push(
+fn enqueueExternalRendererContinuation(self: *Thread) bool {
+    return self.app_mailbox.push(
         .{ .redraw_surface = self.surface },
         .{ .instant = {} },
-    );
+    ) != 0;
 }
 
 /// Retain a finite follow-up turn without draining renderer state from the
@@ -1490,7 +1636,8 @@ test "external redraw host rejection releases and preserves later wakes" {
     request.enqueueCompleted(true);
     try std.testing.expect(!request.request());
     try std.testing.expect(request.actionCompleted(false));
-    try std.testing.expect(request.retryFailedEnqueue());
+    try std.testing.expect(!request.retryFailedEnqueue());
+    try std.testing.expect(request.request());
 }
 
 test "external render start consumes queued and coalesced wakes" {

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -857,7 +857,10 @@ fn enqueueExternalRendererContinuation(
     _ = self.app_mailbox.pushObserved(
         .{ .redraw_surface = .{
             .surface = self.surface,
-            .external_generation = generation,
+            .external_ticket = .{
+                .surface_id = self.surface.core().id,
+                .generation = generation,
+            },
         } },
         .{ .instant = {} },
         ExternalRedrawEnqueueObserver{

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -1650,6 +1650,22 @@ test "external render start consumes queued and coalesced wakes" {
     try std.testing.expect(request.request());
 }
 
+test "external redraw stale acknowledgment cannot clear a newer request" {
+    var delivery: ExternalRedrawDelivery = .{};
+
+    const first = delivery.request().?;
+    delivery.renderStarted();
+    const second = delivery.request().?;
+    try std.testing.expect(first != second);
+
+    try std.testing.expect(!delivery.actionCompleted(first, false));
+    delivery.enqueueFailed(second);
+    try std.testing.expectEqual(
+        second,
+        delivery.retryFailedEnqueue().?,
+    );
+}
+
 test "surface lifecycle state bypasses a full renderer mailbox and keeps latest values" {
     const mailbox = try Mailbox.create(std.testing.allocator);
     defer mailbox.destroy(std.testing.allocator);

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -224,6 +224,16 @@ fn drainSynchronousMailbox(context: anytype) !void {
     _ = try context.drainMailbox();
 }
 
+fn scheduleExternalRendererContinuation(context: anytype) void {
+    if (!context.markExternalRendererContinuationRequested()) return;
+    context.enqueueExternalRendererContinuation();
+}
+
+fn retryExternalRendererContinuation(context: anytype) void {
+    if (!context.externalRendererContinuationRequested()) return;
+    context.enqueueExternalRendererContinuation();
+}
+
 /// Apply the one renderer visibility transition left after mailbox
 /// coalescing. The context seam keeps the wake behavior directly testable
 /// without constructing a platform renderer.
@@ -406,6 +416,12 @@ frame_acquire_timeouts: u64 = 0,
 /// mutate renderer state; the renderer OS thread only keeps async stop alive.
 external_drain: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
 
+/// True from the first external redraw request until an external render starts.
+/// This retains wake-only redraws across a full app mailbox; such redraws have
+/// no renderer mailbox entry that could otherwise prove a retry is needed.
+external_redraw_requested: std.atomic.Value(bool) =
+    std.atomic.Value(bool).init(false),
+
 /// Monotonic millisecond epoch used to derive cursor blink phase while
 /// `external_drain` disables the renderer-thread cursor timer.
 cursor_blink_epoch_ms: i64 = 0,
@@ -539,6 +555,7 @@ pub fn deinit(self: *Thread) void {
 /// when upstream exposes a synchronous embedder render tick.
 pub fn renderNow(self: *Thread) void {
     self.enterExternalDrainMode();
+    self.clearExternalRendererContinuation();
     drainSynchronousMailbox(self) catch |err| {
         log.err("renderNow: error draining mailbox err={}", .{err});
     };
@@ -561,6 +578,7 @@ pub fn renderNowWithPresentation(
     presentation: rendererpkg.FramePresentation,
 ) void {
     self.enterExternalDrainMode();
+    self.clearExternalRendererContinuation();
     drainSynchronousMailbox(self) catch |err| {
         log.err("renderNowWithPresentation: error draining mailbox err={}", .{err});
     };
@@ -643,10 +661,10 @@ pub fn publishDisplayID(self: *Thread, value: u32) void {
 /// retained reveal retry.
 pub fn appMailboxDrained(self: *Thread) void {
     // A rejected external continuation uses the app mailbox's existing
-    // retained-redraw signal. Once capacity returns, enqueue it again if the
-    // renderer still has work.
+    // retained-redraw signal. Once capacity returns, enqueue it again even for
+    // a wake-only redraw with no renderer mailbox entry.
     if (self.externalDrainActive()) {
-        self.scheduleRendererContinuationIfNeeded();
+        retryExternalRendererContinuation(self);
     }
 
     const generation = self.visibility_regain.pendingGeneration() orelse return;
@@ -675,7 +693,20 @@ fn hasPendingRendererWork(self: *const Thread) bool {
         self.surface_state_requests.hasPending();
 }
 
-fn scheduleExternalRendererContinuation(self: *Thread) void {
+fn markExternalRendererContinuationRequested(self: *Thread) bool {
+    return !self.external_redraw_requested.swap(true, .acq_rel);
+}
+
+fn externalRendererContinuationRequested(self: *const Thread) bool {
+    return self.external_redraw_requested.load(.acquire);
+}
+
+fn clearExternalRendererContinuation(self: *Thread) void {
+    if (!self.externalDrainActive()) return;
+    self.external_redraw_requested.store(false, .release);
+}
+
+fn enqueueExternalRendererContinuation(self: *Thread) void {
     _ = self.app_mailbox.push(
         .{ .redraw_surface = self.surface },
         .{ .instant = {} },
@@ -690,7 +721,7 @@ fn scheduleRendererContinuationIfNeeded(self: *Thread) void {
     if (!self.hasPendingRendererWork()) return;
 
     if (self.externalDrainActive()) {
-        self.scheduleExternalRendererContinuation();
+        scheduleExternalRendererContinuation(self);
         return;
     }
 
@@ -1212,7 +1243,7 @@ fn wakeupCallback(
         // coalesced xev wake into an unconditional embedder render request.
         // Unconditional scheduling closes the race where a producer publishes
         // after a pending-work check while this callback is still active.
-        t.scheduleExternalRendererContinuation();
+        scheduleExternalRendererContinuation(t);
         return .rearm;
     }
     const regain_was_pending = t.visibility_regain.isPending();
@@ -1429,6 +1460,44 @@ test "synchronous renderer retains continuation after drain error" {
         drainSynchronousMailbox(&context),
     );
     try std.testing.expectEqual(@as(usize, 1), context.continuations);
+}
+
+test "rejected wake-only external redraw retries without mailbox work" {
+    const Context = struct {
+        requested: bool = false,
+        enqueues: usize = 0,
+
+        fn markExternalRendererContinuationRequested(self: *@This()) bool {
+            if (self.requested) return false;
+            self.requested = true;
+            return true;
+        }
+
+        fn externalRendererContinuationRequested(self: *const @This()) bool {
+            return self.requested;
+        }
+
+        fn enqueueExternalRendererContinuation(self: *@This()) void {
+            self.enqueues += 1;
+        }
+    };
+
+    var context: Context = .{};
+    scheduleExternalRendererContinuation(&context);
+    try std.testing.expect(context.requested);
+    try std.testing.expectEqual(@as(usize, 1), context.enqueues);
+
+    // A second wake coalesces while the request is outstanding. If the first
+    // app-mailbox push was rejected, its capacity callback retries without
+    // consulting renderer-mailbox contents.
+    scheduleExternalRendererContinuation(&context);
+    try std.testing.expectEqual(@as(usize, 1), context.enqueues);
+    retryExternalRendererContinuation(&context);
+    try std.testing.expectEqual(@as(usize, 2), context.enqueues);
+
+    context.requested = false;
+    retryExternalRendererContinuation(&context);
+    try std.testing.expectEqual(@as(usize, 2), context.enqueues);
 }
 
 test "surface lifecycle state bypasses a full renderer mailbox and keeps latest values" {

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -1462,42 +1462,45 @@ test "synchronous renderer retains continuation after drain error" {
     try std.testing.expectEqual(@as(usize, 1), context.continuations);
 }
 
-test "rejected wake-only external redraw retries without mailbox work" {
-    const Context = struct {
-        requested: bool = false,
-        enqueues: usize = 0,
+test "external redraw retries only the surface whose enqueue failed" {
+    var queued: ExternalRedrawRequest = .{};
+    var failed: ExternalRedrawRequest = .{};
 
-        fn markExternalRendererContinuationRequested(self: *@This()) bool {
-            if (self.requested) return false;
-            self.requested = true;
-            return true;
-        }
+    try std.testing.expect(queued.request());
+    queued.enqueueCompleted(true);
+    try std.testing.expect(failed.request());
+    failed.enqueueCompleted(false);
 
-        fn externalRendererContinuationRequested(self: *const @This()) bool {
-            return self.requested;
-        }
+    try std.testing.expect(!queued.retryFailedEnqueue());
+    try std.testing.expect(failed.retryFailedEnqueue());
+    try std.testing.expect(!failed.retryFailedEnqueue());
+}
 
-        fn enqueueExternalRendererContinuation(self: *@This()) void {
-            self.enqueues += 1;
-        }
-    };
+test "external redraw host rejection releases and preserves later wakes" {
+    var request: ExternalRedrawRequest = .{};
 
-    var context: Context = .{};
-    scheduleExternalRendererContinuation(&context);
-    try std.testing.expect(context.requested);
-    try std.testing.expectEqual(@as(usize, 1), context.enqueues);
+    // A rejected action without a newer wake is released. A later wake can
+    // enqueue again instead of remaining latched behind the rejected action.
+    try std.testing.expect(request.request());
+    request.enqueueCompleted(true);
+    try std.testing.expect(!request.actionCompleted(false));
+    try std.testing.expect(request.request());
 
-    // A second wake coalesces while the request is outstanding. If the first
-    // app-mailbox push was rejected, its capacity callback retries without
-    // consulting renderer-mailbox contents.
-    scheduleExternalRendererContinuation(&context);
-    try std.testing.expectEqual(@as(usize, 1), context.enqueues);
-    retryExternalRendererContinuation(&context);
-    try std.testing.expectEqual(@as(usize, 2), context.enqueues);
+    // A wake coalesced behind an outstanding action must survive rejection.
+    request.enqueueCompleted(true);
+    try std.testing.expect(!request.request());
+    try std.testing.expect(request.actionCompleted(false));
+    try std.testing.expect(request.retryFailedEnqueue());
+}
 
-    context.requested = false;
-    retryExternalRendererContinuation(&context);
-    try std.testing.expectEqual(@as(usize, 2), context.enqueues);
+test "external render start consumes queued and coalesced wakes" {
+    var request: ExternalRedrawRequest = .{};
+    try std.testing.expect(request.request());
+    request.enqueueCompleted(true);
+    try std.testing.expect(!request.request());
+
+    request.renderStarted();
+    try std.testing.expect(request.request());
 }
 
 test "surface lifecycle state bypasses a full renderer mailbox and keeps latest values" {


### PR DESCRIPTION
## Summary

Austin Wang merged https://github.com/manaflow-ai/ghostty/pull/136 at `f2f1dfeb8` while its final local review was still running. That merged head correctly bounds synchronous renderer drains and retains continuation after handler errors.

The completed review found a remaining lost-wake case: an external xev wake can require a frame solely because terminal state is dirty, with no renderer-mailbox item. A full app mailbox could reject that redraw, and the old retry path had no per-surface proof that the wake still needed delivery.

This follow-up gives external redraw delivery one explicit owner:

- every external redraw app message carries a monotonically increasing generation and the surface's stable 64-bit lifetime ID
- enqueue failure is published to that exact generation before the shared capacity retry and app wake
- capacity callbacks retry only the surface and generation whose enqueue failed
- host action acknowledgments mutate only their own generation, so stale rejection cannot clear newer work
- pointer and lifetime ID are validated before host dispatch and again before completion, so allocator address reuse cannot target or acknowledge a replacement surface
- each validated surface is retained through host dispatch; embedded owner teardown unregisters immediately and defers destruction until in-flight callbacks return, while GTK uses its GObject reference
- the registry lock is released before the reentrant host callback, avoiding teardown deadlock without reopening the lifetime race
- a newer wake coalesced behind a rejected action receives one bounded xev retry
- render start satisfies all redraw demand published before its delivery critical section
- all delivery transitions are short mutex critical sections; mailbox push, callbacks, and renderer work happen after unlock

cmux handles the existing `GHOSTTY_ACTION_RENDER` action through its shared Ghostty runtime entrypoint. This adds no C ABI.

## Tests

Zig 0.15.2 focused suites and format checks passed on exact head `cf1dee45dea9b35a898eb47f7a72f2a72fc48ba1` locally and on `cmuxs-mac-mini-3.1`, the 48 GB fleet Mac running macOS 26.5:

- reentrant owner teardown versus in-flight action lease regression
- action-lifetime final-reference state regression
- allocator-address-reuse surface lifetime regression
- publish-before-wake mailbox ordering regression
- stale acknowledgment versus newer enqueue regression
- external redraw generation, rejection, render-start, and multi-surface regressions
- finite synchronous drain and error-continuation regressions
- producer-during-drain starvation regression
- lifecycle full-mailbox and retry-restoration regressions
- visibility-regain suite
- full app-mailbox retry regression

The complete native Zig test binary also passed locally. Ghostty's unfiltered build then entered its separate Xcode test step, which the HQ local-build guard does not permit; the focused and fleet evidence above cover every changed ownership and renderer path.

Follow-up to https://github.com/manaflow-ai/ghostty/pull/136 and https://github.com/manaflow-ai/cmux/issues/8808.
