### PR TITLE
Reclaim hidden macOS tab GPU memory

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1618,6 +1618,9 @@ GHOSTTY_API void ghostty_surface_free_text(ghostty_surface_t, ghostty_text_s*);
 #ifdef __APPLE__
 GHOSTTY_API void ghostty_surface_set_display_id(ghostty_surface_t, uint32_t);
 GHOSTTY_API bool ghostty_surface_set_renderer_realized(ghostty_surface_t, bool);
+// Force one renderer-thread unrealize/realize transaction without freeing the
+// surface, PTY, terminal state, or scrollback.
+GHOSTTY_API bool ghostty_surface_rebuild_renderer(ghostty_surface_t);
 GHOSTTY_API void* ghostty_surface_quicklook_font(ghostty_surface_t);
 GHOSTTY_API bool ghostty_surface_quicklook_word(ghostty_surface_t, ghostty_text_s*);
 #endif

--- a/macos/Sources/Features/Terminal/BaseTerminalController.swift
+++ b/macos/Sources/Features/Terminal/BaseTerminalController.swift
@@ -49,6 +49,16 @@ enum RendererTabVisibility {
     }
 }
 
+enum RendererReclamationRetry {
+    static func shouldRetry(
+        hasSurface: Bool,
+        releaseAccepted: @autoclosure () -> Bool
+    ) -> Bool {
+        guard hasSurface else { return false }
+        return !releaseAccepted()
+    }
+}
+
 /// A base class for windows that can contain Ghostty windows. This base class implements
 /// the bare minimum functionality that every terminal window in Ghostty should implement.
 ///
@@ -1491,7 +1501,10 @@ class BaseTerminalController: NSWindowController,
 
         var needsRetry = false
         for view in surfaceTree where !view.isWindowVisible {
-            if !view.setRendererRealized(false) {
+            if RendererReclamationRetry.shouldRetry(
+                hasSurface: view.surface != nil,
+                releaseAccepted: view.setRendererRealized(false)
+            ) {
                 needsRetry = true
             }
         }

--- a/macos/Sources/Features/Terminal/BaseTerminalController.swift
+++ b/macos/Sources/Features/Terminal/BaseTerminalController.swift
@@ -26,6 +26,17 @@ enum RendererTabSelection: Equatable {
     }
 }
 
+enum RendererTabVisibility {
+    static func isVisible(
+        selection: RendererTabSelection,
+        occlusionVisible: Bool,
+        isKeyOrMain: Bool
+    ) -> Bool {
+        guard selection != .deselected else { return false }
+        return occlusionVisible || (selection == .selected && isKeyOrMain)
+    }
+}
+
 /// A base class for windows that can contain Ghostty windows. This base class implements
 /// the bare minimum functionality that every terminal window in Ghostty should implement.
 ///
@@ -1389,8 +1400,11 @@ class BaseTerminalController: NSWindowController,
         selection: RendererTabSelection
     ) -> Bool {
         guard let window else { return false }
-        guard selection != .deselected else { return false }
-        return window.occlusionState.contains(.visible)
+        return RendererTabVisibility.isVisible(
+            selection: selection,
+            occlusionVisible: window.occlusionState.contains(.visible),
+            isKeyOrMain: window.isKeyWindow || window.isMainWindow
+        )
     }
 
     private func syncSurfaceTreeOcclusionState() {

--- a/macos/Sources/Features/Terminal/BaseTerminalController.swift
+++ b/macos/Sources/Features/Terminal/BaseTerminalController.swift
@@ -6,13 +6,18 @@ import GhosttyKit
 enum RendererTabSelection: Equatable {
     case selected
     case deselected
+    case overview
     case ambiguous
 
     static func classify(
         hasTabGroup: Bool,
         selectedWindowMatches: Bool?,
-        isKeyOrMain: Bool
+        isKeyOrMain: Bool,
+        isOverviewVisible: Bool = false
     ) -> Self {
+        if hasTabGroup, isOverviewVisible {
+            return .overview
+        }
         if isKeyOrMain {
             return .selected
         }
@@ -32,6 +37,7 @@ enum RendererTabVisibility {
         occlusionVisible: Bool,
         isKeyOrMain: Bool
     ) -> Bool {
+        if selection == .overview { return true }
         guard selection != .deselected else { return false }
         return occlusionVisible || (selection == .selected && isKeyOrMain)
     }
@@ -118,6 +124,7 @@ class BaseTerminalController: NSWindowController,
     private var rendererReclamationTimer: Timer?
     private weak var observedRendererTabGroup: NSWindowTabGroup?
     private var rendererTabSelectionObservation: NSKeyValueObservation?
+    private var rendererTabOverviewObservation: NSKeyValueObservation?
 
     /// The previous frame information from the window
     private var savedFrame: SavedFrame?
@@ -272,6 +279,7 @@ class BaseTerminalController: NSWindowController,
     deinit {
         rendererReclamationTimer?.invalidate()
         rendererTabSelectionObservation?.invalidate()
+        rendererTabOverviewObservation?.invalidate()
         NotificationCenter.default.removeObserver(self)
         undoManager?.removeAllActions(withTarget: self)
         if let eventMonitor {
@@ -1292,6 +1300,8 @@ class BaseTerminalController: NSWindowController,
         rendererReclamationTimer = nil
         rendererTabSelectionObservation?.invalidate()
         rendererTabSelectionObservation = nil
+        rendererTabOverviewObservation?.invalidate()
+        rendererTabOverviewObservation = nil
         observedRendererTabGroup = nil
 
         // Emit a final bell-state transition so any observers can clear state
@@ -1378,14 +1388,16 @@ class BaseTerminalController: NSWindowController,
         }
     }
 
-    /// Observe native tab selection directly. Key/main-window callbacks do not
-    /// cover every AppKit tab activation path, especially tab-bar clicks.
+    /// Observe native tab selection and overview directly. Key/main-window
+    /// callbacks do not cover tab-bar clicks or Show All Tabs transitions.
     private func syncRendererTabSelectionObservation() {
         let tabGroup = window?.tabGroup
         guard observedRendererTabGroup !== tabGroup else { return }
 
         rendererTabSelectionObservation?.invalidate()
         rendererTabSelectionObservation = nil
+        rendererTabOverviewObservation?.invalidate()
+        rendererTabOverviewObservation = nil
         observedRendererTabGroup = tabGroup
 
         guard let tabGroup else { return }
@@ -1393,15 +1405,23 @@ class BaseTerminalController: NSWindowController,
             \.selectedWindow,
              options: [.new]
         ) { [weak self] _, _ in
-            DispatchQueue.main.async { [weak self] in
+            Task { @MainActor [weak self] in
+                self?.syncRendererVisibilityForWindowGroup()
+            }
+        }
+        rendererTabOverviewObservation = tabGroup.observe(
+            \.isOverviewVisible,
+             options: [.new]
+        ) { [weak self] _, _ in
+            Task { @MainActor [weak self] in
                 self?.syncRendererVisibilityForWindowGroup()
             }
         }
     }
 
-    /// Native-tab selection is durable across AppKit's transient occlusion
-    /// changes while tab groups are being assembled. Key/main status is a
-    /// conservative fallback because AppKit can briefly report no selected
+    /// Native-tab selection and overview are durable across AppKit's transient
+    /// occlusion changes while tab groups are being assembled. Key/main status
+    /// is a conservative fallback because AppKit can briefly report no selected
     /// window while the active tab is changing.
     private var rendererTabSelection: RendererTabSelection {
         guard let window else { return .ambiguous }
@@ -1409,7 +1429,8 @@ class BaseTerminalController: NSWindowController,
         return .classify(
             hasTabGroup: tabGroup != nil,
             selectedWindowMatches: tabGroup?.selectedWindow.map { $0 === window },
-            isKeyOrMain: window.isKeyWindow || window.isMainWindow
+            isKeyOrMain: window.isKeyWindow || window.isMainWindow,
+            isOverviewVisible: tabGroup?.isOverviewVisible ?? false
         )
     }
 

--- a/macos/Sources/Features/Terminal/BaseTerminalController.swift
+++ b/macos/Sources/Features/Terminal/BaseTerminalController.swift
@@ -35,6 +35,12 @@ enum RendererTabVisibility {
         guard selection != .deselected else { return false }
         return occlusionVisible || (selection == .selected && isKeyOrMain)
     }
+
+    static func shouldReclaimSynchronously(
+        selection: RendererTabSelection
+    ) -> Bool {
+        selection == .deselected
+    }
 }
 
 /// A base class for windows that can contain Ghostty windows. This base class implements
@@ -106,8 +112,9 @@ class BaseTerminalController: NSWindowController,
     private var eventMonitor: Any?
 
     /// Hidden terminal windows keep their PTYs and terminal state but release
-    /// GPU swap-chain resources after this grace period.
-    private static let rendererReclamationDelay: TimeInterval = 5
+    /// GPU swap-chain resources in the same tab-selection pass. Retry only if
+    /// the renderer state handoff is temporarily unavailable.
+    private static let rendererReclamationRetryDelay: TimeInterval = 0.05
     private var rendererReclamationTimer: Timer?
     private weak var observedRendererTabGroup: NSWindowTabGroup?
     private var rendererTabSelectionObservation: NSKeyValueObservation?
@@ -1357,6 +1364,16 @@ class BaseTerminalController: NSWindowController,
 
         for controller in controllers {
             controller.syncRendererTabSelectionObservation()
+        }
+
+        // Publish every deselection before realizing the selected tab. This
+        // prevents a tab switch from growing two renderer allocations at once.
+        for controller in controllers
+            where controller.rendererTabSelection == .deselected {
+            controller.syncSurfaceTreeOcclusionState()
+        }
+        for controller in controllers
+            where controller.rendererTabSelection != .deselected {
             controller.syncSurfaceTreeOcclusionState()
         }
     }
@@ -1432,39 +1449,47 @@ class BaseTerminalController: NSWindowController,
                 ghostty_surface_set_occlusion(surface, true)
                 view.isWindowVisible = true
             } else {
-                // Stop drawing immediately. The renderer itself stays warm for
-                // the grace period so rapid tab switches remain instant.
+                // Stop drawing before releasing this deselected tab's renderer.
                 ghostty_surface_set_occlusion(surface, false)
                 view.isWindowVisible = false
             }
         }
 
-        if selection == .deselected {
-            scheduleRendererReclamation()
+        if RendererTabVisibility.shouldReclaimSynchronously(
+            selection: selection
+        ) {
+            reclaimDeselectedRenderers()
         }
     }
 
-    private func scheduleRendererReclamation() {
+    private func reclaimDeselectedRenderers() {
+        guard rendererTabSelection == .deselected else { return }
+
+        rendererReclamationTimer?.invalidate()
+        rendererReclamationTimer = nil
+
+        var needsRetry = false
+        for view in surfaceTree where !view.isWindowVisible {
+            if !view.setRendererRealized(false) {
+                needsRetry = true
+            }
+        }
+
+        if needsRetry {
+            scheduleRendererReclamationRetry()
+        }
+    }
+
+    private func scheduleRendererReclamationRetry() {
         guard rendererReclamationTimer == nil else { return }
 
         rendererReclamationTimer = Timer.scheduledTimer(
-            withTimeInterval: Self.rendererReclamationDelay,
+            withTimeInterval: Self.rendererReclamationRetryDelay,
             repeats: false
         ) { [weak self] _ in
             guard let self else { return }
             self.rendererReclamationTimer = nil
-            guard self.rendererTabSelection == .deselected else { return }
-
-            var needsRetry = false
-            for view in self.surfaceTree where !view.isWindowVisible {
-                if !view.setRendererRealized(false) {
-                    needsRetry = true
-                }
-            }
-
-            if needsRetry {
-                self.scheduleRendererReclamation()
-            }
+            self.reclaimDeselectedRenderers()
         }
     }
 

--- a/macos/Sources/Features/Terminal/BaseTerminalController.swift
+++ b/macos/Sources/Features/Terminal/BaseTerminalController.swift
@@ -3,6 +3,29 @@ import SwiftUI
 import Combine
 import GhosttyKit
 
+enum RendererTabSelection: Equatable {
+    case selected
+    case deselected
+    case ambiguous
+
+    static func classify(
+        hasTabGroup: Bool,
+        selectedWindowMatches: Bool?,
+        isKeyOrMain: Bool
+    ) -> Self {
+        if isKeyOrMain {
+            return .selected
+        }
+        guard hasTabGroup else {
+            return .selected
+        }
+        guard let selectedWindowMatches else {
+            return .ambiguous
+        }
+        return selectedWindowMatches ? .selected : .deselected
+    }
+}
+
 /// A base class for windows that can contain Ghostty windows. This base class implements
 /// the bare minimum functionality that every terminal window in Ghostty should implement.
 ///
@@ -70,6 +93,13 @@ class BaseTerminalController: NSWindowController,
 
     /// Event monitor (see individual events for why)
     private var eventMonitor: Any?
+
+    /// Hidden terminal windows keep their PTYs and terminal state but release
+    /// GPU swap-chain resources after this grace period.
+    private static let rendererReclamationDelay: TimeInterval = 5
+    private var rendererReclamationTimer: Timer?
+    private weak var observedRendererTabGroup: NSWindowTabGroup?
+    private var rendererTabSelectionObservation: NSKeyValueObservation?
 
     /// The previous frame information from the window
     private var savedFrame: SavedFrame?
@@ -222,6 +252,8 @@ class BaseTerminalController: NSWindowController,
     }
 
     deinit {
+        rendererReclamationTimer?.invalidate()
+        rendererTabSelectionObservation?.invalidate()
         NotificationCenter.default.removeObserver(self)
         undoManager?.removeAllActions(withTarget: self)
         if let eventMonitor {
@@ -292,7 +324,7 @@ class BaseTerminalController: NSWindowController,
         if to.isEmpty {
             focusedSurface = nil
         }
-        syncSurfaceTreeOcclusionState()
+        syncRendererVisibilityForWindowGroup()
     }
 
     /// Update all surfaces with the focus state. This ensures that libghostty has an accurate view about
@@ -1238,6 +1270,12 @@ class BaseTerminalController: NSWindowController,
     func windowWillClose(_ notification: Notification) {
         guard let window else { return }
 
+        rendererReclamationTimer?.invalidate()
+        rendererReclamationTimer = nil
+        rendererTabSelectionObservation?.invalidate()
+        rendererTabSelectionObservation = nil
+        observedRendererTabGroup = nil
+
         // Emit a final bell-state transition so any observers can clear state
         // without separately tracking NSWindow lifecycle events.
         if bell {
@@ -1259,6 +1297,8 @@ class BaseTerminalController: NSWindowController,
     }
 
     func windowDidBecomeKey(_ notification: Notification) {
+        syncRendererVisibilityForWindowGroup()
+
         // If when we become key our first responder is the window itself, then we
         // want to move focus to our focused terminal surface. This works around
         // various weirdness with moving surfaces around.
@@ -1279,18 +1319,137 @@ class BaseTerminalController: NSWindowController,
         // Becoming/losing key means we have to notify our surface(s) that we have focus
         // so things like cursors blink, pty events are sent, etc.
         self.syncFocusToSurfaceTree()
+        syncRendererVisibilityForWindowGroup()
     }
 
     func windowDidChangeOcclusionState(_ notification: Notification) {
-        syncSurfaceTreeOcclusionState()
+        syncRendererVisibilityForWindowGroup()
+    }
+
+    /// Reconcile every native tab from the tab group's authoritative selection.
+    /// AppKit can switch selected tabs without sending key-window notifications
+    /// to each underlying NSWindow.
+    func syncRendererVisibilityForWindowGroup() {
+        guard let window else {
+            syncSurfaceTreeOcclusionState()
+            return
+        }
+
+        let windows = window.tabGroup?.windows ?? [window]
+        let controllers = windows.compactMap {
+            $0.windowController as? BaseTerminalController
+        }
+        if controllers.isEmpty {
+            syncSurfaceTreeOcclusionState()
+            return
+        }
+
+        for controller in controllers {
+            controller.syncRendererTabSelectionObservation()
+            controller.syncSurfaceTreeOcclusionState()
+        }
+    }
+
+    /// Observe native tab selection directly. Key/main-window callbacks do not
+    /// cover every AppKit tab activation path, especially tab-bar clicks.
+    private func syncRendererTabSelectionObservation() {
+        let tabGroup = window?.tabGroup
+        guard observedRendererTabGroup !== tabGroup else { return }
+
+        rendererTabSelectionObservation?.invalidate()
+        rendererTabSelectionObservation = nil
+        observedRendererTabGroup = tabGroup
+
+        guard let tabGroup else { return }
+        rendererTabSelectionObservation = tabGroup.observe(
+            \.selectedWindow,
+             options: [.new]
+        ) { [weak self] _, _ in
+            DispatchQueue.main.async { [weak self] in
+                self?.syncRendererVisibilityForWindowGroup()
+            }
+        }
+    }
+
+    /// Native-tab selection is durable across AppKit's transient occlusion
+    /// changes while tab groups are being assembled. Key/main status is a
+    /// conservative fallback because AppKit can briefly report no selected
+    /// window while the active tab is changing.
+    private var rendererTabSelection: RendererTabSelection {
+        guard let window else { return .ambiguous }
+        let tabGroup = window.tabGroup
+        return .classify(
+            hasTabGroup: tabGroup != nil,
+            selectedWindowMatches: tabGroup?.selectedWindow.map { $0 === window },
+            isKeyOrMain: window.isKeyWindow || window.isMainWindow
+        )
+    }
+
+    private func windowIsRendererVisible(
+        selection: RendererTabSelection
+    ) -> Bool {
+        guard let window else { return false }
+        guard selection != .deselected else { return false }
+        return window.occlusionState.contains(.visible)
     }
 
     private func syncSurfaceTreeOcclusionState() {
-        let visible = self.window?.occlusionState.contains(.visible) ?? false
+        let selection = rendererTabSelection
+        let selected = selection == .selected
+        let visible = windowIsRendererVisible(selection: selection)
+
+        if selection != .deselected {
+            rendererReclamationTimer?.invalidate()
+            rendererReclamationTimer = nil
+        }
+
         for view in surfaceTree {
-            if let surface = view.surface, view.isWindowVisible != visible {
-                ghostty_surface_set_occlusion(surface, visible)
-                view.isWindowVisible = visible
+            guard let surface = view.surface else { continue }
+
+            // A selected tab owns a renderer even while AppKit transiently
+            // reports it occluded during native-tab assembly. An ambiguous
+            // tab only realizes when AppKit says it is actually visible.
+            if (selected || visible), !view.setRendererRealized(true) {
+                continue
+            }
+            guard view.isWindowVisible != visible else { continue }
+
+            if visible {
+                ghostty_surface_set_occlusion(surface, true)
+                view.isWindowVisible = true
+            } else {
+                // Stop drawing immediately. The renderer itself stays warm for
+                // the grace period so rapid tab switches remain instant.
+                ghostty_surface_set_occlusion(surface, false)
+                view.isWindowVisible = false
+            }
+        }
+
+        if selection == .deselected {
+            scheduleRendererReclamation()
+        }
+    }
+
+    private func scheduleRendererReclamation() {
+        guard rendererReclamationTimer == nil else { return }
+
+        rendererReclamationTimer = Timer.scheduledTimer(
+            withTimeInterval: Self.rendererReclamationDelay,
+            repeats: false
+        ) { [weak self] _ in
+            guard let self else { return }
+            self.rendererReclamationTimer = nil
+            guard self.rendererTabSelection == .deselected else { return }
+
+            var needsRetry = false
+            for view in self.surfaceTree where !view.isWindowVisible {
+                if !view.setRendererRealized(false) {
+                    needsRetry = true
+                }
+            }
+
+            if needsRetry {
+                self.scheduleRendererReclamation()
             }
         }
     }

--- a/macos/Sources/Ghostty/Surface View/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/Surface View/SurfaceView_AppKit.swift
@@ -98,6 +98,23 @@ extension Ghostty {
         /// after this surface is dragged to another window
         var isWindowVisible = false
 
+        /// Whether libghostty currently owns this surface's GPU renderer.
+        /// Hidden-window reclamation updates this only after libghostty accepts
+        /// the idempotent latest-value request.
+        private(set) var isRendererRealized = true
+
+        @discardableResult
+        func setRendererRealized(_ realized: Bool) -> Bool {
+            guard isRendererRealized != realized else { return true }
+            guard let surface else { return false }
+            guard ghostty_surface_set_renderer_realized(surface, realized) else {
+                return false
+            }
+
+            isRendererRealized = realized
+            return true
+        }
+
         /// The configuration derived from the Ghostty config so we don't need to rely on references.
         @Published private(set) var derivedConfig: DerivedConfig
 

--- a/macos/Tests/Ghostty/RendererTabSelectionTests.swift
+++ b/macos/Tests/Ghostty/RendererTabSelectionTests.swift
@@ -1,0 +1,44 @@
+import Testing
+@testable import Ghostty
+
+struct RendererTabSelectionTests {
+    @Test func standaloneWindowIsSelected() {
+        #expect(RendererTabSelection.classify(
+            hasTabGroup: false,
+            selectedWindowMatches: nil,
+            isKeyOrMain: false
+        ) == .selected)
+    }
+
+    @Test func matchingGroupSelectionIsSelected() {
+        #expect(RendererTabSelection.classify(
+            hasTabGroup: true,
+            selectedWindowMatches: true,
+            isKeyOrMain: false
+        ) == .selected)
+    }
+
+    @Test func differentGroupSelectionIsDeselected() {
+        #expect(RendererTabSelection.classify(
+            hasTabGroup: true,
+            selectedWindowMatches: false,
+            isKeyOrMain: false
+        ) == .deselected)
+    }
+
+    @Test func missingGroupSelectionIsAmbiguous() {
+        #expect(RendererTabSelection.classify(
+            hasTabGroup: true,
+            selectedWindowMatches: nil,
+            isKeyOrMain: false
+        ) == .ambiguous)
+    }
+
+    @Test func keyWindowOverridesTransientGroupSelection() {
+        #expect(RendererTabSelection.classify(
+            hasTabGroup: true,
+            selectedWindowMatches: false,
+            isKeyOrMain: true
+        ) == .selected)
+    }
+}

