### PR TITLE
fix: match binding releases after modifier key-up

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -357,6 +357,9 @@ test "keyboard menu action owns the paired release outside sequences and tables"
 
     var release = press;
     release.action = .release;
+    // Modifier key-up can arrive first, so the paired C release no longer
+    // necessarily carries Super even though the consumed press did.
+    release.mods = .{};
     try testing.expect(keyboard.consumesBindingRelease(release));
 }
 

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -304,9 +304,14 @@ pub const Keyboard = struct {
     /// of the prior (namely since you can't bind modifier-only).
     last_trigger: ?u64 = null,
 
+    fn prepareBindingEvent(self: *Keyboard, event: input.KeyEvent) void {
+        const last = self.last_trigger orelse return;
+        if (last == event.bindingReleaseHash()) self.last_trigger = null;
+    }
+
     fn consumesBindingRelease(self: *const Keyboard, event: input.KeyEvent) bool {
         const last = self.last_trigger orelse return false;
-        return last == event.bindingHash();
+        return last == event.bindingReleaseHash();
     }
 
     fn consumeMenuAction(
@@ -320,7 +325,7 @@ pub const Keyboard = struct {
         }
         if (!value.isMenuEquivalentAction(action)) return false;
 
-        self.last_trigger = event.bindingHash();
+        self.last_trigger = event.bindingReleaseHash();
         return true;
     }
 };
@@ -361,6 +366,18 @@ test "keyboard menu action owns the paired release outside sequences and tables"
     // necessarily carries Super even though the consumed press did.
     release.mods = .{};
     try testing.expect(keyboard.consumesBindingRelease(release));
+    try testing.expect(keyboard.consumesBindingRelease(release));
+
+    var next_press = release;
+    next_press.action = .press;
+    keyboard.prepareBindingEvent(next_press);
+    try testing.expect(!keyboard.consumesBindingRelease(release));
+
+    try testing.expect(keyboard.consumeMenuAction(value, press, copy));
+    var repeat = release;
+    repeat.action = .repeat;
+    keyboard.prepareBindingEvent(repeat);
+    try testing.expect(!keyboard.consumesBindingRelease(release));
 }
 
 /// The configuration that a surface has, this is copied from the main
@@ -3399,8 +3416,11 @@ fn maybeHandleBinding(
             return null;
         },
 
-        // Carry on processing.
-        .press, .repeat => {},
+        // Resolve each press or repeat transactionally: expire any prior
+        // release identity for this key first, then record it again below only
+        // when this event is consumed. A forwarded event therefore keeps its
+        // eventual release, while duplicate release events remain consumed.
+        .press, .repeat => self.keyboard.prepareBindingEvent(event),
     }
 
     // Find an entry in the keybind set that matches our event.
@@ -3585,7 +3605,7 @@ fn maybeHandleBinding(
         self.endKeySequence(.drop, .retain);
 
         // Store our last trigger so we don't encode the release event
-        self.keyboard.last_trigger = event.bindingHash();
+        self.keyboard.last_trigger = event.bindingReleaseHash();
 
         if (insp_ev) |ev| {
             ev.binding = self.alloc.dupe(

--- a/src/input/key.zig
+++ b/src/input/key.zig
@@ -75,6 +75,16 @@ pub const KeyEvent = struct {
 
         return hasher.final();
     }
+
+    /// Returns a stable identity for pairing a consumed binding press with its
+    /// release. Modifiers are intentionally omitted because their key-up
+    /// events may arrive before the bound key's release.
+    pub fn bindingReleaseHash(self: KeyEvent) u64 {
+        var hasher = std.hash.Wyhash.init(0);
+        std.hash.autoHash(&hasher, self.key);
+        std.hash.autoHash(&hasher, self.unshifted_codepoint);
+        return hasher.final();
+    }
 };
 
 /// The action associated with an input event. This is backed by a c_int


### PR DESCRIPTION
## Summary

Keep a consumed binding release paired with its press when modifier key-up arrives first. Release identity now uses the physical/logical key without live modifiers.

Before each later press or repeat of that key, Ghostty clears the prior identity and records it again only if the new event is consumed. Duplicate releases remain suppressed, while forwarded repeats retain their eventual release.

This closes the remaining Cmd+C menu-miss lifecycle gap found while reviewing https://github.com/manaflow-ai/cmux/pull/8895.

## Verification

- Red `985dd1e96`: macOS 15, Zig 0.15.2, 72/73 tests passed; only the new modifier-first assertion failed
- Green `d9311bb99`: the same focused test and Zig formatting pass
- Canonical autoreview: no findings, patch correct, confidence 0.96
- Required Checks: Test and Socket checks pass
- macOS 15 GhosttyKit artifact build required before updating cmux
