### PR TITLE
Revert owned userdata leasing and restore synchronous teardown

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -567,7 +567,6 @@ typedef void (*ghostty_pty_tee_cb)(void* userdata,
 // bookkeeping completes. Metal delivers after assigning its IOSurface on the
 // main thread. Synchronous backends deliver on the rendering caller's thread.
 typedef void (*ghostty_render_presented_cb)(void*, uint64_t);
-typedef void (*ghostty_userdata_release_cb)(void* userdata);
 
 // Content-free renderer activity events emitted only when a surface installs
 // ghostty_renderer_event_cb. Begin/end pairs run on the renderer thread.
@@ -1261,18 +1260,6 @@ GHOSTTY_API ghostty_surface_config_s ghostty_surface_config_new();
 
 GHOSTTY_API ghostty_surface_t ghostty_surface_new(ghostty_app_t,
                                                      const ghostty_surface_config_s*);
-/**
- * Creates a surface that owns `config->userdata`.
- *
- * On success, `release_userdata` is called exactly once with that userdata
- * after surface teardown has stopped internal callbacks and all in-flight app
- * actions have returned. The callback may run on any thread. If creation
- * fails, ownership remains with the caller and the callback is not invoked.
- */
-GHOSTTY_API ghostty_surface_t ghostty_surface_new_with_owned_userdata(
-    ghostty_app_t,
-    const ghostty_surface_config_s*,
-    ghostty_userdata_release_cb release_userdata);
 // cmux fork: create a surface with an embedder-owned scrollback upper bound
 // without changing ghostty_surface_config_s's public ABI. A zero limit inherits
 // the configured scrollback-limit; a nonzero limit can only lower it.

--- a/src/App.zig
+++ b/src/App.zig
@@ -902,62 +902,6 @@ test "external redraw rejects allocator-reused surface address" {
     }
 }
 
