### PR TITLE
Expose exact key binding action probes

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1381,6 +1381,13 @@ GHOSTTY_API bool ghostty_surface_key(ghostty_surface_t, ghostty_input_key_s);
 GHOSTTY_API bool ghostty_surface_key_is_binding(ghostty_surface_t,
                                                    ghostty_input_key_s,
                                                    ghostty_binding_flags_e*);
+// cmux fork: inspect the exact binding action resolved by the current surface
+// key-table/sequence state without dispatching the key event.
+GHOSTTY_API bool ghostty_surface_key_binding_is_exact_action(
+    ghostty_surface_t,
+    ghostty_input_key_s,
+    const char*,
+    uintptr_t);
 GHOSTTY_API void ghostty_surface_text(ghostty_surface_t, const char*, uintptr_t);
 // cmux fork: delete when upstream separates committed typed text from paste
 // delivery for libghostty embedders.

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -3052,6 +3052,30 @@ pub fn keyEventIsBinding(
     self: *Surface,
     event_orig: input.KeyEvent,
 ) ?input.Binding.Flags {
+    const entry = self.keyEventBindingEntry(event_orig) orelse return null;
+
+    return switch (entry.value_ptr.*) {
+        .leader => .{},
+        inline .leaf, .leaf_chained => |v| v.flags,
+    };
+}
+
+/// Returns true when the key event resolves to exactly one binding action
+/// equal to `action`. This applies the same remappings, active key tables, and
+/// sequence state as key processing without executing the binding.
+pub fn keyEventBindingIsExactAction(
+    self: *Surface,
+    event_orig: input.KeyEvent,
+    action: input.Binding.Action,
+) bool {
+    const entry = self.keyEventBindingEntry(event_orig) orelse return false;
+    return entry.value_ptr.*.isExactAction(action);
+}
+
+fn keyEventBindingEntry(
+    self: *Surface,
+    event_orig: input.KeyEvent,
+) ?input.Binding.Set.Entry {
     // Apply key remappings for consistency with keyCallback
     var event = event_orig;
     if (self.config.key_remaps.isRemapped(event_orig.mods)) {
@@ -3083,11 +3107,7 @@ pub fn keyEventIsBinding(
         break :entry self.config.keybind.set.getEvent(event) orelse return null;
     };
 
-    // Return flags based on the
-    return switch (entry.value_ptr.*) {
-        .leader => .{},
-        inline .leaf, .leaf_chained => |v| v.flags,
-    };
+    return entry;
 }
 
 /// Called for any key events. This handles keybindings, encoding and

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -3929,6 +3929,34 @@ pub const CAPI = struct {
         return true;
     }
 
+    /// Returns true when the key event would resolve to exactly the requested
+    /// binding action if it were sent to the surface right now. This does not
+    /// execute the binding.
+    export fn ghostty_surface_key_binding_is_exact_action(
+        surface: *Surface,
+        event: KeyEvent,
+        action_ptr: [*]const u8,
+        action_len: usize,
+    ) bool {
+        const core_event = event.keyEvent().core() orelse {
+            log.warn("error processing key event", .{});
+            return false;
+        };
+        const action_str = action_ptr[0..action_len];
+        const action = input.Binding.Action.parse(action_str) catch |err| {
+            log.warn(
+                "error parsing binding action action={s} err={}",
+                .{ action_str, err },
+            );
+            return false;
+        };
+
+        return surface.core_surface.keyEventBindingIsExactAction(
+            core_event,
+            action,
+        );
+    }
+
     /// Send raw text to the terminal. This is treated like a paste
     /// so this isn't useful for sending escape sequences. For that,
     /// individual key input should be used.

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -2128,6 +2128,16 @@ pub const Set = struct {
         /// A set of actions to take in response to a trigger.
         leaf_chained: LeafChained,
 
+        /// Returns true only when this value resolves to one non-chained action
+        /// equal to `action`. Leaders and chains retain distinct sequence
+        /// semantics and therefore never match.
+        pub fn isExactAction(self: Value, action: Action) bool {
+            return switch (self) {
+                .leaf => |leaf| leaf.action.equal(action),
+                .leader, .leaf_chained => false,
+            };
+        }
+
         /// Implements the formatter for the fmt package. This encodes the
         /// action back into the format used by parse.
         pub fn format(

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -4116,6 +4116,26 @@ test "set: performable is not part of reverse mappings" {
     }
 }
 
+test "set value: exact action match excludes custom and chained bindings" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const trigger = try Trigger.parse("super+c");
+    const copy: Action = .{ .copy_to_clipboard = .mixed };
+
+    var s: Set = .{};
+    defer s.deinit(alloc);
+
+    try s.parseAndPut(alloc, "performable:super+c=copy_to_clipboard");
+    try testing.expect(s.get(trigger).?.value_ptr.*.isExactAction(copy));
+
+    try s.parseAndPut(alloc, "performable:super+c=toggle_fullscreen");
+    try testing.expect(!s.get(trigger).?.value_ptr.*.isExactAction(copy));
+
+    try s.parseAndPut(alloc, "performable:super+c=copy_to_clipboard");
+    try s.parseAndPut(alloc, "chain=ignore");
+    try testing.expect(!s.get(trigger).?.value_ptr.*.isExactAction(copy));
+}
+
 test "set: overriding a mapping updates reverse" {
     const testing = std.testing;
     const alloc = testing.allocator;


### PR DESCRIPTION
Adds a read-only libghostty probe that resolves a key event through current remaps, key tables, and key-sequence state, then compares the exact non-chained binding action without dispatching it.

Includes regression coverage distinguishing Copy from custom and chained bindings.

Companion: https://github.com/manaflow-ai/cmux/pull/8895

Verification: Zig 0.15.2 formatting passed. The local Zig test runner is blocked by unresolved macOS 26.5 system symbols, so repository checks and the companion cmux cloud build provide compile and runtime verification.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/149"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787618612&installation_model_id=21920&pr_number=149&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F149&signature=246c594c9cd061f5db7a6ae633d6639b956f0329fb7cece2b8a4a009c5093592"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a read-only `libghostty` probe to check if a key event would resolve to an exact, non‑chained binding action without dispatching. Useful for distinguishing `copy_to_clipboard` from custom or chained bindings.

- **New Features**
  - Exposes `ghostty_surface_key_binding_is_exact_action(surface, event, action_ptr, action_len)`; respects remaps, active key tables, and sequence state; does not execute the binding.
  - Matches only exact leaf actions; leaders and chained bindings never match.
  - Adds tests to distinguish `copy_to_clipboard` from custom and chained cases.

- **Refactors**
  - Extracts shared key binding entry resolver for consistent handling across probes.

<sup>Written for commit ee6f082dbf67b6fe58ec9d93f1a91fbbe315593c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/149?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

