### PR TITLE
Preserve menu-owned binding key lifecycle

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1380,9 +1380,9 @@ GHOSTTY_API bool ghostty_surface_key(ghostty_surface_t, ghostty_input_key_s);
 GHOSTTY_API bool ghostty_surface_key_is_binding(ghostty_surface_t,
                                                    ghostty_input_key_s,
                                                    ghostty_binding_flags_e*);
-// cmux fork: inspect the exact binding action resolved by the current surface
-// key-table/sequence state without dispatching the key event.
-GHOSTTY_API bool ghostty_surface_key_binding_is_exact_action(
+// cmux fork: consume a safe menu-owned binding after its native menu action
+// declined the key event, including the paired release lifecycle.
+GHOSTTY_API bool ghostty_surface_key_consume_if_menu_action(
     ghostty_surface_t,
     ghostty_input_key_s,
     const char*,

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -303,7 +303,62 @@ pub const Keyboard = struct {
     /// a combination to be handled by different bindings before the release
     /// of the prior (namely since you can't bind modifier-only).
     last_trigger: ?u64 = null,
+
+    fn consumesBindingRelease(self: *const Keyboard, event: input.KeyEvent) bool {
+        const last = self.last_trigger orelse return false;
+        return last == event.bindingHash();
+    }
+
+    fn consumeMenuAction(
+        self: *Keyboard,
+        value: input.Binding.Set.Value,
+        event: input.KeyEvent,
+        action: input.Binding.Action,
+    ) bool {
+        if (self.sequence_set != null or self.table_stack.items.len > 0) {
+            return false;
+        }
+        if (!value.isMenuEquivalentAction(action)) return false;
+
+        self.last_trigger = event.bindingHash();
+        return true;
+    }
 };
+
+test "keyboard menu action owns the paired release outside sequences and tables" {
+    const testing = std.testing;
+    const copy: input.Binding.Action = .{ .copy_to_clipboard = .mixed };
+    const value: input.Binding.Set.Value = .{ .leaf = .{
+        .action = copy,
+        .flags = .{ .performable = true },
+    } };
+    const press: input.KeyEvent = .{
+        .action = .press,
+        .key = .key_c,
+        .mods = .{ .super = true },
+        .unshifted_codepoint = 'c',
+    };
+
+    var keyboard: Keyboard = .{};
+    var sequence_set: input.Binding.Set = .{};
+    keyboard.sequence_set = &sequence_set;
+    try testing.expect(!keyboard.consumeMenuAction(value, press, copy));
+
+    keyboard.sequence_set = null;
+    try keyboard.table_stack.append(testing.allocator, .{
+        .set = &sequence_set,
+        .once = true,
+    });
+    defer keyboard.table_stack.deinit(testing.allocator);
+    try testing.expect(!keyboard.consumeMenuAction(value, press, copy));
+
+    keyboard.table_stack.clearRetainingCapacity();
+    try testing.expect(keyboard.consumeMenuAction(value, press, copy));
+
+    var release = press;
+    release.action = .release;
+    try testing.expect(keyboard.consumesBindingRelease(release));
+}
 
 /// The configuration that a surface has, this is copied from the main
 /// Config struct usually to prevent sharing a single value.
@@ -3060,27 +3115,33 @@ pub fn keyEventIsBinding(
     };
 }
 
-/// Returns true when the key event resolves to exactly one binding action
-/// equal to `action`. This applies the same remappings, active key tables, and
-/// sequence state as key processing without executing the binding.
-pub fn keyEventBindingIsExactAction(
+/// Consume a key event whose corresponding native menu action was unavailable.
+///
+/// This is intentionally limited to a root, single-action, consumed,
+/// performable binding. Sequences, key tables, unconsumed bindings, and
+/// application-wide bindings must continue through normal key processing.
+/// Recording the trigger here also consumes the paired release event through
+/// the same lifecycle used by normally handled bindings.
+pub fn keyEventConsumeIfMenuAction(
     self: *Surface,
     event_orig: input.KeyEvent,
     action: input.Binding.Action,
 ) bool {
-    const entry = self.keyEventBindingEntry(event_orig) orelse return false;
-    return entry.value_ptr.*.isExactAction(action);
+    const event = self.keyEventWithRemappedMods(event_orig);
+    switch (event.action) {
+        .release => return false,
+        .press, .repeat => {},
+    }
+
+    const entry = self.config.keybind.set.getEvent(event) orelse return false;
+    return self.keyboard.consumeMenuAction(entry.value_ptr.*, event, action);
 }
 
 fn keyEventBindingEntry(
     self: *Surface,
     event_orig: input.KeyEvent,
 ) ?input.Binding.Set.Entry {
-    // Apply key remappings for consistency with keyCallback
-    var event = event_orig;
-    if (self.config.key_remaps.isRemapped(event_orig.mods)) {
-        event.mods = self.config.key_remaps.apply(event_orig.mods);
-    }
+    const event = self.keyEventWithRemappedMods(event_orig);
 
     switch (event.action) {
         .release => return null,
@@ -3110,6 +3171,17 @@ fn keyEventBindingEntry(
     return entry;
 }
 
+fn keyEventWithRemappedMods(
+    self: *const Surface,
+    event_orig: input.KeyEvent,
+) input.KeyEvent {
+    var event = event_orig;
+    if (self.config.key_remaps.isRemapped(event_orig.mods)) {
+        event.mods = self.config.key_remaps.apply(event_orig.mods);
+    }
+    return event;
+}
+
 /// Called for any key events. This handles keybindings, encoding and
 /// sending to the terminal, etc.
 pub fn keyCallback(
@@ -3120,10 +3192,7 @@ pub fn keyCallback(
 
     // Apply key remappings to transform modifiers before any processing.
     // This allows users to remap modifier keys at the app level.
-    var event = event_orig;
-    if (self.config.key_remaps.isRemapped(event_orig.mods)) {
-        event.mods = self.config.key_remaps.apply(event_orig.mods);
-    }
+    const event = self.keyEventWithRemappedMods(event_orig);
 
     // Crash metadata in case we crash in here
     crash.sentry.thread_state = self.crashThreadState();
@@ -3317,13 +3386,11 @@ fn maybeHandleBinding(
         // Release events never trigger a binding but we need to check if
         // we consumed the press event so we don't encode the release.
         .release => {
-            if (self.keyboard.last_trigger) |last| {
-                if (last == event.bindingHash()) {
-                    // We don't reset the last trigger on release because
-                    // an apprt may send multiple release events for a single
-                    // press event.
-                    return .consumed;
-                }
+            if (self.keyboard.consumesBindingRelease(event)) {
+                // We don't reset the last trigger on release because
+                // an apprt may send multiple release events for a single
+                // press event.
+                return .consumed;
             }
 
             return null;

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -3836,10 +3836,9 @@ pub const CAPI = struct {
         return true;
     }
 
-    /// Returns true when the key event would resolve to exactly the requested
-    /// binding action if it were sent to the surface right now. This does not
-    /// execute the binding.
-    export fn ghostty_surface_key_binding_is_exact_action(
+    /// Consumes a safe menu-owned binding after the corresponding native menu
+    /// action declined the key event.
+    export fn ghostty_surface_key_consume_if_menu_action(
         surface: *Surface,
         event: KeyEvent,
         action_ptr: [*]const u8,
@@ -3858,7 +3857,7 @@ pub const CAPI = struct {
             return false;
         };
 
-        return surface.core_surface.keyEventBindingIsExactAction(
+        return surface.core_surface.keyEventConsumeIfMenuAction(
             core_event,
             action,
         );

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -4126,7 +4126,7 @@ test "set: performable is not part of reverse mappings" {
     }
 }
 
-test "set value: exact action match excludes custom and chained bindings" {
+test "set value: menu-equivalent action excludes unsafe flags, custom, and chained bindings" {
     const testing = std.testing;
     const alloc = testing.allocator;
     const trigger = try Trigger.parse("super+c");
@@ -4137,6 +4137,15 @@ test "set value: exact action match excludes custom and chained bindings" {
 
     try s.parseAndPut(alloc, "performable:super+c=copy_to_clipboard");
     try testing.expect(s.get(trigger).?.value_ptr.*.isExactAction(copy));
+
+    try s.parseAndPut(alloc, "unconsumed:performable:super+c=copy_to_clipboard");
+    try testing.expect(!s.get(trigger).?.value_ptr.*.isExactAction(copy));
+
+    try s.parseAndPut(alloc, "all:performable:super+c=copy_to_clipboard");
+    try testing.expect(!s.get(trigger).?.value_ptr.*.isExactAction(copy));
+
+    try s.parseAndPut(alloc, "super+c=copy_to_clipboard");
+    try testing.expect(!s.get(trigger).?.value_ptr.*.isExactAction(copy));
 
     try s.parseAndPut(alloc, "performable:super+c=toggle_fullscreen");
     try testing.expect(!s.get(trigger).?.value_ptr.*.isExactAction(copy));

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -2128,12 +2128,16 @@ pub const Set = struct {
         /// A set of actions to take in response to a trigger.
         leaf_chained: LeafChained,
 
-        /// Returns true only when this value resolves to one non-chained action
-        /// equal to `action`. Leaders and chains retain distinct sequence
-        /// semantics and therefore never match.
-        pub fn isExactAction(self: Value, action: Action) bool {
+        /// Returns true only when this value can be owned by an unavailable
+        /// native menu action. Menu-owned bindings are one consumed,
+        /// performable action scoped to the focused surface.
+        pub fn isMenuEquivalentAction(self: Value, action: Action) bool {
             return switch (self) {
-                .leaf => |leaf| leaf.action.equal(action),
+                .leaf => |leaf| leaf.flags.consumed and
+                    leaf.flags.performable and
+                    !leaf.flags.all and
+                    !leaf.flags.global and
+                    leaf.action.equal(action),
                 .leader, .leaf_chained => false,
             };
         }
@@ -4136,23 +4140,23 @@ test "set value: menu-equivalent action excludes unsafe flags, custom, and chain
     defer s.deinit(alloc);
 
     try s.parseAndPut(alloc, "performable:super+c=copy_to_clipboard");
-    try testing.expect(s.get(trigger).?.value_ptr.*.isExactAction(copy));
+    try testing.expect(s.get(trigger).?.value_ptr.*.isMenuEquivalentAction(copy));
 
     try s.parseAndPut(alloc, "unconsumed:performable:super+c=copy_to_clipboard");
-    try testing.expect(!s.get(trigger).?.value_ptr.*.isExactAction(copy));
+    try testing.expect(!s.get(trigger).?.value_ptr.*.isMenuEquivalentAction(copy));
 
     try s.parseAndPut(alloc, "all:performable:super+c=copy_to_clipboard");
-    try testing.expect(!s.get(trigger).?.value_ptr.*.isExactAction(copy));
+    try testing.expect(!s.get(trigger).?.value_ptr.*.isMenuEquivalentAction(copy));
 
     try s.parseAndPut(alloc, "super+c=copy_to_clipboard");
-    try testing.expect(!s.get(trigger).?.value_ptr.*.isExactAction(copy));
+    try testing.expect(!s.get(trigger).?.value_ptr.*.isMenuEquivalentAction(copy));
 
     try s.parseAndPut(alloc, "performable:super+c=toggle_fullscreen");
-    try testing.expect(!s.get(trigger).?.value_ptr.*.isExactAction(copy));
+    try testing.expect(!s.get(trigger).?.value_ptr.*.isMenuEquivalentAction(copy));
 
     try s.parseAndPut(alloc, "performable:super+c=copy_to_clipboard");
     try s.parseAndPut(alloc, "chain=ignore");
-    try testing.expect(!s.get(trigger).?.value_ptr.*.isExactAction(copy));
+    try testing.expect(!s.get(trigger).?.value_ptr.*.isMenuEquivalentAction(copy));
 }
 
 test "set: overriding a mapping updates reverse" {


### PR DESCRIPTION
Follow-up to https://github.com/manaflow-ai/ghostty/pull/149 for https://github.com/manaflow-ai/cmux/pull/8895.

Replace the read-only exact-action probe with one transactional menu-miss API. Ghostty now accepts only a root, single-action, consumed, performable binding when no sequence or key table is active, then records the trigger so the paired release is consumed by normal binding lifecycle handling.

Custom, unconsumed, global, all-surface, chained, sequence, and key-table bindings retain normal processing.

Tests cover unsafe binding flags, custom and chained actions, active sequences and tables, and paired release ownership. Zig 0.15.2 formatting passes. The local Zig 0.15.2 build runner is blocked by macOS 26 system-linker symbols, so the cmux macOS 15 GhosttyKit workflow will provide the authoritative compile and test artifact.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/150"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787620375&installation_model_id=21920&pr_number=150&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F150&signature=dd8411ff150c61f6000bc0edcbedead36ac6632d0523260987e59dfc0dea6491"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the press/release lifecycle for menu-owned keybindings by replacing the read-only probe with a transactional consume path when the native menu declines a key. Prevents double-handling and ensures the paired release is consumed like normal bindings.

- **Bug Fixes**
  - Added `consume-if-menu-action` path for root, single-action, consumed, performable, surface-scoped bindings when no sequence or key table is active.
  - Records the press trigger to consume the paired release via normal binding lifecycle.
  - Leaves custom, unconsumed, global, all-surface, chained, sequence, and key-table bindings unchanged.

- **Migration**
  - Replace `ghostty_surface_key_binding_is_exact_action` with `ghostty_surface_key_consume_if_menu_action`.
  - Call only after a native menu action declines the key; it consumes the event and returns true when Ghostty should own the press/release pair.

<sup>Written for commit 22d6c589fe0c38a20ab92631d7b34da436af8679. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/150?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

