### PR TITLE
fix(renderer): rotate serial frame leases

### DIFF
--- a/src/renderer/frame_lease.zig
+++ b/src/renderer/frame_lease.zig
@@ -245,6 +245,22 @@ test "frame lease pool reuses the exact out-of-order released slot" {
     try std.testing.expect(pool.releaseHost(third.token));
 }
 
+test "frame lease pool rotates slots for serial frames" {
+    const LeasePool = Pool(3);
+    var pool: LeasePool = .{};
+
+    var slots: [4]LeasePool.Lease = undefined;
+    for (&slots) |*lease| {
+        lease.* = try pool.acquire(null);
+        try std.testing.expect(pool.finish(lease.token, false));
+    }
+
+    try std.testing.expectEqual(@as(usize, 0), slots[0].slot);
+    try std.testing.expectEqual(@as(usize, 1), slots[1].slot);
+    try std.testing.expectEqual(@as(usize, 2), slots[2].slot);
+    try std.testing.expectEqual(@as(usize, 0), slots[3].slot);
+}
+
 test "frame lease pool accepts release racing the presentation callback" {
     const LeasePool = Pool(1);
     var pool: LeasePool = .{};

--- a/src/renderer/frame_lease.zig
+++ b/src/renderer/frame_lease.zig
@@ -45,6 +45,9 @@ pub fn Pool(comptime slot_count: usize) type {
         available: std.Thread.Semaphore = .{ .permits = slot_count },
         slots: [slot_count]Slot = [_]Slot{.{}} ** slot_count,
         next_token: Token = 0,
+        /// Start each search after the last acquired slot so a serial producer
+        /// still rotates IOSurfaces and forces Core Animation to recomposite.
+        next_slot: usize = 0,
         defunct: bool = false,
 
         /// Acquire one exact free slot. A null timeout waits indefinitely.
@@ -64,7 +67,9 @@ pub fn Pool(comptime slot_count: usize) type {
 
             if (self.defunct) return error.Defunct;
 
-            for (&self.slots, 0..) |*slot, index| {
+            for (0..self.slots.len) |offset| {
+                const index = (self.next_slot + offset) % self.slots.len;
+                const slot = &self.slots[index];
                 if (slot.state != .free) continue;
 
                 const token = self.freshTokenLocked();
@@ -72,6 +77,7 @@ pub fn Pool(comptime slot_count: usize) type {
                     .state = .gpu,
                     .token = token,
                 };
+                self.next_slot = (index + 1) % self.slots.len;
                 return .{
                     .slot = @intCast(index),
                     .token = token,


### PR DESCRIPTION
Fixes the remaining macOS typing batching reported in https://github.com/manaflow-ai/cmux/issues/8808 without reverting the new renderer scheduler or exact-slot ownership.

Root cause: https://github.com/manaflow-ai/ghostty/commit/8c645641a introduced exact-slot frame leases and replaced the prior rotating frame index with a first-free scan from slot zero. When typing slowly enough for each Metal frame to finish before the next key, every frame reacquires slot zero and reassigns the same IOSurface object. Core Animation can deduplicate that same-object contents assignment, so the IOSurface seed advances while the window waits for unrelated layer activity to recomposite.

This change preserves exact-slot ownership and backpressure while rotating the free-slot scan after every successful acquire.

Red proof: commit 3a43d5edc fails the new serial-frame assertion with expected slot 1, found slot 0.

Green proof: commit fcafac572 passes the assertion and the filtered Ghostty test run (73/73 tests). No Swift or user-facing strings changed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/145"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787523805&installation_model_id=21920&pr_number=145&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F145&signature=0a78cfae552a03f11f21874879ba358ab8de3122900e84b48c947480e0773e6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rotate frame lease acquisition across slots to stop macOS typing from batching frames while keeping the new renderer scheduler intact. This forces Core Animation to recomposite by using different IOSurfaces per serial frame.

- **Bug Fixes**
  - Rotate the free-slot scan cursor after each successful acquire to distribute serial frames across IOSurfaces.
  - Preserve exact-slot ownership and backpressure; no API or behavior regressions.
  - Add a unit test that enforces 0 → 1 → 2 → 0 rotation for a 3-slot pool.
  - No user-facing changes.

<sup>Written for commit fcafac572970e615c9ac5ecd25eaa325cec1f7ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/145?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

