### PR TITLE
Revert renderer lifecycle experiment causing typing lag

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -567,7 +567,6 @@ typedef void (*ghostty_pty_tee_cb)(void* userdata,
 // bookkeeping completes. Metal delivers after assigning its IOSurface on the
 // main thread. Synchronous backends deliver on the rendering caller's thread.
 typedef void (*ghostty_render_presented_cb)(void*, uint64_t);
-typedef void (*ghostty_userdata_release_cb)(void* userdata);
 
 // Content-free renderer activity events emitted only when a surface installs
 // ghostty_renderer_event_cb. Begin/end pairs run on the renderer thread.
@@ -1261,18 +1260,6 @@ GHOSTTY_API ghostty_surface_config_s ghostty_surface_config_new();
 
 GHOSTTY_API ghostty_surface_t ghostty_surface_new(ghostty_app_t,
                                                      const ghostty_surface_config_s*);
-/**
- * Creates a surface that owns `config->userdata`.
- *
- * On success, `release_userdata` is called exactly once with that userdata
- * after surface teardown has stopped internal callbacks and all in-flight app
- * actions have returned. The callback may run on any thread. If creation
- * fails, ownership remains with the caller and the callback is not invoked.
- */
-GHOSTTY_API ghostty_surface_t ghostty_surface_new_with_owned_userdata(
-    ghostty_app_t,
-    const ghostty_surface_config_s*,
-    ghostty_userdata_release_cb release_userdata);
 // cmux fork: create a surface with an embedder-owned scrollback upper bound
 // without changing ghostty_surface_config_s's public ABI. A zero limit inherits
 // the configured scrollback-limit; a nonzero limit can only lower it.

--- a/src/App.zig
+++ b/src/App.zig
@@ -87,39 +87,6 @@ fn hasRtSurfaceLocked(self: *const App, surface: *apprt.Surface) bool {
     return false;
 }
 
-fn hasRedrawSurfaceLocked(
-    self: *const App,
-    redraw: Message.RedrawSurface,
-) bool {
-    for (self.surfaces.items) |surface| {
-        if (surface != redraw.surface) continue;
-        const ticket = redraw.external_ticket orelse return true;
-        return surface.core().id == ticket.surface_id;
-    }
-
-    return false;
-}
-
-const RedrawSurfaceLease = struct {
-    surface: *apprt.Surface,
-
-    fn release(self: RedrawSurfaceLease) void {
-        self.surface.releaseForAppAction();
-    }
-};
-
-fn acquireRedrawSurface(
-    self: *App,
-    redraw: Message.RedrawSurface,
-) ?RedrawSurfaceLease {
-    self.lockSurfaceRegistry();
-    defer self.unlockSurfaceRegistry();
-
-    if (!self.hasRedrawSurfaceLocked(redraw)) return null;
-    redraw.surface.retainForAppAction();
-    return .{ .surface = redraw.surface };
-}
-
 /// General purpose allocator
 alloc: Allocator,
 
@@ -385,7 +352,7 @@ fn drainMailbox(self: *App, rt_app: *apprt.App) !void {
             .new_window => |msg| try self.newWindow(rt_app, msg),
             .close => |surface| self.closeSurface(surface),
             .surface_message => |msg| try self.surfaceMessage(msg.surface, msg.message),
-            .redraw_surface => |redraw| try self.redrawSurface(rt_app, redraw),
+            .redraw_surface => |surface| try self.redrawSurface(rt_app, surface),
 
             // If we're quitting, then we set the quit flag and stop
             // draining the mailbox immediately. This lets us defer
@@ -428,48 +395,15 @@ pub fn focusSurface(self: *App, surface: *Surface) void {
 fn redrawSurface(
     self: *App,
     rt_app: *apprt.App,
-    redraw: Message.RedrawSurface,
+    surface: *apprt.Surface,
 ) !void {
-    const lease = self.acquireRedrawSurface(redraw) orelse return;
-    defer lease.release();
-    const surface = lease.surface;
+    if (!self.hasRtSurface(surface)) return;
 
-    const accepted = rt_app.performAction(
+    _ = try rt_app.performAction(
         .{ .surface = surface.core() },
         .render,
         {},
-    ) catch |err| {
-        if (redraw.external_ticket) |ticket| {
-            self.externalRenderActionCompleted(
-                surface,
-                ticket,
-                false,
-            );
-        }
-        return err;
-    };
-    if (redraw.external_ticket) |ticket| {
-        self.externalRenderActionCompleted(
-            surface,
-            ticket,
-            accepted,
-        );
-    }
-}
-
-fn externalRenderActionCompleted(
-    self: *App,
-    surface: *apprt.Surface,
-    ticket: Message.ExternalRedrawTicket,
-    accepted: bool,
-) void {
-    self.lockSurfaceRegistry();
-    defer self.unlockSurfaceRegistry();
-    if (!self.hasRedrawSurfaceLocked(.{
-        .surface = surface,
-        .external_ticket = ticket,
-    })) return;
-    surface.core().externalRenderActionCompleted(ticket.generation, accepted);
+    );
 }
 
 /// Create a new window
@@ -731,17 +665,7 @@ pub const Message = union(enum) {
     /// use single-threaded draws. To redraw a surface for all runtimes,
     /// wake up the renderer thread. The renderer thread will send this
     /// message if it needs to.
-    redraw_surface: RedrawSurface,
-
-    pub const RedrawSurface = struct {
-        surface: *apprt.Surface,
-        external_ticket: ?ExternalRedrawTicket = null,
-    };
-
-    pub const ExternalRedrawTicket = struct {
-        surface_id: u64,
-        generation: u64,
-    };
+    redraw_surface: *apprt.Surface,
 
     const NewWindow = struct {
         /// The parent surface
@@ -760,25 +684,8 @@ pub const Mailbox = struct {
 
     /// Send a message to the surface.
     pub fn push(self: Mailbox, msg: Message, timeout: Queue.Timeout) Queue.Size {
-        const NoopObserver = struct {
-            fn pushCompleted(_: @This(), _: Queue.Size) void {}
-        };
-        return self.pushObserved(msg, timeout, NoopObserver{});
-    }
-
-    /// Push a message, publish its result to the caller, then publish the
-    /// shared capacity retry and wake the app. The observer closes the race
-    /// where an app drain consumes the wake before a renderer records which
-    /// surface enqueue failed.
-    pub fn pushObserved(
-        self: Mailbox,
-        msg: Message,
-        timeout: Queue.Timeout,
-        observer: anytype,
-    ) Queue.Size {
         const redraw = std.meta.activeTag(msg) == .redraw_surface;
         const result = self.mailbox.push(msg, timeout);
-        observer.pushCompleted(result);
         recordRejectedRedraw(self.redraw_retry_requested, redraw, result);
 
         // Wake up our app loop
@@ -847,117 +754,6 @@ fn testAction(_: *apprt.App, _: apprt.Target.C, _: apprt.Action.C) callconv(.c) 
     return true;
 }
 
-test "external redraw rejects allocator-reused surface address" {
-    if (comptime !@hasField(apprt.App, "opts")) return error.SkipZigTest;
-    if (comptime !@hasField(apprt.Surface, "core_surface")) return error.SkipZigTest;
-
-    if (comptime @hasField(Message.RedrawSurface, "external_ticket")) {
-        const ActionContext = struct {
-            calls: usize = 0,
-
-            fn action(
-                rt_app: *apprt.App,
-                _: apprt.Target.C,
-                _: apprt.Action.C,
-            ) callconv(.c) bool {
-                const self: *@This() = @ptrCast(@alignCast(
-                    rt_app.opts.userdata.?,
-                ));
-                self.calls += 1;
-                return true;
-            }
-        };
-
-        var app: App = undefined;
-        try app.init(std.testing.allocator);
-        defer {
-            app.surfaces.deinit(std.testing.allocator);
-            app.font_grid_set.deinit();
-        }
-
-        var action_context: ActionContext = .{};
-        var rt_app: apprt.App = undefined;
-        rt_app.core_app = &app;
-        rt_app.opts = undefined;
-        rt_app.opts.userdata = &action_context;
-        rt_app.opts.action = ActionContext.action;
-        rt_app.opts.wakeup = testWakeup;
-
-        var surface: apprt.Surface = undefined;
-        surface.app = &rt_app;
-        surface.core_surface.id = 22;
-        try app.surfaces.append(std.testing.allocator, &surface);
-
-        try app.redrawSurface(&rt_app, .{
-            .surface = &surface,
-            .external_ticket = .{
-                .surface_id = 11,
-                .generation = 1,
-            },
-        });
-
-        try std.testing.expectEqual(@as(usize, 0), action_context.calls);
-    } else {
-        try std.testing.expect(false);
-    }
-}
-
-test "redraw action lease defers reentrant embedded surface teardown" {
-    if (comptime !@hasField(apprt.App, "opts")) return error.SkipZigTest;
-    if (comptime !@hasField(apprt.Surface, "core_surface")) return error.SkipZigTest;
-
-    if (comptime @hasDecl(App, "acquireRedrawSurface") and
-        @hasField(apprt.Surface, "app_action_lifetime"))
-    {
-        var app: App = undefined;
-        try app.init(std.testing.allocator);
-        defer {
-            app.surfaces.deinit(std.testing.allocator);
-            app.font_grid_set.deinit();
-        }
-
-        var rt_app: apprt.App = undefined;
-        rt_app.core_app = &app;
-        rt_app.opts = undefined;
-        rt_app.opts.action = testAction;
-        rt_app.opts.wakeup = testWakeup;
-
-        var surface: apprt.Surface = undefined;
-        surface.app = &rt_app;
-        surface.core_surface.id = 22;
-        surface.app_action_lifetime = .{};
-        try app.surfaces.append(std.testing.allocator, &surface);
-
-        const lease = app.acquireRedrawSurface(.{
-            .surface = &surface,
-            .external_ticket = .{
-                .surface_id = 22,
-                .generation = 1,
-            },
-        }).?;
-        try std.testing.expectEqual(
-            @as(usize, 2),
-            surface.app_action_lifetime.countForTesting(),
-        );
-
-        // Models ghostty_surface_free re-entering from the host action. The
-        // owner release must unregister the surface without touching its core
-        // while the action lease is still live.
-        surface.deinit();
-        try std.testing.expect(!app.hasRtSurface(&surface));
-        try std.testing.expectEqual(
-            @as(usize, 1),
-            surface.app_action_lifetime.countForTesting(),
-        );
-
-        // Releasing this fake stack surface would intentionally run its final
-        // destructor. The lifetime state test covers that final transition.
-        _ = lease;
-    } else {
-        try std.testing.expect(false);
-    }
-}
-
 test "full app mailbox retains redraw retry until drain" {
     var queue: Mailbox.Queue = .{};
     var retry_requested = std.atomic.Value(bool).init(false);
@@ -967,9 +763,7 @@ test "full app mailbox retains redraw retry until drain" {
     }
 
     const redraw: Message = .{
-        .redraw_surface = .{
-            .surface = @ptrFromInt(@alignOf(apprt.Surface)),
-        },
+        .redraw_surface = @ptrFromInt(@alignOf(apprt.Surface)),
     };
     const rejected = queue.push(redraw, .instant);
     try std.testing.expectEqual(0, rejected);
@@ -985,66 +779,6 @@ test "full app mailbox retains redraw retry until drain" {
     try std.testing.expectEqual(64, drained);
     try std.testing.expect(takeRedrawRetryRequest(&retry_requested));
     try std.testing.expect(!takeRedrawRetryRequest(&retry_requested));
-}
-
-test "observed mailbox push publishes failure before retry wake" {
-    if (comptime !@hasField(apprt.App, "opts")) return error.SkipZigTest;
-
-    const Ordering = struct {
-        observed: bool = false,
-        woke_after_observer: bool = false,
-        woke_after_retry_publication: bool = false,
-        retry_requested: *std.atomic.Value(bool),
-
-        fn wakeup(userdata: ?*anyopaque) callconv(.c) void {
-            const self: *@This() = @ptrCast(@alignCast(userdata.?));
-            self.woke_after_observer = self.observed;
-            self.woke_after_retry_publication =
-                self.retry_requested.load(.acquire);
-        }
-    };
-    const Observer = struct {
-        ordering: *Ordering,
-
-        fn pushCompleted(
-            self: @This(),
-            queue_size: Mailbox.Queue.Size,
-        ) void {
-            self.ordering.observed = queue_size == 0;
-        }
-    };
-
-    var queue: Mailbox.Queue = .{};
-    var retry_requested = std.atomic.Value(bool).init(false);
-    var ordering: Ordering = .{
-        .retry_requested = &retry_requested,
-    };
-    var rt_app: apprt.App = undefined;
-    rt_app.opts = undefined;
-    rt_app.opts.userdata = &ordering;
-    rt_app.opts.wakeup = Ordering.wakeup;
-    const mailbox: Mailbox = .{
-        .rt_app = &rt_app,
-        .mailbox = &queue,
-        .redraw_retry_requested = &retry_requested,
-    };
-
-    for (0..64) |_| {
-        try std.testing.expect(queue.push(.{ .open_config = {} }, .instant) > 0);
-    }
-    const result = mailbox.pushObserved(
-        .{
-            .redraw_surface = .{
-                .surface = @ptrFromInt(@alignOf(apprt.Surface)),
-            },
-        },
-        .instant,
-        Observer{ .ordering = &ordering },
-    );
-
-    try std.testing.expectEqual(@as(Mailbox.Queue.Size, 0), result);
-    try std.testing.expect(ordering.woke_after_observer);
-    try std.testing.expect(ordering.woke_after_retry_publication);
 }
 
 test "surface registry mutations are serialized" {

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -928,20 +928,6 @@ pub fn appMailboxDrained(self: *Surface) void {
     self.renderer_thread.appMailboxDrained();
 }
 
-/// Acknowledge whether the embedder accepted an externally requested render.
-/// The renderer owns retry/coalescing state; the app thread only reports the
-/// result while this surface remains registered.
-pub fn externalRenderActionCompleted(
-    self: *Surface,
-    generation: u64,
-    accepted: bool,
-) void {
-    self.renderer_thread.externalRenderActionCompleted(
-        generation,
-        accepted,
-    );
-}
-
 /// Close this surface. This will trigger the runtime to start the
 /// close process, which should ultimately deinitialize this surface.
 pub fn close(self: *Surface) void {
@@ -3753,10 +3739,22 @@ pub fn occlusionCallback(self: *Surface, visible: bool) !void {
     crash.sentry.thread_state = self.crashThreadState();
     defer crash.sentry.thread_state = null;
 
-    // Surface lifecycle callbacks run on the embedder's UI executor. Publish
-    // idempotent state through the renderer thread's coalesced latest-value
-    // path so a full mailbox or wedged renderer can never park that executor.
-    self.renderer_thread.publishVisible(visible);
+    // cmux iOS fork: this runs on the MAIN thread (the iOS embedder calls
+    // `set_occlusion` from `@MainActor` lifecycle code). A `.forever` push here
+    // blocks main until `render_now` drains the renderer mailbox, while a
+    // serial-queue `surface_mailbox` `.forever` push blocks the serial queue
+    // until the main-thread app tick drains it: main waits for serial, serial
+    // waits for main = permanent deadlock. Invariant: nothing reachable from the
+    // iOS render serial queue (here: via the renderer mailbox it shares) may
+    // block unboundedly. `.visible` is an idempotent bool and `Message.deinit`
+    // frees nothing for it, so an instant drop leaks nothing. The companion gate
+    // in `renderer/Thread.zig:drawFrame` keeps iOS rendering even if a
+    // `.visible=true` is dropped (Swift owns occlusion via `renderingSuspended`).
+    if (comptime builtin.os.tag == .ios) {
+        _ = self.renderer_thread.mailbox.push(.{ .visible = visible }, .{ .instant = {} });
+    } else {
+        _ = self.renderer_thread.mailbox.push(.{ .visible = visible }, .{ .forever = {} });
+    }
     try self.queueRender();
 }
 
@@ -3773,9 +3771,19 @@ pub fn focusCallback(self: *Surface, focused: bool) !void {
     if (self.focused == focused) return;
     self.focused = focused;
 
-    // Focus is latest-value lifecycle state. Publishing it cannot wait for the
-    // renderer mailbox that the renderer itself must drain.
-    self.renderer_thread.publishFocused(focused);
+    // Notify our render thread of the new state.
+    //
+    // cmux iOS fork: runs on the MAIN thread (the iOS embedder calls `set_focus`
+    // from `@MainActor` code). Same main↔serial renderer-mailbox deadlock as
+    // `.visible` above; gate to a non-blocking instant push. `.focus` is an
+    // idempotent bool that `drawFrame` re-reads each frame and `Message.deinit`
+    // frees nothing for it, so a drop at worst shows a hollow cursor until the
+    // next focus change. macOS keeps the proven blocking path.
+    if (comptime builtin.os.tag == .ios) {
+        _ = self.renderer_thread.mailbox.push(.{ .focus = focused }, .{ .instant = {} });
+    } else {
+        _ = self.renderer_thread.mailbox.push(.{ .focus = focused }, .{ .forever = {} });
+    }
 
     if (!focused) unfocused: {
         // If we lost focus and we have a keypress, then we want to send a key

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -264,25 +264,22 @@ pub const App = struct {
         self: *App,
         opts: Surface.Options,
         scrollback_limit_bytes: usize,
-        userdata_release_cb: ?UserdataReleaseCallback,
     ) !*Surface {
         // Grab a surface allocation because we're going to need it.
         var surface = try self.core_app.alloc.create(Surface);
         errdefer self.core_app.alloc.destroy(surface);
 
         // Create the surface
-        try surface.init(
-            self,
-            opts,
-            scrollback_limit_bytes,
-            userdata_release_cb,
-        );
+        try surface.init(self, opts, scrollback_limit_bytes);
+        errdefer surface.deinit();
+
         return surface;
     }
 
     /// Close the given surface.
-    pub fn closeSurface(_: *App, surface: *Surface) void {
+    pub fn closeSurface(self: *App, surface: *Surface) void {
         surface.deinit();
+        self.core_app.alloc.destroy(surface);
     }
 
     pub fn redrawInspector(self: *App, surface: *Surface) void {
@@ -298,13 +295,6 @@ pub const App = struct {
         comptime action: apprt.Action.Key,
         value: apprt.Action.Value(action),
     ) !bool {
-        const userdata_lease: ?SurfaceUserdata.Lease = switch (target) {
-            .app => null,
-            .surface => |surface| surface.rt_surface.userdata.acquire() orelse
-                return false,
-        };
-        defer if (userdata_lease) |lease| lease.release();
-
         // Special case certain actions before they are sent to the
         // embedded apprt.
         self.performPreAction(target, action, value);
@@ -674,151 +664,12 @@ pub const IoWriteCallback = *const fn (?*anyopaque, [*]const u8, usize) callconv
 pub const PtyTeeCallback = *const fn (?*anyopaque, [*]const u8, usize) callconv(.c) void;
 pub const RendererEventCallback = renderer.InstrumentationCallback;
 pub const RenderPresentedCallback = *const fn (?*anyopaque, u64) callconv(.c) void;
-pub const UserdataReleaseCallback = *const fn (?*anyopaque) callconv(.c) void;
-
-const SurfaceUserdata = struct {
-    value: ?*anyopaque = null,
-    state: State = .borrowed,
-
-    const State = union(enum) {
-        borrowed,
-        owned: *Lifetime,
-        released,
-    };
-
-    const Lifetime = struct {
-        alloc: Allocator,
-        value: ?*anyopaque,
-        release_cb: UserdataReleaseCallback,
-        references: std.atomic.Value(usize) = .{ .raw = 1 },
-
-        fn tryRetain(self: *Lifetime) bool {
-            var count = self.references.load(.seq_cst);
-            while (count > 0) {
-                assert(count < std.math.maxInt(usize));
-                if (self.references.cmpxchgWeak(
-                    count,
-                    count + 1,
-                    .seq_cst,
-                    .seq_cst,
-                )) |actual| {
-                    count = actual;
-                } else {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
-        fn release(self: *Lifetime) void {
-            const previous = self.references.fetchSub(1, .seq_cst);
-            assert(previous > 0);
-            if (previous != 1) return;
-
-            const alloc = self.alloc;
-            const value = self.value;
-            const release_cb = self.release_cb;
-            release_cb(value);
-            alloc.destroy(self);
-        }
-    };
-
-    const Lease = struct {
-        lifetime: ?*Lifetime,
-
-        fn release(self: Lease) void {
-            if (self.lifetime) |lifetime| lifetime.release();
-        }
-    };
-
-    fn init(
-        alloc: Allocator,
-        value: ?*anyopaque,
-        release_cb: ?UserdataReleaseCallback,
-    ) Allocator.Error!SurfaceUserdata {
-        const callback = release_cb orelse return .{ .value = value };
-        const lifetime = try alloc.create(Lifetime);
-        lifetime.* = .{
-            .alloc = alloc,
-            .value = value,
-            .release_cb = callback,
-        };
-        return .{
-            .value = value,
-            .state = .{ .owned = lifetime },
-        };
-    }
-
-    fn acquire(self: *const SurfaceUserdata) ?Lease {
-        return switch (self.state) {
-            .borrowed => .{ .lifetime = null },
-            .owned => |lifetime| if (lifetime.tryRetain())
-                .{ .lifetime = lifetime }
-            else
-                null,
-            .released => null,
-        };
-    }
-
-    fn abort(self: *SurfaceUserdata) void {
-        const lifetime = switch (self.state) {
-            .owned => |lifetime| lifetime,
-            .borrowed, .released => {
-                self.state = .released;
-                self.value = null;
-                return;
-            },
-        };
-        self.state = .released;
-        self.value = null;
-        assert(lifetime.references.load(.seq_cst) == 1);
-        lifetime.alloc.destroy(lifetime);
-    }
-
-    fn deinit(self: *SurfaceUserdata) void {
-        const lifetime = switch (self.state) {
-            .owned => |lifetime| lifetime,
-            .borrowed, .released => {
-                self.state = .released;
-                self.value = null;
-                return;
-            },
-        };
-        self.state = .released;
-        self.value = null;
-        lifetime.release();
-    }
-};
-
-const SurfaceActionLifetime = struct {
-    references: std.atomic.Value(usize) = .{ .raw = 1 },
-
-    fn retain(self: *SurfaceActionLifetime) void {
-        const previous = self.references.fetchAdd(1, .seq_cst);
-        assert(previous > 0);
-        assert(previous < std.math.maxInt(usize));
-    }
-
-    /// Returns true when the caller released the final reference.
-    fn release(self: *SurfaceActionLifetime) bool {
-        const previous = self.references.fetchSub(1, .seq_cst);
-        assert(previous > 0);
-        return previous == 1;
-    }
-
-    pub fn countForTesting(self: *const SurfaceActionLifetime) usize {
-        if (!builtin.is_test) @compileError("testing only");
-        return self.references.load(.seq_cst);
-    }
-};
 
 pub const Surface = struct {
     app: *App,
     platform: Platform,
-    userdata: SurfaceUserdata = .{},
+    userdata: ?*anyopaque = null,
     core_surface: CoreSurface,
-    app_action_lifetime: SurfaceActionLifetime = .{},
     content_scale: apprt.ContentScale,
     size: apprt.SurfaceSize,
     cursor_pos: apprt.CursorPos,
@@ -912,19 +763,11 @@ pub const Surface = struct {
         app: *App,
         opts: Options,
         scrollback_limit_bytes: usize,
-        userdata_release_cb: ?UserdataReleaseCallback,
     ) !void {
-        var userdata = try SurfaceUserdata.init(
-            app.core_app.alloc,
-            opts.userdata,
-            userdata_release_cb,
-        );
-        errdefer userdata.abort();
-
         self.* = .{
             .app = app,
             .platform = try .init(opts.platform_tag, opts.platform),
-            .userdata = userdata,
+            .userdata = opts.userdata,
             .core_surface = undefined,
             .content_scale = .{
                 .x = @floatCast(opts.scale_factor),
@@ -1111,38 +954,17 @@ pub const Surface = struct {
     }
 
     pub fn deinit(self: *Surface) void {
-        // Stop new app actions before releasing the embedder's owner
-        // reference. An action already in progress retains this allocation and
-        // performs the final destruction after its reentrant host callback
-        // returns.
-        self.app.core_app.deleteSurface(self);
-        if (self.app_action_lifetime.release()) self.destroy();
-    }
-
-    /// Retain the opaque embedded surface while an app action is dispatched.
-    /// The core app calls this only while holding its surface registry lock,
-    /// so teardown cannot remove and release the owner reference first.
-    pub fn retainForAppAction(self: *Surface) void {
-        self.app_action_lifetime.retain();
-    }
-
-    pub fn releaseForAppAction(self: *Surface) void {
-        if (self.app_action_lifetime.release()) self.destroy();
-    }
-
-    fn destroy(self: *Surface) void {
-        const alloc = self.app.core_app.alloc;
-
         // Shut down our inspector
         self.freeInspector();
 
         // Free our title
-        if (self.title) |v| alloc.free(v);
+        if (self.title) |v| self.app.core_app.alloc.free(v);
+
+        // Remove ourselves from the list of known surfaces in the app.
+        self.app.core_app.deleteSurface(self);
 
         // Clean up our core surface so that all the rendering and IO stop.
         self.core_surface.deinit();
-        self.userdata.deinit();
-        alloc.destroy(self);
     }
 
     /// Initialize the inspector instance. A surface can only have one
@@ -1175,27 +997,23 @@ pub const Surface = struct {
         return self.app;
     }
 
-    pub fn close(self: *Surface, process_alive: bool) void {
+    pub fn close(self: *const Surface, process_alive: bool) void {
         const func = self.app.opts.close_surface orelse {
             log.info("runtime embedder does not support closing a surface", .{});
             return;
         };
-        const userdata_lease = self.userdata.acquire() orelse return;
-        defer userdata_lease.release();
 
-        func(self.userdata.value, process_alive);
+        func(self.userdata, process_alive);
     }
 
     pub fn tmuxControl(
-        self: *Surface,
+        self: *const Surface,
         event: apprt.surface.Message.TmuxControlMsg.Event,
         id: u32,
         data: []const u8,
     ) void {
         const func = self.app.opts.tmux_control orelse return;
-        const userdata_lease = self.userdata.acquire() orelse return;
-        defer userdata_lease.release();
-        func(self.userdata.value, event, id, data.ptr, data.len);
+        func(self.userdata, event, id, data.ptr, data.len);
     }
 
     pub fn getContentScale(self: *const Surface) !apprt.ContentScale {
@@ -1223,79 +1041,30 @@ pub const Surface = struct {
     }
 
     pub fn ioWriteCallback(self: *const Surface) ?IoWriteCallback {
-        return if (self.io_write_cb != null) ioWrite else null;
+        return self.io_write_cb;
     }
 
     pub fn ioWriteUserdata(self: *const Surface) ?*anyopaque {
-        return if (self.io_write_cb != null) @constCast(self) else null;
-    }
-
-    fn ioWrite(
-        userdata: ?*anyopaque,
-        data: [*]const u8,
-        len: usize,
-    ) callconv(.c) void {
-        const self: *Surface = @ptrCast(@alignCast(userdata.?));
-        const callback = self.io_write_cb orelse return;
-        const userdata_lease = self.userdata.acquire() orelse return;
-        defer userdata_lease.release();
-        callback(self.io_write_userdata, data, len);
+        return self.io_write_userdata;
     }
 
     pub fn ptyTeeCallback(self: *const Surface) ?PtyTeeCallback {
-        return if (self.pty_tee_cb != null) ptyTee else null;
+        return self.pty_tee_cb;
     }
 
     pub fn ptyTeeUserdata(self: *const Surface) ?*anyopaque {
-        return if (self.pty_tee_cb != null) @constCast(self) else null;
-    }
-
-    fn ptyTee(
-        userdata: ?*anyopaque,
-        data: [*]const u8,
-        len: usize,
-    ) callconv(.c) void {
-        const self: *Surface = @ptrCast(@alignCast(userdata.?));
-        const callback = self.pty_tee_cb orelse return;
-        const userdata_lease = self.userdata.acquire() orelse return;
-        defer userdata_lease.release();
-        callback(self.pty_tee_userdata, data, len);
-    }
-
-    fn setPtyTeeCallback(
-        self: *Surface,
-        callback: ?PtyTeeCallback,
-        userdata: ?*anyopaque,
-    ) void {
-        self.pty_tee_cb = callback;
-        self.pty_tee_userdata = userdata;
-        self.core_surface.io.pty_tee_cb = if (callback != null) ptyTee else null;
-        self.core_surface.io.pty_tee_userdata = if (callback != null) self else null;
+        return self.pty_tee_userdata;
     }
 
     pub fn suppressTerminalResponses(self: *const Surface) bool {
         return self.io_mode.suppressesTerminalResponses();
     }
 
-    pub fn rendererInstrumentation(self: *Surface) renderer.Instrumentation {
+    pub fn rendererInstrumentation(self: *const Surface) renderer.Instrumentation {
         return .{
-            .callback = if (self.renderer_event_cb != null)
-                rendererEvent
-            else
-                null,
-            .userdata = self,
+            .callback = self.renderer_event_cb,
+            .userdata = self.userdata,
         };
-    }
-
-    fn rendererEvent(
-        userdata: ?*anyopaque,
-        event: renderer.InstrumentationEvent,
-    ) callconv(.c) void {
-        const self: *Surface = @ptrCast(@alignCast(userdata.?));
-        const callback = self.renderer_event_cb orelse return;
-        const userdata_lease = self.userdata.acquire() orelse return;
-        defer userdata_lease.release();
-        callback(self.userdata.value, event);
     }
 
     pub fn getTitle(self: *Surface) ?[:0]const u8 {
@@ -1326,10 +1095,8 @@ pub const Surface = struct {
         errdefer alloc.destroy(state_ptr);
         state_ptr.* = state;
 
-        const userdata_lease = self.userdata.acquire() orelse return false;
-        defer userdata_lease.release();
         const started = self.app.opts.read_clipboard(
-            self.userdata.value,
+            self.userdata,
             @intCast(@intFromEnum(clipboard_type)),
             state_ptr,
         );
@@ -1359,10 +1126,8 @@ pub const Surface = struct {
             error.UnsafePaste,
             error.UnauthorizedPaste,
             => {
-                const userdata_lease = self.userdata.acquire() orelse return;
-                defer userdata_lease.release();
                 self.app.opts.confirm_read_clipboard(
-                    self.userdata.value,
+                    self.userdata,
                     str.ptr,
                     state,
                     state.*,
@@ -1380,7 +1145,7 @@ pub const Surface = struct {
     }
 
     pub fn setClipboard(
-        self: *Surface,
+        self: *const Surface,
         clipboard_type: apprt.Clipboard,
         contents: []const apprt.ClipboardContent,
         confirm: bool,
@@ -1395,10 +1160,8 @@ pub const Surface = struct {
             };
         }
 
-        const userdata_lease = self.userdata.acquire() orelse return;
-        defer userdata_lease.release();
         self.app.opts.write_clipboard(
-            self.userdata.value,
+            self.userdata,
             @intCast(@intFromEnum(clipboard_type)),
             array.ptr,
             array.len,
@@ -1430,27 +1193,16 @@ pub const Surface = struct {
     }
 
     pub fn renderNowWithToken(self: *Surface, token: u64) void {
-        if (self.render_presented_cb == null) {
+        const callback = self.render_presented_cb orelse {
             self.renderNow();
             return;
-        }
+        };
         self.core_surface.applyPendingResizeIfNeeded();
         self.core_surface.renderer_thread.renderNowWithPresentation(.{
-            .callback = renderPresented,
-            .userdata = self,
+            .callback = callback,
+            .userdata = self.render_presented_userdata,
             .token = token,
         });
-    }
-
-    fn renderPresented(
-        userdata: ?*anyopaque,
-        token: u64,
-    ) callconv(.c) void {
-        const self: *Surface = @ptrCast(@alignCast(userdata.?));
-        const callback = self.render_presented_cb orelse return;
-        const userdata_lease = self.userdata.acquire() orelse return;
-        defer userdata_lease.release();
-        callback(self.render_presented_userdata, token);
     }
 
     pub fn updateContentScale(self: *Surface, x: f64, y: f64) void {
@@ -1702,138 +1454,6 @@ pub const Surface = struct {
         return .{ .x = pos.x * scale.x, .y = pos.y * scale.y };
     }
 };
-
-test "surface action lifetime defers owner destruction until lease release" {
-    const Lifetime = if (@hasDecl(@This(), "SurfaceActionLifetime"))
-        @field(@This(), "SurfaceActionLifetime")
-    else
-        struct {
-            fn retain(_: *@This()) void {}
-            fn release(_: *@This()) bool {
-                return false;
-            }
-        };
-
-    var lifetime: Lifetime = .{};
-    lifetime.retain();
-    try std.testing.expect(!lifetime.release());
-    try std.testing.expect(lifetime.release());
-}
-
-test "owned surface userdata releases after final action lease" {
-    const ReleaseState = struct {
-        releases: usize = 0,
-
-        fn release(userdata: ?*anyopaque) callconv(.c) void {
-            const self: *@This() = @ptrCast(@alignCast(userdata.?));
-            self.releases += 1;
-        }
-    };
-
-    var state: ReleaseState = .{};
-    var userdata = try SurfaceUserdata.init(
-        std.testing.allocator,
-        &state,
-        ReleaseState.release,
-    );
-    var lifetime: SurfaceActionLifetime = .{};
-    lifetime.retain();
-
-    if (lifetime.release()) userdata.deinit();
-    try std.testing.expectEqual(@as(usize, 0), state.releases);
-
-    if (lifetime.release()) userdata.deinit();
-    try std.testing.expectEqual(@as(usize, 1), state.releases);
-
-    userdata.deinit();
-    try std.testing.expectEqual(@as(usize, 1), state.releases);
-}
-
-test "owned surface userdata remains alive through host callback lease" {
-    const ReleaseState = struct {
-        releases: usize = 0,
-
-        fn release(userdata: ?*anyopaque) callconv(.c) void {
-            const self: *@This() = @ptrCast(@alignCast(userdata.?));
-            self.releases += 1;
-        }
-    };
-
-    var state: ReleaseState = .{};
-    var userdata = try SurfaceUserdata.init(
-        std.testing.allocator,
-        &state,
-        ReleaseState.release,
-    );
-    const callback_lease = userdata.acquire().?;
-
-    userdata.deinit();
-    try std.testing.expectEqual(@as(usize, 0), state.releases);
-    try std.testing.expect(userdata.acquire() == null);
-
-    callback_lease.release();
-    try std.testing.expectEqual(@as(usize, 1), state.releases);
-}
-
-test "post-construction PTY tee retains owned userdata through callback" {
-    const ReleaseState = struct {
-        releases: usize = 0,
-
-        fn release(userdata: ?*anyopaque) callconv(.c) void {
-            const self: *@This() = @ptrCast(@alignCast(userdata.?));
-            self.releases += 1;
-        }
-    };
-
-    const CallbackState = struct {
-        surface: *Surface,
-        release_state: *ReleaseState,
-        releases_during_callback: usize = 0,
-
-        fn callback(
-            userdata: ?*anyopaque,
-            _: [*]const u8,
-            _: usize,
-        ) callconv(.c) void {
-            const self: *@This() = @ptrCast(@alignCast(userdata.?));
-            self.surface.userdata.deinit();
-            self.releases_during_callback = self.release_state.releases;
-        }
-    };
-
-    var release_state: ReleaseState = .{};
-    var surface: Surface = undefined;
-    surface.userdata = try SurfaceUserdata.init(
-        std.testing.allocator,
-        &release_state,
-        ReleaseState.release,
-    );
-    surface.pty_tee_cb = null;
-    surface.pty_tee_userdata = null;
-
-    var callback_state: CallbackState = .{
-        .surface = &surface,
-        .release_state = &release_state,
-    };
-    CAPI.ghostty_surface_set_pty_tee_cb(
-        &surface,
-        CallbackState.callback,
-        &callback_state,
-    );
-
-    const data = "x";
-    surface.core_surface.io.pty_tee_cb.?(
-        surface.core_surface.io.pty_tee_userdata,
-        data.ptr,
-        data.len,
-    );
-
-    try std.testing.expectEqual(
-        @as(usize, 0),
-        callback_state.releases_during_callback,
-    );
-    try std.testing.expectEqual(@as(usize, 1), release_state.releases);
-}
 
 // The cmux integration combines the OpenGL platform payload (the largest
 // Platform.C variant) with the startup PTY tee fields. Keep the resulting C
@@ -2432,19 +2052,7 @@ pub const CAPI = struct {
         app: *App,
         opts: *const apprt.Surface.Options,
     ) ?*Surface {
-        return surface_new_(app, opts, 0, null) catch |err| {
-            log.err("error initializing surface err={}", .{err});
-            return null;
-        };
-    }
-
-    /// Create a surface that owns its userdata until final destruction.
-    export fn ghostty_surface_new_with_owned_userdata(
-        app: *App,
-        opts: *const apprt.Surface.Options,
-        userdata_release_cb: UserdataReleaseCallback,
-    ) ?*Surface {
-        return surface_new_(app, opts, 0, userdata_release_cb) catch |err| {
+        return surface_new_(app, opts, 0) catch |err| {
             log.err("error initializing surface err={}", .{err});
             return null;
         };
@@ -2457,7 +2065,7 @@ pub const CAPI = struct {
         opts: *const apprt.Surface.Options,
         scrollback_limit_bytes: usize,
     ) ?*Surface {
-        return surface_new_(app, opts, scrollback_limit_bytes, null) catch |err| {
+        return surface_new_(app, opts, scrollback_limit_bytes) catch |err| {
             log.err("error initializing surface err={}", .{err});
             return null;
         };
@@ -2467,13 +2075,8 @@ pub const CAPI = struct {
         app: *App,
         opts: *const apprt.Surface.Options,
         scrollback_limit_bytes: usize,
-        userdata_release_cb: ?UserdataReleaseCallback,
     ) !*Surface {
-        return try app.newSurface(
-            opts.*,
-            scrollback_limit_bytes,
-            userdata_release_cb,
-        );
+        return try app.newSurface(opts.*, scrollback_limit_bytes);
     }
 
     export fn ghostty_surface_free(ptr: *Surface) void {
@@ -2482,7 +2085,7 @@ pub const CAPI = struct {
 
     /// Returns the userdata associated with the surface.
     export fn ghostty_surface_userdata(surface: *Surface) ?*anyopaque {
-        return surface.userdata.value;
+        return surface.userdata;
     }
 
     /// Returns the app associated with a surface.
@@ -3988,10 +3591,11 @@ pub const CAPI = struct {
     /// matching grid. Upstream candidate.
     export fn ghostty_surface_set_pty_tee_cb(
         surface: *Surface,
-        cb: ?PtyTeeCallback,
+        cb: ?*const fn (?*anyopaque, [*]const u8, usize) callconv(.c) void,
         userdata: ?*anyopaque,
     ) void {
-        surface.setPtyTeeCallback(cb, userdata);
+        surface.core_surface.io.pty_tee_cb = cb;
+        surface.core_surface.io.pty_tee_userdata = userdata;
     }
 
     /// Returns true if the surface currently has mouse capturing
@@ -4294,7 +3898,10 @@ pub const CAPI = struct {
     const Darwin = struct {
         export fn ghostty_surface_set_display_id(ptr: *Surface, display_id: u32) void {
             const surface = &ptr.core_surface;
-            surface.renderer_thread.publishDisplayID(display_id);
+            _ = surface.renderer_thread.mailbox.push(
+                .{ .macos_display_id = display_id },
+                .{ .forever = {} },
+            );
             surface.renderer_thread.wakeup.notify() catch {};
         }
 

--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -15,16 +15,6 @@ pub fn deinit(self: *Self) void {
     _ = self;
 }
 
-/// Keep the GObject and its embedded runtime surface alive while an app action
-/// invokes a potentially reentrant host callback.
-pub fn retainForAppAction(self: *Self) void {
-    _ = self.surface.ref();
-}
-
-pub fn releaseForAppAction(self: *Self) void {
-    self.surface.unref();
-}
-
 /// Returns the GObject surface for this apprt surface. This is a function
 /// so we can add some extra logic if we ever have to here.
 pub fn gobj(self: *Self) *Surface {

--- a/src/apprt/none.zig
+++ b/src/apprt/none.zig
@@ -16,7 +16,4 @@ pub const App = struct {
         return false;
     }
 };
-pub const Surface = struct {
-    pub fn retainForAppAction(_: *@This()) void {}
-    pub fn releaseForAppAction(_: *@This()) void {}
-};
+pub const Surface = struct {};

--- a/src/datastruct/blocking_queue.zig
+++ b/src/datastruct/blocking_queue.zig
@@ -156,18 +156,6 @@ pub fn BlockingQueue(
             return self.data[n];
         }
 
-        /// Return the number of values currently queued.
-        ///
-        /// Consumers can use this to bound one processing turn to a snapshot
-        /// of the queue. Producers may add more values after this returns, but
-        /// a single-consumer queue retains at least this many values until that
-        /// consumer pops them.
-        pub fn count(self: *Self) Size {
-            self.mutex.lock();
-            defer self.mutex.unlock();
-            return self.len;
-        }
-
         /// Pop all values from the queue. This will hold the big mutex
         /// until `deinit` is called on the return value. This is used if
         /// you know you're going to "pop" and utilize all the values
@@ -241,25 +229,6 @@ test "basic push and pop" {
 
     // Verify we can still push
     try testing.expectEqual(@as(Q.Size, 1), q.push(1, .{ .instant = {} }));
-}
-
-test "count snapshots one bounded consumer turn" {
-    const testing = std.testing;
-    const Q = BlockingQueue(u64, 4);
-    const q = try Q.create(testing.allocator);
-    defer q.destroy(testing.allocator);
-
-    try testing.expectEqual(@as(Q.Size, 1), q.push(1, .{ .instant = {} }));
-    try testing.expectEqual(@as(Q.Size, 2), q.push(2, .{ .instant = {} }));
-
-    var remaining = q.count();
-    try testing.expectEqual(@as(Q.Size, 3), q.push(3, .{ .instant = {} }));
-    while (remaining > 0) : (remaining -= 1) {
-        _ = q.pop().?;
-    }
-
-    try testing.expectEqual(@as(u64, 3), q.pop().?);
-    try testing.expectEqual(@as(Q.Size, 0), q.count());
 }
 
 test "timed push" {

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -43,89 +43,6 @@ const VisibilityDrainState = struct {
     }
 };
 
-/// Latest-value publication for surface lifecycle state. These values are
-/// idempotent and have no owned payloads, so producers can replace an unread
-/// request instead of waiting for space in the ordered renderer mailbox.
-///
-/// Each property has its own atomic slot. Zero means no pending request;
-/// booleans use one/ two for false/true, and display ids are offset by one so
-/// every u32 value remains representable. A producer that races `take` either
-/// lands in the returned update or remains pending for the next renderer wake.
-const SurfaceStateRequests = struct {
-    const Update = struct {
-        visible: ?bool = null,
-        focused: ?bool = null,
-        display_id: ?u32 = null,
-    };
-
-    visible: std.atomic.Value(u8) = std.atomic.Value(u8).init(0),
-    focused: std.atomic.Value(u8) = std.atomic.Value(u8).init(0),
-    display_id: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
-
-    fn publishVisible(self: *SurfaceStateRequests, value: bool) void {
-        self.visible.store(if (value) 2 else 1, .release);
-    }
-
-    fn publishFocused(self: *SurfaceStateRequests, value: bool) void {
-        self.focused.store(if (value) 2 else 1, .release);
-    }
-
-    fn publishDisplayID(self: *SurfaceStateRequests, value: u32) void {
-        self.display_id.store(@as(u64, value) + 1, .release);
-    }
-
-    fn restoreFocusedIfEmpty(
-        self: *SurfaceStateRequests,
-        value: bool,
-    ) void {
-        _ = self.focused.cmpxchgStrong(
-            0,
-            if (value) 2 else 1,
-            .release,
-            .monotonic,
-        );
-    }
-
-    fn restoreDisplayIDIfEmpty(
-        self: *SurfaceStateRequests,
-        value: u32,
-    ) void {
-        _ = self.display_id.cmpxchgStrong(
-            0,
-            @as(u64, value) + 1,
-            .release,
-            .monotonic,
-        );
-    }
-
-    fn take(self: *SurfaceStateRequests) Update {
-        return .{
-            .visible = decodeBool(self.visible.swap(0, .acq_rel)),
-            .focused = decodeBool(self.focused.swap(0, .acq_rel)),
-            .display_id = decodeDisplayID(self.display_id.swap(0, .acq_rel)),
-        };
-    }
-
-    fn hasPending(self: *const SurfaceStateRequests) bool {
-        return self.visible.load(.acquire) != 0 or
-            self.focused.load(.acquire) != 0 or
-            self.display_id.load(.acquire) != 0;
-    }
-
-    fn decodeBool(value: u8) ?bool {
-        return switch (value) {
-            0 => null,
-            1 => false,
-            2 => true,
-            else => unreachable,
-        };
-    }
-
-    fn decodeDisplayID(value: u64) ?u32 {
-        return if (value == 0) null else @intCast(value - 1);
-    }
-};
-
 const DrawFrameResult = enum {
     skipped_invisible,
     deferred_to_vsync,
@@ -213,157 +130,6 @@ const VisibilityRegainState = struct {
 const MailboxDrainResult = struct {
     visibility_regain_started: bool = false,
     rendered_visibility_regain: bool = false,
-    wake_pending: bool = false,
-};
-
-/// Service one finite mailbox turn for a synchronous renderer and retain a
-/// follow-up turn on both success and failure. The caller renders after this
-/// returns, so a continuously replenished queue cannot postpone the frame.
-fn drainSynchronousMailbox(context: anytype) !void {
-    defer context.scheduleRendererContinuationIfNeeded();
-    _ = try context.drainMailbox();
-}
-
-fn scheduleExternalRendererContinuation(context: anytype) void {
-    const generation =
-        context.requestExternalRendererContinuation() orelse return;
-    context.enqueueExternalRendererContinuation(generation);
-}
-
-fn retryExternalRendererContinuation(context: anytype) void {
-    const generation =
-        context.retryFailedExternalRendererContinuation() orelse return;
-    context.enqueueExternalRendererContinuation(generation);
-}
-
-/// Owns one ticketed external-redraw delivery at a time.
-///
-/// The generation travels with the app-mailbox message, so a stale host
-/// acknowledgment cannot mutate a newer request. All transitions are short
-/// critical sections; mailbox pushes, host callbacks, and renderer work occur
-/// after the mutex is released.
-const ExternalRedrawDelivery = struct {
-    const Phase = enum {
-        queued,
-        enqueue_failed,
-    };
-
-    const Request = struct {
-        generation: u64,
-        phase: Phase,
-    };
-
-    mutex: std.Thread.Mutex = .{},
-    next_generation: u64 = 0,
-    active: ?Request = null,
-    wake_behind_active: bool = false,
-
-    /// Claim a ticket for a renderer wake. A wake can reuse a ticket whose
-    /// enqueue failed, because the resulting frame covers both old and new
-    /// terminal state. Wakes behind a queued host action remain coalesced.
-    fn request(self: *ExternalRedrawDelivery) ?u64 {
-        self.mutex.lock();
-        defer self.mutex.unlock();
-
-        if (self.active) |*active| {
-            if (active.phase == .enqueue_failed) {
-                active.phase = .queued;
-                return active.generation;
-            }
-            self.wake_behind_active = true;
-            return null;
-        }
-        return self.startRequestLocked();
-    }
-
-    /// Publish a failed enqueue for this exact ticket. `Mailbox.pushObserved`
-    /// invokes this before it publishes the shared capacity retry and wakes the
-    /// app thread.
-    fn enqueueFailed(
-        self: *ExternalRedrawDelivery,
-        generation: u64,
-    ) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
-
-        if (self.active) |*active| {
-            if (active.generation == generation) {
-                active.phase = .enqueue_failed;
-            }
-        }
-    }
-
-    /// Claim only a ticket whose own enqueue failed. A capacity callback for
-    /// one surface cannot duplicate a queued ticket for another surface.
-    fn retryFailedEnqueue(self: *ExternalRedrawDelivery) ?u64 {
-        self.mutex.lock();
-        defer self.mutex.unlock();
-
-        if (self.active) |*active| {
-            if (active.phase == .enqueue_failed) {
-                active.phase = .queued;
-                return active.generation;
-            }
-        }
-        return null;
-    }
-
-    /// Record the host result for an exact ticket. A rejected action releases
-    /// its own request. Return true when a newer wake had coalesced behind it,
-    /// so xev schedules that later wake once without rejection spin.
-    fn actionCompleted(
-        self: *ExternalRedrawDelivery,
-        generation: u64,
-        accepted: bool,
-    ) bool {
-        if (accepted) return false;
-
-        self.mutex.lock();
-        defer self.mutex.unlock();
-
-        const active = self.active orelse return false;
-        if (active.generation != generation) return false;
-
-        const notify = self.wake_behind_active;
-        self.active = null;
-        self.wake_behind_active = false;
-        return notify;
-    }
-
-    /// A frame start covers every request published before this critical
-    /// section. A concurrent later wake either lands before the reset and is
-    /// covered, or lands after it and receives a new ticket.
-    fn renderStarted(self: *ExternalRedrawDelivery) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
-        self.active = null;
-        self.wake_behind_active = false;
-    }
-
-    /// Caller holds `mutex`.
-    fn startRequestLocked(self: *ExternalRedrawDelivery) u64 {
-        self.next_generation +%= 1;
-        if (self.next_generation == 0) self.next_generation = 1;
-        self.active = .{
-            .generation = self.next_generation,
-            .phase = .queued,
-        };
-        return self.next_generation;
-    }
-};
-
-const ExternalRedrawEnqueueObserver = struct {
-    delivery: *ExternalRedrawDelivery,
-    generation: u64,
-
-    pub fn pushCompleted(
-        self: @This(),
-        queue_size: App.Mailbox.Queue.Size,
-    ) void {
-        if (queue_size == 0) {
-            self.delivery.enqueueFailed(self.generation);
-        }
-    }
 };
 
 /// Apply the one renderer visibility transition left after mailbox
@@ -527,9 +293,6 @@ instrumentation: instrumentationpkg.Instrumentation,
 /// Retained until a visibility-regain frame is actually submitted.
 visibility_regain: VisibilityRegainState = .{},
 
-/// Coalesced surface state published without entering the bounded mailbox.
-surface_state_requests: SurfaceStateRequests = .{},
-
 /// Last visibility state forwarded to the renderer. Renderer-thread owned.
 /// This can temporarily differ from `flags.visible` only when a later
 /// mailbox handler aborts a drain before its coalesced transition commits.
@@ -547,11 +310,6 @@ frame_acquire_timeouts: u64 = 0,
 /// this is set, only the external render serial queue may drain the mailbox or
 /// mutate renderer state; the renderer OS thread only keeps async stop alive.
 external_drain: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
-
-/// Ticketed external redraw delivery retained across app-mailbox pressure and
-/// host action dispatch. Wake-only redraws have no renderer mailbox entry that
-/// could otherwise prove a retry is needed.
-external_redraw_delivery: ExternalRedrawDelivery = .{},
 
 /// Monotonic millisecond epoch used to derive cursor blink phase while
 /// `external_drain` disables the renderer-thread cursor timer.
@@ -686,9 +444,9 @@ pub fn deinit(self: *Thread) void {
 /// when upstream exposes a synchronous embedder render tick.
 pub fn renderNow(self: *Thread) void {
     self.enterExternalDrainMode();
-    self.external_redraw_delivery.renderStarted();
-    drainSynchronousMailbox(self) catch |err| {
+    _ = self.drainMailbox() catch |err| fallback: {
         log.err("renderNow: error draining mailbox err={}", .{err});
+        break :fallback MailboxDrainResult{};
     };
 
     self.notifySelectionChanged();
@@ -709,9 +467,9 @@ pub fn renderNowWithPresentation(
     presentation: rendererpkg.FramePresentation,
 ) void {
     self.enterExternalDrainMode();
-    self.external_redraw_delivery.renderStarted();
-    drainSynchronousMailbox(self) catch |err| {
+    _ = self.drainMailbox() catch |err| fallback: {
         log.err("renderNowWithPresentation: error draining mailbox err={}", .{err});
+        break :fallback MailboxDrainResult{};
     };
 
     self.notifySelectionChanged();
@@ -751,7 +509,7 @@ fn finishRenderNowWithPresentation(
     value.deliver();
 }
 
-/// Drain one finite external renderer mailbox turn.
+/// Drain the renderer mailbox once, applying every queued message.
 ///
 /// cmux iOS fork: a public seam over the private `drainMailbox` so a producer
 /// running on the iOS render serial queue (where `render_now` is the mailbox's
@@ -759,31 +517,16 @@ fn finishRenderNowWithPresentation(
 /// message that must NOT be dropped (e.g. `.font_grid`, whose handler derefs the
 /// old grid). Safe to call from that queue for the same reason `render_now` is:
 /// `render_now` already calls `drainMailbox` on this serial queue every frame
-/// (see `renderNow`). Any remainder schedules another embedder render through
-/// the existing `.render` action, so this call stays bounded even if another
-/// producer is active. `drainMailbox` and its handlers take no
-/// `renderer_state.mutex`, so it cannot self-deadlock against a caller that
-/// holds it. Delete when upstream exposes a synchronous embedder render tick.
+/// (see `renderNow`), so this is byte-identical drain behavior and adds no new
+/// concurrency. `drainMailbox` and its handlers take no `renderer_state.mutex`,
+/// so it cannot self-deadlock against a caller that holds it. Delete when
+/// upstream exposes a synchronous embedder render tick.
 pub fn drainMailboxNow(self: *Thread) void {
     self.enterExternalDrainMode();
-    drainSynchronousMailbox(self) catch |err| {
+    _ = self.drainMailbox() catch |err| {
         log.err("drainMailboxNow: error draining mailbox err={}", .{err});
         return;
     };
-}
-
-/// Publish latest-value surface lifecycle state without waiting for renderer
-/// mailbox capacity. Callers must notify `wakeup` after publishing.
-pub fn publishVisible(self: *Thread, value: bool) void {
-    self.surface_state_requests.publishVisible(value);
-}
-
-pub fn publishFocused(self: *Thread, value: bool) void {
-    self.surface_state_requests.publishFocused(value);
-}
-
-pub fn publishDisplayID(self: *Thread, value: u32) void {
-    self.surface_state_requests.publishDisplayID(value);
 }
 
 /// The app thread calls this after draining its mailbox. A failed
@@ -791,35 +534,10 @@ pub fn publishDisplayID(self: *Thread, value: u32) void {
 /// so mailbox capacity becoming available is the readiness signal for one
 /// retained reveal retry.
 pub fn appMailboxDrained(self: *Thread) void {
-    // Once capacity returns, retry only a continuation whose own enqueue
-    // failed. Already queued requests for other surfaces remain coalesced.
-    if (self.externalDrainActive()) {
-        retryExternalRendererContinuation(self);
-    }
-
     const generation = self.visibility_regain.pendingGeneration() orelse return;
     self.visibility_retry_generation.store(generation, .release);
     self.visibility_retry.notify() catch |err| {
         log.warn("failed to notify visibility-regain retry err={}", .{err});
-    };
-}
-
-/// Complete delivery of the app mailbox's `.redraw_surface` action. A rejected
-/// action releases its request so a later renderer wake can enqueue again. If
-/// a newer wake was coalesced behind the rejected action, wake xev once to
-/// preserve that later request without retrying a permanently rejected action.
-pub fn externalRenderActionCompleted(
-    self: *Thread,
-    generation: u64,
-    accepted: bool,
-) void {
-    if (!self.externalDrainActive()) return;
-    if (!self.external_redraw_delivery.actionCompleted(
-        generation,
-        accepted,
-    )) return;
-    self.wakeup.notify() catch |err| {
-        log.warn("failed to retry external redraw after rejected action err={}", .{err});
     };
 }
 
@@ -835,56 +553,6 @@ fn enterExternalDrainMode(self: *Thread) void {
 fn externalDrainActive(self: *const Thread) bool {
     if (comptime builtin.os.tag != .ios) return false;
     return self.external_drain.load(.seq_cst);
-}
-
-fn hasPendingRendererWork(self: *const Thread) bool {
-    return self.mailbox.count() > 0 or
-        self.surface_state_requests.hasPending();
-}
-
-fn requestExternalRendererContinuation(self: *Thread) ?u64 {
-    return self.external_redraw_delivery.request();
-}
-
-fn retryFailedExternalRendererContinuation(self: *Thread) ?u64 {
-    return self.external_redraw_delivery.retryFailedEnqueue();
-}
-
-fn enqueueExternalRendererContinuation(
-    self: *Thread,
-    generation: u64,
-) void {
-    _ = self.app_mailbox.pushObserved(
-        .{ .redraw_surface = .{
-            .surface = self.surface,
-            .external_ticket = .{
-                .surface_id = self.surface.core().id,
-                .generation = generation,
-            },
-        } },
-        .{ .instant = {} },
-        ExternalRedrawEnqueueObserver{
-            .delivery = &self.external_redraw_delivery,
-            .generation = generation,
-        },
-    );
-}
-
-/// Retain a finite follow-up turn without draining renderer state from the
-/// wrong thread. Normal rendering re-notifies xev. External iOS rendering uses
-/// the app mailbox's established `.render` action, whose embedder callback
-/// schedules the next `render_now` invocation.
-fn scheduleRendererContinuationIfNeeded(self: *Thread) void {
-    if (!self.hasPendingRendererWork()) return;
-
-    if (self.externalDrainActive()) {
-        scheduleExternalRendererContinuation(self);
-        return;
-    }
-
-    self.wakeup.notify() catch |err| {
-        log.warn("failed to continue pending renderer work err={}", .{err});
-    };
 }
 
 fn resetExternalCursorBlink(self: *Thread) void {
@@ -1071,22 +739,80 @@ fn drainMailbox(self: *Thread) !MailboxDrainResult {
     const external_drain = self.externalDrainActive();
     var visibility = VisibilityDrainState.init(self.flags.visible);
 
-    // Process only the messages present at the start of this renderer turn.
-    // Producers can refill the queue as we pop. Draining until a transient
-    // empty state lets sustained terminal output monopolize the renderer loop,
-    // delaying lifecycle state below and the render that follows this drain.
-    // A snapshot gives both bounded latency while preserving FIFO ordering.
-    var remaining = self.mailbox.count();
-
-    while (remaining > 0) : (remaining -= 1) {
-        const message = self.mailbox.pop() orelse break;
+    while (self.mailbox.pop()) |message| {
         log.debug("mailbox message={}", .{message});
         switch (message) {
             .crash => @panic("crash request, crashing intentionally"),
 
-            .visible => |v| self.applyVisible(&visibility, v),
+            .visible => |v| visible: {
+                // If our state didn't change we do nothing.
+                if (!visibility.apply(v)) break :visible;
 
-            .focus => |v| try self.applyFocused(v, external_drain),
+                // Set our visible state
+                self.flags.visible = v;
+
+                // Visibility affects our QoS class
+                self.setQosClass();
+
+                // Note that we're explicitly today not stopping any
+                // cursor timers, draw timers, etc. These things have very
+                // little resource cost and properly maintaining their active
+                // state across different transitions is going to be bug-prone,
+                // so its easier to just let them keep firing and have them
+                // check the visible state themselves to control their behavior.
+            },
+
+            .focus => |v| focus: {
+                // If our state didn't change we do nothing.
+                if (self.flags.focused == v) break :focus;
+
+                // Set our state
+                self.flags.focused = v;
+
+                // Focus affects our QoS class
+                self.setQosClass();
+
+                // Set it on the renderer
+                try self.renderer.setFocus(v);
+
+                if (external_drain) {
+                    if (v) self.resetExternalCursorBlink();
+                    break :focus;
+                }
+
+                // We always resync our draw timer (may disable it)
+                self.syncDrawTimer();
+
+                if (!v) {
+                    // If we're not focused, then we stop the cursor blink
+                    if (self.cursor_c.state() == .active and
+                        self.cursor_c_cancel.state() == .dead)
+                    {
+                        self.cursor_h.cancel(
+                            &self.loop,
+                            &self.cursor_c,
+                            &self.cursor_c_cancel,
+                            void,
+                            null,
+                            cursorCancelCallback,
+                        );
+                    }
+                } else {
+                    // If we're focused, we immediately show the cursor again
+                    // and then restart the timer.
+                    if (self.cursor_c.state() != .active) {
+                        self.flags.cursor_blink_visible = true;
+                        self.cursor_h.run(
+                            &self.loop,
+                            &self.cursor_c,
+                            cursorBlinkInterval(),
+                            Thread,
+                            self,
+                            cursorTimerCallback,
+                        );
+                    }
+                }
+            },
 
             .reset_cursor_blink => {
                 self.flags.cursor_blink_visible = true;
@@ -1145,7 +871,11 @@ fn drainMailbox(self: *Thread) !MailboxDrainResult {
                 self.flags.has_inspector = v;
             },
 
-            .macos_display_id => |v| try self.applyDisplayID(v),
+            .macos_display_id => |v| {
+                if (@hasDecl(rendererpkg.Renderer, "setMacOSDisplayID")) {
+                    try self.renderer.setMacOSDisplayID(v);
+                }
+            },
 
             // cmux fork: release/recreate the renderer's GPU resources (swap
             // chain / IOSurface) without freeing the surface. Safe here because
@@ -1162,112 +892,17 @@ fn drainMailbox(self: *Thread) !MailboxDrainResult {
         }
     }
 
-    // Lifecycle state is latest-value rather than ordered work. Apply it after
-    // this bounded ordinary-mailbox snapshot so an older compatibility message
-    // cannot overwrite a newer request, without waiting for a producer-refilled
-    // queue to become transiently empty.
-    const surface_state = self.surface_state_requests.take();
-    // Visibility application cannot fail, so its thread-owned state is already
-    // committed if a later lifecycle operation fails. A normal wake reconciles
-    // renderer visibility in `renderAfterMailboxDrain`; external iOS rendering
-    // deliberately leaves visibility and frame gating to its platform owner.
-    if (surface_state.visible) |value| self.applyVisible(&visibility, value);
-    if (surface_state.focused) |value| {
-        self.applyFocused(value, external_drain) catch |err| {
-            // Restore only into an empty slot. A newer publication must remain
-            // authoritative over this failed request.
-            self.surface_state_requests.restoreFocusedIfEmpty(value);
-            if (surface_state.display_id) |display_id| {
-                self.surface_state_requests.restoreDisplayIDIfEmpty(display_id);
-            }
-            return err;
-        };
-    }
-    if (surface_state.display_id) |value| {
-        self.applyDisplayID(value) catch |err| {
-            self.surface_state_requests.restoreDisplayIDIfEmpty(value);
-            return err;
-        };
-    }
-
-    const wake_pending =
-        self.mailbox.count() > 0 or self.surface_state_requests.hasPending();
-    if (external_drain) return .{ .wake_pending = wake_pending };
+    if (external_drain) return .{};
 
     // Hidden wakeups leave terminal dirty flags untouched. Rebuild exactly
     // once from their union before making the renderer visible again, then
     // present immediately. A full-redraw dirty bit remains authoritative
     // inside RenderState.update.
-    var result = applyRendererVisibilityTransition(
+    return applyRendererVisibilityTransition(
         self,
         &self.visibility_regain,
         visibility.rendererTransition(),
     );
-    result.wake_pending = wake_pending;
-    return result;
-}
-
-fn applyVisible(
-    self: *Thread,
-    visibility: *VisibilityDrainState,
-    value: bool,
-) void {
-    if (!visibility.apply(value)) return;
-    self.flags.visible = value;
-    self.setQosClass();
-
-    // Timers are intentionally left armed across visibility changes. Their
-    // callbacks already consult this renderer-owned flag.
-}
-
-fn applyFocused(self: *Thread, value: bool, external_drain: bool) !void {
-    if (self.flags.focused == value) return;
-
-    // Commit the fallible renderer operation first. If it fails, the caller
-    // can retain the request without the thread flag suppressing its retry.
-    try self.renderer.setFocus(value);
-    self.flags.focused = value;
-    self.setQosClass();
-
-    if (external_drain) {
-        if (value) self.resetExternalCursorBlink();
-        return;
-    }
-
-    self.syncDrawTimer();
-    if (!value) {
-        if (self.cursor_c.state() == .active and
-            self.cursor_c_cancel.state() == .dead)
-        {
-            self.cursor_h.cancel(
-                &self.loop,
-                &self.cursor_c,
-                &self.cursor_c_cancel,
-                void,
-                null,
-                cursorCancelCallback,
-            );
-        }
-        return;
-    }
-
-    if (self.cursor_c.state() != .active) {
-        self.flags.cursor_blink_visible = true;
-        self.cursor_h.run(
-            &self.loop,
-            &self.cursor_c,
-            cursorBlinkInterval(),
-            Thread,
-            self,
-            cursorTimerCallback,
-        );
-    }
-}
-
-fn applyDisplayID(self: *Thread, value: u32) !void {
-    if (@hasDecl(rendererpkg.Renderer, "setMacOSDisplayID")) {
-        try self.renderer.setMacOSDisplayID(value);
-    }
 }
 
 fn changeConfig(self: *Thread, config: *const DerivedConfig) !void {
@@ -1341,7 +976,7 @@ fn drawFrame(self: *Thread, now: bool) DrawFrameResult {
 
     if (must_draw_from_app_thread) {
         const pushed = self.app_mailbox.push(
-            .{ .redraw_surface = .{ .surface = self.surface } },
+            .{ .redraw_surface = self.surface },
             .{ .instant = {} },
         );
         if (pushed == 0) return .app_mailbox_full;
@@ -1395,42 +1030,20 @@ fn wakeupCallback(
     };
 
     const t = self_.?;
-    if (t.externalDrainActive()) {
-        // External mode owns renderer state on its serial queue. Convert the
-        // coalesced xev wake into an unconditional embedder render request.
-        // Unconditional scheduling closes the race where a producer publishes
-        // after a pending-work check while this callback is still active.
-        scheduleExternalRendererContinuation(t);
-        return .rearm;
-    }
+    if (t.externalDrainActive()) return .rearm;
     const regain_was_pending = t.visibility_regain.isPending();
 
     // When we wake up, we check the mailbox. Mailbox producers should
     // wake up our thread after publishing.
     const drain_result = t.drainMailbox() catch |err| fallback: {
         log.err("error draining mailbox err={}", .{err});
-        break :fallback MailboxDrainResult{
-            .wake_pending = t.mailbox.count() > 0 or
-                t.surface_state_requests.hasPending(),
-        };
+        break :fallback MailboxDrainResult{};
     };
 
     // Render immediately unless a successful visibility regain already did.
     renderAfterMailboxDrain(t, &t.visibility_regain, drain_result);
     if (regain_was_pending and !t.visibility_regain.isPending()) {
         t.syncDrawTimer();
-    }
-
-    // Producer notifications can coalesce with the wake currently being
-    // handled. Render this finite snapshot before explicitly retaining another
-    // turn. Recheck after rendering so work published during the render is
-    // included rather than relying on its possibly coalesced notification.
-    const wake_pending = drain_result.wake_pending or
-        t.mailbox.count() > 0 or t.surface_state_requests.hasPending();
-    if (wake_pending) {
-        t.wakeup.notify() catch |err| {
-            log.warn("failed to continue pending renderer work err={}", .{err});
-        };
     }
 
     // PageList mutations maintain their own compression dirty state. Checking
@@ -1575,169 +1188,6 @@ test "visibility drain coalesces rapid hide show ordering" {
     try std.testing.expect(canceled.apply(false));
     try std.testing.expect(canceled.apply(true));
     try std.testing.expectEqual(null, canceled.rendererTransition());
-}
-
-test "synchronous renderer drains one finite batch and retains continuation" {
-    const Context = struct {
-        drains: usize = 0,
-        continuations: usize = 0,
-
-        fn drainMailbox(self: *@This()) !MailboxDrainResult {
-            self.drains += 1;
-            return .{ .wake_pending = true };
-        }
-
-        fn scheduleRendererContinuationIfNeeded(self: *@This()) void {
-            self.continuations += 1;
-        }
-    };
-
-    var context: Context = .{};
-    try drainSynchronousMailbox(&context);
-    try std.testing.expectEqual(@as(usize, 1), context.drains);
-    try std.testing.expectEqual(@as(usize, 1), context.continuations);
-}
-
-test "synchronous renderer retains continuation after drain error" {
-    const Context = struct {
-        continuations: usize = 0,
-
-        fn drainMailbox(_: *@This()) !MailboxDrainResult {
-            return error.DrainFailed;
-        }
-
-        fn scheduleRendererContinuationIfNeeded(self: *@This()) void {
-            self.continuations += 1;
-        }
-    };
-
-    var context: Context = .{};
-    try std.testing.expectError(
-        error.DrainFailed,
-        drainSynchronousMailbox(&context),
-    );
-    try std.testing.expectEqual(@as(usize, 1), context.continuations);
-}
-
-test "external redraw retries only the surface whose enqueue failed" {
-    var queued: ExternalRedrawDelivery = .{};
-    var failed: ExternalRedrawDelivery = .{};
-
-    _ = queued.request().?;
-    const failed_generation = failed.request().?;
-    failed.enqueueFailed(failed_generation);
-
-    try std.testing.expectEqual(
-        @as(?u64, null),
-        queued.retryFailedEnqueue(),
-    );
-    try std.testing.expectEqual(
-        failed_generation,
-        failed.retryFailedEnqueue().?,
-    );
-    try std.testing.expectEqual(
-        @as(?u64, null),
-        failed.retryFailedEnqueue(),
-    );
-}
-
-test "external redraw host rejection releases and preserves later wakes" {
-    var delivery: ExternalRedrawDelivery = .{};
-
-    // A rejected action without a newer wake is released. A later wake can
-    // enqueue again instead of remaining latched behind the rejected action.
-    const first = delivery.request().?;
-    try std.testing.expect(!delivery.actionCompleted(first, false));
-    const second = delivery.request().?;
-
-    // A wake coalesced behind an outstanding action must survive rejection.
-    try std.testing.expectEqual(@as(?u64, null), delivery.request());
-    try std.testing.expect(delivery.actionCompleted(second, false));
-    try std.testing.expectEqual(
-        @as(?u64, null),
-        delivery.retryFailedEnqueue(),
-    );
-    const third = delivery.request().?;
-    try std.testing.expect(third != second);
-}
-
-test "external render start consumes queued and coalesced wakes" {
-    var delivery: ExternalRedrawDelivery = .{};
-    const first = delivery.request().?;
-    try std.testing.expectEqual(@as(?u64, null), delivery.request());
-
-    delivery.renderStarted();
-    const second = delivery.request().?;
-    try std.testing.expect(first != second);
-}
-
-test "external redraw stale acknowledgment cannot clear a newer request" {
-    var delivery: ExternalRedrawDelivery = .{};
-
-    const first = delivery.request().?;
-    delivery.renderStarted();
-    const second = delivery.request().?;
-    try std.testing.expect(first != second);
-
-    try std.testing.expect(!delivery.actionCompleted(first, false));
-    delivery.enqueueFailed(second);
-    try std.testing.expectEqual(
-        second,
-        delivery.retryFailedEnqueue().?,
-    );
-}
-
-test "surface lifecycle state bypasses a full renderer mailbox and keeps latest values" {
-    const mailbox = try Mailbox.create(std.testing.allocator);
-    defer mailbox.destroy(std.testing.allocator);
-
-    for (0..64) |_| {
-        try std.testing.expect(mailbox.push(
-            .{ .visible = false },
-            .{ .instant = {} },
-        ) != 0);
-    }
-    try std.testing.expectEqual(
-        @as(Mailbox.Size, 0),
-        mailbox.push(.{ .visible = false }, .{ .instant = {} }),
-    );
-
-    var state: SurfaceStateRequests = .{};
-    state.publishVisible(false);
-    state.publishVisible(true);
-    state.publishFocused(false);
-    state.publishDisplayID(7);
-    state.publishDisplayID(42);
-
-    const update = state.take();
-    try std.testing.expectEqual(true, update.visible);
-    try std.testing.expectEqual(false, update.focused);
-    try std.testing.expectEqual(@as(u32, 42), update.display_id);
-    try std.testing.expectEqual(
-        @as(Mailbox.Size, 0),
-        mailbox.push(.{ .visible = false }, .{ .instant = {} }),
-    );
-}
-
-test "surface lifecycle retry restoration preserves newer publications" {
-    var state: SurfaceStateRequests = .{};
-    try std.testing.expect(!state.hasPending());
-
-    state.restoreFocusedIfEmpty(false);
-    state.restoreDisplayIDIfEmpty(7);
-    try std.testing.expect(state.hasPending());
-    const restored = state.take();
-    try std.testing.expectEqual(false, restored.focused);
-    try std.testing.expectEqual(@as(u32, 7), restored.display_id);
-    try std.testing.expect(!state.hasPending());
-
-    state.publishFocused(true);
-    state.publishDisplayID(42);
-    state.restoreFocusedIfEmpty(false);
-    state.restoreDisplayIDIfEmpty(7);
-    const newer = state.take();
-    try std.testing.expectEqual(true, newer.focused);
-    try std.testing.expectEqual(@as(u32, 42), newer.display_id);
 }
 
 test "synchronous presentation is delivered after thread draw cleanup" {


### PR DESCRIPTION
Fixes the fork-side cause of https://github.com/manaflow-ai/cmux/issues/8808.

The lifecycle experiment from https://github.com/manaflow-ai/ghostty/pull/132 published visibility, focus, and display state outside the ordered renderer mailbox, then consumed that state only after an unbounded mailbox drain reached empty. Continuous terminal traffic could keep the mailbox non-empty and starve lifecycle processing and rendering. Follow-ups https://github.com/manaflow-ai/ghostty/pull/135, https://github.com/manaflow-ai/ghostty/pull/136, https://github.com/manaflow-ai/ghostty/pull/139, and https://github.com/manaflow-ai/ghostty/pull/140 added scheduling and ownership machinery around that design without eliminating the nightly regression.

This PR reverts that complete experiment while retaining unrelated wrapped-link, external-frame, Kitty graphics, and PTY cleanup work.

Validation:
- Zig 0.15.2 formatting passed on a 48 GB fleet Mac
- native suite passed 3,112 runnable tests with 16 skips in the normal configuration
- full Xcode packaging is pending GitHub CI because the leased Mac lacks msgfmt

Residual risk: this restores the pre-experiment blocking macOS lifecycle path, so the original full-mailbox UI-freeze risk returns until the clean upstream/Zig upgrade PR implements a bounded ordered solution.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/144"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787523035&installation_model_id=21920&pr_number=144&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F144&signature=d2cd9d576fba138a6ee1917144da9dbebbea6b8129dcdb7ed69a363edf752443"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Revert the renderer lifecycle experiment and restore mailbox-ordered handling for visibility, focus, and display state to remove typing lag and renderer starvation (addresses cmux#8808). Keeps unrelated link, external-frame, Kitty graphics, and PTY cleanup changes.

- **Bug Fixes**
  - Remove latest-value lifecycle path and external redraw ticketing; renderer now drains the ordered mailbox as before.
  - iOS: push `.visible`/`.focus` as instant (non-blocking) to avoid main/serial deadlocks; macOS keeps the blocking path.
  - Trade-off: the pre-experiment macOS behavior returns; a full mailbox can freeze UI until a bounded solution lands upstream.

- **Migration**
  - Remove `ghostty_surface_new_with_owned_userdata` and `ghostty_userdata_release_cb`. Use `ghostty_surface_new` and manage `userdata` lifetime yourself.
  - Callbacks now receive your original `userdata` directly; no runtime retain/release is performed.

<sup>Written for commit 852e840779a64c0ce1288b72439d47e7664f49c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/144?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

