### PR TITLE
fix: release action lease before teardown wake

### DIFF
--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -718,12 +718,13 @@ const SurfaceActionLifetime = struct {
         self.mutex.lock();
         assert(self.active_actions > 0);
         assert(self.active_thread.? == std.Thread.getCurrentId());
-        self.active_actions -= 1;
-        if (self.active_actions == 0) {
-            self.active_thread = null;
-            self.drained.broadcast();
-        }
-        self.mutex.unlock();
+
+        // Release the allocation reference before publishing that all actions
+        // drained. A teardown waiter may destroy the app as soon as it observes
+        // zero active actions, so the action must not touch the surface or app
+        // after that wake becomes visible.
+        const previous = self.references.fetchSub(1, .seq_cst);
+        assert(previous > 0);
 
         if (builtin.is_test) {
             if (self.release_pause_for_testing) |pause| {
@@ -732,8 +733,13 @@ const SurfaceActionLifetime = struct {
             }
         }
 
-        const previous = self.references.fetchSub(1, .seq_cst);
-        assert(previous > 0);
+        self.active_actions -= 1;
+        if (self.active_actions == 0) {
+            self.active_thread = null;
+            self.drained.broadcast();
+        }
+        self.mutex.unlock();
+
         return previous == 1;
     }
 

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -663,12 +663,19 @@ pub const RendererEventCallback = renderer.InstrumentationCallback;
 pub const RenderPresentedCallback = *const fn (?*anyopaque, u64) callconv(.c) void;
 
 const SurfaceActionLifetime = struct {
+    const ReleasePauseForTesting = struct {
+        reached: *std.Thread.ResetEvent,
+        continue_release: *std.Thread.ResetEvent,
+    };
+
     references: std.atomic.Value(usize) = .{ .raw = 1 },
     mutex: std.Thread.Mutex = .{},
     drained: std.Thread.Condition = .{},
     active_actions: usize = 0,
     active_thread: ?std.Thread.Id = null,
     teardown_started: bool = false,
+    release_pause_for_testing: if (builtin.is_test) ?ReleasePauseForTesting else void =
+        if (builtin.is_test) null else {},
 
     fn retain(self: *SurfaceActionLifetime) void {
         self.mutex.lock();
@@ -717,6 +724,13 @@ const SurfaceActionLifetime = struct {
             self.drained.broadcast();
         }
         self.mutex.unlock();
+
+        if (builtin.is_test) {
+            if (self.release_pause_for_testing) |pause| {
+                pause.reached.set();
+                pause.continue_release.wait();
+            }
+        }
 
         const previous = self.references.fetchSub(1, .seq_cst);
         assert(previous > 0);
@@ -1649,6 +1663,8 @@ test "surface teardown waits for a cross-thread action lease" {
             action_ready: std.Thread.ResetEvent = .{},
             allow_action_return: std.Thread.ResetEvent = .{},
             action_finished: std.Thread.ResetEvent = .{},
+            release_action_reached: std.Thread.ResetEvent = .{},
+            allow_release_completion: std.Thread.ResetEvent = .{},
             teardown_started: std.Thread.ResetEvent = .{},
             teardown_finished: std.Thread.ResetEvent = .{},
             action_released_final: std.atomic.Value(bool) = .{ .raw = true },
@@ -1674,11 +1690,16 @@ test "surface teardown waits for a cross-thread action lease" {
 
         var lifetime: Lifetime = .{};
         var context: Context = .{ .lifetime = &lifetime };
+        lifetime.release_pause_for_testing = .{
+            .reached = &context.release_action_reached,
+            .continue_release = &context.allow_release_completion,
+        };
         const action_thread = try std.Thread.spawn(.{}, Context.runAction, .{&context});
         defer action_thread.join();
         const teardown_thread = try std.Thread.spawn(.{}, Context.runTeardown, .{&context});
         defer teardown_thread.join();
         defer context.allow_action_return.set();
+        defer context.allow_release_completion.set();
 
         context.teardown_started.wait();
         try std.testing.expectError(
@@ -1687,6 +1708,12 @@ test "surface teardown waits for a cross-thread action lease" {
         );
 
         context.allow_action_return.set();
+        context.release_action_reached.wait();
+        try std.testing.expectError(
+            error.Timeout,
+            context.teardown_finished.timedWait(100 * std.time.ns_per_ms),
+        );
+        context.allow_release_completion.set();
         context.teardown_finished.wait();
         context.action_finished.wait();
         try std.testing.expect(


### PR DESCRIPTION
## Summary

- release an app-action allocation reference before publishing that all actions drained
- keep the reference drop and teardown wake ordered under the lifetime mutex
- add a deterministic cross-thread regression that pauses between those lifecycle steps

## Why

`ghostty_surface_free` could wake after `active_actions` reached zero but before the action dropped its allocation reference. The teardown thread could then return, the embedder could free the app, and the action release path could dereference that freed app while destroying the retained surface allocation.

The new order makes zero active actions mean the action reference is already gone. Cross-thread teardown owns final destruction; reentrant teardown still defers final destruction to the action lease.

## Verification

- Red at `b8efe0f45`: 72/73 focused tests passed; only `surface teardown waits for a cross-thread action lease` failed because teardown returned before action release completed.
- Green at `af4dfb43f`: `zig fmt --check src/apprt/embedded.zig` passed and the same focused Zig test command passed.

Required by https://github.com/manaflow-ai/cmux/pull/8895.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/152"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787628303&installation_model_id=21920&pr_number=152&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F152&signature=18d52e7cd0067c87475c9249454e3446e1b1dcf5c8d44efb933e4ea681039bca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race in surface teardown that could dereference a freed app by releasing the action’s allocation reference before signaling that all actions are drained. Adds a deterministic cross-thread test to prevent regressions.

- **Bug Fixes**
  - Drop the action’s allocation reference before publishing `active_actions == 0` and broadcasting `drained`, ordered under the lifetime mutex.
  - Add a test-only pause and cross-thread test to verify teardown waits until the action lease completes.

<sup>Written for commit af4dfb43ff9d1dffe8c1b49b5c1e1ce31d05e9ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/152?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