-test "redraw action lease defers reentrant embedded surface teardown" {
-    if (comptime !@hasField(apprt.App, "opts")) return error.SkipZigTest;
-    if (comptime !@hasField(apprt.Surface, "core_surface")) return error.SkipZigTest;
-
-    if (comptime @hasDecl(App, "acquireRedrawSurface") and
-        @hasField(apprt.Surface, "app_action_lifetime"))
-    {
-        var app: App = undefined;
-        try app.init(std.testing.allocator);
-        defer {
-            app.surfaces.deinit(std.testing.allocator);
-            app.font_grid_set.deinit();
-        }
-
-        var rt_app: apprt.App = undefined;
-        rt_app.core_app = &app;
-        rt_app.opts = undefined;
-        rt_app.opts.action = testAction;
-        rt_app.opts.wakeup = testWakeup;
-
-        var surface: apprt.Surface = undefined;
-        surface.app = &rt_app;
-        surface.core_surface.id = 22;
-        surface.app_action_lifetime = .{};
-        try app.surfaces.append(std.testing.allocator, &surface);
-
-        const lease = app.acquireRedrawSurface(.{
-            .surface = &surface,
-            .external_ticket = .{
-                .surface_id = 22,
-                .generation = 1,
-            },
-        }).?;
-        try std.testing.expectEqual(
-            @as(usize, 2),
-            surface.app_action_lifetime.countForTesting(),
-        );
-
-        // Models ghostty_surface_free re-entering from the host action. The
-        // owner release must unregister the surface without touching its core
-        // while the action lease is still live.
-        surface.deinit();
-        try std.testing.expect(!app.hasRtSurface(&surface));
-        try std.testing.expectEqual(
-            @as(usize, 1),
-            surface.app_action_lifetime.countForTesting(),
-        );
-
-        // Releasing this fake stack surface would intentionally run its final
-        // destructor. The lifetime state test covers that final transition.
-        _ = lease;
-    } else {
-        try std.testing.expect(false);
-    }
-}
-
 test "full app mailbox retains redraw retry until drain" {
     var queue: Mailbox.Queue = .{};
     var retry_requested = std.atomic.Value(bool).init(false);

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -664,15 +664,67 @@ pub const RenderPresentedCallback = *const fn (?*anyopaque, u64) callconv(.c) vo
 
 const SurfaceActionLifetime = struct {
     references: std.atomic.Value(usize) = .{ .raw = 1 },
+    mutex: std.Thread.Mutex = .{},
+    drained: std.Thread.Condition = .{},
+    active_actions: usize = 0,
+    active_thread: ?std.Thread.Id = null,
+    teardown_started: bool = false,
 
     fn retain(self: *SurfaceActionLifetime) void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+
+        assert(!self.teardown_started);
+        const current_thread = std.Thread.getCurrentId();
+        if (self.active_thread) |active_thread| {
+            // App mailbox actions are serialized. Nested actions are valid,
+            // but concurrent action dispatch from another thread is not.
+            assert(active_thread == current_thread);
+        } else {
+            self.active_thread = current_thread;
+        }
+        self.active_actions += 1;
+
         const previous = self.references.fetchAdd(1, .seq_cst);
         assert(previous > 0);
         assert(previous < std.math.maxInt(usize));
     }
 
-    /// Returns true when the caller released the final reference.
-    fn release(self: *SurfaceActionLifetime) bool {
+    /// Wait for an action running on another thread. A free re-entering from
+    /// the current host callback must continue immediately to avoid deadlock;
+    /// that callback's lease still keeps the outer allocation alive.
+    fn waitForActionsBeforeTeardown(self: *SurfaceActionLifetime) void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+
+        self.teardown_started = true;
+        const current_thread = std.Thread.getCurrentId();
+        while (self.active_actions > 0 and
+            self.active_thread.? != current_thread)
+        {
+            self.drained.wait(&self.mutex);
+        }
+    }
+
+    /// Returns true when an action released the final allocation reference.
+    fn releaseAction(self: *SurfaceActionLifetime) bool {
+        self.mutex.lock();
+        assert(self.active_actions > 0);
+        assert(self.active_thread.? == std.Thread.getCurrentId());
+        self.active_actions -= 1;
+        if (self.active_actions == 0) {
+            self.active_thread = null;
+            self.drained.broadcast();
+        }
+        self.mutex.unlock();
+
+        const previous = self.references.fetchSub(1, .seq_cst);
+        assert(previous > 0);
+        return previous == 1;
+    }
+
+    /// Returns true when the surface owner released the final reference.
+    fn releaseOwner(self: *SurfaceActionLifetime) bool {
         const previous = self.references.fetchSub(1, .seq_cst);
         assert(previous > 0);
         return previous == 1;
@@ -1038,11 +1090,13 @@ pub const Surface = struct {
     ) void {
         const alloc = self.app.core_app.alloc;
 
-        // Stop new app actions first. Existing actions retain only this outer
-        // allocation, not the live renderer, IO, or callback state.
+        // Stop new app actions first. Wait for an action on another thread;
+        // a reentrant action on this thread retains the outer allocation while
+        // the live renderer, IO, and callback state are torn down.
         self.app.core_app.deleteSurface(self);
+        self.app_action_lifetime.waitForActionsBeforeTeardown();
         deinit_contents(self);
-        if (self.app_action_lifetime.release()) alloc.destroy(self);
+        if (self.app_action_lifetime.releaseOwner()) alloc.destroy(self);
     }
 
     /// Retain the opaque embedded surface allocation while an app action is
@@ -1053,7 +1107,7 @@ pub const Surface = struct {
     }
 
     pub fn releaseForAppAction(self: *Surface) void {
-        if (self.app_action_lifetime.release()) {
+        if (self.app_action_lifetime.releaseAction()) {
             self.app.core_app.alloc.destroy(self);
         }
     }
@@ -1565,15 +1619,20 @@ test "surface action lifetime defers owner destruction until lease release" {
     else
         struct {
             fn retain(_: *@This()) void {}
-            fn release(_: *@This()) bool {
+            fn waitForActionsBeforeTeardown(_: *@This()) void {}
+            fn releaseOwner(_: *@This()) bool {
+                return false;
+            }
+            fn releaseAction(_: *@This()) bool {
                 return false;
             }
         };
 
     var lifetime: Lifetime = .{};
     lifetime.retain();
-    try std.testing.expect(!lifetime.release());
-    try std.testing.expect(lifetime.release());
+    lifetime.waitForActionsBeforeTeardown();
+    try std.testing.expect(!lifetime.releaseOwner());
+    try std.testing.expect(lifetime.releaseAction());
 }
 
 test "surface teardown waits for a cross-thread action lease" {
@@ -3775,9 +3834,11 @@ pub const CAPI = struct {
     /// matching grid. Upstream candidate.
     export fn ghostty_surface_set_pty_tee_cb(
         surface: *Surface,
-        cb: ?*const fn (?*anyopaque, [*]const u8, usize) callconv(.c) void,
+        cb: ?PtyTeeCallback,
         userdata: ?*anyopaque,
     ) void {
+        surface.pty_tee_cb = cb;
+        surface.pty_tee_userdata = userdata;
         surface.core_surface.io.pty_tee_cb = cb;
         surface.core_surface.io.pty_tee_userdata = userdata;
     }

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1576,6 +1576,69 @@ test "surface action lifetime defers owner destruction until lease release" {
     try std.testing.expect(lifetime.release());
 }
 
+test "surface teardown waits for a cross-thread action lease" {
+    const Lifetime = if (@hasDecl(@This(), "SurfaceActionLifetime"))
+        @field(@This(), "SurfaceActionLifetime")
+    else
+        struct {};
+
+    if (comptime @hasDecl(Lifetime, "waitForActionsBeforeTeardown") and
+        @hasDecl(Lifetime, "releaseAction"))
+    {
+        const Context = struct {
+            lifetime: *Lifetime,
+            action_ready: std.Thread.ResetEvent = .{},
+            allow_action_return: std.Thread.ResetEvent = .{},
+            teardown_started: std.Thread.ResetEvent = .{},
+            teardown_finished: std.Thread.ResetEvent = .{},
+            action_released_final: std.atomic.Value(bool) = .{ .raw = true },
+
+            fn runAction(self: *@This()) void {
+                self.lifetime.retain();
+                self.action_ready.set();
+                self.allow_action_return.wait();
+                self.action_released_final.store(
+                    self.lifetime.releaseAction(),
+                    .release,
+                );
+            }
+
+            fn runTeardown(self: *@This()) void {
+                self.action_ready.wait();
+                self.teardown_started.set();
+                self.lifetime.waitForActionsBeforeTeardown();
+                self.teardown_finished.set();
+            }
+        };
+
+        var lifetime: Lifetime = .{};
+        var context: Context = .{ .lifetime = &lifetime };
+        const action_thread = try std.Thread.spawn(.{}, Context.runAction, .{&context});
+        defer action_thread.join();
+        const teardown_thread = try std.Thread.spawn(.{}, Context.runTeardown, .{&context});
+        defer teardown_thread.join();
+        defer context.allow_action_return.set();
+
+        context.teardown_started.wait();
+        try std.testing.expectError(
+            error.Timeout,
+            context.teardown_finished.timedWait(20 * std.time.ns_per_ms),
+        );
+
+        context.allow_action_return.set();
+        context.teardown_finished.wait();
+        try std.testing.expect(
+            !context.action_released_final.load(.acquire),
+        );
+        try std.testing.expectEqual(
+            @as(usize, 1),
+            lifetime.countForTesting(),
+        );
+    } else {
+        try std.testing.expect(false);
+    }
+}
+
 // The cmux integration combines the OpenGL platform payload (the largest
 // Platform.C variant) with the startup PTY tee fields. Keep the resulting C
 // layout pinned so every exact-revision consumer fails loudly on drift.

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -264,19 +264,13 @@ pub const App = struct {
         self: *App,
         opts: Surface.Options,
         scrollback_limit_bytes: usize,
-        userdata_release_cb: ?UserdataReleaseCallback,
     ) !*Surface {
         // Grab a surface allocation because we're going to need it.
         var surface = try self.core_app.alloc.create(Surface);
         errdefer self.core_app.alloc.destroy(surface);
 
         // Create the surface
-        try surface.init(
-            self,
-            opts,
-            scrollback_limit_bytes,
-            userdata_release_cb,
-        );
+        try surface.init(self, opts, scrollback_limit_bytes);
         return surface;
     }
 
@@ -298,13 +292,6 @@ pub const App = struct {
         comptime action: apprt.Action.Key,
         value: apprt.Action.Value(action),
     ) !bool {
-        const userdata_lease: ?SurfaceUserdata.Lease = switch (target) {
-            .app => null,
-            .surface => |surface| surface.rt_surface.userdata.acquire() orelse
-                return false,
-        };
-        defer if (userdata_lease) |lease| lease.release();
-
         // Special case certain actions before they are sent to the
         // embedded apprt.
         self.performPreAction(target, action, value);
@@ -674,122 +661,6 @@ pub const IoWriteCallback = *const fn (?*anyopaque, [*]const u8, usize) callconv
 pub const PtyTeeCallback = *const fn (?*anyopaque, [*]const u8, usize) callconv(.c) void;
 pub const RendererEventCallback = renderer.InstrumentationCallback;
 pub const RenderPresentedCallback = *const fn (?*anyopaque, u64) callconv(.c) void;
-pub const UserdataReleaseCallback = *const fn (?*anyopaque) callconv(.c) void;
-
-const SurfaceUserdata = struct {
-    value: ?*anyopaque = null,
-    state: State = .borrowed,
-
-    const State = union(enum) {
-        borrowed,
-        owned: *Lifetime,
-        released,
-    };
-
-    const Lifetime = struct {
-        alloc: Allocator,
-        value: ?*anyopaque,
-        release_cb: UserdataReleaseCallback,
-        references: std.atomic.Value(usize) = .{ .raw = 1 },
-
-        fn tryRetain(self: *Lifetime) bool {
-            var count = self.references.load(.seq_cst);
-            while (count > 0) {
-                assert(count < std.math.maxInt(usize));
-                if (self.references.cmpxchgWeak(
-                    count,
-                    count + 1,
-                    .seq_cst,
-                    .seq_cst,
-                )) |actual| {
-                    count = actual;
-                } else {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
-        fn release(self: *Lifetime) void {
-            const previous = self.references.fetchSub(1, .seq_cst);
-            assert(previous > 0);
-            if (previous != 1) return;
-
-            const alloc = self.alloc;
-            const value = self.value;
-            const release_cb = self.release_cb;
-            release_cb(value);
-            alloc.destroy(self);
-        }
-    };
-
-    const Lease = struct {
-        lifetime: ?*Lifetime,
-
-        fn release(self: Lease) void {
-            if (self.lifetime) |lifetime| lifetime.release();
-        }
-    };
-
-    fn init(
-        alloc: Allocator,
-        value: ?*anyopaque,
-        release_cb: ?UserdataReleaseCallback,
-    ) Allocator.Error!SurfaceUserdata {
-        const callback = release_cb orelse return .{ .value = value };
-        const lifetime = try alloc.create(Lifetime);
-        lifetime.* = .{
-            .alloc = alloc,
-            .value = value,
-            .release_cb = callback,
-        };
-        return .{
-            .value = value,
-            .state = .{ .owned = lifetime },
-        };
-    }
-
-    fn acquire(self: *const SurfaceUserdata) ?Lease {
-        return switch (self.state) {
-            .borrowed => .{ .lifetime = null },
-            .owned => |lifetime| if (lifetime.tryRetain())
-                .{ .lifetime = lifetime }
-            else
-                null,
-            .released => null,
-        };
-    }
-
-    fn abort(self: *SurfaceUserdata) void {
-        const lifetime = switch (self.state) {
-            .owned => |lifetime| lifetime,
-            .borrowed, .released => {
-                self.state = .released;
-                self.value = null;
-                return;
-            },
-        };
-        self.state = .released;
-        self.value = null;
-        assert(lifetime.references.load(.seq_cst) == 1);
-        lifetime.alloc.destroy(lifetime);
-    }
-
-    fn deinit(self: *SurfaceUserdata) void {
-        const lifetime = switch (self.state) {
-            .owned => |lifetime| lifetime,
-            .borrowed, .released => {
-                self.state = .released;
-                self.value = null;
-                return;
-            },
-        };
-        self.state = .released;
-        self.value = null;
-        lifetime.release();
-    }
-};
 
 const SurfaceActionLifetime = struct {
     references: std.atomic.Value(usize) = .{ .raw = 1 },
@@ -816,7 +687,7 @@ const SurfaceActionLifetime = struct {
 pub const Surface = struct {
     app: *App,
     platform: Platform,
-    userdata: SurfaceUserdata = .{},
+    userdata: ?*anyopaque = null,
     core_surface: CoreSurface,
     app_action_lifetime: SurfaceActionLifetime = .{},
     content_scale: apprt.ContentScale,
@@ -912,19 +783,11 @@ pub const Surface = struct {
         app: *App,
         opts: Options,
         scrollback_limit_bytes: usize,
-        userdata_release_cb: ?UserdataReleaseCallback,
     ) !void {
-        var userdata = try SurfaceUserdata.init(
-            app.core_app.alloc,
-            opts.userdata,
-            userdata_release_cb,
-        );
-        errdefer userdata.abort();
-
         self.* = .{
             .app = app,
             .platform = try .init(opts.platform_tag, opts.platform),
-            .userdata = userdata,
+            .userdata = opts.userdata,
             .core_surface = undefined,
             .content_scale = .{
                 .x = @floatCast(opts.scale_factor),
@@ -1141,7 +1004,6 @@ pub const Surface = struct {
 
         // Clean up our core surface so that all the rendering and IO stop.
         self.core_surface.deinit();
-        self.userdata.deinit();
         alloc.destroy(self);
     }
 
@@ -1175,27 +1037,23 @@ pub const Surface = struct {
         return self.app;
     }
 
-    pub fn close(self: *Surface, process_alive: bool) void {
+    pub fn close(self: *const Surface, process_alive: bool) void {
         const func = self.app.opts.close_surface orelse {
             log.info("runtime embedder does not support closing a surface", .{});
             return;
         };
-        const userdata_lease = self.userdata.acquire() orelse return;
-        defer userdata_lease.release();
 
-        func(self.userdata.value, process_alive);
+        func(self.userdata, process_alive);
     }
 
     pub fn tmuxControl(
-        self: *Surface,
+        self: *const Surface,
         event: apprt.surface.Message.TmuxControlMsg.Event,
         id: u32,
         data: []const u8,
     ) void {
         const func = self.app.opts.tmux_control orelse return;
-        const userdata_lease = self.userdata.acquire() orelse return;
-        defer userdata_lease.release();
-        func(self.userdata.value, event, id, data.ptr, data.len);
+        func(self.userdata, event, id, data.ptr, data.len);
     }
 
     pub fn getContentScale(self: *const Surface) !apprt.ContentScale {
@@ -1223,79 +1081,30 @@ pub const Surface = struct {
     }
 
     pub fn ioWriteCallback(self: *const Surface) ?IoWriteCallback {
-        return if (self.io_write_cb != null) ioWrite else null;
+        return self.io_write_cb;
     }
 
     pub fn ioWriteUserdata(self: *const Surface) ?*anyopaque {
-        return if (self.io_write_cb != null) @constCast(self) else null;
-    }
-
-    fn ioWrite(
-        userdata: ?*anyopaque,
-        data: [*]const u8,
-        len: usize,
-    ) callconv(.c) void {
-        const self: *Surface = @ptrCast(@alignCast(userdata.?));
-        const callback = self.io_write_cb orelse return;
-        const userdata_lease = self.userdata.acquire() orelse return;
-        defer userdata_lease.release();
-        callback(self.io_write_userdata, data, len);
+        return self.io_write_userdata;
     }
 
     pub fn ptyTeeCallback(self: *const Surface) ?PtyTeeCallback {
-        return if (self.pty_tee_cb != null) ptyTee else null;
+        return self.pty_tee_cb;
     }
 
     pub fn ptyTeeUserdata(self: *const Surface) ?*anyopaque {
-        return if (self.pty_tee_cb != null) @constCast(self) else null;
-    }
-
-    fn ptyTee(
-        userdata: ?*anyopaque,
-        data: [*]const u8,
-        len: usize,
-    ) callconv(.c) void {
-        const self: *Surface = @ptrCast(@alignCast(userdata.?));
-        const callback = self.pty_tee_cb orelse return;
-        const userdata_lease = self.userdata.acquire() orelse return;
-        defer userdata_lease.release();
-        callback(self.pty_tee_userdata, data, len);
-    }
-
-    fn setPtyTeeCallback(
-        self: *Surface,
-        callback: ?PtyTeeCallback,
-        userdata: ?*anyopaque,
-    ) void {
-        self.pty_tee_cb = callback;
-        self.pty_tee_userdata = userdata;
-        self.core_surface.io.pty_tee_cb = if (callback != null) ptyTee else null;
-        self.core_surface.io.pty_tee_userdata = if (callback != null) self else null;
+        return self.pty_tee_userdata;
     }
 
     pub fn suppressTerminalResponses(self: *const Surface) bool {
         return self.io_mode.suppressesTerminalResponses();
     }
 
-    pub fn rendererInstrumentation(self: *Surface) renderer.Instrumentation {
+    pub fn rendererInstrumentation(self: *const Surface) renderer.Instrumentation {
         return .{
-            .callback = if (self.renderer_event_cb != null)
-                rendererEvent
-            else
-                null,
-            .userdata = self,
+            .callback = self.renderer_event_cb,
+            .userdata = self.userdata,
         };
-    }
-
-    fn rendererEvent(
-        userdata: ?*anyopaque,
-        event: renderer.InstrumentationEvent,
-    ) callconv(.c) void {
-        const self: *Surface = @ptrCast(@alignCast(userdata.?));
-        const callback = self.renderer_event_cb orelse return;
-        const userdata_lease = self.userdata.acquire() orelse return;
-        defer userdata_lease.release();
-        callback(self.userdata.value, event);
     }
 
     pub fn getTitle(self: *Surface) ?[:0]const u8 {
@@ -1326,10 +1135,8 @@ pub const Surface = struct {
         errdefer alloc.destroy(state_ptr);
         state_ptr.* = state;
 
-        const userdata_lease = self.userdata.acquire() orelse return false;
-        defer userdata_lease.release();
         const started = self.app.opts.read_clipboard(
-            self.userdata.value,
+            self.userdata,
             @intCast(@intFromEnum(clipboard_type)),
             state_ptr,
         );
@@ -1359,10 +1166,8 @@ pub const Surface = struct {
             error.UnsafePaste,
             error.UnauthorizedPaste,
             => {
-                const userdata_lease = self.userdata.acquire() orelse return;
-                defer userdata_lease.release();
                 self.app.opts.confirm_read_clipboard(
-                    self.userdata.value,
+                    self.userdata,
                     str.ptr,
                     state,
                     state.*,
@@ -1380,7 +1185,7 @@ pub const Surface = struct {
     }
 
     pub fn setClipboard(
-        self: *Surface,
+        self: *const Surface,
         clipboard_type: apprt.Clipboard,
         contents: []const apprt.ClipboardContent,
         confirm: bool,
@@ -1395,10 +1200,8 @@ pub const Surface = struct {
             };
         }
 
-        const userdata_lease = self.userdata.acquire() orelse return;
-        defer userdata_lease.release();
         self.app.opts.write_clipboard(
-            self.userdata.value,
+            self.userdata,
             @intCast(@intFromEnum(clipboard_type)),
             array.ptr,
             array.len,
@@ -1430,27 +1233,16 @@ pub const Surface = struct {
     }
 
     pub fn renderNowWithToken(self: *Surface, token: u64) void {
-        if (self.render_presented_cb == null) {
+        const callback = self.render_presented_cb orelse {
             self.renderNow();
             return;
-        }
+        };
         self.core_surface.applyPendingResizeIfNeeded();
         self.core_surface.renderer_thread.renderNowWithPresentation(.{
-            .callback = renderPresented,
-            .userdata = self,
+            .callback = callback,
+            .userdata = self.render_presented_userdata,
             .token = token,
         });
-    }
-
-    fn renderPresented(
-        userdata: ?*anyopaque,
-        token: u64,
-    ) callconv(.c) void {
-        const self: *Surface = @ptrCast(@alignCast(userdata.?));
-        const callback = self.render_presented_cb orelse return;
-        const userdata_lease = self.userdata.acquire() orelse return;
-        defer userdata_lease.release();
-        callback(self.render_presented_userdata, token);
     }
 
     pub fn updateContentScale(self: *Surface, x: f64, y: f64) void {
@@ -1718,121 +1510,6 @@ test "surface action lifetime defers owner destruction until lease release" {
     lifetime.retain();
     try std.testing.expect(!lifetime.release());
     try std.testing.expect(lifetime.release());
-}
-
-test "owned surface userdata releases after final action lease" {
-    const ReleaseState = struct {
-        releases: usize = 0,
-
-        fn release(userdata: ?*anyopaque) callconv(.c) void {
-            const self: *@This() = @ptrCast(@alignCast(userdata.?));
-            self.releases += 1;
-        }
-    };
-
-    var state: ReleaseState = .{};
-    var userdata = try SurfaceUserdata.init(
-        std.testing.allocator,
-        &state,
-        ReleaseState.release,
-    );
-    var lifetime: SurfaceActionLifetime = .{};
-    lifetime.retain();
-
-    if (lifetime.release()) userdata.deinit();
-    try std.testing.expectEqual(@as(usize, 0), state.releases);
-
-    if (lifetime.release()) userdata.deinit();
-    try std.testing.expectEqual(@as(usize, 1), state.releases);
-
-    userdata.deinit();
-    try std.testing.expectEqual(@as(usize, 1), state.releases);
-}
-
-test "owned surface userdata remains alive through host callback lease" {
-    const ReleaseState = struct {
-        releases: usize = 0,
-
-        fn release(userdata: ?*anyopaque) callconv(.c) void {
-            const self: *@This() = @ptrCast(@alignCast(userdata.?));
-            self.releases += 1;
-        }
-    };
-
-    var state: ReleaseState = .{};
-    var userdata = try SurfaceUserdata.init(
-        std.testing.allocator,
-        &state,
-        ReleaseState.release,
-    );
-    const callback_lease = userdata.acquire().?;
-
-    userdata.deinit();
-    try std.testing.expectEqual(@as(usize, 0), state.releases);
-    try std.testing.expect(userdata.acquire() == null);
-
-    callback_lease.release();
-    try std.testing.expectEqual(@as(usize, 1), state.releases);
-}
-
-test "post-construction PTY tee retains owned userdata through callback" {
-    const ReleaseState = struct {
-        releases: usize = 0,
-
-        fn release(userdata: ?*anyopaque) callconv(.c) void {
-            const self: *@This() = @ptrCast(@alignCast(userdata.?));
-            self.releases += 1;
-        }
-    };
-
-    const CallbackState = struct {
-        surface: *Surface,
-        release_state: *ReleaseState,
-        releases_during_callback: usize = 0,
-
-        fn callback(
-            userdata: ?*anyopaque,
-            _: [*]const u8,
-            _: usize,
-        ) callconv(.c) void {
-            const self: *@This() = @ptrCast(@alignCast(userdata.?));
-            self.surface.userdata.deinit();
-            self.releases_during_callback = self.release_state.releases;
-        }
-    };
-
-    var release_state: ReleaseState = .{};
-    var surface: Surface = undefined;
-    surface.userdata = try SurfaceUserdata.init(
-        std.testing.allocator,
-        &release_state,
-        ReleaseState.release,
-    );
-    surface.pty_tee_cb = null;
-    surface.pty_tee_userdata = null;
-
-    var callback_state: CallbackState = .{
-        .surface = &surface,
-        .release_state = &release_state,
-    };
-    CAPI.ghostty_surface_set_pty_tee_cb(
-        &surface,
-        CallbackState.callback,
-        &callback_state,
-    );
-
-    const data = "x";
-    surface.core_surface.io.pty_tee_cb.?(
-        surface.core_surface.io.pty_tee_userdata,
-        data.ptr,
-        data.len,
-    );
-
-    try std.testing.expectEqual(
-        @as(usize, 0),
-        callback_state.releases_during_callback,
-    );
-    try std.testing.expectEqual(@as(usize, 1), release_state.releases);
 }
 
 // The cmux integration combines the OpenGL platform payload (the largest
@@ -2432,19 +2109,7 @@ pub const CAPI = struct {
         app: *App,
         opts: *const apprt.Surface.Options,
     ) ?*Surface {
-        return surface_new_(app, opts, 0, null) catch |err| {
-            log.err("error initializing surface err={}", .{err});
-            return null;
-        };
-    }
-
-    /// Create a surface that owns its userdata until final destruction.
-    export fn ghostty_surface_new_with_owned_userdata(
-        app: *App,
-        opts: *const apprt.Surface.Options,
-        userdata_release_cb: UserdataReleaseCallback,
-    ) ?*Surface {
-        return surface_new_(app, opts, 0, userdata_release_cb) catch |err| {
+        return surface_new_(app, opts, 0) catch |err| {
             log.err("error initializing surface err={}", .{err});
             return null;
         };
@@ -2457,7 +2122,7 @@ pub const CAPI = struct {
         opts: *const apprt.Surface.Options,
         scrollback_limit_bytes: usize,
     ) ?*Surface {
-        return surface_new_(app, opts, scrollback_limit_bytes, null) catch |err| {
+        return surface_new_(app, opts, scrollback_limit_bytes) catch |err| {
             log.err("error initializing surface err={}", .{err});
             return null;
         };
@@ -2467,13 +2132,8 @@ pub const CAPI = struct {
         app: *App,
         opts: *const apprt.Surface.Options,
         scrollback_limit_bytes: usize,
-        userdata_release_cb: ?UserdataReleaseCallback,
     ) !*Surface {
-        return try app.newSurface(
-            opts.*,
-            scrollback_limit_bytes,
-            userdata_release_cb,
-        );
+        return try app.newSurface(opts.*, scrollback_limit_bytes);
     }
 
     export fn ghostty_surface_free(ptr: *Surface) void {
@@ -2482,7 +2142,7 @@ pub const CAPI = struct {
 
     /// Returns the userdata associated with the surface.
     export fn ghostty_surface_userdata(surface: *Surface) ?*anyopaque {
-        return surface.userdata.value;
+        return surface.userdata;
     }
 
     /// Returns the app associated with a surface.
@@ -3988,10 +3648,11 @@ pub const CAPI = struct {
     /// matching grid. Upstream candidate.
     export fn ghostty_surface_set_pty_tee_cb(
         surface: *Surface,
-        cb: ?PtyTeeCallback,
+        cb: ?*const fn (?*anyopaque, [*]const u8, usize) callconv(.c) void,
         userdata: ?*anyopaque,
     ) void {
-        surface.setPtyTeeCallback(cb, userdata);
+        surface.core_surface.io.pty_tee_cb = cb;
+        surface.core_surface.io.pty_tee_userdata = userdata;
     }
 
     /// Returns true if the surface currently has mouse capturing

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1648,6 +1648,7 @@ test "surface teardown waits for a cross-thread action lease" {
             lifetime: *Lifetime,
             action_ready: std.Thread.ResetEvent = .{},
             allow_action_return: std.Thread.ResetEvent = .{},
+            action_finished: std.Thread.ResetEvent = .{},
             teardown_started: std.Thread.ResetEvent = .{},
             teardown_finished: std.Thread.ResetEvent = .{},
             action_released_final: std.atomic.Value(bool) = .{ .raw = true },
@@ -1660,6 +1661,7 @@ test "surface teardown waits for a cross-thread action lease" {
                     self.lifetime.releaseAction(),
                     .release,
                 );
+                self.action_finished.set();
             }
 
             fn runTeardown(self: *@This()) void {
@@ -1686,6 +1688,7 @@ test "surface teardown waits for a cross-thread action lease" {
 
         context.allow_action_return.set();
         context.teardown_finished.wait();
+        context.action_finished.wait();
         try std.testing.expect(
             !context.action_released_final.load(.acquire),
         );

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1029,26 +1029,36 @@ pub const Surface = struct {
     }
 
     pub fn deinit(self: *Surface) void {
-        // Stop new app actions before releasing the embedder's owner
-        // reference. An action already in progress retains this allocation and
-        // performs the final destruction after its reentrant host callback
-        // returns.
-        self.app.core_app.deleteSurface(self);
-        if (self.app_action_lifetime.release()) self.destroy();
+        self.deinitWith(destroyContents);
     }
 
-    /// Retain the opaque embedded surface while an app action is dispatched.
-    /// The core app calls this only while holding its surface registry lock,
-    /// so teardown cannot remove and release the owner reference first.
+    fn deinitWith(
+        self: *Surface,
+        comptime deinit_contents: fn (*Surface) void,
+    ) void {
+        const alloc = self.app.core_app.alloc;
+
+        // Stop new app actions first. Existing actions retain only this outer
+        // allocation, not the live renderer, IO, or callback state.
+        self.app.core_app.deleteSurface(self);
+        deinit_contents(self);
+        if (self.app_action_lifetime.release()) alloc.destroy(self);
+    }
+
+    /// Retain the opaque embedded surface allocation while an app action is
+    /// dispatched. Core teardown remains synchronous so host-owned callback
+    /// userdata may still be released when ghostty_surface_free returns.
     pub fn retainForAppAction(self: *Surface) void {
         self.app_action_lifetime.retain();
     }
 
     pub fn releaseForAppAction(self: *Surface) void {
-        if (self.app_action_lifetime.release()) self.destroy();
+        if (self.app_action_lifetime.release()) {
+            self.app.core_app.alloc.destroy(self);
+        }
     }
 
-    fn destroy(self: *Surface) void {
+    fn destroyContents(self: *Surface) void {
         const alloc = self.app.core_app.alloc;
 
         // Shut down our inspector
@@ -1059,7 +1069,6 @@ pub const Surface = struct {
 
         // Clean up our core surface so that all the rendering and IO stop.
         self.core_surface.deinit();
-        alloc.destroy(self);
     }
 
     /// Initialize the inspector instance. A surface can only have one

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -684,6 +684,61 @@ const SurfaceActionLifetime = struct {
     }
 };
 
+test "embedded surface teardown completes before a retained action returns" {
+    if (comptime !@hasDecl(Surface, "deinitWith")) {
+        try std.testing.expect(false);
+        return;
+    }
+
+    const Callbacks = struct {
+        fn wakeup(_: ?*anyopaque) callconv(.c) void {}
+
+        fn action(
+            _: *App,
+            _: apprt.Target.C,
+            _: apprt.Action.C,
+        ) callconv(.c) bool {
+            return true;
+        }
+
+        fn teardown(surface: *Surface) void {
+            const completed: *bool = @ptrCast(@alignCast(surface.userdata.?));
+            completed.* = true;
+        }
+    };
+
+    var core_app: CoreApp = undefined;
+    try core_app.init(std.testing.allocator);
+    defer {
+        core_app.surfaces.deinit(std.testing.allocator);
+        core_app.font_grid_set.deinit();
+    }
+
+    var rt_app: App = undefined;
+    rt_app.core_app = &core_app;
+    rt_app.opts = undefined;
+    rt_app.opts.action = Callbacks.action;
+    rt_app.opts.wakeup = Callbacks.wakeup;
+
+    var teardown_completed = false;
+    var surface: Surface = undefined;
+    surface.app = &rt_app;
+    surface.userdata = &teardown_completed;
+    surface.core_surface.id = 22;
+    surface.app_action_lifetime = .{};
+    try core_app.surfaces.append(std.testing.allocator, &surface);
+
+    surface.retainForAppAction();
+    surface.deinitWith(Callbacks.teardown);
+
+    try std.testing.expect(teardown_completed);
+    try std.testing.expectEqual(@as(usize, 0), core_app.surfaces.items.len);
+    try std.testing.expectEqual(
+        @as(usize, 1),
+        surface.app_action_lifetime.countForTesting(),
+    );
+}
+
 pub const Surface = struct {
     app: *App,
     platform: Platform,


### PR DESCRIPTION
Reverts https://github.com/manaflow-ai/ghostty/pull/140 while preserving the bounded renderer drain from https://github.com/manaflow-ai/ghostty/pull/135 and https://github.com/manaflow-ai/ghostty/pull/136 that fixes https://github.com/manaflow-ai/cmux/issues/8808.

PR 140 changed the embedder contract by adding atomic userdata leases around every host callback. That broad ownership layer is unnecessary if `ghostty_surface_free` keeps its established contract: stop renderer and IO callbacks synchronously before returning.

This PR restores borrowed callback userdata, keeps an outer surface allocation alive only for an in-flight app action, and always tears down the live core synchronously. The regression test is a separate commit before the fix.

Validation:
- Zig 0.15.2 formatting passed on a 48 GB fleet Mac
- focused embedded teardown, action lifetime, and redraw tests passed
- full GitHub checks required before merge

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/146"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787524163&installation_model_id=21920&pr_number=146&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F146&signature=ccce07446e21f393ea78a941d617b055f21e6465454a0bd01577e8e1276f2dc0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts owned userdata leasing and restores synchronous surface teardown. `ghostty_surface_free` now stops renderer and IO before returning and serializes teardown with cross-thread actions, while keeping the bounded renderer drain that fixes `cmux` issue 8808.

- **Bug Fixes**
  - Teardown is synchronous and waits for actions running on other threads before destroying core state.
  - Reentrant free on the action thread skips the wait; only the outer allocation is retained until the callback returns.
  - Keeps PTY tee callback fields synchronized with the IO setter.
  - Adds tests for retained-action teardown and cross-thread free during redraw.

- **Migration**
  - Removes `ghostty_userdata_release_cb` and `ghostty_surface_new_with_owned_userdata` from the C API.
  - Use `ghostty_surface_new` and manage callback `userdata` yourself.
  - Callbacks now receive the original `userdata` directly; no internal leases.

<sup>Written for commit 28c0f9bf564abf1b88d89015aa5f829fe9867644. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/146?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

