### PR TITLE
termio: stop dead PTY polling and reap exited children

### DIFF
--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -1173,7 +1173,13 @@ const Subprocess = struct {
     }
 
     fn killPid(pid: c.pid_t) !void {
-        const pgid = getpgid(pid) orelse return;
+        const pgid = getpgid(pid) orelse {
+            // Darwin no longer exposes a process group for an exited child,
+            // even while its wait status is still pending. The process
+            // watcher normally owns reaping, but teardown can win that race.
+            _ = try reapExitedChild(pid);
+            return;
+        };
 
         // It is possible to send a killpg between the time that
         // our child process calls setsid but before or simultaneous
@@ -1185,6 +1191,12 @@ const Subprocess = struct {
         while (true) {
             switch (posix.errno(c.killpg(pgid, c.SIGHUP))) {
                 .SUCCESS => log.debug("process group killed pgid={}", .{pgid}),
+                .SRCH => {
+                    // The child may have exited between getpgid and killpg.
+                    // Consume its wait status if the process watcher has not.
+                    _ = try reapExitedChild(pid);
+                    return;
+                },
                 else => |err| killpg: {
                     if ((comptime builtin.target.os.tag.isDarwin()) and
                         err == .PERM)
@@ -1202,10 +1214,33 @@ const Subprocess = struct {
             // The gist is that it lets us detect when children
             // are still alive without blocking so that we can
             // kill them again.
-            const res = posix.waitpid(pid, std.c.W.NOHANG);
-            log.debug("waitpid result={}", .{res.pid});
-            if (res.pid != 0) break;
+            if (try reapExitedChild(pid)) break;
             std.Thread.sleep(10 * std.time.ns_per_ms);
+        }
+    }
+
+    /// Reap the child if it has exited without racing the process watcher.
+    /// Returns true when no further wait is needed and false while the child
+    /// is still running.
+    fn reapExitedChild(pid: c.pid_t) !bool {
+        while (true) {
+            var status: c_int = 0;
+            const result = std.c.waitpid(pid, &status, std.c.W.NOHANG);
+            switch (posix.errno(result)) {
+                .SUCCESS => {
+                    log.debug("waitpid result={}", .{result});
+                    return result != 0;
+                },
+                .INTR => continue,
+
+                // The process watcher won the race and already reaped it.
+                .CHILD => return true,
+
+                else => |err| {
+                    log.warn("error waiting for child pid={} err={}", .{ pid, err });
+                    return error.WaitFailed;
+                },
+            }
         }
     }
 
@@ -1232,13 +1267,15 @@ const Subprocess = struct {
             // Don't know why it would be zero but its not a valid pid
             if (pgid == 0) return null;
 
-            // If the pid doesn't exist then... we're done!
-            if (pgid == c.ESRCH) return null;
-
-            // If we have an error we're done.
             if (pgid < 0) {
-                log.warn("error getting pgid for kill", .{});
-                return null;
+                switch (posix.errno(pgid)) {
+                    // The child already exited or another waiter reaped it.
+                    .SRCH => return null,
+                    else => |err| {
+                        log.warn("error getting pgid for kill err={}", .{err});
+                        return null;
+                    },
+                }
             }
 
             return pgid;
@@ -1398,6 +1435,11 @@ pub const ReadThread = struct {
     /// milliseconds is well under one display frame, so batching is
     /// invisible on screen.
     const gather_budget_ns = 3 * std.time.ns_per_ms;
+
+    /// Events that make a polled descriptor permanently ready. Readable data
+    /// may accompany these events, so callers drain POLLIN before exiting.
+    const terminal_poll_events =
+        posix.POLL.HUP | posix.POLL.ERR | posix.POLL.NVAL;
 
     /// The state shared between the gather and parse stages. This is
     /// a fixed ring of buffers plus the metadata to rotate ownership
@@ -1678,7 +1720,9 @@ pub const ReadThread = struct {
 
                         // On a quit signal we deliver what we have
                         // and stop.
-                        if (pollfds[1].revents & posix.POLL.IN != 0) {
+                        if (pollfds[1].revents &
+                            (posix.POLL.IN | terminal_poll_events) != 0)
+                        {
                             log.info("read thread got quit signal", .{});
                             fatal = true;
                             break :gather;
@@ -1701,11 +1745,15 @@ pub const ReadThread = struct {
                             break :gather;
                         }
 
-                        // HUP without IN means no more data is
-                        // coming. Deliver and let the outer poll
-                        // decide what to do.
-                        if (pollfds[0].revents & posix.POLL.IN == 0)
+                        // Terminal readiness without data means no more data
+                        // is coming. If POLLIN is also set, drain the final
+                        // bytes first; EOF or a read error will end the loop.
+                        if (pollfds[0].revents & terminal_poll_events != 0 and
+                            pollfds[0].revents & posix.POLL.IN == 0)
+                        {
+                            fatal = true;
                             break :gather;
+                        }
 
                         continue :gather;
                     },
@@ -1726,10 +1774,13 @@ pub const ReadThread = struct {
                     },
                 };
 
-                // This happens on macOS instead of WouldBlock when the
-                // child process dies. Deliver what we have and let the
-                // outer poll detect HUP.
-                if (n == 0) break :gather;
+                // EOF is authoritative even when poll omits HUP. Some fd
+                // types remain readable forever after returning zero, so
+                // polling again would turn EOF into a permanent busy loop.
+                if (n == 0) {
+                    fatal = true;
+                    break :gather;
+                }
 
                 total += n;
 
@@ -1762,15 +1813,19 @@ pub const ReadThread = struct {
             };
 
             // If our quit fd is set, we're done.
-            if (pollfds[1].revents & posix.POLL.IN != 0) {
+            if (pollfds[1].revents &
+                (posix.POLL.IN | terminal_poll_events) != 0)
+            {
                 log.info("read thread got quit signal", .{});
                 return;
             }
 
-            // If our pty fd is closed, then we're also done with our
-            // read thread.
-            if (pollfds[0].revents & posix.POLL.HUP != 0) {
-                log.info("pty fd closed, read thread exiting", .{});
+            // Drain any readable tail bytes before honoring a terminal
+            // condition. The next read will end on EOF or an fd error.
+            if (pollfds[0].revents & terminal_poll_events != 0 and
+                pollfds[0].revents & posix.POLL.IN == 0)
+            {
+                log.info("pty fd terminal event, read thread exiting", .{});
                 return;
             }
         }

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -1947,6 +1947,92 @@ pub const ReadThread = struct {
     }
 };
 
+test "io-gather exits on persistent EOF readiness" {
+    if (comptime builtin.os.tag == .windows) return error.SkipZigTest;
+
+    const testing = std.testing;
+    const source = try posix.open(
+        "/dev/null",
+        .{
+            .ACCMODE = .RDONLY,
+            .CLOEXEC = true,
+            .NONBLOCK = true,
+        },
+        0,
+    );
+    defer posix.close(source);
+
+    const quit_pipe = try posix.pipe2(.{
+        .CLOEXEC = true,
+        .NONBLOCK = true,
+    });
+    defer posix.close(quit_pipe[0]);
+    defer posix.close(quit_pipe[1]);
+
+    var pipeline: ReadThread.Pipeline = .{};
+    var returned: std.Thread.ResetEvent = .{};
+    const thread = try std.Thread.spawn(.{}, struct {
+        fn run(
+            fd: posix.fd_t,
+            quit: posix.fd_t,
+            pipeline_ptr: *ReadThread.Pipeline,
+            returned_ptr: *std.Thread.ResetEvent,
+        ) void {
+            ReadThread.gatherMainPosix(fd, quit, pipeline_ptr);
+            returned_ptr.set();
+        }
+    }.run, .{ source, quit_pipe[0], &pipeline, &returned });
+    defer {
+        _ = posix.write(quit_pipe[1], "q") catch {};
+        thread.join();
+    }
+
+    try returned.timedWait(std.time.ns_per_s);
+    try testing.expect(pipeline.done);
+}
+
+test "subprocess stop reaps an already-exited child on Darwin" {
+    if (comptime !builtin.os.tag.isDarwin()) return error.SkipZigTest;
+
+    const testing = std.testing;
+    const c = Subprocess.c;
+    const pid = try posix.fork();
+    if (pid == 0) {
+        _ = c.setsid();
+        c._exit(0);
+    }
+
+    var reaped = false;
+    defer if (!reaped) {
+        var status: c_int = 0;
+        _ = std.c.waitpid(pid, &status, 0);
+    };
+
+    // An exited-but-unreaped child is no longer visible to getpgid on
+    // Darwin. Wait for that state without consuming its wait status.
+    var exited = false;
+    for (0..100) |_| {
+        const pgid = c.getpgid(pid);
+        if (pgid < 0 and posix.errno(pgid) == .SRCH) {
+            exited = true;
+            break;
+        }
+        std.Thread.sleep(10 * std.time.ns_per_ms);
+    }
+    try testing.expect(exited);
+
+    try Subprocess.killPid(pid);
+
+    var status: c_int = 0;
+    const wait_result = std.c.waitpid(pid, &status, std.c.W.NOHANG);
+    const wait_err = posix.errno(wait_result);
+    reaped = wait_result == pid or
+        (wait_result < 0 and wait_err == .CHILD);
+
+    try testing.expectEqual(@as(c.pid_t, -1), wait_result);
+    try testing.expectEqual(posix.E.CHILD, wait_err);
+}
+
 /// Builds the argv array for the process we should exec for the
 /// configured command. This isn't as straightforward as it seems since
 /// we deal with shell-wrapping, macOS login shells, etc.


### PR DESCRIPTION
## Summary
- treat zero-byte PTY reads as terminal EOF, independent of platform-specific poll flags
- handle POLLHUP, POLLERR, and POLLNVAL without dropping readable tail bytes
- reap an already-exited child when surface teardown wins the process-watcher race

## Root cause
The POSIX gather loop treated only POLLHUP as terminal. If read returned zero while poll continued to report immediate readability, the io-gather thread re-polled the permanently-ready descriptor forever. Separately, killPid returned when Darwin getpgid could no longer see an exited child, leaving its wait status unconsumed if teardown raced the normal process watcher.

## Verification
- Test-only commit 8bf503f98 fails on the old implementation:
  - persistent EOF test times out waiting for io-gather to return
  - teardown test observes waitpid returning the zombie child
- Fix commit 5ef5cba63 passes both tests and the full termio.Exec filtered Zig test slice:
  - zig build test -Dtest-filter=termio.Exec

This branch is intentionally rooted at cmux pinned Ghostty SHA c55514dd5. A merge commit makes the scoped fix reachable from fork main while allowing cmux to advance its submodule pointer by only these two commits.

Fixes the Ghostty-owned lifecycle portion of manaflow-ai/cmux#8872.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/143"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787521784&installation_model_id=21920&pr_number=143&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F143&signature=2a35da8324eb594f252d83553881470c0e333df4e06ad1dfd28b307eeec107b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the PTY read thread from spinning on persistent EOF and reaps already-exited children during teardown on Darwin. This prevents CPU burn, lost tail bytes, and zombie processes.

- **Bug Fixes**
  - Treat zero-byte PTY reads as EOF; exit the gather loop even if `poll` reports readable.
  - Handle terminal poll events (`POLLHUP`, `POLLERR`, `POLLNVAL`) without dropping tail bytes; drain `POLLIN` before exit.
  - On Darwin, reap already-exited children in teardown via a non-blocking `waitpid` helper when `getpgid`/`killpg` return `SRCH`.
  - Added tests for persistent EOF readiness and Darwin child reaping.

<sup>Written for commit 5ef5cba6351dbdf315307fc7efd1aaa4a36ab31c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/143?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