--- a/macos/Tests/Ghostty/RendererTabSelectionTests.swift
+++ b/macos/Tests/Ghostty/RendererTabSelectionTests.swift
@@ -41,4 +41,12 @@ struct RendererTabSelectionTests {
             isKeyOrMain: true
         ) == .selected)
     }
+
+    @Test func keyWindowRemainsVisibleWhileOcclusionStateLagsTabSelection() {
+        #expect(RendererTabVisibility.isVisible(
+            selection: .selected,
+            occlusionVisible: false,
+            isKeyOrMain: true
+        ))
+    }
 }

--- a/macos/Tests/Ghostty/RendererTabSelectionTests.swift
+++ b/macos/Tests/Ghostty/RendererTabSelectionTests.swift
@@ -81,4 +81,19 @@ struct RendererTabSelectionTests {
             selection: .ambiguous
         ))
     }
+
+    @Test func missingSurfaceDoesNotRetryRendererReclamation() {
+        var releaseAttempts = 0
+
+        let needsRetry = RendererReclamationRetry.shouldRetry(
+            hasSurface: false,
+            releaseAccepted: {
+                releaseAttempts += 1
+                return false
+            }()
+        )
+
+        #expect(!needsRetry)
+        #expect(releaseAttempts == 0)
+    }
 }

--- a/macos/Tests/Ghostty/RendererTabSelectionTests.swift
+++ b/macos/Tests/Ghostty/RendererTabSelectionTests.swift
@@ -50,6 +50,26 @@ struct RendererTabSelectionTests {
         ))
     }
 
+    @Test func tabOverviewClassifiesEveryMemberAsOverview() {
+        #expect(RendererTabSelection.classify(
+            hasTabGroup: true,
+            selectedWindowMatches: false,
+            isKeyOrMain: false,
+            isOverviewVisible: true
+        ) == .overview)
+    }
+
+    @Test func tabOverviewKeepsRendererVisibleAndNonReclaimable() {
+        #expect(RendererTabVisibility.isVisible(
+            selection: .overview,
+            occlusionVisible: false,
+            isKeyOrMain: false
+        ))
+        #expect(!RendererTabVisibility.shouldReclaimSynchronously(
+            selection: .overview
+        ))
+    }
+
     @Test func deselectedTabReclaimsRendererInCurrentVisibilityPass() {
         #expect(RendererTabVisibility.shouldReclaimSynchronously(
             selection: .deselected

--- a/macos/Tests/Ghostty/RendererTabSelectionTests.swift
+++ b/macos/Tests/Ghostty/RendererTabSelectionTests.swift
@@ -49,4 +49,16 @@ struct RendererTabSelectionTests {
             isKeyOrMain: true
         ))
     }
