### PR TITLE
Share embedded Ghostty runtime state

### DIFF
--- a/src/renderer/scene/CApi.zig
+++ b/src/renderer/scene/CApi.zig
@@ -5,7 +5,12 @@
 //! mailbox, or terminal IO thread.
 
 const std = @import("std");
-const state = &@import("../../scene_runtime.zig").state;
+const build_config = @import("../../build_config.zig");
+const runtime = if (build_config.scene_renderer_only)
+    @import("../../scene_runtime.zig")
+else
+    @import("../../global.zig");
+const state = &runtime.state;
 const Config = @import("../../config/Config.zig");
 const font = @import("../../font/main.zig");
 const rendererpkg = @import("../../renderer.zig");
@@ -707,6 +712,16 @@ test "frame C conversion preserves the exact release fence" {
         .height = 9,
     };
     try std.testing.expect(std.meta.eql(lease, leaseFromFrame(frameFromLease(lease))));
+}
+
+test "embedded renderer shares the initialized Ghostty process runtime" {
+    if (!build_config.scene_renderer_only) {
+        const global_state = &@import("../../global.zig").state;
+        try std.testing.expectEqual(
+            @intFromPtr(global_state),
+            @intFromPtr(state),
+        );
+    }
 }
 
 test "receiver defaults come from each renderer config" {


### PR DESCRIPTION
Summary
- Preserve the initialized embedded Ghostty process runtime for renderer-side reuse.
- Keep the iOS scene renderer on the same runtime state as the Mac scene capture path.

Verification
- zig build test -Dtest-filter=embedded renderer shares the initialized Ghostty process runtime
- zig fmt --check
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/141"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787520557&installation_model_id=21920&pr_number=141&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F141&signature=680b9e7f0bf0bd44bc2c249a25f85c99ef40e1c27464948aa01b44f9f7bcaff8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shares the embedded Ghostty runtime state with the renderer so both iOS scene rendering and macOS scene capture run on the same initialized runtime.

- **Bug Fixes**
  - Select runtime via `build_config.scene_renderer_only`: use `global.zig` for embedded, `scene_runtime.zig` for renderer-only builds.
  - Added test to verify the embedded renderer and process share the same `state` pointer.

<sup>Written for commit 647849ee9a8e23ceb0e1ebb135ea82cb9aa578be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/141?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

