### PR TITLE
fix: bind embedder userdata to surface lifetime

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -567,6 +567,7 @@ typedef void (*ghostty_pty_tee_cb)(void* userdata,
 // bookkeeping completes. Metal delivers after assigning its IOSurface on the
 // main thread. Synchronous backends deliver on the rendering caller's thread.
 typedef void (*ghostty_render_presented_cb)(void*, uint64_t);
+typedef void (*ghostty_userdata_release_cb)(void* userdata);
 
 // Content-free renderer activity events emitted only when a surface installs
 // ghostty_renderer_event_cb. Begin/end pairs run on the renderer thread.
@@ -1260,6 +1261,18 @@ GHOSTTY_API ghostty_surface_config_s ghostty_surface_config_new();
 
 GHOSTTY_API ghostty_surface_t ghostty_surface_new(ghostty_app_t,
                                                      const ghostty_surface_config_s*);
+/**
+ * Creates a surface that owns `config->userdata`.
+ *
+ * On success, `release_userdata` is called exactly once with that userdata
+ * after surface teardown has stopped internal callbacks and all in-flight app
+ * actions have returned. The callback may run on any thread. If creation
+ * fails, ownership remains with the caller and the callback is not invoked.
+ */
+GHOSTTY_API ghostty_surface_t ghostty_surface_new_with_owned_userdata(
+    ghostty_app_t,
+    const ghostty_surface_config_s*,
+    ghostty_userdata_release_cb release_userdata);
 // cmux fork: create a surface with an embedder-owned scrollback upper bound
 // without changing ghostty_surface_config_s's public ABI. A zero limit inherits
 // the configured scrollback-limit; a nonzero limit can only lower it.

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -298,6 +298,13 @@ pub const App = struct {
         comptime action: apprt.Action.Key,
         value: apprt.Action.Value(action),
     ) !bool {
+        const userdata_lease: ?SurfaceUserdata.Lease = switch (target) {
+            .app => null,
+            .surface => |surface| surface.rt_surface.userdata.acquire() orelse
+                return false,
+        };
+        defer if (userdata_lease) |lease| lease.release();
+
         // Special case certain actions before they are sent to the
         // embedded apprt.
         self.performPreAction(target, action, value);
@@ -671,23 +678,116 @@ pub const UserdataReleaseCallback = *const fn (?*anyopaque) callconv(.c) void;
 
 const SurfaceUserdata = struct {
     value: ?*anyopaque = null,
-    release_cb: ?UserdataReleaseCallback = null,
+    state: State = .borrowed,
 
-    fn init(
+    const State = union(enum) {
+        borrowed,
+        owned: *Lifetime,
+        released,
+    };
+
+    const Lifetime = struct {
+        alloc: Allocator,
         value: ?*anyopaque,
         release_cb: UserdataReleaseCallback,
-    ) SurfaceUserdata {
+        references: std.atomic.Value(usize) = .{ .raw = 1 },
+
+        fn tryRetain(self: *Lifetime) bool {
+            var count = self.references.load(.seq_cst);
+            while (count > 0) {
+                assert(count < std.math.maxInt(usize));
+                if (self.references.cmpxchgWeak(
+                    count,
+                    count + 1,
+                    .seq_cst,
+                    .seq_cst,
+                )) |actual| {
+                    count = actual;
+                } else {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        fn release(self: *Lifetime) void {
+            const previous = self.references.fetchSub(1, .seq_cst);
+            assert(previous > 0);
+            if (previous != 1) return;
+
+            const alloc = self.alloc;
+            const value = self.value;
+            const release_cb = self.release_cb;
+            release_cb(value);
+            alloc.destroy(self);
+        }
+    };
+
+    const Lease = struct {
+        lifetime: ?*Lifetime,
+
+        fn release(self: Lease) void {
+            if (self.lifetime) |lifetime| lifetime.release();
+        }
+    };
+
+    fn init(
+        alloc: Allocator,
+        value: ?*anyopaque,
+        release_cb: ?UserdataReleaseCallback,
+    ) Allocator.Error!SurfaceUserdata {
+        const callback = release_cb orelse return .{ .value = value };
+        const lifetime = try alloc.create(Lifetime);
+        lifetime.* = .{
+            .alloc = alloc,
+            .value = value,
+            .release_cb = callback,
+        };
         return .{
             .value = value,
-            .release_cb = release_cb,
+            .state = .{ .owned = lifetime },
         };
     }
 
-    fn deinit(self: *SurfaceUserdata) void {
-        const release_cb = self.release_cb orelse return;
-        self.release_cb = null;
-        release_cb(self.value);
+    fn acquire(self: *const SurfaceUserdata) ?Lease {
+        return switch (self.state) {
+            .borrowed => .{ .lifetime = null },
+            .owned => |lifetime| if (lifetime.tryRetain())
+                .{ .lifetime = lifetime }
+            else
+                null,
+            .released => null,
+        };
+    }
+
+    fn abort(self: *SurfaceUserdata) void {
+        const lifetime = switch (self.state) {
+            .owned => |lifetime| lifetime,
+            .borrowed, .released => {
+                self.state = .released;
+                self.value = null;
+                return;
+            },
+        };
+        self.state = .released;
         self.value = null;
+        assert(lifetime.references.load(.seq_cst) == 1);
+        lifetime.alloc.destroy(lifetime);
+    }
+
+    fn deinit(self: *SurfaceUserdata) void {
+        const lifetime = switch (self.state) {
+            .owned => |lifetime| lifetime,
+            .borrowed, .released => {
+                self.state = .released;
+                self.value = null;
+                return;
+            },
+        };
+        self.state = .released;
+        self.value = null;
+        lifetime.release();
     }
 };
 
@@ -814,13 +914,17 @@ pub const Surface = struct {
         scrollback_limit_bytes: usize,
         userdata_release_cb: ?UserdataReleaseCallback,
     ) !void {
+        var userdata = try SurfaceUserdata.init(
+            app.core_app.alloc,
+            opts.userdata,
+            userdata_release_cb,
+        );
+        errdefer userdata.abort();
+
         self.* = .{
             .app = app,
             .platform = try .init(opts.platform_tag, opts.platform),
-            .userdata = if (userdata_release_cb) |release_cb|
-                .init(opts.userdata, release_cb)
-            else
-                .{ .value = opts.userdata },
+            .userdata = userdata,
             .core_surface = undefined,
             .content_scale = .{
                 .x = @floatCast(opts.scale_factor),
@@ -1071,22 +1175,26 @@ pub const Surface = struct {
         return self.app;
     }
 
-    pub fn close(self: *const Surface, process_alive: bool) void {
+    pub fn close(self: *Surface, process_alive: bool) void {
         const func = self.app.opts.close_surface orelse {
             log.info("runtime embedder does not support closing a surface", .{});
             return;
         };
+        const userdata_lease = self.userdata.acquire() orelse return;
+        defer userdata_lease.release();
 
         func(self.userdata.value, process_alive);
     }
 
     pub fn tmuxControl(
-        self: *const Surface,
+        self: *Surface,
         event: apprt.surface.Message.TmuxControlMsg.Event,
         id: u32,
         data: []const u8,
     ) void {
         const func = self.app.opts.tmux_control orelse return;
+        const userdata_lease = self.userdata.acquire() orelse return;
+        defer userdata_lease.release();
         func(self.userdata.value, event, id, data.ptr, data.len);
     }
 
@@ -1115,30 +1223,68 @@ pub const Surface = struct {
     }
 
     pub fn ioWriteCallback(self: *const Surface) ?IoWriteCallback {
-        return self.io_write_cb;
+        return if (self.io_write_cb != null) ioWrite else null;
     }
 
     pub fn ioWriteUserdata(self: *const Surface) ?*anyopaque {
-        return self.io_write_userdata;
+        return if (self.io_write_cb != null) @constCast(self) else null;
+    }
+
+    fn ioWrite(
+        userdata: ?*anyopaque,
+        data: [*]const u8,
+        len: usize,
+    ) callconv(.c) void {
+        const self: *Surface = @ptrCast(@alignCast(userdata.?));
+        const callback = self.io_write_cb orelse return;
+        const userdata_lease = self.userdata.acquire() orelse return;
+        defer userdata_lease.release();
+        callback(self.io_write_userdata, data, len);
     }
 
     pub fn ptyTeeCallback(self: *const Surface) ?PtyTeeCallback {
-        return self.pty_tee_cb;
+        return if (self.pty_tee_cb != null) ptyTee else null;
     }
 
     pub fn ptyTeeUserdata(self: *const Surface) ?*anyopaque {
-        return self.pty_tee_userdata;
+        return if (self.pty_tee_cb != null) @constCast(self) else null;
+    }
+
+    fn ptyTee(
+        userdata: ?*anyopaque,
+        data: [*]const u8,
+        len: usize,
+    ) callconv(.c) void {
+        const self: *Surface = @ptrCast(@alignCast(userdata.?));
+        const callback = self.pty_tee_cb orelse return;
+        const userdata_lease = self.userdata.acquire() orelse return;
+        defer userdata_lease.release();
+        callback(self.pty_tee_userdata, data, len);
     }
 
     pub fn suppressTerminalResponses(self: *const Surface) bool {
         return self.io_mode.suppressesTerminalResponses();
     }
 
-    pub fn rendererInstrumentation(self: *const Surface) renderer.Instrumentation {
+    pub fn rendererInstrumentation(self: *Surface) renderer.Instrumentation {
         return .{
-            .callback = self.renderer_event_cb,
-            .userdata = self.userdata.value,
+            .callback = if (self.renderer_event_cb != null)
+                rendererEvent
+            else
+                null,
+            .userdata = self,
         };
+    }
+
+    fn rendererEvent(
+        userdata: ?*anyopaque,
+        event: renderer.InstrumentationEvent,
+    ) callconv(.c) void {
+        const self: *Surface = @ptrCast(@alignCast(userdata.?));
+        const callback = self.renderer_event_cb orelse return;
+        const userdata_lease = self.userdata.acquire() orelse return;
+        defer userdata_lease.release();
+        callback(self.userdata.value, event);
     }
 
     pub fn getTitle(self: *Surface) ?[:0]const u8 {
@@ -1169,6 +1315,8 @@ pub const Surface = struct {
         errdefer alloc.destroy(state_ptr);
         state_ptr.* = state;
 
+        const userdata_lease = self.userdata.acquire() orelse return false;
+        defer userdata_lease.release();
         const started = self.app.opts.read_clipboard(
             self.userdata.value,
             @intCast(@intFromEnum(clipboard_type)),
@@ -1200,6 +1348,8 @@ pub const Surface = struct {
             error.UnsafePaste,
             error.UnauthorizedPaste,
             => {
+                const userdata_lease = self.userdata.acquire() orelse return;
+                defer userdata_lease.release();
                 self.app.opts.confirm_read_clipboard(
                     self.userdata.value,
                     str.ptr,
@@ -1219,7 +1369,7 @@ pub const Surface = struct {
     }
 
     pub fn setClipboard(
-        self: *const Surface,
+        self: *Surface,
         clipboard_type: apprt.Clipboard,
         contents: []const apprt.ClipboardContent,
         confirm: bool,
@@ -1234,6 +1384,8 @@ pub const Surface = struct {
             };
         }
 
+        const userdata_lease = self.userdata.acquire() orelse return;
+        defer userdata_lease.release();
         self.app.opts.write_clipboard(
             self.userdata.value,
             @intCast(@intFromEnum(clipboard_type)),
@@ -1267,16 +1419,27 @@ pub const Surface = struct {
     }
 
     pub fn renderNowWithToken(self: *Surface, token: u64) void {
-        const callback = self.render_presented_cb orelse {
+        if (self.render_presented_cb == null) {
             self.renderNow();
             return;
-        };
+        }
         self.core_surface.applyPendingResizeIfNeeded();
         self.core_surface.renderer_thread.renderNowWithPresentation(.{
-            .callback = callback,
-            .userdata = self.render_presented_userdata,
+            .callback = renderPresented,
+            .userdata = self,
             .token = token,
         });
+    }
+
+    fn renderPresented(
+        userdata: ?*anyopaque,
+        token: u64,
+    ) callconv(.c) void {
+        const self: *Surface = @ptrCast(@alignCast(userdata.?));
+        const callback = self.render_presented_cb orelse return;
+        const userdata_lease = self.userdata.acquire() orelse return;
+        defer userdata_lease.release();
+        callback(self.render_presented_userdata, token);
     }
 
     pub fn updateContentScale(self: *Surface, x: f64, y: f64) void {
@@ -1547,20 +1710,6 @@ test "surface action lifetime defers owner destruction until lease release" {
 }
 
 test "owned surface userdata releases after final action lease" {
-    const OwnedUserdata = if (@hasDecl(@This(), "SurfaceUserdata"))
-        @field(@This(), "SurfaceUserdata")
-    else
-        struct {
-            fn init(
-                _: ?*anyopaque,
-                _: *const fn (?*anyopaque) callconv(.c) void,
-            ) @This() {
-                return .{};
-            }
-
-            fn deinit(_: *@This()) void {}
-        };
-
     const ReleaseState = struct {
         releases: usize = 0,
 
@@ -1571,7 +1720,11 @@ test "owned surface userdata releases after final action lease" {
     };
 
     var state: ReleaseState = .{};
-    var userdata = OwnedUserdata.init(&state, ReleaseState.release);
+    var userdata = try SurfaceUserdata.init(
+        std.testing.allocator,
+        &state,
+        ReleaseState.release,
+    );
     var lifetime: SurfaceActionLifetime = .{};
     lifetime.retain();
 
@@ -1586,19 +1739,6 @@ test "owned surface userdata releases after final action lease" {
 }
 
 test "owned surface userdata remains alive through host callback lease" {
-    const CallbackLifetime = if (@hasDecl(SurfaceActionLifetime, "tryRetain"))
-        SurfaceActionLifetime
-    else
-        struct {
-            fn tryRetain(_: *@This()) bool {
-                return false;
-            }
-
-            fn release(_: *@This()) bool {
-                return false;
-            }
-        };
-
     const ReleaseState = struct {
         releases: usize = 0,
 
@@ -1609,14 +1749,18 @@ test "owned surface userdata remains alive through host callback lease" {
     };
 
     var state: ReleaseState = .{};
-    var userdata = SurfaceUserdata.init(&state, ReleaseState.release);
-    var lifetime: CallbackLifetime = .{};
+    var userdata = try SurfaceUserdata.init(
+        std.testing.allocator,
+        &state,
+        ReleaseState.release,
+    );
+    const callback_lease = userdata.acquire().?;
 
-    try std.testing.expect(lifetime.tryRetain());
-    if (lifetime.release()) userdata.deinit();
+    userdata.deinit();
     try std.testing.expectEqual(@as(usize, 0), state.releases);
+    try std.testing.expect(userdata.acquire() == null);
 
-    if (lifetime.release()) userdata.deinit();
+    callback_lease.release();
     try std.testing.expectEqual(@as(usize, 1), state.releases);
 }
 

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1764,6 +1764,66 @@ test "owned surface userdata remains alive through host callback lease" {
     try std.testing.expectEqual(@as(usize, 1), state.releases);
 }
 
+test "post-construction PTY tee retains owned userdata through callback" {
+    const ReleaseState = struct {
+        releases: usize = 0,
+
+        fn release(userdata: ?*anyopaque) callconv(.c) void {
+            const self: *@This() = @ptrCast(@alignCast(userdata.?));
+            self.releases += 1;
+        }
+    };
+
+    const CallbackState = struct {
+        surface: *Surface,
+        release_state: *ReleaseState,
+        releases_during_callback: usize = 0,
+
+        fn callback(
+            userdata: ?*anyopaque,
+            _: [*]const u8,
+            _: usize,
+        ) callconv(.c) void {
+            const self: *@This() = @ptrCast(@alignCast(userdata.?));
+            self.surface.userdata.deinit();
+            self.releases_during_callback = self.release_state.releases;
+        }
+    };
+
+    var release_state: ReleaseState = .{};
+    var surface: Surface = undefined;
+    surface.userdata = try SurfaceUserdata.init(
+        std.testing.allocator,
+        &release_state,
+        ReleaseState.release,
+    );
+    surface.pty_tee_cb = null;
+    surface.pty_tee_userdata = null;
+
+    var callback_state: CallbackState = .{
+        .surface = &surface,
+        .release_state = &release_state,
+    };
+    CAPI.ghostty_surface_set_pty_tee_cb(
+        &surface,
+        CallbackState.callback,
+        &callback_state,
+    );
+
+    const data = "x";
+    surface.core_surface.io.pty_tee_cb.?(
+        surface.core_surface.io.pty_tee_userdata,
+        data.ptr,
+        data.len,
+    );
+
+    try std.testing.expectEqual(
+        @as(usize, 0),
+        callback_state.releases_during_callback,
+    );
+    try std.testing.expectEqual(@as(usize, 1), release_state.releases);
+}
+
 // The cmux integration combines the OpenGL platform payload (the largest
 // Platform.C variant) with the startup PTY tee fields. Keep the resulting C
 // layout pinned so every exact-revision consumer fails loudly on drift.

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -264,13 +264,19 @@ pub const App = struct {
         self: *App,
         opts: Surface.Options,
         scrollback_limit_bytes: usize,
+        userdata_release_cb: ?UserdataReleaseCallback,
     ) !*Surface {
         // Grab a surface allocation because we're going to need it.
         var surface = try self.core_app.alloc.create(Surface);
         errdefer self.core_app.alloc.destroy(surface);
 
         // Create the surface
-        try surface.init(self, opts, scrollback_limit_bytes);
+        try surface.init(
+            self,
+            opts,
+            scrollback_limit_bytes,
+            userdata_release_cb,
+        );
         return surface;
     }
 
@@ -661,6 +667,29 @@ pub const IoWriteCallback = *const fn (?*anyopaque, [*]const u8, usize) callconv
 pub const PtyTeeCallback = *const fn (?*anyopaque, [*]const u8, usize) callconv(.c) void;
 pub const RendererEventCallback = renderer.InstrumentationCallback;
 pub const RenderPresentedCallback = *const fn (?*anyopaque, u64) callconv(.c) void;
+pub const UserdataReleaseCallback = *const fn (?*anyopaque) callconv(.c) void;
+
+const SurfaceUserdata = struct {
+    value: ?*anyopaque = null,
+    release_cb: ?UserdataReleaseCallback = null,
+
+    fn init(
+        value: ?*anyopaque,
+        release_cb: UserdataReleaseCallback,
+    ) SurfaceUserdata {
+        return .{
+            .value = value,
+            .release_cb = release_cb,
+        };
+    }
+
+    fn deinit(self: *SurfaceUserdata) void {
+        const release_cb = self.release_cb orelse return;
+        self.release_cb = null;
+        release_cb(self.value);
+        self.value = null;
+    }
+};
 
 const SurfaceActionLifetime = struct {
     references: std.atomic.Value(usize) = .{ .raw = 1 },
@@ -687,7 +716,7 @@ const SurfaceActionLifetime = struct {
 pub const Surface = struct {
     app: *App,
     platform: Platform,
-    userdata: ?*anyopaque = null,
+    userdata: SurfaceUserdata = .{},
     core_surface: CoreSurface,
     app_action_lifetime: SurfaceActionLifetime = .{},
     content_scale: apprt.ContentScale,
@@ -783,11 +812,15 @@ pub const Surface = struct {
         app: *App,
         opts: Options,
         scrollback_limit_bytes: usize,
+        userdata_release_cb: ?UserdataReleaseCallback,
     ) !void {
         self.* = .{
             .app = app,
             .platform = try .init(opts.platform_tag, opts.platform),
-            .userdata = opts.userdata,
+            .userdata = if (userdata_release_cb) |release_cb|
+                .init(opts.userdata, release_cb)
+            else
+                .{ .value = opts.userdata },
             .core_surface = undefined,
             .content_scale = .{
                 .x = @floatCast(opts.scale_factor),
@@ -1004,6 +1037,7 @@ pub const Surface = struct {
 
         // Clean up our core surface so that all the rendering and IO stop.
         self.core_surface.deinit();
+        self.userdata.deinit();
         alloc.destroy(self);
     }
 
@@ -1043,7 +1077,7 @@ pub const Surface = struct {
             return;
         };
 
-        func(self.userdata, process_alive);
+        func(self.userdata.value, process_alive);
     }
 
     pub fn tmuxControl(
@@ -1053,7 +1087,7 @@ pub const Surface = struct {
         data: []const u8,
     ) void {
         const func = self.app.opts.tmux_control orelse return;
-        func(self.userdata, event, id, data.ptr, data.len);
+        func(self.userdata.value, event, id, data.ptr, data.len);
     }
 
     pub fn getContentScale(self: *const Surface) !apprt.ContentScale {
@@ -1103,7 +1137,7 @@ pub const Surface = struct {
     pub fn rendererInstrumentation(self: *const Surface) renderer.Instrumentation {
         return .{
             .callback = self.renderer_event_cb,
-            .userdata = self.userdata,
+            .userdata = self.userdata.value,
         };
     }
 
@@ -1136,7 +1170,7 @@ pub const Surface = struct {
         state_ptr.* = state;
 
         const started = self.app.opts.read_clipboard(
-            self.userdata,
+            self.userdata.value,
             @intCast(@intFromEnum(clipboard_type)),
             state_ptr,
         );
@@ -1167,7 +1201,7 @@ pub const Surface = struct {
             error.UnauthorizedPaste,
             => {
                 self.app.opts.confirm_read_clipboard(
-                    self.userdata,
+                    self.userdata.value,
                     str.ptr,
                     state,
                     state.*,
@@ -1201,7 +1235,7 @@ pub const Surface = struct {
         }
 
         self.app.opts.write_clipboard(
-            self.userdata,
+            self.userdata.value,
             @intCast(@intFromEnum(clipboard_type)),
             array.ptr,
             array.len,
@@ -2148,7 +2182,19 @@ pub const CAPI = struct {
         app: *App,
         opts: *const apprt.Surface.Options,
     ) ?*Surface {
-        return surface_new_(app, opts, 0) catch |err| {
+        return surface_new_(app, opts, 0, null) catch |err| {
+            log.err("error initializing surface err={}", .{err});
+            return null;
+        };
+    }
+
+    /// Create a surface that owns its userdata until final destruction.
+    export fn ghostty_surface_new_with_owned_userdata(
+        app: *App,
+        opts: *const apprt.Surface.Options,
+        userdata_release_cb: UserdataReleaseCallback,
+    ) ?*Surface {
+        return surface_new_(app, opts, 0, userdata_release_cb) catch |err| {
             log.err("error initializing surface err={}", .{err});
             return null;
         };
@@ -2161,7 +2207,7 @@ pub const CAPI = struct {
         opts: *const apprt.Surface.Options,
         scrollback_limit_bytes: usize,
     ) ?*Surface {
-        return surface_new_(app, opts, scrollback_limit_bytes) catch |err| {
+        return surface_new_(app, opts, scrollback_limit_bytes, null) catch |err| {
             log.err("error initializing surface err={}", .{err});
             return null;
         };
@@ -2171,8 +2217,13 @@ pub const CAPI = struct {
         app: *App,
         opts: *const apprt.Surface.Options,
         scrollback_limit_bytes: usize,
+        userdata_release_cb: ?UserdataReleaseCallback,
     ) !*Surface {
-        return try app.newSurface(opts.*, scrollback_limit_bytes);
+        return try app.newSurface(
+            opts.*,
+            scrollback_limit_bytes,
+            userdata_release_cb,
+        );
     }
 
     export fn ghostty_surface_free(ptr: *Surface) void {
@@ -2181,7 +2232,7 @@ pub const CAPI = struct {
 
     /// Returns the userdata associated with the surface.
     export fn ghostty_surface_userdata(surface: *Surface) ?*anyopaque {
-        return surface.userdata;
+        return surface.userdata.value;
     }
 
     /// Returns the app associated with a surface.

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1585,6 +1585,41 @@ test "owned surface userdata releases after final action lease" {
     try std.testing.expectEqual(@as(usize, 1), state.releases);
 }
 
+test "owned surface userdata remains alive through host callback lease" {
+    const CallbackLifetime = if (@hasDecl(SurfaceActionLifetime, "tryRetain"))
+        SurfaceActionLifetime
+    else
+        struct {
+            fn tryRetain(_: *@This()) bool {
+                return false;
+            }
+
+            fn release(_: *@This()) bool {
+                return false;
+            }
+        };
+
+    const ReleaseState = struct {
+        releases: usize = 0,
+
+        fn release(userdata: ?*anyopaque) callconv(.c) void {
+            const self: *@This() = @ptrCast(@alignCast(userdata.?));
+            self.releases += 1;
+        }
+    };
+
+    var state: ReleaseState = .{};
+    var userdata = SurfaceUserdata.init(&state, ReleaseState.release);
+    var lifetime: CallbackLifetime = .{};
+
+    try std.testing.expect(lifetime.tryRetain());
+    if (lifetime.release()) userdata.deinit();
+    try std.testing.expectEqual(@as(usize, 0), state.releases);
+
+    if (lifetime.release()) userdata.deinit();
+    try std.testing.expectEqual(@as(usize, 1), state.releases);
+}
+
 // The cmux integration combines the OpenGL platform payload (the largest
 // Platform.C variant) with the startup PTY tee fields. Keep the resulting C
 // layout pinned so every exact-revision consumer fails loudly on drift.

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1512,6 +1512,45 @@ test "surface action lifetime defers owner destruction until lease release" {
     try std.testing.expect(lifetime.release());
 }
 
+test "owned surface userdata releases after final action lease" {
+    const OwnedUserdata = if (@hasDecl(@This(), "SurfaceUserdata"))
+        @field(@This(), "SurfaceUserdata")
+    else
+        struct {
+            fn init(
+                _: ?*anyopaque,
+                _: *const fn (?*anyopaque) callconv(.c) void,
+            ) @This() {
+                return .{};
+            }
+
+            fn deinit(_: *@This()) void {}
+        };
+
+    const ReleaseState = struct {
+        releases: usize = 0,
+
+        fn release(userdata: ?*anyopaque) callconv(.c) void {
+            const self: *@This() = @ptrCast(@alignCast(userdata.?));
+            self.releases += 1;
+        }
+    };
+
+    var state: ReleaseState = .{};
+    var userdata = OwnedUserdata.init(&state, ReleaseState.release);
+    var lifetime: SurfaceActionLifetime = .{};
+    lifetime.retain();
+
+    if (lifetime.release()) userdata.deinit();
+    try std.testing.expectEqual(@as(usize, 0), state.releases);
+
+    if (lifetime.release()) userdata.deinit();
+    try std.testing.expectEqual(@as(usize, 1), state.releases);
+
+    userdata.deinit();
+    try std.testing.expectEqual(@as(usize, 1), state.releases);
+}
+
 // The cmux integration combines the OpenGL platform payload (the largest
 // Platform.C variant) with the startup PTY tee fields. Keep the resulting C
 // layout pinned so every exact-revision consumer fails loudly on drift.

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1262,6 +1262,17 @@ pub const Surface = struct {
         callback(self.pty_tee_userdata, data, len);
     }
 
+    fn setPtyTeeCallback(
+        self: *Surface,
+        callback: ?PtyTeeCallback,
+        userdata: ?*anyopaque,
+    ) void {
+        self.pty_tee_cb = callback;
+        self.pty_tee_userdata = userdata;
+        self.core_surface.io.pty_tee_cb = if (callback != null) ptyTee else null;
+        self.core_surface.io.pty_tee_userdata = if (callback != null) self else null;
+    }
+
     pub fn suppressTerminalResponses(self: *const Surface) bool {
         return self.io_mode.suppressesTerminalResponses();
     }
@@ -3977,11 +3988,10 @@ pub const CAPI = struct {
     /// matching grid. Upstream candidate.
     export fn ghostty_surface_set_pty_tee_cb(
         surface: *Surface,
-        cb: ?*const fn (?*anyopaque, [*]const u8, usize) callconv(.c) void,
+        cb: ?PtyTeeCallback,
         userdata: ?*anyopaque,
     ) void {
-        surface.core_surface.io.pty_tee_cb = cb;
-        surface.core_surface.io.pty_tee_userdata = userdata;
+        surface.setPtyTeeCallback(cb, userdata);
     }
 
     /// Returns true if the surface currently has mouse capturing


### PR DESCRIPTION
## Summary

Fix the remaining lifetime race in the bounded renderer action path used by cmux.

An app-action lease can intentionally keep an embedded C surface alive after `ghostty_surface_free` returns. The Swift embedder previously released its userdata bridge when that function returned, so a lease acquired before teardown could later dispatch `GHOSTTY_ACTION_RENDER` and dereference freed userdata.

This adds an owned-userdata surface constructor without changing `ghostty_surface_config_s`. On successful creation, Ghostty owns the userdata release callback and invokes it exactly once from final surface destruction, after core teardown stops internal callbacks and after the last app-action lease returns. Failed creation leaves ownership with the caller.

This is the Ghostty-side lifetime completion for https://github.com/manaflow-ai/cmux/issues/8808 and https://github.com/manaflow-ai/cmux/pull/8848.

## Tests

Red commit `4e45e6c77` failed only the new owned-userdata assertion: 72/73 tests passed, expected one release and observed zero.

Green commit `289097387` passes:

- owned userdata after the final action lease
- surface action lifetime final-reference behavior
- redraw action lease teardown behavior
- Zig formatting and diff checks

The regression also calls the userdata finalizer a second time and verifies the release callback remains exactly-once.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/140"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787489568&installation_model_id=21920&pr_number=140&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F140&signature=ebb4c2b9aa2a913e8758365bbfae5e9831dd417bf74c131c328d53e81c6f0de1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bind embedder userdata to the surface lifetime to prevent use-after-free during app actions and host callbacks. Userdata releases exactly once after core teardown and the final in-flight lease returns.

- **New Features**
  - Added `ghostty_surface_new_with_owned_userdata(..., ghostty_userdata_release_cb)` to transfer ownership of `config->userdata`; on failure, ownership stays with the caller.
  - Introduced a refcounted userdata wrapper that provides leases and invokes the release callback once at final surface destruction; `ghostty_surface_new` is unchanged.

- **Bug Fixes**
  - Acquired a userdata lease across every path that can call into the embedder (IO write/tee, renderer events, render-presented, clipboard, tmux, close) and during app/surface actions; includes setter-installed PTY tee callbacks via `ghostty_surface_set_pty_tee_cb`.
  - Deferred release to `Surface.deinit` after `core_surface.deinit`, and only after the final in-flight lease completes.

<sup>Written for commit 365fe1d2ccb0df9077bdd4440a9383e940212865. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/140?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a surface creation option that transfers ownership of embedder-provided userdata.
  * Added a release callback invoked once after the surface is fully torn down and all in-flight actions finish.
  * Preserved userdata availability during host callbacks and supported callbacks running on any thread.

* **Bug Fixes**
  * Ensured userdata remains owned by the caller, with no release callback invoked, when surface creation fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->