+
+    @Test func deselectedTabReclaimsRendererInCurrentVisibilityPass() {
+        #expect(RendererTabVisibility.shouldReclaimSynchronously(
+            selection: .deselected
+        ))
+        #expect(!RendererTabVisibility.shouldReclaimSynchronously(
+            selection: .selected
+        ))
+        #expect(!RendererTabVisibility.shouldReclaimSynchronously(
+            selection: .ambiguous
+        ))
+    }
 }

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -4275,26 +4275,17 @@ pub const CAPI = struct {
         /// terminal state alive; the swap chain is rebuilt on re-show.
         ///
         /// Darwin-only by placement: iOS owns occlusion via `renderingSuspended`
-        /// and must not be driven through this path. The message is
-        /// non-idempotent (it must strictly alternate with the swap chain's
-        /// `defunct` state), so the caller (cmux) must only advance its own
-        /// realize/unrealize state when this returns `true`. The push is
-        /// `.instant` (non-blocking): this runs on the caller's main actor and
-        /// must never stall the UI waiting on the renderer thread to drain. When
-        /// the mailbox is full the push drops and returns `false`; cmux keeps its
-        /// mirror state unchanged and retries on its next reclamation pass, so a
-        /// drop is harmless rather than tripping `displayRealized`'s
-        /// `assert(swap_chain.defunct)`. On re-show the mailbox is normally empty,
-        /// so the realize enqueues immediately and the surface is never presented
-        /// against a defunct swap chain.
+        /// and must not be driven through this path. The request is idempotent
+        /// latest-value state rather than ordered mailbox work. Publishing never
+        /// blocks or drops when the renderer mailbox is full, and the renderer
+        /// retries a failed GPU recreation without requiring the caller to mirror
+        /// delivery state. The return value remains for source compatibility and
+        /// means the request was accepted.
         export fn ghostty_surface_set_renderer_realized(ptr: *Surface, realized: bool) bool {
             const surface = &ptr.core_surface;
-            const enqueued = surface.renderer_thread.mailbox.push(
-                .{ .display_realized = realized },
-                .{ .instant = {} },
-            ) != 0;
+            surface.renderer_thread.publishRendererRealized(realized);
             surface.renderer_thread.wakeup.notify() catch {};
-            return enqueued;
+            return true;
         }
 
         /// This returns a CTFontRef that should be used for quicklook

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -4615,6 +4615,17 @@ pub const CAPI = struct {
             return true;
         }
 
+        /// Force one unrealize/realize transaction on the renderer thread.
+        /// Unlike two latest-value boolean publications, this cannot lose the
+        /// unrealize step when a surface becomes presentable before the renderer
+        /// consumes its earlier state.
+        export fn ghostty_surface_rebuild_renderer(ptr: *Surface) bool {
+            const surface = &ptr.core_surface;
+            surface.renderer_thread.publishRendererRebuild();
+            surface.renderer_thread.wakeup.notify() catch {};
+            return true;
+        }
+
         /// This returns a CTFontRef that should be used for quicklook
         /// highlighted text. This is always the primary font in use
         /// regardless of the selected text. If coretext is not in use

--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -99,6 +99,17 @@ test "forced draw transfers synchronous presentation to its caller" {
     try testing.expect(payload == ?FramePresentation);
 }
 
+test "renderer thread exposes lossless realization publication" {
+    const testing = @import("std").testing;
+    try testing.expect(@hasDecl(Thread, "publishRendererRealized"));
+}
+
+test "metal frame resources expose destructive disposal" {
+    const testing = @import("std").testing;
+    try testing.expect(@hasDecl(Metal.Texture, "discard"));
+    try testing.expect(@hasDecl(Metal.Buffer(u8), "discard"));
+}
+
 /// The implementation to use for the renderer. This is comptime chosen
 /// so that every build has exactly one renderer implementation.
 pub const Renderer = switch (build_config.renderer) {

--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -7,6 +7,7 @@
 //! APIs. The renderers in this package assume that the renderer is already
 //! setup (OpenGL has a context, Vulkan has a surface, etc.)
 
+const builtin = @import("builtin");
 const build_config = @import("build_config.zig");
 
 const cursor = @import("renderer/cursor.zig");
@@ -105,9 +106,11 @@ test "renderer thread exposes lossless realization publication" {
 }
 
 test "metal frame resources expose destructive disposal" {
-    const testing = @import("std").testing;
-    try testing.expect(@hasDecl(Metal.Texture, "discard"));
-    try testing.expect(@hasDecl(Metal.Buffer(u8), "discard"));
+    if (comptime builtin.os.tag.isDarwin()) {
+        const testing = @import("std").testing;
+        try testing.expect(@hasDecl(Metal.Texture, "discard"));
+        try testing.expect(@hasDecl(Metal.Buffer(u8), "discard"));
+    }
 }
 
 /// The implementation to use for the renderer. This is comptime chosen

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -154,13 +154,13 @@ const Presenter = union(enum) {
 const RecreatableCommandQueue = struct {
     value: ?objc.Object,
 
-    fn init(device: objc.Object) RecreatableCommandQueue {
+    fn init(device: objc.Object) !RecreatableCommandQueue {
         return .{
-            .value = device.msgSend(
-                objc.Object,
+            .value = try commandQueueFromId(device.msgSend(
+                ?*anyopaque,
                 objc.sel("newCommandQueue"),
                 .{},
-            ),
+            )),
         };
     }
 
@@ -177,9 +177,9 @@ const RecreatableCommandQueue = struct {
     fn ensureLive(
         self: *RecreatableCommandQueue,
         device: objc.Object,
-    ) void {
+    ) !void {
         if (self.value != null) return;
-        self.* = .init(device);
+        self.* = try .init(device);
     }
 
     fn get(self: *const RecreatableCommandQueue) objc.Object {
@@ -190,6 +190,10 @@ const RecreatableCommandQueue = struct {
         return self.value != null;
     }
 };
+
+fn commandQueueFromId(value: ?*anyopaque) !objc.Object {
+    return objc.Object.fromId(value orelse return error.CommandQueueUnavailable);
+}
 
 presenter: Presenter,
 
@@ -229,7 +233,7 @@ pub fn init(alloc: Allocator, opts: rendererpkg.Options) !Metal {
     // Choose our MTLDevice and create a MTLCommandQueue for that device.
     const device = try chooseDevice();
     errdefer device.release();
-    var queue = RecreatableCommandQueue.init(device);
+    var queue = try RecreatableCommandQueue.init(device);
     errdefer queue.deinit();
 
     // Grab metadata about the device.
@@ -313,8 +317,8 @@ pub fn displayUnrealizedAfterDrain(self: *Metal) void {
 /// Restore the per-renderer submission queue after hidden-tab reclamation.
 /// Pipeline state remains shared, while the queue's driver allocation pools
 /// exist only for renderers that can submit frames.
-pub fn displayRealized(self: *Metal) void {
-    self.queue.ensureLive(self.device);
+pub fn displayRealized(self: *Metal) !void {
+    try self.queue.ensureLive(self.device);
 }
 
 /// Install a distinct gate before replacement swap-chain frames can be used.
@@ -860,14 +864,14 @@ test "metal command queue releases and recreates across renderer realization" {
     const device = try chooseDevice();
     defer device.release();
 
-    var queue = RecreatableCommandQueue.init(device);
+    var queue = try RecreatableCommandQueue.init(device);
     defer queue.deinit();
     try testing.expect(queue.isLive());
 
     queue.release();
     try testing.expect(!queue.isLive());
 
-    queue.ensureLive(device);
+    try queue.ensureLive(device);
     try testing.expect(queue.isLive());
 }
 

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -39,6 +39,7 @@ pub const custom_shader_y_is_down = true;
 
 /// Triple buffering.
 pub const swap_chain_count = 3;
+const shared_command_queue_max_inflight: usize = swap_chain_count * 5 + 1;
 
 const log = std.log.scoped(.metal);
 
@@ -212,10 +213,12 @@ fn acquireSharedCommandQueue(device: objc.Object) *SharedCommandQueue {
 
     // Apple recommends one long-lived command queue per GPU. Command queues
     // are thread-safe, so every renderer can submit through this shared queue.
+    // Sixteen slots let five triple-buffered surfaces submit concurrently;
+    // additional surfaces apply backpressure instead of growing driver pools.
     const queue = device.msgSend(
         objc.Object,
-        objc.sel("newCommandQueue"),
-        .{},
+        objc.sel("newCommandQueueWithMaxCommandBufferCount:"),
+        .{shared_command_queue_max_inflight},
     );
     const entry = shared_command_queue_allocator.create(
         SharedCommandQueue,

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -321,6 +321,12 @@ pub fn displayRealized(self: *Metal) !void {
     try self.queue.ensureLive(self.device);
 }
 
+/// Undo API resources recreated before generic swap-chain realization failed.
+/// The renderer remains logically unrealized and may retry from a clean state.
+pub fn displayRealizedRollback(self: *Metal) void {
+    self.queue.release();
+}
+
 /// Install a distinct gate before replacement swap-chain frames can be used.
 pub fn startFrameGeneration(self: *Metal) !void {
     const renderer: *Renderer = @alignCast(@fieldParentPtr("api", self));

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -934,6 +934,13 @@ test "metal command queue is process-shared per device" {
     try testing.expectEqual(hidden.get().value, restored.get().value);
 }
 
+test "shared Metal queue bounds process-wide in-flight frames" {
+    try std.testing.expectEqual(
+        @as(usize, swap_chain_count * 5 + 1),
+        shared_command_queue_max_inflight,
+    );
+}
+
 test "metal completion generation rejects old callbacks after rotation" {
     const testing = std.testing;
     const Context = struct {

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -152,15 +152,11 @@ const Presenter = union(enum) {
 };
 
 const RecreatableCommandQueue = struct {
-    value: ?objc.Object,
+    value: ?*SharedCommandQueue,
 
     fn init(device: objc.Object) RecreatableCommandQueue {
         return .{
-            .value = device.msgSend(
-                objc.Object,
-                objc.sel("newCommandQueue"),
-                .{},
-            ),
+            .value = acquireSharedCommandQueue(device),
         };
     }
 
@@ -171,7 +167,7 @@ const RecreatableCommandQueue = struct {
     fn release(self: *RecreatableCommandQueue) void {
         const value = self.value orelse return;
         self.value = null;
-        value.release();
+        releaseSharedCommandQueue(value);
     }
 
     fn ensureLive(
@@ -183,13 +179,69 @@ const RecreatableCommandQueue = struct {
     }
 
     fn get(self: *const RecreatableCommandQueue) objc.Object {
-        return self.value orelse unreachable;
+        return (self.value orelse unreachable).queue;
     }
 
     fn isLive(self: *const RecreatableCommandQueue) bool {
         return self.value != null;
     }
 };
+
+const SharedCommandQueue = struct {
+    device: usize,
+    queue: objc.Object,
+    references: usize,
+};
+
+const shared_command_queue_allocator = std.heap.c_allocator;
+var shared_command_queue_mutex: std.Thread.Mutex = .{};
+var shared_command_queues: std.ArrayListUnmanaged(*SharedCommandQueue) = .empty;
+
+fn acquireSharedCommandQueue(device: objc.Object) *SharedCommandQueue {
+    const device_key = @intFromPtr(device.value);
+
+    shared_command_queue_mutex.lock();
+    defer shared_command_queue_mutex.unlock();
+
+    for (shared_command_queues.items) |entry| {
+        if (entry.device == device_key) {
+            entry.references += 1;
+            return entry;
+        }
+    }
+
+    // Apple recommends one long-lived command queue per GPU. Command queues
+    // are thread-safe, so every renderer can submit through this shared queue.
+    const queue = device.msgSend(
+        objc.Object,
+        objc.sel("newCommandQueue"),
+        .{},
+    );
+    const entry = shared_command_queue_allocator.create(
+        SharedCommandQueue,
+    ) catch @panic("failed to allocate shared Metal command queue");
+    entry.* = .{
+        .device = device_key,
+        .queue = queue,
+        .references = 1,
+    };
+    shared_command_queues.append(
+        shared_command_queue_allocator,
+        entry,
+    ) catch @panic("failed to cache shared Metal command queue");
+    return entry;
+}
+
+fn releaseSharedCommandQueue(entry: *SharedCommandQueue) void {
+    shared_command_queue_mutex.lock();
+    defer shared_command_queue_mutex.unlock();
+
+    std.debug.assert(entry.references > 0);
+    entry.references -= 1;
+    // Keep the queue alive for the process lifetime. Metal retains substantial
+    // driver pools after a queue first submits work, so destroying and
+    // recreating queues across tab switches only increases retained memory.
+}
 
 presenter: Presenter,
 
@@ -301,7 +353,7 @@ pub fn finishFrameGeneration(self: *Metal) void {
 }
 
 /// Drop the compositor's last IOSurface after all frame completion callbacks
-/// have drained. The persistent command queue remains valid across swaps.
+/// have drained, then release this renderer's shared-queue reference.
 pub fn displayUnrealizedAfterDrain(self: *Metal) void {
     switch (self.presenter) {
         .layer => |*layer| layer.clearSurface(),
@@ -310,9 +362,8 @@ pub fn displayUnrealizedAfterDrain(self: *Metal) void {
     self.queue.release();
 }
 
-/// Restore the per-renderer submission queue after hidden-tab reclamation.
-/// Pipeline state remains shared, while the queue's driver allocation pools
-/// exist only for renderers that can submit frames.
+/// Restore this renderer's reference to the process-wide submission queue
+/// after hidden-tab reclamation.
 pub fn displayRealized(self: *Metal) void {
     self.queue.ensureLive(self.device);
 }

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -39,7 +39,6 @@ pub const custom_shader_y_is_down = true;
 
 /// Triple buffering.
 pub const swap_chain_count = 3;
-const command_queue_max_inflight: usize = swap_chain_count;
 
 const log = std.log.scoped(.metal);
 
@@ -159,8 +158,8 @@ const RecreatableCommandQueue = struct {
         return .{
             .value = device.msgSend(
                 objc.Object,
-                objc.sel("newCommandQueueWithMaxCommandBufferCount:"),
-                .{command_queue_max_inflight},
+                objc.sel("newCommandQueue"),
+                .{},
             ),
         };
     }
@@ -864,13 +863,6 @@ test "metal command queue releases and recreates across renderer realization" {
 
     queue.ensureLive(device);
     try testing.expect(queue.isLive());
-}
-
-test "metal command queue capacity matches the swap chain" {
-    try std.testing.expectEqual(
-        @as(usize, swap_chain_count),
-        command_queue_max_inflight,
-    );
 }
 
 test "metal completion generation rejects old callbacks after rotation" {

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -695,6 +695,12 @@ pub inline fn beginFrame(
     return try Frame.begin(.{
         .queue = self.queue.get(),
         .completion_lifetime = self.completion_generation.lifetime(),
+        .retain_references = Frame.commandBufferRequiresMetalRetention(
+            renderer.bg_image != null,
+            renderer.images.kitty_placements.items.len > 0 or
+                renderer.images.overlay_placements.items.len > 0,
+            renderer.has_custom_shaders,
+        ),
     }, target, frame_token, host_context, gated);
 }
 

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -39,7 +39,6 @@ pub const custom_shader_y_is_down = true;
 
 /// Triple buffering.
 pub const swap_chain_count = 3;
-const shared_command_queue_max_inflight: usize = swap_chain_count * 5 + 1;
 
 const log = std.log.scoped(.metal);
 
@@ -153,11 +152,15 @@ const Presenter = union(enum) {
 };
 
 const RecreatableCommandQueue = struct {
-    value: ?*SharedCommandQueue,
+    value: ?objc.Object,
 
     fn init(device: objc.Object) RecreatableCommandQueue {
         return .{
-            .value = acquireSharedCommandQueue(device),
+            .value = device.msgSend(
+                objc.Object,
+                objc.sel("newCommandQueue"),
+                .{},
+            ),
         };
     }
 
@@ -168,7 +171,7 @@ const RecreatableCommandQueue = struct {
     fn release(self: *RecreatableCommandQueue) void {
         const value = self.value orelse return;
         self.value = null;
-        releaseSharedCommandQueue(value);
+        value.release();
     }
 
     fn ensureLive(
@@ -180,71 +183,13 @@ const RecreatableCommandQueue = struct {
     }
 
     fn get(self: *const RecreatableCommandQueue) objc.Object {
-        return (self.value orelse unreachable).queue;
+        return self.value orelse unreachable;
     }
 
     fn isLive(self: *const RecreatableCommandQueue) bool {
         return self.value != null;
     }
 };
-
-const SharedCommandQueue = struct {
-    device: usize,
-    queue: objc.Object,
-    references: usize,
-};
-
-const shared_command_queue_allocator = std.heap.c_allocator;
-var shared_command_queue_mutex: std.Thread.Mutex = .{};
-var shared_command_queues: std.ArrayListUnmanaged(*SharedCommandQueue) = .empty;
-
-fn acquireSharedCommandQueue(device: objc.Object) *SharedCommandQueue {
-    const device_key = @intFromPtr(device.value);
-
-    shared_command_queue_mutex.lock();
-    defer shared_command_queue_mutex.unlock();
-
-    for (shared_command_queues.items) |entry| {
-        if (entry.device == device_key) {
-            entry.references += 1;
-            return entry;
-        }
-    }
-
-    // Apple recommends one long-lived command queue per GPU. Command queues
-    // are thread-safe, so every renderer can submit through this shared queue.
-    // Sixteen slots let five triple-buffered surfaces submit concurrently;
-    // additional surfaces apply backpressure instead of growing driver pools.
-    const queue = device.msgSend(
-        objc.Object,
-        objc.sel("newCommandQueueWithMaxCommandBufferCount:"),
-        .{shared_command_queue_max_inflight},
-    );
-    const entry = shared_command_queue_allocator.create(
-        SharedCommandQueue,
-    ) catch @panic("failed to allocate shared Metal command queue");
-    entry.* = .{
-        .device = device_key,
-        .queue = queue,
-        .references = 1,
-    };
-    shared_command_queues.append(
-        shared_command_queue_allocator,
-        entry,
-    ) catch @panic("failed to cache shared Metal command queue");
-    return entry;
-}
-
-fn releaseSharedCommandQueue(entry: *SharedCommandQueue) void {
-    shared_command_queue_mutex.lock();
-    defer shared_command_queue_mutex.unlock();
-
-    std.debug.assert(entry.references > 0);
-    entry.references -= 1;
-    // Keep the queue alive for the process lifetime. Metal retains substantial
-    // driver pools after a queue first submits work, so destroying and
-    // recreating queues across tab switches only increases retained memory.
-}
 
 presenter: Presenter,
 
@@ -356,7 +301,7 @@ pub fn finishFrameGeneration(self: *Metal) void {
 }
 
 /// Drop the compositor's last IOSurface after all frame completion callbacks
-/// have drained, then release this renderer's shared-queue reference.
+/// have drained. The persistent command queue remains valid across swaps.
 pub fn displayUnrealizedAfterDrain(self: *Metal) void {
     switch (self.presenter) {
         .layer => |*layer| layer.clearSurface(),
@@ -365,8 +310,9 @@ pub fn displayUnrealizedAfterDrain(self: *Metal) void {
     self.queue.release();
 }
 
-/// Restore this renderer's reference to the process-wide submission queue
-/// after hidden-tab reclamation.
+/// Restore the per-renderer submission queue after hidden-tab reclamation.
+/// Pipeline state remains shared, while the queue's driver allocation pools
+/// exist only for renderers that can submit frames.
 pub fn displayRealized(self: *Metal) void {
     self.queue.ensureLive(self.device);
 }
@@ -917,31 +863,6 @@ test "metal command queue releases and recreates across renderer realization" {
 
     queue.ensureLive(device);
     try testing.expect(queue.isLive());
-}
-
-test "metal command queue is process-shared per device" {
-    const testing = std.testing;
-    const device = try chooseDevice();
-    defer device.release();
-
-    var active = RecreatableCommandQueue.init(device);
-    defer active.deinit();
-    var hidden = RecreatableCommandQueue.init(device);
-    defer hidden.deinit();
-
-    try testing.expectEqual(active.get().value, hidden.get().value);
-
-    active.release();
-    var restored = RecreatableCommandQueue.init(device);
-    defer restored.deinit();
-    try testing.expectEqual(hidden.get().value, restored.get().value);
-}
-
-test "shared Metal queue bounds process-wide in-flight frames" {
-    try std.testing.expectEqual(
-        @as(usize, swap_chain_count * 5 + 1),
-        shared_command_queue_max_inflight,
-    );
 }
 
 test "metal completion generation rejects old callbacks after rotation" {

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -865,6 +865,24 @@ test "metal command queue releases and recreates across renderer realization" {
     try testing.expect(queue.isLive());
 }
 
+test "metal command queue is process-shared per device" {
+    const testing = std.testing;
+    const device = try chooseDevice();
+    defer device.release();
+
+    var active = RecreatableCommandQueue.init(device);
+    defer active.deinit();
+    var hidden = RecreatableCommandQueue.init(device);
+    defer hidden.deinit();
+
+    try testing.expectEqual(active.get().value, hidden.get().value);
+
+    active.release();
+    var restored = RecreatableCommandQueue.init(device);
+    defer restored.deinit();
+    try testing.expectEqual(hidden.get().value, restored.get().value);
+}
+
 test "metal completion generation rejects old callbacks after rotation" {
     const testing = std.testing;
     const Context = struct {

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -260,6 +260,15 @@ pub fn finishFrameGeneration(self: *Metal) void {
     self.completion_generation.finish();
 }
 
+/// Drop the compositor's last IOSurface after all frame completion callbacks
+/// have drained. The persistent command queue remains valid across swaps.
+pub fn displayUnrealizedAfterDrain(self: *Metal) void {
+    switch (self.presenter) {
+        .layer => |*layer| layer.clearSurface(),
+        .external, .external_leased => {},
+    }
+}
+
 /// Install a distinct gate before replacement swap-chain frames can be used.
 pub fn startFrameGeneration(self: *Metal) !void {
     const renderer: *Renderer = @alignCast(@fieldParentPtr("api", self));

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -871,6 +871,13 @@ test "metal command queue releases and recreates across renderer realization" {
     try testing.expect(queue.isLive());
 }
 
+test "metal command queue rejects a nil Objective-C result" {
+    try std.testing.expectError(
+        error.CommandQueueUnavailable,
+        commandQueueFromId(null),
+    );
+}
+
 test "metal completion generation rejects old callbacks after rotation" {
     const testing = std.testing;
     const Context = struct {

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -801,6 +801,22 @@ test "metal completion invalidation waits for an active callback lease" {
     try testing.expect(lifetime.acquire() == null);
 }
 
+test "metal command queue releases and recreates across renderer realization" {
+    const testing = std.testing;
+    const device = try chooseDevice();
+    defer device.release();
+
+    var queue = RecreatableCommandQueue.init(device);
+    defer queue.deinit();
+    try testing.expect(queue.isLive());
+
+    queue.release();
+    try testing.expect(!queue.isLive());
+
+    queue.ensureLive(device);
+    try testing.expect(queue.isLive());
+}
+
 test "metal completion generation rejects old callbacks after rotation" {
     const testing = std.testing;
     const Context = struct {

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -39,6 +39,7 @@ pub const custom_shader_y_is_down = true;
 
 /// Triple buffering.
 pub const swap_chain_count = 3;
+const command_queue_max_inflight: usize = swap_chain_count;
 
 const log = std.log.scoped(.metal);
 
@@ -158,8 +159,8 @@ const RecreatableCommandQueue = struct {
         return .{
             .value = device.msgSend(
                 objc.Object,
-                objc.sel("newCommandQueue"),
-                .{},
+                objc.sel("newCommandQueueWithMaxCommandBufferCount:"),
+                .{command_queue_max_inflight},
             ),
         };
     }

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -151,12 +151,52 @@ const Presenter = union(enum) {
     }
 };
 
+const RecreatableCommandQueue = struct {
+    value: ?objc.Object,
+
+    fn init(device: objc.Object) RecreatableCommandQueue {
+        return .{
+            .value = device.msgSend(
+                objc.Object,
+                objc.sel("newCommandQueue"),
+                .{},
+            ),
+        };
+    }
+
+    fn deinit(self: *RecreatableCommandQueue) void {
+        self.release();
+    }
+
+    fn release(self: *RecreatableCommandQueue) void {
+        const value = self.value orelse return;
+        self.value = null;
+        value.release();
+    }
+
+    fn ensureLive(
+        self: *RecreatableCommandQueue,
+        device: objc.Object,
+    ) void {
+        if (self.value != null) return;
+        self.* = .init(device);
+    }
+
+    fn get(self: *const RecreatableCommandQueue) objc.Object {
+        return self.value orelse unreachable;
+    }
+
+    fn isLive(self: *const RecreatableCommandQueue) bool {
+        return self.value != null;
+    }
+};
+
 presenter: Presenter,
 
 /// MTLDevice
 device: objc.Object,
 /// MTLCommandQueue
-queue: objc.Object,
+queue: RecreatableCommandQueue,
 
 /// Alpha blending mode
 blending: configpkg.Config.AlphaBlending,
@@ -189,8 +229,8 @@ pub fn init(alloc: Allocator, opts: rendererpkg.Options) !Metal {
     // Choose our MTLDevice and create a MTLCommandQueue for that device.
     const device = try chooseDevice();
     errdefer device.release();
-    const queue = device.msgSend(objc.Object, objc.sel("newCommandQueue"), .{});
-    errdefer queue.release();
+    var queue = RecreatableCommandQueue.init(device);
+    errdefer queue.deinit();
 
     // Grab metadata about the device.
     const default_storage_mode: mtl.MTLResourceOptions.StorageMode = switch (comptime builtin.os.tag) {
@@ -228,7 +268,7 @@ pub fn deinit(self: *Metal) void {
     // Init failures can deinitialize Metal without the generic renderer's
     // prepare/finish hooks. Invalidation is idempotent.
     self.completion_generation.deinit();
-    self.queue.release();
+    self.queue.deinit();
     self.device.release();
     self.presenter.deinit();
 }
@@ -267,6 +307,14 @@ pub fn displayUnrealizedAfterDrain(self: *Metal) void {
         .layer => |*layer| layer.clearSurface(),
         .external, .external_leased => {},
     }
+    self.queue.release();
+}
+
+/// Restore the per-renderer submission queue after hidden-tab reclamation.
+/// Pipeline state remains shared, while the queue's driver allocation pools
+/// exist only for renderers that can submit frames.
+pub fn displayRealized(self: *Metal) void {
+    self.queue.ensureLive(self.device);
 }
 
 /// Install a distinct gate before replacement swap-chain frames can be used.
@@ -645,7 +693,7 @@ pub inline fn beginFrame(
         value.delivery_gate_userdata = renderer;
     }
     return try Frame.begin(.{
-        .queue = self.queue,
+        .queue = self.queue.get(),
         .completion_lifetime = self.completion_generation.lifetime(),
     }, target, frame_token, host_context, gated);
 }

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -865,6 +865,13 @@ test "metal command queue releases and recreates across renderer realization" {
     try testing.expect(queue.isLive());
 }
 
+test "metal command queue capacity matches the swap chain" {
+    try std.testing.expectEqual(
+        @as(usize, swap_chain_count),
+        command_queue_max_inflight,
+    );
+}
+
 test "metal completion generation rejects old callbacks after rotation" {
     const testing = std.testing;
     const Context = struct {

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -269,16 +269,11 @@ pub fn threadExit(self: *const OpenGL) void {
     }
 }
 
-pub fn displayRealized(self: *const OpenGL) void {
+pub fn displayRealized(self: *const OpenGL) !void {
     _ = self;
 
     switch (apprt.runtime) {
-        apprt.gtk => prepareContext(null) catch |err| {
-            log.warn(
-                "Error preparing GL context in displayRealized, err={}",
-                .{err},
-            );
-        },
+        apprt.gtk => try prepareContext(null),
 
         // Embedded contexts are prepared by surfaceInit and threadEnter. The
         // embedder owns one context for the surface lifetime and never enters

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -455,6 +455,48 @@ fn renderAfterMailboxDrain(
     context.renderWakeFrame();
 }
 
+/// Renderer realization can allocate Metal resources and fail under memory
+/// pressure. Keep the latest desired value while pacing retries so a failed
+/// tab restore cannot turn the renderer wakeup into a tight loop.
+const RendererRealizedRetryState = struct {
+    const initial_delay_ms = 250;
+    const maximum_delay_ms = 4_000;
+
+    value: ?bool = null,
+    scheduled: bool = false,
+    delay_ms: u64 = initial_delay_ms,
+
+    /// Record a failed value and return the delay for a newly required timer.
+    /// An already scheduled timer owns delivery of the coalesced latest value.
+    fn failed(self: *RendererRealizedRetryState, value: bool) ?u64 {
+        self.value = value;
+        if (self.scheduled) return null;
+
+        self.scheduled = true;
+        const delay_ms = self.delay_ms;
+        self.delay_ms = @min(self.delay_ms * 2, maximum_delay_ms);
+        return delay_ms;
+    }
+
+    /// A newer lifecycle publication supersedes the retry value. The timer may
+    /// remain armed and becomes a no-op unless another failure coalesces into it.
+    fn supersede(self: *RendererRealizedRetryState) void {
+        self.value = null;
+    }
+
+    fn resolved(self: *RendererRealizedRetryState) void {
+        self.value = null;
+        self.delay_ms = initial_delay_ms;
+    }
+
+    fn fired(self: *RendererRealizedRetryState) ?bool {
+        self.scheduled = false;
+        const value = self.value;
+        self.value = null;
+        return value;
+    }
+};
+
 /// Whether calls to `drawFrame` must be done from the app thread.
 ///
 /// If this is `true` then we send a `redraw_surface` message to the apprt
@@ -492,9 +534,12 @@ stop_c: xev.Completion = .{},
 /// a stop notification could still be lost during thread startup.
 started: std.Thread.ResetEvent = .{},
 
-/// The timer used for rendering
-render_h: xev.Timer,
-render_c: xev.Completion = .{},
+/// One-shot timer and coalesced state for fallible Metal realization retries.
+/// This repurposes the renderer's otherwise unused legacy render timer, so the
+/// recovery path does not add another xev handle to every terminal surface.
+renderer_realized_retry_h: xev.Timer,
+renderer_realized_retry_c: xev.Completion = .{},
+renderer_realized_retry: RendererRealizedRetryState = .{},
 
 /// The timer used for draw calls. Draw calls don't update from the
 /// terminal state so they're much cheaper. They're used for animation
@@ -639,9 +684,10 @@ pub fn init(
     var stop_h = try xev.Async.init();
     errdefer stop_h.deinit();
 
-    // The primary timer for rendering.
-    var render_h = try xev.Timer.init();
-    errdefer render_h.deinit();
+    // Paced Metal realization recovery. This was historically an unused
+    // general render timer, so reusing it keeps per-surface handles flat.
+    var renderer_realized_retry_h = try xev.Timer.init();
+    errdefer renderer_realized_retry_h.deinit();
 
     // Draw timer, see comments.
     var draw_h = try xev.Timer.init();
@@ -669,7 +715,7 @@ pub fn init(
         .loop = loop,
         .wakeup = wakeup_h,
         .stop = stop_h,
-        .render_h = render_h,
+        .renderer_realized_retry_h = renderer_realized_retry_h,
         .draw_h = draw_h,
         .draw_now = draw_now,
         .visibility_retry = visibility_retry,
@@ -696,7 +742,7 @@ pub fn init(
 pub fn deinit(self: *Thread) void {
     self.stop.deinit();
     self.wakeup.deinit();
-    self.render_h.deinit();
+    self.renderer_realized_retry_h.deinit();
     self.draw_h.deinit();
     self.draw_now.deinit();
     self.visibility_retry.deinit();
@@ -1201,10 +1247,11 @@ fn drainMailbox(self: *Thread) !MailboxDrainResult {
     // deliberately leaves visibility and frame gating to its platform owner.
     if (surface_state.visible) |value| self.applyVisible(&visibility, value);
     if (surface_state.renderer_realized) |value| {
+        // Any publication is newer than a retained retry. A failed application
+        // below records this value again behind the paced timer.
+        self.renderer_realized_retry.supersede();
         self.applyRendererRealized(value) catch |err| {
-            // A failed GPU recreation remains the desired state. Restore only
-            // into an empty slot so a newer visibility-derived request wins.
-            self.surface_state_requests.restoreRendererRealizedIfEmpty(value);
+            self.scheduleRendererRealizedRetry(value);
             if (surface_state.focused) |focused| {
                 self.surface_state_requests.restoreFocusedIfEmpty(focused);
             }
@@ -1213,6 +1260,7 @@ fn drainMailbox(self: *Thread) !MailboxDrainResult {
             }
             return err;
         };
+        self.renderer_realized_retry.resolved();
     }
     if (surface_state.focused) |value| {
         self.applyFocused(value, external_drain) catch |err| {
@@ -1501,23 +1549,6 @@ fn wakeupCallback(
     // it here covers output, resize, and viewport scrolling uniformly.
     t.compression.wake(t);
 
-    // The below is not used anymore but if we ever want to introduce
-    // a configuration to introduce a delay to coalesce renders, we can
-    // use this.
-    //
-    // // If the timer is already active then we don't have to do anything.
-    // if (t.render_c.state() == .active) return .rearm;
-    //
-    // // Timer is not active, let's start it
-    // t.render_h.run(
-    //     &t.loop,
-    //     &t.render_c,
-    //     10,
-    //     Thread,
-    //     t,
-    //     renderCallback,
-    // );
-
     return .rearm;
 }
 
@@ -1560,6 +1591,41 @@ fn visibilityRetryCallback(
         t.syncDrawTimer();
     }
     return .rearm;
+}
+
+fn scheduleRendererRealizedRetry(self: *Thread, value: bool) void {
+    const delay_ms = self.renderer_realized_retry.failed(value) orelse return;
+    self.renderer_realized_retry_h.run(
+        &self.loop,
+        &self.renderer_realized_retry_c,
+        delay_ms,
+        Thread,
+        self,
+        rendererRealizedRetryCallback,
+    );
+}
+
+fn rendererRealizedRetryCallback(
+    self_: ?*Thread,
+    _: *xev.Loop,
+    _: *xev.Completion,
+    result: xev.Timer.RunError!void,
+) xev.CallbackAction {
+    _ = result catch |err| switch (err) {
+        error.Canceled => return .disarm,
+        else => {
+            log.warn("error in renderer realization retry timer err={}", .{err});
+            return .disarm;
+        },
+    };
+
+    const self = self_ orelse return .disarm;
+    const value = self.renderer_realized_retry.fired() orelse return .disarm;
+    self.surface_state_requests.restoreRendererRealizedIfEmpty(value);
+    self.wakeup.notify() catch |err| {
+        log.warn("failed to notify renderer realization retry err={}", .{err});
+    };
+    return .disarm;
 }
 
 fn drawCallback(
@@ -1810,6 +1876,36 @@ test "surface lifecycle retry restoration preserves newer publications" {
     try std.testing.expectEqual(true, newer.focused);
     try std.testing.expectEqual(true, newer.renderer_realized);
     try std.testing.expectEqual(@as(u32, 42), newer.display_id);
+}
+
+test "renderer realization retries coalesce with bounded backoff" {
+    const testing = std.testing;
+
+    var retry: RendererRealizedRetryState = .{};
+    try testing.expectEqual(@as(?u64, 250), retry.failed(true));
+    try testing.expectEqual(@as(?u64, null), retry.failed(false));
+    try testing.expectEqual(@as(?bool, false), retry.fired());
+
+    try testing.expectEqual(@as(?u64, 500), retry.failed(true));
+    retry.supersede();
+    try testing.expectEqual(@as(?bool, null), retry.fired());
+
+    try testing.expectEqual(@as(?u64, 1_000), retry.failed(true));
+    try testing.expectEqual(@as(?bool, true), retry.fired());
+    retry.resolved();
+    try testing.expectEqual(@as(?u64, 250), retry.failed(true));
+    _ = retry.fired();
+
+    retry.delay_ms = RendererRealizedRetryState.maximum_delay_ms;
+    try testing.expectEqual(
+        @as(?u64, RendererRealizedRetryState.maximum_delay_ms),
+        retry.failed(true),
+    );
+    _ = retry.fired();
+    try testing.expectEqual(
+        @as(?u64, RendererRealizedRetryState.maximum_delay_ms),
+        retry.failed(true),
+    );
 }
 
 test "synchronous presentation is delivered after thread draw cleanup" {

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -509,6 +509,7 @@ const RendererRealizedRetryState = struct {
     const initial_delay_ms = 250;
     const maximum_delay_ms = 4_000;
 
+    mutex: std.Thread.Mutex = .{},
     value: ?RendererRealizedRequest = null,
     scheduled: bool = false,
     delay_ms: u64 = initial_delay_ms,
@@ -519,6 +520,9 @@ const RendererRealizedRetryState = struct {
         self: *RendererRealizedRetryState,
         value: RendererRealizedRequest,
     ) ?u64 {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+
         self.value = value;
         if (self.scheduled) return null;
 
@@ -531,19 +535,43 @@ const RendererRealizedRetryState = struct {
     /// A newer lifecycle publication supersedes the retry value. The timer may
     /// remain armed and becomes a no-op unless another failure coalesces into it.
     fn supersede(self: *RendererRealizedRetryState) void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
         self.value = null;
     }
 
     fn resolved(self: *RendererRealizedRetryState) void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
         self.value = null;
         self.delay_ms = initial_delay_ms;
     }
 
     fn fired(self: *RendererRealizedRetryState) ?RendererRealizedRequest {
+        self.mutex.lock();
+        defer self.mutex.unlock();
         self.scheduled = false;
         const value = self.value;
         self.value = null;
         return value;
+    }
+};
+
+/// Cross-thread one-shot request to arm the realization retry timer. External
+/// iOS rendering owns renderer state on its serial queue, but xev loop handles
+/// must only be mutated by the renderer OS thread.
+const RendererRealizedRetryTimerHandoff = struct {
+    delay_ms: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
+
+    fn publish(self: *RendererRealizedRetryTimerHandoff, delay_ms: u64) void {
+        std.debug.assert(delay_ms > 0);
+        const previous = self.delay_ms.swap(delay_ms, .acq_rel);
+        std.debug.assert(previous == 0);
+    }
+
+    fn take(self: *RendererRealizedRetryTimerHandoff) ?u64 {
+        const delay_ms = self.delay_ms.swap(0, .acq_rel);
+        return if (delay_ms == 0) null else delay_ms;
     }
 };
 
@@ -590,6 +618,7 @@ started: std.Thread.ResetEvent = .{},
 renderer_realized_retry_h: xev.Timer,
 renderer_realized_retry_c: xev.Completion = .{},
 renderer_realized_retry: RendererRealizedRetryState = .{},
+renderer_realized_retry_timer_handoff: RendererRealizedRetryTimerHandoff = .{},
 
 /// The timer used for draw calls. Draw calls don't update from the
 /// terminal state so they're much cheaper. They're used for animation
@@ -1572,6 +1601,7 @@ fn wakeupCallback(
     };
 
     const t = self_.?;
+    t.armPendingRendererRealizedRetryTimer();
     if (t.externalDrainActive()) {
         // External mode owns renderer state on its serial queue. Convert the
         // coalesced xev wake into an unconditional embedder render request.
@@ -1663,6 +1693,26 @@ fn scheduleRendererRealizedRetry(
     value: RendererRealizedRequest,
 ) void {
     const delay_ms = self.renderer_realized_retry.failed(value) orelse return;
+    if (self.externalDrainActive()) {
+        self.renderer_realized_retry_timer_handoff.publish(delay_ms);
+        self.wakeup.notify() catch |err| {
+            log.warn(
+                "failed to hand renderer realization retry to loop owner err={}",
+                .{err},
+            );
+        };
+        return;
+    }
+    self.armRendererRealizedRetryTimer(delay_ms);
+}
+
+fn armPendingRendererRealizedRetryTimer(self: *Thread) void {
+    const delay_ms =
+        self.renderer_realized_retry_timer_handoff.take() orelse return;
+    self.armRendererRealizedRetryTimer(delay_ms);
+}
+
+fn armRendererRealizedRetryTimer(self: *Thread, delay_ms: u64) void {
     self.renderer_realized_retry_h.run(
         &self.loop,
         &self.renderer_realized_retry_c,

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -54,16 +54,22 @@ const VisibilityDrainState = struct {
 const SurfaceStateRequests = struct {
     const Update = struct {
         visible: ?bool = null,
+        renderer_realized: ?bool = null,
         focused: ?bool = null,
         display_id: ?u32 = null,
     };
 
     visible: std.atomic.Value(u8) = std.atomic.Value(u8).init(0),
+    renderer_realized: std.atomic.Value(u8) = std.atomic.Value(u8).init(0),
     focused: std.atomic.Value(u8) = std.atomic.Value(u8).init(0),
     display_id: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
 
     fn publishVisible(self: *SurfaceStateRequests, value: bool) void {
         self.visible.store(if (value) 2 else 1, .release);
+    }
+
+    fn publishRendererRealized(self: *SurfaceStateRequests, value: bool) void {
+        self.renderer_realized.store(if (value) 2 else 1, .release);
     }
 
     fn publishFocused(self: *SurfaceStateRequests, value: bool) void {
@@ -86,6 +92,18 @@ const SurfaceStateRequests = struct {
         );
     }
 
+    fn restoreRendererRealizedIfEmpty(
+        self: *SurfaceStateRequests,
+        value: bool,
+    ) void {
+        _ = self.renderer_realized.cmpxchgStrong(
+            0,
+            if (value) 2 else 1,
+            .release,
+            .monotonic,
+        );
+    }
+
     fn restoreDisplayIDIfEmpty(
         self: *SurfaceStateRequests,
         value: u32,
@@ -101,6 +119,9 @@ const SurfaceStateRequests = struct {
     fn take(self: *SurfaceStateRequests) Update {
         return .{
             .visible = decodeBool(self.visible.swap(0, .acq_rel)),
+            .renderer_realized = decodeBool(
+                self.renderer_realized.swap(0, .acq_rel),
+            ),
             .focused = decodeBool(self.focused.swap(0, .acq_rel)),
             .display_id = decodeDisplayID(self.display_id.swap(0, .acq_rel)),
         };
@@ -108,6 +129,7 @@ const SurfaceStateRequests = struct {
 
     fn hasPending(self: *const SurfaceStateRequests) bool {
         return self.visible.load(.acquire) != 0 or
+            self.renderer_realized.load(.acquire) != 0 or
             self.focused.load(.acquire) != 0 or
             self.display_id.load(.acquire) != 0;
     }
@@ -535,6 +557,12 @@ surface_state_requests: SurfaceStateRequests = .{},
 /// mailbox handler aborts a drain before its coalesced transition commits.
 renderer_visible: bool = true,
 
+/// Whether the renderer currently owns a live swap chain and shaders.
+/// Renderer-thread owned. Realization requests are idempotent so embedders can
+/// publish authoritative visibility-derived state without mirroring queue
+/// delivery.
+renderer_realized: bool = true,
+
 /// Configuration we need derived from the main config.
 config: DerivedConfig,
 
@@ -776,6 +804,10 @@ pub fn drainMailboxNow(self: *Thread) void {
 /// mailbox capacity. Callers must notify `wakeup` after publishing.
 pub fn publishVisible(self: *Thread, value: bool) void {
     self.surface_state_requests.publishVisible(value);
+}
+
+pub fn publishRendererRealized(self: *Thread, value: bool) void {
+    self.surface_state_requests.publishRendererRealized(value);
 }
 
 pub fn publishFocused(self: *Thread, value: bool) void {
@@ -1153,11 +1185,7 @@ fn drainMailbox(self: *Thread) !MailboxDrainResult {
             // surface is occluded when this is sent (macOS `drawFrame` early-
             // returns on `!flags.visible`), and both calls take `draw_mutex`.
             .display_realized => |v| {
-                if (v) {
-                    try self.renderer.displayRealized();
-                } else {
-                    self.renderer.displayUnrealized();
-                }
+                try self.applyRendererRealized(v);
             },
         }
     }
@@ -1172,6 +1200,20 @@ fn drainMailbox(self: *Thread) !MailboxDrainResult {
     // renderer visibility in `renderAfterMailboxDrain`; external iOS rendering
     // deliberately leaves visibility and frame gating to its platform owner.
     if (surface_state.visible) |value| self.applyVisible(&visibility, value);
+    if (surface_state.renderer_realized) |value| {
+        self.applyRendererRealized(value) catch |err| {
+            // A failed GPU recreation remains the desired state. Restore only
+            // into an empty slot so a newer visibility-derived request wins.
+            self.surface_state_requests.restoreRendererRealizedIfEmpty(value);
+            if (surface_state.focused) |focused| {
+                self.surface_state_requests.restoreFocusedIfEmpty(focused);
+            }
+            if (surface_state.display_id) |display_id| {
+                self.surface_state_requests.restoreDisplayIDIfEmpty(display_id);
+            }
+            return err;
+        };
+    }
     if (surface_state.focused) |value| {
         self.applyFocused(value, external_drain) catch |err| {
             // Restore only into an empty slot. A newer publication must remain
@@ -1201,7 +1243,7 @@ fn drainMailbox(self: *Thread) !MailboxDrainResult {
     var result = applyRendererVisibilityTransition(
         self,
         &self.visibility_regain,
-        visibility.rendererTransition(),
+        self.pendingRendererVisibilityTransition(),
     );
     result.wake_pending = wake_pending;
     return result;
@@ -1218,6 +1260,24 @@ fn applyVisible(
 
     // Timers are intentionally left armed across visibility changes. Their
     // callbacks already consult this renderer-owned flag.
+}
+
+fn applyRendererRealized(self: *Thread, value: bool) !void {
+    if (self.renderer_realized == value) return;
+
+    if (value) {
+        try self.renderer.displayRealized();
+        self.renderer_realized = true;
+        return;
+    }
+
+    // Stop presentation before releasing the swap chain. displayUnrealized
+    // waits for in-flight frame leases, so no draw can retain a released
+    // IOSurface after this call returns.
+    self.visibility_regain.cancel();
+    self.setRendererVisible(false);
+    self.renderer.displayUnrealized();
+    self.renderer_realized = false;
 }
 
 fn applyFocused(self: *Thread, value: bool, external_drain: bool) !void {
@@ -1285,6 +1345,7 @@ fn changeConfig(self: *Thread, config: *const DerivedConfig) !void {
 }
 
 fn updateVisibilityRegainFrame(self: *Thread) bool {
+    if (!self.renderer_realized) return false;
     self.updateFrame(self.flags.cursor_blink_visible) catch |err| {
         log.warn("error rendering err={}", .{err});
         return false;
@@ -1308,6 +1369,7 @@ fn setRendererVisible(self: *Thread, visible: bool) void {
 }
 
 fn pendingRendererVisibilityTransition(self: *Thread) ?bool {
+    if (!self.renderer_realized) return null;
     if (self.renderer_visible == self.flags.visible) return null;
     return self.flags.visible;
 }
@@ -1319,6 +1381,8 @@ fn renderWakeFrame(self: *Thread) void {
 /// Trigger a draw. This will not update frame data or anything, it will
 /// just trigger a draw/paint.
 fn drawFrame(self: *Thread, now: bool) DrawFrameResult {
+    if (!self.renderer_realized) return .skipped_invisible;
+
     // If we're invisible, we do not draw.
     //
     // cmux iOS fork: skip this early-return on iOS. The iOS embedder owns
@@ -1552,7 +1616,7 @@ fn renderCallback(
 
     // Preserve terminal dirty state while hidden. The visibility regain path
     // consumes the accumulated row union in one update before presenting.
-    if (!t.flags.visible) return .disarm;
+    if (!t.flags.visible or !t.renderer_realized) return .disarm;
 
     // Update our frame data
     t.updateFrame(t.flags.cursor_blink_visible) catch |err|
@@ -1705,12 +1769,15 @@ test "surface lifecycle state bypasses a full renderer mailbox and keeps latest 
     var state: SurfaceStateRequests = .{};
     state.publishVisible(false);
     state.publishVisible(true);
+    state.publishRendererRealized(false);
+    state.publishRendererRealized(true);
     state.publishFocused(false);
     state.publishDisplayID(7);
     state.publishDisplayID(42);
 
     const update = state.take();
     try std.testing.expectEqual(true, update.visible);
+    try std.testing.expectEqual(true, update.renderer_realized);
     try std.testing.expectEqual(false, update.focused);
     try std.testing.expectEqual(@as(u32, 42), update.display_id);
     try std.testing.expectEqual(
@@ -1724,19 +1791,24 @@ test "surface lifecycle retry restoration preserves newer publications" {
     try std.testing.expect(!state.hasPending());
 
     state.restoreFocusedIfEmpty(false);
+    state.restoreRendererRealizedIfEmpty(false);
     state.restoreDisplayIDIfEmpty(7);
     try std.testing.expect(state.hasPending());
     const restored = state.take();
     try std.testing.expectEqual(false, restored.focused);
+    try std.testing.expectEqual(false, restored.renderer_realized);
     try std.testing.expectEqual(@as(u32, 7), restored.display_id);
     try std.testing.expect(!state.hasPending());
 
     state.publishFocused(true);
+    state.publishRendererRealized(true);
     state.publishDisplayID(42);
     state.restoreFocusedIfEmpty(false);
+    state.restoreRendererRealizedIfEmpty(false);
     state.restoreDisplayIDIfEmpty(7);
     const newer = state.take();
     try std.testing.expectEqual(true, newer.focused);
+    try std.testing.expectEqual(true, newer.renderer_realized);
     try std.testing.expectEqual(@as(u32, 42), newer.display_id);
 }
 

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -1861,6 +1861,32 @@ test "surface lifecycle state bypasses a full renderer mailbox and keeps latest 
     );
 }
 
+test "renderer rebuild survives a redundant realize publication" {
+    var state: SurfaceStateRequests = .{};
+
+    state.publishRendererRebuild();
+    state.publishRendererRealized(true);
+
+    const update = state.take();
+    try std.testing.expectEqual(
+        .rebuild,
+        update.renderer_realized.?,
+    );
+}
+
+test "renderer unrealize supersedes a pending rebuild" {
+    var state: SurfaceStateRequests = .{};
+
+    state.publishRendererRebuild();
+    state.publishRendererRealized(false);
+
+    const update = state.take();
+    try std.testing.expectEqual(
+        .unrealize,
+        update.renderer_realized.?,
+    );
+}
+
 test "surface lifecycle retry restoration preserves newer publications" {
     var state: SurfaceStateRequests = .{};
     try std.testing.expect(!state.hasPending());

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -2035,6 +2035,15 @@ test "renderer realization retries coalesce with bounded backoff" {
     );
 }
 
+test "external renderer retry timer is handed to loop owner once" {
+    var handoff: RendererRealizedRetryTimerHandoff = .{};
+
+    handoff.publish(250);
+
+    try std.testing.expectEqual(@as(?u64, 250), handoff.take());
+    try std.testing.expectEqual(@as(?u64, null), handoff.take());
+}
+
 test "synchronous presentation is delivered after thread draw cleanup" {
     const Event = enum { begin, renderer_cleanup, end, callback };
     const State = struct {

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -43,18 +43,31 @@ const VisibilityDrainState = struct {
     }
 };
 
-/// Latest-value publication for surface lifecycle state. These values are
-/// idempotent and have no owned payloads, so producers can replace an unread
-/// request instead of waiting for space in the ordered renderer mailbox.
+const RendererRealizedRequest = enum(u8) {
+    unrealize = 1,
+    realize = 2,
+    rebuild = 3,
+
+    fn fromBool(value: bool) RendererRealizedRequest {
+        return if (value) .realize else .unrealize;
+    }
+};
+
+/// Latest-value publication for surface lifecycle state. These values have no
+/// owned payloads, so producers can replace an unread request instead of
+/// waiting for space in the ordered renderer mailbox. Renderer rebuild is the
+/// one stronger operation: a redundant realize publication preserves it so a
+/// forced unrealize/realize transaction cannot be coalesced away.
 ///
 /// Each property has its own atomic slot. Zero means no pending request;
-/// booleans use one/ two for false/true, and display ids are offset by one so
-/// every u32 value remains representable. A producer that races `take` either
-/// lands in the returned update or remains pending for the next renderer wake.
+/// booleans use one/two for false/true, renderer realization uses the enum
+/// values above, and display ids are offset by one so every u32 value remains
+/// representable. A producer that races `take` either lands in the returned
+/// update or remains pending for the next renderer wake.
 const SurfaceStateRequests = struct {
     const Update = struct {
         visible: ?bool = null,
-        renderer_realized: ?bool = null,
+        renderer_realized: ?RendererRealizedRequest = null,
         focused: ?bool = null,
         display_id: ?u32 = null,
     };
@@ -69,7 +82,31 @@ const SurfaceStateRequests = struct {
     }
 
     fn publishRendererRealized(self: *SurfaceStateRequests, value: bool) void {
-        self.renderer_realized.store(if (value) 2 else 1, .release);
+        const request = RendererRealizedRequest.fromBool(value);
+        if (request == .unrealize) {
+            self.renderer_realized.store(@intFromEnum(request), .release);
+            return;
+        }
+
+        // Rebuild already has the same final realized state, but also carries
+        // the required unrealize transition. A redundant realize must not
+        // weaken it before the renderer consumes the slot.
+        var current = self.renderer_realized.load(.monotonic);
+        while (current != @intFromEnum(RendererRealizedRequest.rebuild)) {
+            current = self.renderer_realized.cmpxchgWeak(
+                current,
+                @intFromEnum(request),
+                .release,
+                .monotonic,
+            ) orelse return;
+        }
+    }
+
+    fn publishRendererRebuild(self: *SurfaceStateRequests) void {
+        self.renderer_realized.store(
+            @intFromEnum(RendererRealizedRequest.rebuild),
+            .release,
+        );
     }
 
     fn publishFocused(self: *SurfaceStateRequests, value: bool) void {
@@ -94,11 +131,11 @@ const SurfaceStateRequests = struct {
 
     fn restoreRendererRealizedIfEmpty(
         self: *SurfaceStateRequests,
-        value: bool,
+        value: RendererRealizedRequest,
     ) void {
         _ = self.renderer_realized.cmpxchgStrong(
             0,
-            if (value) 2 else 1,
+            @intFromEnum(value),
             .release,
             .monotonic,
         );
@@ -119,7 +156,7 @@ const SurfaceStateRequests = struct {
     fn take(self: *SurfaceStateRequests) Update {
         return .{
             .visible = decodeBool(self.visible.swap(0, .acq_rel)),
-            .renderer_realized = decodeBool(
+            .renderer_realized = decodeRendererRealized(
                 self.renderer_realized.swap(0, .acq_rel),
             ),
             .focused = decodeBool(self.focused.swap(0, .acq_rel)),
@@ -139,6 +176,16 @@ const SurfaceStateRequests = struct {
             0 => null,
             1 => false,
             2 => true,
+            else => unreachable,
+        };
+    }
+
+    fn decodeRendererRealized(value: u8) ?RendererRealizedRequest {
+        return switch (value) {
+            0 => null,
+            1 => .unrealize,
+            2 => .realize,
+            3 => .rebuild,
             else => unreachable,
         };
     }
@@ -462,13 +509,16 @@ const RendererRealizedRetryState = struct {
     const initial_delay_ms = 250;
     const maximum_delay_ms = 4_000;
 
-    value: ?bool = null,
+    value: ?RendererRealizedRequest = null,
     scheduled: bool = false,
     delay_ms: u64 = initial_delay_ms,
 
     /// Record a failed value and return the delay for a newly required timer.
     /// An already scheduled timer owns delivery of the coalesced latest value.
-    fn failed(self: *RendererRealizedRetryState, value: bool) ?u64 {
+    fn failed(
+        self: *RendererRealizedRetryState,
+        value: RendererRealizedRequest,
+    ) ?u64 {
         self.value = value;
         if (self.scheduled) return null;
 
@@ -489,7 +539,7 @@ const RendererRealizedRetryState = struct {
         self.delay_ms = initial_delay_ms;
     }
 
-    fn fired(self: *RendererRealizedRetryState) ?bool {
+    fn fired(self: *RendererRealizedRetryState) ?RendererRealizedRequest {
         self.scheduled = false;
         const value = self.value;
         self.value = null;
@@ -854,6 +904,10 @@ pub fn publishVisible(self: *Thread, value: bool) void {
 
 pub fn publishRendererRealized(self: *Thread, value: bool) void {
     self.surface_state_requests.publishRendererRealized(value);
+}
+
+pub fn publishRendererRebuild(self: *Thread) void {
+    self.surface_state_requests.publishRendererRebuild();
 }
 
 pub fn publishFocused(self: *Thread, value: bool) void {
@@ -1231,7 +1285,9 @@ fn drainMailbox(self: *Thread) !MailboxDrainResult {
             // surface is occluded when this is sent (macOS `drawFrame` early-
             // returns on `!flags.visible`), and both calls take `draw_mutex`.
             .display_realized => |v| {
-                try self.applyRendererRealized(v);
+                try self.applyRendererRealized(
+                    RendererRealizedRequest.fromBool(v),
+                );
             },
         }
     }
@@ -1310,7 +1366,16 @@ fn applyVisible(
     // callbacks already consult this renderer-owned flag.
 }
 
-fn applyRendererRealized(self: *Thread, value: bool) !void {
+fn applyRendererRealized(
+    self: *Thread,
+    request: RendererRealizedRequest,
+) !void {
+    if (request == .rebuild) {
+        try self.applyRendererRealized(.unrealize);
+        return self.applyRendererRealized(.realize);
+    }
+
+    const value = request == .realize;
     if (self.renderer_realized == value) return;
 
     if (value) {
@@ -1593,7 +1658,10 @@ fn visibilityRetryCallback(
     return .rearm;
 }
 
-fn scheduleRendererRealizedRetry(self: *Thread, value: bool) void {
+fn scheduleRendererRealizedRetry(
+    self: *Thread,
+    value: RendererRealizedRequest,
+) void {
     const delay_ms = self.renderer_realized_retry.failed(value) orelse return;
     self.renderer_realized_retry_h.run(
         &self.loop,
@@ -1852,7 +1920,10 @@ test "surface lifecycle state bypasses a full renderer mailbox and keeps latest 
 
     const update = state.take();
     try std.testing.expectEqual(true, update.visible);
-    try std.testing.expectEqual(true, update.renderer_realized);
+    try std.testing.expectEqual(
+        RendererRealizedRequest.realize,
+        update.renderer_realized,
+    );
     try std.testing.expectEqual(false, update.focused);
     try std.testing.expectEqual(@as(u32, 42), update.display_id);
     try std.testing.expectEqual(
@@ -1892,12 +1963,15 @@ test "surface lifecycle retry restoration preserves newer publications" {
     try std.testing.expect(!state.hasPending());
 
     state.restoreFocusedIfEmpty(false);
-    state.restoreRendererRealizedIfEmpty(false);
+    state.restoreRendererRealizedIfEmpty(.unrealize);
     state.restoreDisplayIDIfEmpty(7);
     try std.testing.expect(state.hasPending());
     const restored = state.take();
     try std.testing.expectEqual(false, restored.focused);
-    try std.testing.expectEqual(false, restored.renderer_realized);
+    try std.testing.expectEqual(
+        RendererRealizedRequest.unrealize,
+        restored.renderer_realized,
+    );
     try std.testing.expectEqual(@as(u32, 7), restored.display_id);
     try std.testing.expect(!state.hasPending());
 
@@ -1905,11 +1979,14 @@ test "surface lifecycle retry restoration preserves newer publications" {
     state.publishRendererRealized(true);
     state.publishDisplayID(42);
     state.restoreFocusedIfEmpty(false);
-    state.restoreRendererRealizedIfEmpty(false);
+    state.restoreRendererRealizedIfEmpty(.unrealize);
     state.restoreDisplayIDIfEmpty(7);
     const newer = state.take();
     try std.testing.expectEqual(true, newer.focused);
-    try std.testing.expectEqual(true, newer.renderer_realized);
+    try std.testing.expectEqual(
+        RendererRealizedRequest.realize,
+        newer.renderer_realized,
+    );
     try std.testing.expectEqual(@as(u32, 42), newer.display_id);
 }
 
@@ -1917,35 +1994,44 @@ test "renderer realization retries coalesce with bounded backoff" {
     const testing = std.testing;
 
     var retry: RendererRealizedRetryState = .{};
-    try testing.expectEqual(@as(?u64, 250), retry.failed(true));
-    try testing.expectEqual(@as(?u64, null), retry.failed(false));
-    try testing.expectEqual(@as(?bool, false), retry.fired());
+    try testing.expectEqual(@as(?u64, 250), retry.failed(.realize));
+    try testing.expectEqual(@as(?u64, null), retry.failed(.unrealize));
+    try testing.expectEqual(
+        @as(?RendererRealizedRequest, .unrealize),
+        retry.fired(),
+    );
 
-    try testing.expectEqual(@as(?u64, 500), retry.failed(true));
+    try testing.expectEqual(@as(?u64, 500), retry.failed(.realize));
     retry.supersede();
-    try testing.expectEqual(@as(?bool, null), retry.fired());
+    try testing.expectEqual(
+        @as(?RendererRealizedRequest, null),
+        retry.fired(),
+    );
 
-    try testing.expectEqual(@as(?u64, 1_000), retry.failed(true));
-    try testing.expectEqual(@as(?bool, true), retry.fired());
+    try testing.expectEqual(@as(?u64, 1_000), retry.failed(.realize));
+    try testing.expectEqual(
+        @as(?RendererRealizedRequest, .realize),
+        retry.fired(),
+    );
     // A timer backend error consumes the active latch before the callback
     // reschedules the retained value at the next paced delay.
-    try testing.expectEqual(@as(?u64, 2_000), retry.failed(true));
+    try testing.expectEqual(@as(?u64, 2_000), retry.failed(.realize));
     const failed_timer_value = retry.fired().?;
     try testing.expectEqual(@as(?u64, 4_000), retry.failed(failed_timer_value));
     _ = retry.fired();
     retry.resolved();
-    try testing.expectEqual(@as(?u64, 250), retry.failed(true));
+    try testing.expectEqual(@as(?u64, 250), retry.failed(.realize));
     _ = retry.fired();
 
     retry.delay_ms = RendererRealizedRetryState.maximum_delay_ms;
     try testing.expectEqual(
         @as(?u64, RendererRealizedRetryState.maximum_delay_ms),
-        retry.failed(true),
+        retry.failed(.realize),
     );
     _ = retry.fired();
     try testing.expectEqual(
         @as(?u64, RendererRealizedRetryState.maximum_delay_ms),
-        retry.failed(true),
+        retry.failed(.realize),
     );
 }
 

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -1611,15 +1611,24 @@ fn rendererRealizedRetryCallback(
     _: *xev.Completion,
     result: xev.Timer.RunError!void,
 ) xev.CallbackAction {
+    const self = self_ orelse return .disarm;
     _ = result catch |err| switch (err) {
-        error.Canceled => return .disarm,
+        error.Canceled => {
+            _ = self.renderer_realized_retry.fired();
+            return .disarm;
+        },
         else => {
+            // Release the active-timer latch before rearming with the retained
+            // latest value. Otherwise one backend timer error would suppress
+            // every later renderer-realization retry.
+            if (self.renderer_realized_retry.fired()) |value| {
+                self.scheduleRendererRealizedRetry(value);
+            }
             log.warn("error in renderer realization retry timer err={}", .{err});
             return .disarm;
         },
     };
 
-    const self = self_ orelse return .disarm;
     const value = self.renderer_realized_retry.fired() orelse return .disarm;
     self.surface_state_requests.restoreRendererRealizedIfEmpty(value);
     self.wakeup.notify() catch |err| {
@@ -1892,6 +1901,12 @@ test "renderer realization retries coalesce with bounded backoff" {
 
     try testing.expectEqual(@as(?u64, 1_000), retry.failed(true));
     try testing.expectEqual(@as(?bool, true), retry.fired());
+    // A timer backend error consumes the active latch before the callback
+    // reschedules the retained value at the next paced delay.
+    try testing.expectEqual(@as(?u64, 2_000), retry.failed(true));
+    const failed_timer_value = retry.fired().?;
+    try testing.expectEqual(@as(?u64, 4_000), retry.failed(failed_timer_value));
+    _ = retry.fired();
     retry.resolved();
     try testing.expectEqual(@as(?u64, 250), retry.failed(true));
     _ = retry.fired();

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -3828,3 +3828,59 @@ test "swap chain initialization cleans its successful prefix on failure" {
     try testing.expectEqual(@as(usize, 2), state.initialized);
     try testing.expectEqual(state.initialized, state.deinited);
 }
+
+test "renderer realization rolls back failure and redraws cached frame on commit" {
+    const testing = std.testing;
+    const MockAPI = struct {
+        realized: usize = 0,
+        rolled_back: usize = 0,
+
+        fn displayRealized(self: *@This()) !void {
+            self.realized += 1;
+        }
+
+        fn displayRealizedRollback(self: *@This()) void {
+            self.rolled_back += 1;
+        }
+    };
+    const Harness = struct {
+        fn failAfterAPI(
+            api: *MockAPI,
+            cached_frame_redraw: *bool,
+        ) !void {
+            var realization = try RendererRealization(MockAPI).begin(
+                api,
+                cached_frame_redraw,
+            );
+            defer realization.deinit();
+            return error.DownstreamFailure;
+        }
+
+        fn succeed(
+            api: *MockAPI,
+            cached_frame_redraw: *bool,
+        ) !void {
+            var realization = try RendererRealization(MockAPI).begin(
+                api,
+                cached_frame_redraw,
+            );
+            defer realization.deinit();
+            realization.commit();
+        }
+    };
+
+    var api: MockAPI = .{};
+    var cached_frame_redraw = false;
+    try testing.expectError(
+        error.DownstreamFailure,
+        Harness.failAfterAPI(&api, &cached_frame_redraw),
+    );
+    try testing.expectEqual(@as(usize, 1), api.realized);
+    try testing.expectEqual(@as(usize, 1), api.rolled_back);
+    try testing.expect(!cached_frame_redraw);
+
+    try Harness.succeed(&api, &cached_frame_redraw);
+    try testing.expectEqual(@as(usize, 2), api.realized);
+    try testing.expectEqual(@as(usize, 1), api.rolled_back);
+    try testing.expect(cached_frame_redraw);
+}

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -3779,3 +3779,34 @@ test "prepared frame damage remains retryable until draw commit" {
     }
     try std.testing.expect(!cells_rebuilt);
 }
+
+test "swap chain initialization cleans its successful prefix on failure" {
+    const testing = std.testing;
+    const State = struct {
+        initialized: usize = 0,
+        deinited: usize = 0,
+        fail_at: usize = 2,
+    };
+    const Frame = struct {
+        state: *State,
+
+        fn init(state: *State, _: bool) !@This() {
+            if (state.initialized == state.fail_at) return error.InitFailed;
+            state.initialized += 1;
+            return .{ .state = state };
+        }
+
+        fn deinit(self: *@This()) void {
+            self.state.deinited += 1;
+        }
+    };
+
+    var state: State = .{};
+    var frames: [3]Frame = undefined;
+    try testing.expectError(
+        error.InitFailed,
+        initializeFrameStates(&frames, &state, false),
+    );
+    try testing.expectEqual(@as(usize, 2), state.initialized);
+    try testing.expectEqual(state.initialized, state.deinited);
+}

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -3849,8 +3849,13 @@ test "prepared frame damage remains retryable until draw commit" {
 
 test "renderer teardown releases presented target without purging" {
     const Resource = struct {
+        released: *usize,
         deinited: *usize,
         discarded: *usize,
+
+        fn releasePresentationOwnership(self: @This()) void {
+            self.released.* += 1;
+        }
 
         fn deinit(self: *@This()) void {
             self.deinited.* += 1;
@@ -3861,16 +3866,19 @@ test "renderer teardown releases presented target without purging" {
         }
     };
 
+    var released: usize = 0;
     var deinited: usize = 0;
     var discarded: usize = 0;
     var target: Resource = .{
+        .released = &released,
         .deinited = &deinited,
         .discarded = &discarded,
     };
 
     disposePresentedTarget(&target);
 
-    try std.testing.expectEqual(@as(usize, 1), deinited);
+    try std.testing.expectEqual(@as(usize, 1), released);
+    try std.testing.expectEqual(@as(usize, 0), deinited);
     try std.testing.expectEqual(@as(usize, 0), discarded);
 }
 

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -129,6 +129,15 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
         const shaderpkg = GraphicsAPI.shaders;
         const Shaders = shaderpkg.Shaders;
 
+        fn disposeOwned(resource: anytype, comptime purge: bool) void {
+            const Resource = @TypeOf(resource.*);
+            if (comptime purge and @hasDecl(Resource, "discard")) {
+                resource.discard();
+            } else {
+                resource.deinit();
+            }
+        }
+
         /// Allocator that can be used
         alloc: std.mem.Allocator,
 
@@ -311,6 +320,23 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             /// the renderer is deinited after that.
             defunct: bool = false,
 
+            const DrainedFrames = struct {
+                swap_chain: *SwapChain,
+                indices: [buf_count]usize = undefined,
+                count: usize = 0,
+
+                fn dispose(
+                    self: *DrainedFrames,
+                    comptime purge: bool,
+                ) void {
+                    for (self.indices[0..self.count]) |index| {
+                        self.swap_chain.frames[index]
+                            .deinitWithDisposition(purge);
+                    }
+                    self.count = 0;
+                }
+            };
+
             pub fn init(api: GraphicsAPI, custom_shaders: bool) !SwapChain {
                 var result: SwapChain = .{ .frames = undefined };
 
@@ -323,7 +349,18 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             }
 
             pub fn deinit(self: *SwapChain) void {
-                if (self.defunct) return;
+                var drained = self.drainForDeinit();
+                drained.dispose(false);
+            }
+
+            pub fn discard(self: *SwapChain) void {
+                var drained = self.drainForDeinit();
+                drained.dispose(true);
+            }
+
+            fn drainForDeinit(self: *SwapChain) DrainedFrames {
+                var drained: DrainedFrames = .{ .swap_chain = self };
+                if (self.defunct) return drained;
                 self.defunct = true;
                 self.leases.beginDeinit();
 
@@ -335,19 +372,22 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 // slots still owned by the GPU or host. `defunct` is already
                 // set, so no new acquire races us.
                 if (comptime builtin.os.tag == .ios) {
-                    var acquired: usize = 0;
-                    while (acquired < buf_count) : (acquired += 1) {
+                    while (drained.count < buf_count) {
                         const index = self.leases.takeForDeinit(
                             frame_acquire_timeout_ns,
                         ) catch break;
-                        self.frames[index].deinit();
+                        drained.indices[drained.count] = index;
+                        drained.count += 1;
                     }
                 } else {
                     for (0..buf_count) |_| {
                         const index = self.leases.takeForDeinit(null) catch unreachable;
-                        self.frames[index].deinit();
+                        drained.indices[drained.count] = index;
+                        drained.count += 1;
                     }
                 }
+
+                return drained;
             }
 
             const AcquiredFrame = struct {
@@ -512,14 +552,28 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             }
 
             pub fn deinit(self: *FrameState) void {
-                self.target.deinit();
-                self.uniforms.deinit();
-                self.cells.deinit();
-                self.cells_bg.deinit();
-                self.grayscale.deinit();
-                self.color.deinit();
-                self.bg_image_buffer.deinit();
-                if (self.custom_shader_state) |*state| state.deinit();
+                self.deinitWithDisposition(false);
+            }
+
+            pub fn discard(self: *FrameState) void {
+                self.deinitWithDisposition(true);
+            }
+
+            fn deinitWithDisposition(
+                self: *FrameState,
+                comptime purge: bool,
+            ) void {
+                // SwapChain only calls this after the frame lease drains.
+                disposeOwned(&self.target, purge);
+                disposeOwned(&self.uniforms, purge);
+                disposeOwned(&self.cells, purge);
+                disposeOwned(&self.cells_bg, purge);
+                disposeOwned(&self.grayscale, purge);
+                disposeOwned(&self.color, purge);
+                disposeOwned(&self.bg_image_buffer, purge);
+                if (self.custom_shader_state) |*state| {
+                    state.deinitWithDisposition(purge);
+                }
             }
 
             pub fn resize(
@@ -601,10 +655,21 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             }
 
             pub fn deinit(self: *CustomShaderState) void {
-                self.front_texture.deinit();
-                self.back_texture.deinit();
-                self.sampler.deinit();
-                self.uniforms.deinit();
+                self.deinitWithDisposition(false);
+            }
+
+            pub fn discard(self: *CustomShaderState) void {
+                self.deinitWithDisposition(true);
+            }
+
+            fn deinitWithDisposition(
+                self: *CustomShaderState,
+                comptime purge: bool,
+            ) void {
+                disposeOwned(&self.front_texture, purge);
+                disposeOwned(&self.back_texture, purge);
+                disposeOwned(&self.sampler, purge);
+                disposeOwned(&self.uniforms, purge);
             }
 
             pub fn resize(
@@ -1097,20 +1162,34 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 self.api.displayUnrealized();
             }
 
-            // Lock the draw mutex so that we can
-            // safely deinitialize our GPU resources.
-            self.draw_mutex.lock();
-            defer self.draw_mutex.unlock();
-
-            // We deinit our swap chain and shaders.
-            //
-            // This will mark them as defunct so that they
-            // can't be double-freed or used in draw calls.
-            self.swap_chain.deinit();
-            if (@hasDecl(GraphicsAPI, "finishFrameGeneration")) {
-                self.api.finishFrameGeneration();
+            var drained: SwapChain.DrainedFrames = undefined;
+            {
+                // Mark the swap chain defunct and wait for every available
+                // frame lease before releasing the draw lock.
+                self.draw_mutex.lock();
+                defer self.draw_mutex.unlock();
+                drained = self.swap_chain.drainForDeinit();
+                if (@hasDecl(GraphicsAPI, "finishFrameGeneration")) {
+                    self.api.finishFrameGeneration();
+                }
             }
-            self.shaders.deinit(self.alloc);
+
+            // Flush queued compositor assignments after all frame leases drain.
+            // This must run without the draw mutex because a main-thread host
+            // callback may acquire it.
+            if (@hasDecl(GraphicsAPI, "displayUnrealizedAfterDrain")) {
+                self.api.displayUnrealizedAfterDrain();
+            }
+
+            {
+                // No draw can acquire a defunct swap chain. Clear compositor
+                // ownership first, then make only these teardown resources
+                // purgeable before releasing their final renderer references.
+                self.draw_mutex.lock();
+                defer self.draw_mutex.unlock();
+                drained.dispose(true);
+                self.shaders.deinit(self.alloc);
+            }
         }
 
         fn displayLinkCallback(
@@ -3655,11 +3734,9 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             texture: *Texture,
         ) !void {
             if (atlas.size > texture.width) {
-                // Free our old texture
+                const replacement = try self.api.initAtlasTexture(atlas);
                 texture.*.deinit();
-
-                // Reallocate
-                texture.* = try self.api.initAtlasTexture(atlas);
+                texture.* = replacement;
             }
 
             try texture.replaceRegion(0, 0, atlas.size, atlas.size, atlas.data);

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -3839,6 +3839,33 @@ test "prepared frame damage remains retryable until draw commit" {
     try std.testing.expect(!cells_rebuilt);
 }
 
+test "renderer teardown releases presented target without purging" {
+    const Resource = struct {
+        deinited: *usize,
+        discarded: *usize,
+
+        fn deinit(self: *@This()) void {
+            self.deinited.* += 1;
+        }
+
+        fn discard(self: *@This()) void {
+            self.discarded.* += 1;
+        }
+    };
+
+    var deinited: usize = 0;
+    var discarded: usize = 0;
+    var target: Resource = .{
+        .deinited = &deinited,
+        .discarded = &discarded,
+    };
+
+    disposePresentedTarget(&target);
+
+    try std.testing.expectEqual(@as(usize, 1), deinited);
+    try std.testing.expectEqual(@as(usize, 0), discarded);
+}
+
 test "swap chain initialization cleans its successful prefix on failure" {
     const testing = std.testing;
     const State = struct {

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -81,6 +81,45 @@ fn initializeFrameStates(
     }
 }
 
+/// Own the graphics API's partial realization until the replacement renderer
+/// resources commit. Downstream failure rolls the API back to its logically
+/// unrealized state; success forces the cached CPU cells into the fresh swap
+/// chain even when synchronized output suppresses the terminal-state update.
+fn RendererRealization(comptime GraphicsAPI: type) type {
+    return struct {
+        const Realization = @This();
+
+        api: *GraphicsAPI,
+        cached_frame_redraw: *bool,
+        committed: bool = false,
+
+        fn begin(
+            api: *GraphicsAPI,
+            cached_frame_redraw: *bool,
+        ) !Realization {
+            if (@hasDecl(GraphicsAPI, "displayRealized")) {
+                try api.displayRealized();
+            }
+            return .{
+                .api = api,
+                .cached_frame_redraw = cached_frame_redraw,
+            };
+        }
+
+        fn commit(self: *Realization) void {
+            self.cached_frame_redraw.* = true;
+            self.committed = true;
+        }
+
+        fn deinit(self: *Realization) void {
+            if (self.committed) return;
+            if (@hasDecl(GraphicsAPI, "displayRealizedRollback")) {
+                self.api.displayRealizedRollback();
+            }
+        }
+    };
+}
+
 fn advanceShaperCellIndexToX(
     run_offset: usize,
     shaped_cells: []const font.shape.Cell,
@@ -1138,10 +1177,11 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
         /// reinitialized due to any of the events mentioned in
         /// the doc comment for `displayUnrealized`.
         pub fn displayRealized(self: *Self) !void {
-            // If our API has to do things on realize, let it.
-            if (@hasDecl(GraphicsAPI, "displayRealized")) {
-                try self.api.displayRealized();
-            }
+            var realization = try RendererRealization(GraphicsAPI).begin(
+                &self.api,
+                &self.cells_rebuilt,
+            );
+            defer realization.deinit();
 
             // Lock the draw mutex so that we can
             // safely reinitialize our GPU resources.
@@ -1169,6 +1209,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             self.swap_chain = swap_chain;
             self.reinitialize_shaders = false;
             self.target_config_modified = 1;
+            realization.commit();
         }
 
         /// This is called by the GTK apprt when the surface is being destroyed.

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -175,7 +175,12 @@ fn disposePresentedTarget(resource: anytype) void {
     // Release renderer ownership without making its IOSurface purgeable;
     // Core Animation's retained reference keeps the pixels valid until
     // the clear callback removes the layer contents.
-    resource.deinit();
+    const Resource = @TypeOf(resource.*);
+    if (comptime @hasDecl(Resource, "releasePresentationOwnership")) {
+        resource.releasePresentationOwnership();
+    } else {
+        resource.deinit();
+    }
 }
 
 pub fn Renderer(comptime GraphicsAPI: type) type {

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -170,6 +170,14 @@ fn advanceShaperCellIndexToX(
 ///
 /// [ Texture ] - An abstraction over a GPU texture.
 ///
+fn disposePresentedTarget(resource: anytype) void {
+    // A queued main-thread layer clear may still composite this target.
+    // Release renderer ownership without making its IOSurface purgeable;
+    // Core Animation's retained reference keeps the pixels valid until
+    // the clear callback removes the layer contents.
+    resource.deinit();
+}
+
 pub fn Renderer(comptime GraphicsAPI: type) type {
     return struct {
         const Self = @This();
@@ -621,7 +629,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 comptime purge: bool,
             ) void {
                 // SwapChain only calls this after the frame lease drains.
-                disposeOwned(&self.target, purge);
+                disposePresentedTarget(&self.target);
                 disposeOwned(&self.uniforms, purge);
                 disposeOwned(&self.cells, purge);
                 disposeOwned(&self.cells_bg, purge);

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -64,6 +64,23 @@ const DrawDamageCommit = struct {
     }
 };
 
+/// Initialize a fixed frame array transactionally. A failed later frame must
+/// release every resource owned by the successfully initialized prefix before
+/// the caller retries swap-chain realization.
+fn initializeFrameStates(
+    frames: anytype,
+    api: anytype,
+    custom_shaders: bool,
+) !void {
+    var initialized: usize = 0;
+    errdefer for (frames[0..initialized]) |*frame| frame.deinit();
+
+    for (frames) |*frame| {
+        frame.* = try @TypeOf(frame.*).init(api, custom_shaders);
+        initialized += 1;
+    }
+}
+
 fn advanceShaperCellIndexToX(
     run_offset: usize,
     shaped_cells: []const font.shape.Cell,
@@ -340,10 +357,11 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             pub fn init(api: GraphicsAPI, custom_shaders: bool) !SwapChain {
                 var result: SwapChain = .{ .frames = undefined };
 
-                // Initialize all of our frame state.
-                for (&result.frames) |*frame| {
-                    frame.* = try FrameState.init(api, custom_shaders);
-                }
+                try initializeFrameStates(
+                    &result.frames,
+                    api,
+                    custom_shaders,
+                );
 
                 return result;
             }
@@ -1122,7 +1140,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
         pub fn displayRealized(self: *Self) !void {
             // If our API has to do things on realize, let it.
             if (@hasDecl(GraphicsAPI, "displayRealized")) {
-                self.api.displayRealized();
+                try self.api.displayRealized();
             }
 
             // Lock the draw mutex so that we can

--- a/src/renderer/message.zig
+++ b/src/renderer/message.zig
@@ -67,14 +67,10 @@ pub const Message = union(enum) {
     /// The macOS display ID has changed for the window.
     macos_display_id: u32,
 
-    /// cmux fork: realize (true) or unrealize (false) the renderer's GPU
-    /// resources (Metal swap-chain / IOSurface) without freeing the surface.
-    /// Driven by cmux's offscreen renderer-reclamation controller so a surface
-    /// that is occluded for a while releases its ~40MB IOSurface while keeping
-    /// its PTY/io thread + terminal state alive, then rebuilds the swap chain on
-    /// re-show. Non-idempotent (must strictly alternate with the swap chain's
-    /// `defunct` state), so it is only ever pushed `.forever` from macOS, never
-    /// dropped — see `ghostty_surface_set_renderer_realized`.
+    /// Compatibility path for realizing or unrealizing renderer GPU resources
+    /// without freeing the surface. New embedders publish the same idempotent
+    /// state through `SurfaceStateRequests`, so mailbox pressure cannot drop a
+    /// lifecycle transition.
     display_realized: bool,
 
     pub const SearchMatches = struct {

--- a/src/renderer/metal/Frame.zig
+++ b/src/renderer/metal/Frame.zig
@@ -17,6 +17,34 @@ const FramePresentation = rendererpkg.FramePresentation;
 
 const log = std.log.scoped(.metal);
 
+test "metal frame command buffers use renderer-owned resource lifetimes" {
+    try std.testing.expectEqualStrings(
+        "commandBufferWithUnretainedReferences",
+        command_buffer_selector,
+    );
+
+    try std.testing.expect(!commandBufferRequiresMetalRetention(
+        false,
+        false,
+        false,
+    ));
+    try std.testing.expect(commandBufferRequiresMetalRetention(
+        true,
+        false,
+        false,
+    ));
+    try std.testing.expect(commandBufferRequiresMetalRetention(
+        false,
+        true,
+        false,
+    ));
+    try std.testing.expect(commandBufferRequiresMetalRetention(
+        false,
+        false,
+        true,
+    ));
+}
+
 /// Options for beginning a frame.
 pub const Options = struct {
     /// MTLCommandQueue

--- a/src/renderer/metal/Frame.zig
+++ b/src/renderer/metal/Frame.zig
@@ -16,6 +16,17 @@ const FrameToken = rendererpkg.frame_lease.Token;
 const FramePresentation = rendererpkg.FramePresentation;
 
 const log = std.log.scoped(.metal);
+const command_buffer_selector = "commandBufferWithUnretainedReferences";
+
+pub fn commandBufferRequiresMetalRetention(
+    has_background_image: bool,
+    has_terminal_images: bool,
+    has_custom_shaders: bool,
+) bool {
+    return has_background_image or
+        has_terminal_images or
+        has_custom_shaders;
+}
 
 test "metal frame command buffers use renderer-owned resource lifetimes" {
     try std.testing.expectEqualStrings(
@@ -52,6 +63,10 @@ pub const Options = struct {
 
     /// Ref-counted renderer access gate for asynchronous completion.
     completion_lifetime: *Metal.RendererCompletionLifetime,
+
+    /// Dynamic images and custom shaders can replace resources while a prior
+    /// frame is still in flight, so those frames keep Metal's retain table.
+    retain_references: bool,
 };
 
 /// MTLCommandBuffer
@@ -68,11 +83,21 @@ pub fn begin(
     host_context: u64,
     presentation: ?FramePresentation,
 ) !Self {
-    const buffer = opts.queue.msgSend(
-        objc.Object,
-        objc.sel("commandBuffer"),
-        .{},
-    );
+    const buffer = if (opts.retain_references)
+        opts.queue.msgSend(
+            objc.Object,
+            objc.sel("commandBuffer"),
+            .{},
+        )
+    else
+        // Default terminal frames encode swap-chain-owned resources and
+        // process-shared standard pipelines. The exact-slot frame lease keeps
+        // them alive through completion without Metal's duplicate retain table.
+        opts.queue.msgSend(
+            objc.Object,
+            objc.sel(command_buffer_selector),
+            .{},
+        );
 
     // Create our block to register for completion updates.
     // The block is deallocated by the objC runtime on success.

--- a/src/renderer/metal/Frame.zig
+++ b/src/renderer/metal/Frame.zig
@@ -17,6 +17,13 @@ const FramePresentation = rendererpkg.FramePresentation;
 
 const log = std.log.scoped(.metal);
 
+test "metal frame command buffers do not retain renderer resources" {
+    try std.testing.expectEqualStrings(
+        "commandBufferWithUnretainedReferences",
+        command_buffer_selector,
+    );
+}
+
 /// Options for beginning a frame.
 pub const Options = struct {
     /// MTLCommandQueue

--- a/src/renderer/metal/Frame.zig
+++ b/src/renderer/metal/Frame.zig
@@ -16,6 +16,7 @@ const FrameToken = rendererpkg.frame_lease.Token;
 const FramePresentation = rendererpkg.FramePresentation;
 
 const log = std.log.scoped(.metal);
+const command_buffer_selector = "commandBufferWithUnretainedReferences";
 
 test "metal frame command buffers do not retain renderer resources" {
     try std.testing.expectEqualStrings(
@@ -47,9 +48,13 @@ pub fn begin(
     host_context: u64,
     presentation: ?FramePresentation,
 ) !Self {
+    // The swap-chain lease keeps every resource encoded by this frame alive
+    // until bufferCompleted recycles its exact slot. Renderer teardown drains
+    // those leases before releasing shared shaders or per-frame resources, so
+    // Metal does not need a second strong-reference table for every command.
     const buffer = opts.queue.msgSend(
         objc.Object,
-        objc.sel("commandBuffer"),
+        objc.sel(command_buffer_selector),
         .{},
     );
 

--- a/src/renderer/metal/Frame.zig
+++ b/src/renderer/metal/Frame.zig
@@ -16,14 +16,6 @@ const FrameToken = rendererpkg.frame_lease.Token;
 const FramePresentation = rendererpkg.FramePresentation;
 
 const log = std.log.scoped(.metal);
-const command_buffer_selector = "commandBufferWithUnretainedReferences";
-
-test "metal frame command buffers do not retain renderer resources" {
-    try std.testing.expectEqualStrings(
-        "commandBufferWithUnretainedReferences",
-        command_buffer_selector,
-    );
-}
 
 /// Options for beginning a frame.
 pub const Options = struct {
@@ -48,13 +40,9 @@ pub fn begin(
     host_context: u64,
     presentation: ?FramePresentation,
 ) !Self {
-    // The swap-chain lease keeps every resource encoded by this frame alive
-    // until bufferCompleted recycles its exact slot. Renderer teardown drains
-    // those leases before releasing shared shaders or per-frame resources, so
-    // Metal does not need a second strong-reference table for every command.
     const buffer = opts.queue.msgSend(
         objc.Object,
-        objc.sel(command_buffer_selector),
+        objc.sel("commandBuffer"),
         .{},
     );
 

--- a/src/renderer/metal/IOSurfaceLayer.zig
+++ b/src/renderer/metal/IOSurfaceLayer.zig
@@ -210,8 +210,10 @@ pub fn invalidateSurfaceUpdates(self: *IOSurfaceLayer) void {
 
 /// Clear the last presented IOSurface without disabling future assignments.
 /// Renderer teardown enqueues this after every frame lease drains, so FIFO
-/// main-queue ordering clears earlier assignments without synchronously
-/// waiting on AppKit while it may be joining the renderer thread.
+/// main-queue ordering normally clears earlier assignments without
+/// synchronously waiting on AppKit while it may be joining the renderer
+/// thread. The captured IOSurface guard preserves a newer synchronous frame
+/// if realization races the queued clear.
 pub fn clearSurface(self: *IOSurfaceLayer) void {
     const surface: *IOSurface = @ptrCast(self.layer.getProperty(
         ?*anyopaque,
@@ -348,6 +350,8 @@ fn clearSurfaceCallback(
 ) callconv(.c) void {
     defer block.surface.release();
     const layer = objc.Object.fromId(block.layer);
+    const contents = layer.getProperty(?*anyopaque, "contents");
+    if (contents != @as(*anyopaque, @ptrCast(block.surface))) return;
     layer.setProperty("contents", @as(?*anyopaque, null));
 }
 

--- a/src/renderer/metal/IOSurfaceLayer.zig
+++ b/src/renderer/metal/IOSurfaceLayer.zig
@@ -213,8 +213,15 @@ pub fn invalidateSurfaceUpdates(self: *IOSurfaceLayer) void {
 /// main-queue ordering clears earlier assignments without synchronously
 /// waiting on AppKit while it may be joining the renderer thread.
 pub fn clearSurface(self: *IOSurfaceLayer) void {
+    const surface: *IOSurface = @ptrCast(self.layer.getProperty(
+        ?*anyopaque,
+        "contents",
+    ) orelse return);
+    surface.retain();
+
     var block = ClearSurfaceBlock.init(.{
         .layer = self.layer.value,
+        .surface = surface,
     }, &clearSurfaceCallback);
 
     const NSThread = objc.getClass("NSThread").?;
@@ -263,6 +270,7 @@ const InvalidateSurfaceUpdatesBlock = objc.Block(struct {
 
 const ClearSurfaceBlock = objc.Block(struct {
     layer: objc.c.id,
+    surface: *IOSurface,
 }, .{}, void);
 
 fn setSurfaceCallback(
@@ -338,6 +346,7 @@ fn invalidateSurfaceUpdatesCallback(
 fn clearSurfaceCallback(
     block: *const ClearSurfaceBlock.Context,
 ) callconv(.c) void {
+    defer block.surface.release();
     const layer = objc.Object.fromId(block.layer);
     layer.setProperty("contents", @as(?*anyopaque, null));
 }
@@ -486,11 +495,55 @@ test "clear surface drops displayed IOSurface without disabling future updates" 
         layer.layer.getProperty(?*anyopaque, "contents") != null,
     );
 
-    layer.clearSurface();
+    surface.retain();
+    var block = ClearSurfaceBlock.init(.{
+        .layer = layer.layer.value,
+        .surface = surface,
+    }, &clearSurfaceCallback);
+    clearSurfaceCallback(&block);
 
     try testing.expectEqual(
         @as(?*anyopaque, null),
         layer.layer.getProperty(?*anyopaque, "contents"),
     );
     try testing.expect(layer.surfaceUpdatesActive());
+}
+
+test "deferred clear preserves a newer IOSurface" {
+    const testing = std.testing;
+
+    var layer = try IOSurfaceLayer.init();
+    defer layer.release();
+    var old_surface = try IOSurface.init(.{
+        .width = 1,
+        .height = 1,
+        .pixel_format = .@"32BGRA",
+        .bytes_per_element = 4,
+        .colorspace = null,
+    });
+    defer old_surface.deinit();
+    var new_surface = try IOSurface.init(.{
+        .width = 1,
+        .height = 1,
+        .pixel_format = .@"32BGRA",
+        .bytes_per_element = 4,
+        .colorspace = null,
+    });
+    defer new_surface.deinit();
+
+    layer.setSurfaceSync(old_surface);
+    old_surface.retain();
+    var block = ClearSurfaceBlock.init(.{
+        .layer = layer.layer.value,
+        .surface = old_surface,
+    }, &clearSurfaceCallback);
+
+    layer.setSurfaceSync(new_surface);
+    clearSurfaceCallback(&block);
+
+    const contents = layer.layer.getProperty(?*anyopaque, "contents");
+    try testing.expectEqual(
+        @intFromPtr(new_surface),
+        @intFromPtr(contents.?),
+    );
 }

--- a/src/renderer/metal/IOSurfaceLayer.zig
+++ b/src/renderer/metal/IOSurfaceLayer.zig
@@ -574,3 +574,25 @@ test "deferred clear preserves a newer IOSurface" {
         @intFromPtr(contents.?),
     );
 }
+
+test "deferred clear uses the last committed surface generation" {
+    const testing = std.testing;
+
+    var generations = try SurfaceGeneration.create();
+    defer generations.release();
+
+    const committed = generations.schedule();
+    generations.commit(committed);
+
+    // A newer scheduled frame may fail the layer-size guard. Clearing through
+    // that cutoff must still release the older frame that remains displayed.
+    const rejected = generations.schedule();
+    try testing.expect(generations.shouldClear(rejected));
+
+    // A synchronous frame committed after the clear was scheduled belongs to
+    // the replacement swap chain and must survive the deferred callback.
+    const replacement = generations.schedule();
+    generations.commit(replacement);
+    try testing.expect(!generations.shouldClear(rejected));
+    try testing.expect(!generations.shouldCommit(committed));
+}

--- a/src/renderer/metal/IOSurfaceLayer.zig
+++ b/src/renderer/metal/IOSurfaceLayer.zig
@@ -17,13 +17,69 @@ const log = std.log.scoped(.IOSurfaceLayer);
 var Subclass: ?objc.Class = null;
 var surface_updates_active_sentinel: usize = 0;
 
+/// Shared ordering state for layer assignments and deferred clears. Blocks can
+/// outlive the renderer-owned IOSurfaceLayer, so this state is ref-counted
+/// independently rather than capturing the wrapper itself.
+const SurfaceGeneration = struct {
+    const Self = @This();
+
+    refs: std.atomic.Value(usize) = std.atomic.Value(usize).init(1),
+    scheduled: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
+    committed: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
+
+    fn create() !*Self {
+        const self = try std.heap.c_allocator.create(Self);
+        self.* = .{};
+        return self;
+    }
+
+    fn retain(self: *Self) void {
+        const previous = self.refs.fetchAdd(1, .seq_cst);
+        std.debug.assert(previous > 0);
+    }
+
+    fn release(self: *Self) void {
+        const previous = self.refs.fetchSub(1, .seq_cst);
+        std.debug.assert(previous > 0);
+        if (previous == 1) std.heap.c_allocator.destroy(self);
+    }
+
+    fn schedule(self: *Self) u64 {
+        const previous = self.scheduled.fetchAdd(1, .monotonic);
+        std.debug.assert(previous != std.math.maxInt(u64));
+        return previous +% 1;
+    }
+
+    fn latest(self: *const Self) u64 {
+        return self.scheduled.load(.acquire);
+    }
+
+    fn shouldCommit(self: *const Self, generation: u64) bool {
+        return generation >= self.committed.load(.acquire);
+    }
+
+    fn commit(self: *Self, generation: u64) void {
+        var current = self.committed.load(.acquire);
+        while (generation > current) {
+            current = self.committed.cmpxchgWeak(
+                current,
+                generation,
+                .acq_rel,
+                .acquire,
+            ) orelse return;
+        }
+    }
+
+    fn shouldClear(self: *const Self, cutoff: u64) bool {
+        return self.committed.load(.acquire) <= cutoff;
+    }
+};
+
 /// The underlying CALayer
 layer: objc.Object,
 
-/// Latest surface scheduled by the renderer. Its retain transfers to a clear
-/// block so the block can identify its assignment without reading mutable
-/// CALayer state from the renderer thread.
-scheduled_surface: ?*IOSurface = null,
+/// Orders assignments that reach the main queue against a deferred clear.
+surface_generation: *SurfaceGeneration,
 
 pub fn init() !IOSurfaceLayer {
     // The layer returned by `[CALayer layer]` is autoreleased, which means
@@ -35,6 +91,8 @@ pub fn init() !IOSurfaceLayer {
         .{},
     ).retain();
     errdefer layer.release();
+    const surface_generation = try SurfaceGeneration.create();
+    errdefer surface_generation.release();
 
     // The layer gravity is set to top-left so that the contents aren't
     // stretched during resize operations before a new frame has been drawn.
@@ -46,30 +104,15 @@ pub fn init() !IOSurfaceLayer {
         .value = @ptrCast(&surface_updates_active_sentinel),
     });
 
-    return .{ .layer = layer };
+    return .{
+        .layer = layer,
+        .surface_generation = surface_generation,
+    };
 }
 
 pub fn release(self: *IOSurfaceLayer) void {
-    if (self.scheduled_surface) |surface| surface.release();
-    self.scheduled_surface = null;
+    self.surface_generation.release();
     self.layer.release();
-}
-
-fn trackScheduledSurface(
-    self: *IOSurfaceLayer,
-    surface: *IOSurface,
-) void {
-    surface.retain();
-    if (self.scheduled_surface) |previous| previous.release();
-    self.scheduled_surface = surface;
-}
-
-/// Transfer the tracked retain to the clear block. A future assignment takes
-/// its own retain and remains distinguishable from this generation.
-fn takeScheduledSurface(self: *IOSurfaceLayer) ?*IOSurface {
-    const surface = self.scheduled_surface;
-    self.scheduled_surface = null;
-    return surface;
 }
 
 /// Detaches this layer from its host if its display callback still belongs to
@@ -122,6 +165,8 @@ pub inline fn setSurfaceWithPresentation(
 pub const PreparedSurfaceUpdate = struct {
     layer: objc.Object,
     surface: *IOSurface,
+    surface_generation: *SurfaceGeneration,
+    generation: u64,
     presentation: FramePresentation,
 
     /// Transfer this update to the main queue. Dispatch copies and retains the
@@ -132,6 +177,8 @@ pub const PreparedSurfaceUpdate = struct {
         var block = SetSurfaceBlock.init(.{
             .layer = self.layer.value,
             .surface = self.surface,
+            .surface_generation = self.surface_generation,
+            .generation = self.generation,
             .presentation_callback = self.presentation.callback,
             .presentation_userdata = self.presentation.userdata,
             .presentation_token = self.presentation.token,
@@ -152,11 +199,14 @@ pub fn prepareSurfaceWithPresentation(
     surface: *IOSurface,
     presentation: FramePresentation,
 ) PreparedSurfaceUpdate {
-    self.trackScheduledSurface(surface);
+    const generation = self.surface_generation.schedule();
+    self.surface_generation.retain();
     surface.retain();
     return .{
         .layer = self.layer.retain(),
         .surface = surface,
+        .surface_generation = self.surface_generation,
+        .generation = generation,
         .presentation = presentation,
     };
 }
@@ -166,7 +216,8 @@ fn setSurface_(
     surface: *IOSurface,
     presentation: ?FramePresentation,
 ) !void {
-    self.trackScheduledSurface(surface);
+    const generation = self.surface_generation.schedule();
+    self.surface_generation.retain();
     // We retain the surface to make sure it's not GC'd
     // before we can set it as the contents of the layer.
     //
@@ -179,6 +230,8 @@ fn setSurface_(
     var block = SetSurfaceBlock.init(.{
         .layer = self.layer.value,
         .surface = surface,
+        .surface_generation = self.surface_generation,
+        .generation = generation,
         .presentation_callback = if (presentation) |value| value.callback else null,
         .presentation_userdata = if (presentation) |value| value.userdata else null,
         .presentation_token = if (presentation) |value| value.token else 0,
@@ -238,14 +291,18 @@ pub fn invalidateSurfaceUpdates(self: *IOSurfaceLayer) void {
 /// Renderer teardown enqueues this after every frame lease drains, so FIFO
 /// main-queue ordering normally clears earlier assignments without
 /// synchronously waiting on AppKit while it may be joining the renderer
-/// thread. The captured IOSurface guard preserves a newer synchronous frame
-/// if realization races the queued clear.
+/// thread. The captured generation cutoff preserves a newer synchronous frame
+/// if realization races the queued clear, while still clearing an older frame
+/// when a later scheduled assignment fails the layer-size guard.
 pub fn clearSurface(self: *IOSurfaceLayer) void {
-    const surface = self.takeScheduledSurface() orelse return;
+    const cutoff = self.surface_generation.latest();
+    if (cutoff == 0) return;
+    self.surface_generation.retain();
 
     var block = ClearSurfaceBlock.init(.{
         .layer = self.layer.value,
-        .surface = surface,
+        .surface_generation = self.surface_generation,
+        .cutoff = cutoff,
     }, &clearSurfaceCallback);
 
     const NSThread = objc.getClass("NSThread").?;
@@ -269,13 +326,16 @@ fn surfaceClearRunsInline(is_main_thread: bool) bool {
 ///
 /// Does not ensure this happens on the main thread.
 pub inline fn setSurfaceSync(self: *IOSurfaceLayer, surface: *IOSurface) void {
-    self.trackScheduledSurface(surface);
+    const generation = self.surface_generation.schedule();
     self.layer.setProperty("contents", surface);
+    self.surface_generation.commit(generation);
 }
 
 const SetSurfaceBlock = objc.Block(struct {
     layer: objc.c.id,
     surface: *IOSurface,
+    surface_generation: *SurfaceGeneration,
+    generation: u64,
     presentation_callback: ?*const fn (?*anyopaque, u64) callconv(.c) void,
     presentation_userdata: ?*anyopaque,
     presentation_token: u64,
@@ -295,7 +355,8 @@ const InvalidateSurfaceUpdatesBlock = objc.Block(struct {
 
 const ClearSurfaceBlock = objc.Block(struct {
     layer: objc.c.id,
-    surface: *IOSurface,
+    surface_generation: *SurfaceGeneration,
+    cutoff: u64,
 }, .{}, void);
 
 fn setSurfaceCallback(
@@ -306,6 +367,7 @@ fn setSurfaceCallback(
 
     // See explanation of why we retain and release in `setSurface`.
     defer surface.release();
+    defer block.surface_generation.release();
 
     // Teardown invalidates on main. Blocks queued by a late GPU completion
     // retain the layer and IOSurface but must not touch detached UI state or
@@ -328,8 +390,10 @@ fn setSurfaceCallback(
         );
         return;
     }
+    if (!block.surface_generation.shouldCommit(block.generation)) return;
 
     layer.setProperty("contents", surface);
+    block.surface_generation.commit(block.generation);
     if (block.presentation_callback) |callback| {
         if (block.presentation_delivery_gate) |gate| {
             gate(block.presentation_delivery_gate_userdata);
@@ -371,10 +435,9 @@ fn invalidateSurfaceUpdatesCallback(
 fn clearSurfaceCallback(
     block: *const ClearSurfaceBlock.Context,
 ) callconv(.c) void {
-    defer block.surface.release();
+    defer block.surface_generation.release();
+    if (!block.surface_generation.shouldClear(block.cutoff)) return;
     const layer = objc.Object.fromId(block.layer);
-    const contents = layer.getProperty(?*anyopaque, "contents");
-    if (contents != @as(*anyopaque, @ptrCast(block.surface))) return;
     layer.setProperty("contents", @as(?*anyopaque, null));
 }
 
@@ -466,7 +529,7 @@ test "tokened surface updates defer delivery and teardown invalidates them" {
     try testing.expect(!surfaceUpdateRunsInline(false, false));
 
     var layer = try IOSurfaceLayer.init();
-    defer layer.layer.release();
+    defer layer.release();
     try testing.expect(layer.surfaceUpdatesActive());
     layer.invalidateSurfaceUpdates();
     try testing.expect(!layer.surfaceUpdatesActive());
@@ -483,11 +546,14 @@ test "tokened surface updates defer delivery and teardown invalidates them" {
     });
     defer surface.deinit();
     surface.retain();
+    layer.surface_generation.retain();
 
     var state: CallbackState = .{};
     var block = SetSurfaceBlock.init(.{
         .layer = layer.layer.value,
         .surface = surface,
+        .surface_generation = layer.surface_generation,
+        .generation = layer.surface_generation.schedule(),
         .presentation_callback = &CallbackState.callback,
         .presentation_userdata = &state,
         .presentation_token = 42,
@@ -522,10 +588,12 @@ test "clear surface drops displayed IOSurface without disabling future updates" 
         layer.layer.getProperty(?*anyopaque, "contents") != null,
     );
 
-    surface.retain();
+    const cutoff = layer.surface_generation.latest();
+    layer.surface_generation.retain();
     var block = ClearSurfaceBlock.init(.{
         .layer = layer.layer.value,
-        .surface = surface,
+        .surface_generation = layer.surface_generation,
+        .cutoff = cutoff,
     }, &clearSurfaceCallback);
     clearSurfaceCallback(&block);
 
@@ -559,10 +627,12 @@ test "deferred clear preserves a newer IOSurface" {
     defer new_surface.deinit();
 
     layer.setSurfaceSync(old_surface);
-    old_surface.retain();
+    const cutoff = layer.surface_generation.latest();
+    layer.surface_generation.retain();
     var block = ClearSurfaceBlock.init(.{
         .layer = layer.layer.value,
-        .surface = old_surface,
+        .surface_generation = layer.surface_generation,
+        .cutoff = cutoff,
     }, &clearSurfaceCallback);
 
     layer.setSurfaceSync(new_surface);

--- a/src/renderer/metal/IOSurfaceLayer.zig
+++ b/src/renderer/metal/IOSurfaceLayer.zig
@@ -20,6 +20,11 @@ var surface_updates_active_sentinel: usize = 0;
 /// The underlying CALayer
 layer: objc.Object,
 
+/// Latest surface scheduled by the renderer. Its retain transfers to a clear
+/// block so the block can identify its assignment without reading mutable
+/// CALayer state from the renderer thread.
+scheduled_surface: ?*IOSurface = null,
+
 pub fn init() !IOSurfaceLayer {
     // The layer returned by `[CALayer layer]` is autoreleased, which means
     // that at the end of the current autorelease pool it will be deallocated
@@ -45,7 +50,26 @@ pub fn init() !IOSurfaceLayer {
 }
 
 pub fn release(self: *IOSurfaceLayer) void {
+    if (self.scheduled_surface) |surface| surface.release();
+    self.scheduled_surface = null;
     self.layer.release();
+}
+
+fn trackScheduledSurface(
+    self: *IOSurfaceLayer,
+    surface: *IOSurface,
+) void {
+    surface.retain();
+    if (self.scheduled_surface) |previous| previous.release();
+    self.scheduled_surface = surface;
+}
+
+/// Transfer the tracked retain to the clear block. A future assignment takes
+/// its own retain and remains distinguishable from this generation.
+fn takeScheduledSurface(self: *IOSurfaceLayer) ?*IOSurface {
+    const surface = self.scheduled_surface;
+    self.scheduled_surface = null;
+    return surface;
 }
 
 /// Detaches this layer from its host if its display callback still belongs to
@@ -128,6 +152,7 @@ pub fn prepareSurfaceWithPresentation(
     surface: *IOSurface,
     presentation: FramePresentation,
 ) PreparedSurfaceUpdate {
+    self.trackScheduledSurface(surface);
     surface.retain();
     return .{
         .layer = self.layer.retain(),
@@ -141,6 +166,7 @@ fn setSurface_(
     surface: *IOSurface,
     presentation: ?FramePresentation,
 ) !void {
+    self.trackScheduledSurface(surface);
     // We retain the surface to make sure it's not GC'd
     // before we can set it as the contents of the layer.
     //
@@ -215,11 +241,7 @@ pub fn invalidateSurfaceUpdates(self: *IOSurfaceLayer) void {
 /// thread. The captured IOSurface guard preserves a newer synchronous frame
 /// if realization races the queued clear.
 pub fn clearSurface(self: *IOSurfaceLayer) void {
-    const surface: *IOSurface = @ptrCast(self.layer.getProperty(
-        ?*anyopaque,
-        "contents",
-    ) orelse return);
-    surface.retain();
+    const surface = self.takeScheduledSurface() orelse return;
 
     var block = ClearSurfaceBlock.init(.{
         .layer = self.layer.value,
@@ -247,6 +269,7 @@ fn surfaceClearRunsInline(is_main_thread: bool) bool {
 ///
 /// Does not ensure this happens on the main thread.
 pub inline fn setSurfaceSync(self: *IOSurfaceLayer, surface: *IOSurface) void {
+    self.trackScheduledSurface(surface);
     self.layer.setProperty("contents", surface);
 }
 

--- a/src/renderer/metal/IOSurfaceLayer.zig
+++ b/src/renderer/metal/IOSurfaceLayer.zig
@@ -209,23 +209,29 @@ pub fn invalidateSurfaceUpdates(self: *IOSurfaceLayer) void {
 }
 
 /// Clear the last presented IOSurface without disabling future assignments.
-/// The synchronous main-queue hop runs after any earlier queued assignments,
-/// so renderer teardown cannot be followed by a stale surface becoming layer
-/// contents again.
+/// Renderer teardown enqueues this after every frame lease drains, so FIFO
+/// main-queue ordering clears earlier assignments without synchronously
+/// waiting on AppKit while it may be joining the renderer thread.
 pub fn clearSurface(self: *IOSurfaceLayer) void {
     var block = ClearSurfaceBlock.init(.{
         .layer = self.layer.value,
     }, &clearSurfaceCallback);
 
     const NSThread = objc.getClass("NSThread").?;
-    if (NSThread.msgSend(bool, "isMainThread", .{})) {
+    if (surfaceClearRunsInline(
+        NSThread.msgSend(bool, "isMainThread", .{}),
+    )) {
         clearSurfaceCallback(&block);
     } else {
-        macos.dispatch.dispatch_sync(
+        macos.dispatch.dispatch_async(
             @ptrCast(macos.dispatch.queue.getMain()),
             @ptrCast(&block),
         );
     }
+}
+
+fn surfaceClearRunsInline(is_main_thread: bool) bool {
+    return is_main_thread;
 }
 
 /// Sets the layer's `contents` to the provided IOSurface.

--- a/src/renderer/metal/IOSurfaceLayer.zig
+++ b/src/renderer/metal/IOSurfaceLayer.zig
@@ -426,3 +426,31 @@ test "tokened surface updates defer delivery and teardown invalidates them" {
     try testing.expectEqual(@as(usize, 0), state.gate_count);
     try testing.expectEqual(@as(usize, 0), state.callback_count);
 }
+
+test "clear surface drops displayed IOSurface without disabling future updates" {
+    const testing = std.testing;
+
+    var layer = try IOSurfaceLayer.init();
+    defer layer.release();
+    var surface = try IOSurface.init(.{
+        .width = 1,
+        .height = 1,
+        .pixel_format = .@"32BGRA",
+        .bytes_per_element = 4,
+        .colorspace = null,
+    });
+    defer surface.deinit();
+
+    layer.setSurfaceSync(surface);
+    try testing.expect(
+        layer.layer.getProperty(?*anyopaque, "contents") != null,
+    );
+
+    layer.clearSurface();
+
+    try testing.expectEqual(
+        @as(?*anyopaque, null),
+        layer.layer.getProperty(?*anyopaque, "contents"),
+    );
+    try testing.expect(layer.surfaceUpdatesActive());
+}

--- a/src/renderer/metal/IOSurfaceLayer.zig
+++ b/src/renderer/metal/IOSurfaceLayer.zig
@@ -208,6 +208,26 @@ pub fn invalidateSurfaceUpdates(self: *IOSurfaceLayer) void {
     }
 }
 
+/// Clear the last presented IOSurface without disabling future assignments.
+/// The synchronous main-queue hop runs after any earlier queued assignments,
+/// so renderer teardown cannot be followed by a stale surface becoming layer
+/// contents again.
+pub fn clearSurface(self: *IOSurfaceLayer) void {
+    var block = ClearSurfaceBlock.init(.{
+        .layer = self.layer.value,
+    }, &clearSurfaceCallback);
+
+    const NSThread = objc.getClass("NSThread").?;
+    if (NSThread.msgSend(bool, "isMainThread", .{})) {
+        clearSurfaceCallback(&block);
+    } else {
+        macos.dispatch.dispatch_sync(
+            @ptrCast(macos.dispatch.queue.getMain()),
+            @ptrCast(&block),
+        );
+    }
+}
+
 /// Sets the layer's `contents` to the provided IOSurface.
 ///
 /// Does not ensure this happens on the main thread.
@@ -232,6 +252,10 @@ const DetachFromHostBlock = objc.Block(struct {
 }, .{}, void);
 
 const InvalidateSurfaceUpdatesBlock = objc.Block(struct {
+    layer: objc.c.id,
+}, .{}, void);
+
+const ClearSurfaceBlock = objc.Block(struct {
     layer: objc.c.id,
 }, .{}, void);
 
@@ -303,6 +327,13 @@ fn invalidateSurfaceUpdatesCallback(
 ) callconv(.c) void {
     const layer = objc.Object.fromId(block.layer);
     layer.setInstanceVariable("surface_updates_active", .{ .value = null });
+}
+
+fn clearSurfaceCallback(
+    block: *const ClearSurfaceBlock.Context,
+) callconv(.c) void {
+    const layer = objc.Object.fromId(block.layer);
+    layer.setProperty("contents", @as(?*anyopaque, null));
 }
 
 pub const DisplayCallback = ?*align(8) const fn (?*anyopaque) void;

--- a/src/renderer/metal/IOSurfaceLayer.zig
+++ b/src/renderer/metal/IOSurfaceLayer.zig
@@ -461,6 +461,9 @@ test "tokened surface updates defer delivery and teardown invalidates them" {
 test "clear surface drops displayed IOSurface without disabling future updates" {
     const testing = std.testing;
 
+    try testing.expect(surfaceClearRunsInline(true));
+    try testing.expect(!surfaceClearRunsInline(false));
+
     var layer = try IOSurfaceLayer.init();
     defer layer.release();
     var surface = try IOSurface.init(.{

--- a/src/renderer/metal/Target.zig
+++ b/src/renderer/metal/Target.zig
@@ -133,3 +133,11 @@ pub fn deinit(self: *Self) void {
     self.surface.deinit();
     self.texture.release();
 }
+
+/// Mark the target texture empty before releasing a renderer-owned target
+/// whose frame lease and compositor ownership have both drained.
+pub fn discard(self: *Self) void {
+    mtl.discardResource(self.texture);
+    self.surface.deinit();
+    self.texture.release();
+}

--- a/src/renderer/metal/Texture.zig
+++ b/src/renderer/metal/Texture.zig
@@ -86,6 +86,14 @@ pub fn deinit(self: Self) void {
     self.texture.release();
 }
 
+/// Discard texture storage before releasing the final renderer-owned
+/// reference. The caller must prove that no frame or compositor still uses
+/// this texture.
+pub fn discard(self: Self) void {
+    mtl.discardResource(self.texture);
+    self.texture.release();
+}
+
 /// Replace a region of the texture with the provided data.
 ///
 /// Does NOT check the dimensions of the data to ensure correctness.

--- a/src/renderer/metal/api.zig
+++ b/src/renderer/metal/api.zig
@@ -6,6 +6,8 @@
 //!
 //! Ref: https://developer.apple.com/metal/cpp/
 
+const objc = @import("objc");
+
 /// https://developer.apple.com/documentation/metal/mtlcommandbufferstatus?language=objc
 pub const MTLCommandBufferStatus = enum(c_ulong) {
     not_enqueued = 0,
@@ -298,6 +300,17 @@ pub const MTLPurgeableState = enum(c_ulong) {
     @"volatile" = 3,
     empty = 4,
 };
+
+/// Tell Metal that a resource's contents are no longer needed before releasing
+/// its final owner. This keeps hidden-surface teardown from leaving discardable
+/// allocations charged to the process until later system memory pressure.
+pub fn discardResource(resource: objc.Object) void {
+    _ = resource.msgSend(
+        MTLPurgeableState,
+        objc.sel("setPurgeableState:"),
+        .{MTLPurgeableState.empty},
+    );
+}
 
 /// https://developer.apple.com/documentation/metal/mtlsamplerminmagfilter?language=objc
 pub const MTLSamplerMinMagFilter = enum(c_ulong) {

--- a/src/renderer/metal/buffer.zig
+++ b/src/renderer/metal/buffer.zig
@@ -66,6 +66,13 @@ pub fn Buffer(comptime T: type) type {
             self.buffer.msgSend(void, objc.sel("release"), .{});
         }
 
+        /// Discard buffer storage before releasing the final renderer-owned
+        /// reference. The caller must prove that no frame still uses it.
+        pub fn discard(self: *const Self) void {
+            mtl.discardResource(self.buffer);
+            self.buffer.msgSend(void, objc.sel("release"), .{});
+        }
+
         /// Sync new contents to the buffer. The data is expected to be the
         /// complete contents of the buffer. If the amount of data is larger
         /// than the buffer length, the buffer will be reallocated.

--- a/src/renderer/metal/shaders.zig
+++ b/src/renderer/metal/shaders.zig
@@ -307,36 +307,34 @@ fn shadersFromSharedStandard(entry: *SharedStandardShaders) Shaders {
 }
 
 fn releaseSharedStandard(entry: *SharedStandardShaders) void {
-    var destroy = false;
-
     shared_standard_mutex.lock();
+    defer shared_standard_mutex.unlock();
+
     std.debug.assert(entry.references > 0);
     entry.references -= 1;
-    if (entry.references == 0) {
-        for (shared_standard_entries.items, 0..) |candidate, i| {
-            if (candidate != entry) continue;
-            _ = shared_standard_entries.orderedRemove(i);
-            destroy = true;
-            break;
-        }
-        std.debug.assert(destroy);
+    // Keep a zero-reference standard entry alive for the process lifetime.
+    // Native tab selection can unrealize the outgoing renderer before
+    // realizing the incoming renderer. Destroying the entry in that gap
+    // recompiles identical pipelines on every tab switch, and Metal retains
+    // the associated driver allocations after the objects are released.
+}
 
-        if (shared_standard_entries.items.len == 0) {
-            shared_standard_entries.deinit(shared_standard_allocator);
-            shared_standard_entries = .empty;
-        }
+fn clearSharedStandardCacheForTesting() void {
+    shared_standard_mutex.lock();
+    defer shared_standard_mutex.unlock();
+
+    for (shared_standard_entries.items) |entry| {
+        std.debug.assert(entry.references == 0);
+        var owned: Shaders = .{
+            .library = entry.library,
+            .pipelines = entry.pipelines,
+            .post_pipelines = entry.post_pipelines,
+        };
+        owned.deinit(entry.resource_allocator);
+        shared_standard_allocator.destroy(entry);
     }
-    shared_standard_mutex.unlock();
-
-    if (!destroy) return;
-
-    var owned: Shaders = .{
-        .library = entry.library,
-        .pipelines = entry.pipelines,
-        .post_pipelines = entry.post_pipelines,
-    };
-    owned.deinit(entry.resource_allocator);
-    shared_standard_allocator.destroy(entry);
+    shared_standard_entries.deinit(shared_standard_allocator);
+    shared_standard_entries = .empty;
 }
 
 /// The uniforms that are passed to our shaders.
@@ -460,6 +458,7 @@ test "standard shaders reuse pipeline state across surfaces and restores" {
         }
     }
 
+    clearSharedStandardCacheForTesting();
     shared_standard_mutex.lock();
     defer shared_standard_mutex.unlock();
     try testing.expectEqual(@as(usize, 0), shared_standard_entries.items.len);
@@ -510,11 +509,14 @@ test "concurrent standard shader initialization compiles once" {
     start.set();
     for (&threads) |*thread| thread.join();
 
-    defer for (&contexts) |*context| {
-        if (context.shaders) |*value| {
-            value.deinit(std.heap.c_allocator);
+    defer {
+        for (&contexts) |*context| {
+            if (context.shaders) |*value| {
+                value.deinit(std.heap.c_allocator);
+            }
         }
-    };
+        clearSharedStandardCacheForTesting();
+    }
 
     for (&contexts) |*context| {
         if (context.err) |err| return err;
@@ -556,6 +558,7 @@ test "standard shader cache survives a renderer handoff gap" {
         .bgra8unorm,
     );
     restored.deinit(testing.allocator);
+    defer clearSharedStandardCacheForTesting();
 
     try testing.expectEqual(
         @as(usize, 1),

--- a/src/renderer/metal/shaders.zig
+++ b/src/renderer/metal/shaders.zig
@@ -531,6 +531,38 @@ test "concurrent standard shader initialization compiles once" {
     );
 }
 
+test "standard shader cache survives a renderer handoff gap" {
+    const testing = std.testing;
+    const device_ptr = mtl.MTLCreateSystemDefaultDevice() orelse {
+        return error.SkipZigTest;
+    };
+    const device = objc.Object.fromId(device_ptr);
+    defer device.release();
+
+    shared_standard_build_count.store(0, .monotonic);
+
+    var hidden = try Shaders.init(
+        testing.allocator,
+        device,
+        &.{},
+        .bgra8unorm,
+    );
+    hidden.deinit(testing.allocator);
+
+    var restored = try Shaders.init(
+        testing.allocator,
+        device,
+        &.{},
+        .bgra8unorm,
+    );
+    restored.deinit(testing.allocator);
+
+    try testing.expectEqual(
+        @as(usize, 1),
+        shared_standard_build_count.load(.monotonic),
+    );
+}
+
 /// This is a single parameter for the terminal cell shader.
 pub const CellText = extern struct {
     glyph_pos: [2]u32 align(8) = .{ 0, 0 },

--- a/src/renderer/metal/shaders.zig
+++ b/src/renderer/metal/shaders.zig
@@ -236,6 +236,7 @@ const SharedStandardShaders = struct {
 const shared_standard_allocator = std.heap.c_allocator;
 var shared_standard_mutex: std.Thread.Mutex = .{};
 var shared_standard_entries: std.ArrayListUnmanaged(*SharedStandardShaders) = .empty;
+var shared_standard_build_count = std.atomic.Value(usize).init(0);
 
 fn initSharedStandard(
     alloc: Allocator,
@@ -251,6 +252,7 @@ fn initSharedStandard(
         return shadersFromSharedStandard(entry);
     }
 
+    _ = shared_standard_build_count.fetchAdd(1, .monotonic);
     var candidate = try Shaders.initOwned(alloc, device, &.{}, pixel_format);
     const entry = shared_standard_allocator.create(SharedStandardShaders) catch |err| {
         candidate.deinit(alloc);
@@ -476,6 +478,72 @@ test "standard shaders reuse pipeline state across surfaces and restores" {
     shared_standard_mutex.lock();
     defer shared_standard_mutex.unlock();
     try testing.expectEqual(@as(usize, 0), shared_standard_entries.items.len);
+}
+
+test "concurrent standard shader initialization compiles once" {
+    const testing = std.testing;
+    const device_ptr = mtl.MTLCreateSystemDefaultDevice() orelse {
+        return error.SkipZigTest;
+    };
+    const device = objc.Object.fromId(device_ptr);
+    defer device.release();
+
+    const Context = struct {
+        start: *std.Thread.ResetEvent,
+        device: objc.Object,
+        shaders: ?Shaders = null,
+        err: ?anyerror = null,
+
+        fn run(self: *@This()) void {
+            self.start.wait();
+            self.shaders = Shaders.init(
+                std.heap.c_allocator,
+                self.device,
+                &.{},
+                .bgra8unorm_srgb,
+            ) catch |err| {
+                self.err = err;
+                return;
+            };
+        }
+    };
+
+    const thread_count = 5;
+    var start: std.Thread.ResetEvent = .{};
+    var contexts: [thread_count]Context = undefined;
+    var threads: [thread_count]std.Thread = undefined;
+
+    shared_standard_build_count.store(0, .monotonic);
+    for (&contexts, &threads) |*context, *thread| {
+        context.* = .{
+            .start = &start,
+            .device = device,
+        };
+        thread.* = try std.Thread.spawn(.{}, Context.run, .{context});
+    }
+
+    start.set();
+    for (&threads) |*thread| thread.join();
+
+    defer for (&contexts) |*context| {
+        if (context.shaders) |*value| {
+            value.deinit(std.heap.c_allocator);
+        }
+    };
+
+    for (&contexts) |*context| {
+        if (context.err) |err| return err;
+        try testing.expect(context.shaders != null);
+        try testing.expectEqual(
+            contexts[0].shaders.?.pipelines.bg_color.state.value,
+            context.shaders.?.pipelines.bg_color.state.value,
+        );
+    }
+
+    try testing.expectEqual(
+        @as(usize, 1),
+        shared_standard_build_count.load(.monotonic),
+    );
 }
 
 /// This is a single parameter for the terminal cell shader.

--- a/src/renderer/metal/shaders.zig
+++ b/src/renderer/metal/shaders.zig
@@ -226,6 +226,7 @@ const SharedStandardShadersKey = struct {
 
 const SharedStandardShaders = struct {
     key: SharedStandardShadersKey,
+    device: objc.Object,
     resource_allocator: Allocator,
     library: objc.Object,
     pipelines: PipelineCollection,
@@ -268,6 +269,7 @@ fn initSharedStandard(
     };
     entry.* = .{
         .key = key,
+        .device = device.retain(),
         .resource_allocator = alloc,
         .library = candidate.library,
         .pipelines = candidate.pipelines,
@@ -280,6 +282,7 @@ fn initSharedStandard(
         entry,
     ) catch |err| {
         candidate.deinit(alloc);
+        entry.device.release();
         shared_standard_allocator.destroy(entry);
         return err;
     };
@@ -331,6 +334,7 @@ fn clearSharedStandardCacheForTesting() void {
             .post_pipelines = entry.post_pipelines,
         };
         owned.deinit(entry.resource_allocator);
+        entry.device.release();
         shared_standard_allocator.destroy(entry);
     }
     shared_standard_entries.deinit(shared_standard_allocator);

--- a/src/renderer/metal/shaders.zig
+++ b/src/renderer/metal/shaders.zig
@@ -106,6 +106,10 @@ pub const Shaders = struct {
     /// against the output of the previous shader.
     post_pipelines: []const Pipeline,
 
+    /// Non-null only for the process-wide standard pipeline cache. Custom
+    /// shader sets remain renderer-owned because their source is user-specific.
+    shared: ?*SharedStandardShaders = null,
+
     /// Set to true when deinited, if you try to deinit a defunct set
     /// of shaders it will just be ignored, to prevent double-free.
     defunct: bool = false,
@@ -116,6 +120,19 @@ pub const Shaders = struct {
     /// against the final drawable texture. This is an array of shader source
     /// code, not file paths.
     pub fn init(
+        alloc: Allocator,
+        device: objc.Object,
+        post_shaders: []const [:0]const u8,
+        pixel_format: mtl.MTLPixelFormat,
+    ) !Shaders {
+        if (post_shaders.len == 0) {
+            return try initSharedStandard(alloc, device, pixel_format);
+        }
+
+        return try initOwned(alloc, device, post_shaders, pixel_format);
+    }
+
+    fn initOwned(
         alloc: Allocator,
         device: objc.Object,
         post_shaders: []const [:0]const u8,
@@ -172,6 +189,15 @@ pub const Shaders = struct {
         if (self.defunct) return;
         self.defunct = true;
 
+        if (self.shared) |entry| {
+            releaseSharedStandard(entry);
+            return;
+        }
+
+        self.deinitOwned(alloc);
+    }
+
+    fn deinitOwned(self: *Shaders, alloc: Allocator) void {
         // Release our primary shaders
         inline for (pipeline_descs) |pipeline| {
             @field(self.pipelines, pipeline[0]).deinit();
@@ -187,6 +213,144 @@ pub const Shaders = struct {
         }
     }
 };
+
+const SharedStandardShadersKey = struct {
+    device: usize,
+    pixel_format: mtl.MTLPixelFormat,
+
+    fn eql(self: SharedStandardShadersKey, other: SharedStandardShadersKey) bool {
+        return self.device == other.device and
+            self.pixel_format == other.pixel_format;
+    }
+};
+
+const SharedStandardShaders = struct {
+    key: SharedStandardShadersKey,
+    resource_allocator: Allocator,
+    library: objc.Object,
+    pipelines: PipelineCollection,
+    post_pipelines: []const Pipeline,
+    references: usize,
+};
+
+const shared_standard_allocator = std.heap.c_allocator;
+var shared_standard_mutex: std.Thread.Mutex = .{};
+var shared_standard_entries: std.ArrayListUnmanaged(*SharedStandardShaders) = .empty;
+
+fn initSharedStandard(
+    alloc: Allocator,
+    device: objc.Object,
+    pixel_format: mtl.MTLPixelFormat,
+) !Shaders {
+    const key: SharedStandardShadersKey = .{
+        .device = @intFromPtr(device.value),
+        .pixel_format = pixel_format,
+    };
+
+    if (retainSharedStandard(key)) |entry| {
+        return shadersFromSharedStandard(entry);
+    }
+
+    var candidate = try Shaders.initOwned(alloc, device, &.{}, pixel_format);
+    const entry = shared_standard_allocator.create(SharedStandardShaders) catch |err| {
+        candidate.deinit(alloc);
+        return err;
+    };
+    entry.* = .{
+        .key = key,
+        .resource_allocator = alloc,
+        .library = candidate.library,
+        .pipelines = candidate.pipelines,
+        .post_pipelines = candidate.post_pipelines,
+        .references = 1,
+    };
+
+    shared_standard_mutex.lock();
+    if (findSharedStandardLocked(key)) |existing| {
+        existing.references += 1;
+        shared_standard_mutex.unlock();
+
+        candidate.deinit(alloc);
+        shared_standard_allocator.destroy(entry);
+        return shadersFromSharedStandard(existing);
+    }
+
+    shared_standard_entries.append(
+        shared_standard_allocator,
+        entry,
+    ) catch |err| {
+        shared_standard_mutex.unlock();
+        candidate.deinit(alloc);
+        shared_standard_allocator.destroy(entry);
+        return err;
+    };
+    shared_standard_mutex.unlock();
+
+    candidate.shared = entry;
+    return candidate;
+}
+
+fn retainSharedStandard(
+    key: SharedStandardShadersKey,
+) ?*SharedStandardShaders {
+    shared_standard_mutex.lock();
+    defer shared_standard_mutex.unlock();
+
+    const entry = findSharedStandardLocked(key) orelse return null;
+    entry.references += 1;
+    return entry;
+}
+
+fn findSharedStandardLocked(
+    key: SharedStandardShadersKey,
+) ?*SharedStandardShaders {
+    for (shared_standard_entries.items) |entry| {
+        if (entry.key.eql(key)) return entry;
+    }
+    return null;
+}
+
+fn shadersFromSharedStandard(entry: *SharedStandardShaders) Shaders {
+    return .{
+        .library = entry.library,
+        .pipelines = entry.pipelines,
+        .post_pipelines = entry.post_pipelines,
+        .shared = entry,
+    };
+}
+
+fn releaseSharedStandard(entry: *SharedStandardShaders) void {
+    var destroy = false;
+
+    shared_standard_mutex.lock();
+    std.debug.assert(entry.references > 0);
+    entry.references -= 1;
+    if (entry.references == 0) {
+        for (shared_standard_entries.items, 0..) |candidate, i| {
+            if (candidate != entry) continue;
+            _ = shared_standard_entries.orderedRemove(i);
+            destroy = true;
+            break;
+        }
+        std.debug.assert(destroy);
+
+        if (shared_standard_entries.items.len == 0) {
+            shared_standard_entries.deinit(shared_standard_allocator);
+            shared_standard_entries = .empty;
+        }
+    }
+    shared_standard_mutex.unlock();
+
+    if (!destroy) return;
+
+    var owned: Shaders = .{
+        .library = entry.library,
+        .pipelines = entry.pipelines,
+        .post_pipelines = entry.post_pipelines,
+    };
+    owned.deinit(entry.resource_allocator);
+    shared_standard_allocator.destroy(entry);
+}
 
 /// The uniforms that are passed to our shaders.
 pub const Uniforms = extern struct {
@@ -269,43 +433,49 @@ test "standard shaders reuse pipeline state across surfaces and restores" {
     const device = objc.Object.fromId(device_ptr);
     defer device.release();
 
-    var active = try Shaders.init(
-        testing.allocator,
-        device,
-        &.{},
-        .bgra8unorm,
-    );
-    defer active.deinit(testing.allocator);
-
     {
-        var hidden = try Shaders.init(
+        var active = try Shaders.init(
             testing.allocator,
             device,
             &.{},
             .bgra8unorm,
         );
-        defer hidden.deinit(testing.allocator);
+        defer active.deinit(testing.allocator);
 
-        try testing.expectEqual(
-            active.pipelines.bg_color.state.value,
-            hidden.pipelines.bg_color.state.value,
-        );
+        {
+            var hidden = try Shaders.init(
+                testing.allocator,
+                device,
+                &.{},
+                .bgra8unorm,
+            );
+            defer hidden.deinit(testing.allocator);
+
+            try testing.expectEqual(
+                active.pipelines.bg_color.state.value,
+                hidden.pipelines.bg_color.state.value,
+            );
+        }
+
+        {
+            var restored = try Shaders.init(
+                testing.allocator,
+                device,
+                &.{},
+                .bgra8unorm,
+            );
+            defer restored.deinit(testing.allocator);
+
+            try testing.expectEqual(
+                active.pipelines.bg_color.state.value,
+                restored.pipelines.bg_color.state.value,
+            );
+        }
     }
 
-    {
-        var restored = try Shaders.init(
-            testing.allocator,
-            device,
-            &.{},
-            .bgra8unorm,
-        );
-        defer restored.deinit(testing.allocator);
-
-        try testing.expectEqual(
-            active.pipelines.bg_color.state.value,
-            restored.pipelines.bg_color.state.value,
-        );
-    }
+    shared_standard_mutex.lock();
+    defer shared_standard_mutex.unlock();
+    try testing.expectEqual(@as(usize, 0), shared_standard_entries.items.len);
 }
 
 /// This is a single parameter for the terminal cell shader.

--- a/src/renderer/metal/shaders.zig
+++ b/src/renderer/metal/shaders.zig
@@ -261,6 +261,53 @@ pub const Uniforms = extern struct {
     };
 };
 
+test "standard shaders reuse pipeline state across surfaces and restores" {
+    const testing = std.testing;
+    const device_ptr = mtl.MTLCreateSystemDefaultDevice() orelse {
+        return error.SkipZigTest;
+    };
+    const device = objc.Object.fromId(device_ptr);
+    defer device.release();
+
+    var active = try Shaders.init(
+        testing.allocator,
+        device,
+        &.{},
+        .bgra8unorm,
+    );
+    defer active.deinit(testing.allocator);
+
+    {
+        var hidden = try Shaders.init(
+            testing.allocator,
+            device,
+            &.{},
+            .bgra8unorm,
+        );
+        defer hidden.deinit(testing.allocator);
+
+        try testing.expectEqual(
+            active.pipelines.bg_color.state.value,
+            hidden.pipelines.bg_color.state.value,
+        );
+    }
+
+    {
+        var restored = try Shaders.init(
+            testing.allocator,
+            device,
+            &.{},
+            .bgra8unorm,
+        );
+        defer restored.deinit(testing.allocator);
+
+        try testing.expectEqual(
+            active.pipelines.bg_color.state.value,
+            restored.pipelines.bg_color.state.value,
+        );
+    }
+}
+
 /// This is a single parameter for the terminal cell shader.
 pub const CellText = extern struct {
     glyph_pos: [2]u32 align(8) = .{ 0, 0 },

--- a/src/renderer/metal/shaders.zig
+++ b/src/renderer/metal/shaders.zig
@@ -248,7 +248,15 @@ fn initSharedStandard(
         .pixel_format = pixel_format,
     };
 
-    if (retainSharedStandard(key)) |entry| {
+    // Pipeline compilation is expensive and Metal retains significant
+    // process-wide compiler state even after duplicate pipelines are
+    // released. Serialize cache misses so concurrent surface initialization
+    // cannot compile the same standard pipeline collection more than once.
+    shared_standard_mutex.lock();
+    defer shared_standard_mutex.unlock();
+
+    if (findSharedStandardLocked(key)) |entry| {
+        entry.references += 1;
         return shadersFromSharedStandard(entry);
     }
 
@@ -267,40 +275,17 @@ fn initSharedStandard(
         .references = 1,
     };
 
-    shared_standard_mutex.lock();
-    if (findSharedStandardLocked(key)) |existing| {
-        existing.references += 1;
-        shared_standard_mutex.unlock();
-
-        candidate.deinit(alloc);
-        shared_standard_allocator.destroy(entry);
-        return shadersFromSharedStandard(existing);
-    }
-
     shared_standard_entries.append(
         shared_standard_allocator,
         entry,
     ) catch |err| {
-        shared_standard_mutex.unlock();
         candidate.deinit(alloc);
         shared_standard_allocator.destroy(entry);
         return err;
     };
-    shared_standard_mutex.unlock();
 
     candidate.shared = entry;
     return candidate;
-}
-
-fn retainSharedStandard(
-    key: SharedStandardShadersKey,
-) ?*SharedStandardShaders {
-    shared_standard_mutex.lock();
-    defer shared_standard_mutex.unlock();
-
-    const entry = findSharedStandardLocked(key) orelse return null;
-    entry.references += 1;
-    return entry;
 }
 
 fn findSharedStandardLocked(


### PR DESCRIPTION
Five native 80x24 tabs now settle at 101.2 MB retained on the PR head, down from 172.5 MB in Ghostty 1.3.1 (41.3%). GPU-backed dirty memory drops from 106.0 MB to 10.4 MB. Otty with inactive-tab freezing measured 97.0 MB and Termy measured 96.2 MB under the same local protocol.

The fix makes renderer realization lossless latest-value state, reclaims a deselected native tab in the same AppKit visibility pass, drains exact-slot frame leases, releases its swap chain and command queue, and shares standard Metal pipelines process-wide. Standard terminal command buffers use renderer-owned resource lifetimes; frames with dynamic images or custom shaders keep Metal retention.

Peak construction memory remains 456.5 MB in the Xcode-hosted benchmark. This PR fixes settled baseline and tab-switch growth, not construction peak.

Verification:
- ReleaseFast five-tab hosted test: 8/8 passed
- focused Metal lifetime and IOSurface disposal tests passed
- red/green regression commits for renderer-owned Metal lifetimes
- universal GhosttyKit archive validated for arm64 and x86_64
- release: https://github.com/manaflow-ai/ghostty/releases/tag/xcframework-232b24bf2db2f05538a3e034d88f53a4fc548d56-crashsubdir-cmux-crash-v1
- cmux integration: https://github.com/manaflow-ai/cmux/pull/8998

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Optimized macOS tab and split-view renderer activation/deactivation with more deterministic reclamation.
  - Improves Metal command-queue reuse and adds safer GPU resource disposal/“discard” behavior.
  - Reuses standard Metal shader pipelines to reduce repeated compilation work.
- **Reliability**
  - Strengthened renderer realization/visibility synchronization using native tab selection/overview state, including coordinated retries.
  - Improves ordering for surface/layer clears to prevent older updates overwriting newer frames.
  - OpenGL now reports context-preparation failures instead of hiding them.
- **Tests**
  - Added/expanded coverage for renderer tab selection/visibility logic and renderer realization lifecycle behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->