### PR TITLE
fix: expose native keyboard selection geometry

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -614,6 +614,21 @@ typedef struct {
   uint32_t cell_height_px;
 } ghostty_surface_size_s;
 
+// cmux fork: authoritative terminal grid geometry in the embedder's logical
+// coordinate space. Delete when upstream exposes equivalent geometry.
+typedef struct {
+  uint16_t columns;
+  uint16_t rows;
+  uint16_t cursor_column;
+  uint16_t cursor_row;
+  uint16_t cursor_width_cells;
+  bool cursor_in_viewport;
+  double cell_width;
+  double cell_height;
+  double padding_left;
+  double padding_top;
+} ghostty_surface_grid_metrics_s;
+
 // cmux fork: authoritative scrollbar snapshot independent of renderer
 // publication. Delete when upstream exports equivalent row-space identity.
 typedef struct {
@@ -1315,6 +1330,9 @@ GHOSTTY_API void ghostty_surface_set_focus(ghostty_surface_t, bool);
 GHOSTTY_API void ghostty_surface_set_occlusion(ghostty_surface_t, bool);
 GHOSTTY_API void ghostty_surface_set_size(ghostty_surface_t, uint32_t, uint32_t);
 GHOSTTY_API ghostty_surface_size_s ghostty_surface_size(ghostty_surface_t);
+GHOSTTY_API bool ghostty_surface_grid_metrics(
+    ghostty_surface_t,
+    ghostty_surface_grid_metrics_s*);
 // Set an authoritative logical terminal grid. Ghostty derives the exact pixel
 // dimensions from the current cell metrics and padding, applies the resize,
 // and optionally writes the resolved dimensions. Zero or overflowing sizes
@@ -1437,6 +1455,31 @@ GHOSTTY_API bool ghostty_surface_has_selection(ghostty_surface_t);
 GHOSTTY_API bool ghostty_surface_select_cursor_cell(ghostty_surface_t);
 GHOSTTY_API bool ghostty_surface_select_cursor_line(ghostty_surface_t);
 GHOSTTY_API bool ghostty_surface_clear_selection(ghostty_surface_t);
+// cmux fork: tracked keyboard-selection operations in viewport coordinates.
+// These avoid synthesizing mouse gestures and keep terminal row identity,
+// selection motion, rendering, and clipboard formatting inside Ghostty.
+GHOSTTY_API bool ghostty_surface_select_viewport_cell(ghostty_surface_t,
+                                                      uint16_t,
+                                                      uint16_t);
+GHOSTTY_API bool ghostty_surface_select_viewport_rows(ghostty_surface_t,
+                                                      uint16_t,
+                                                      uint16_t);
+GHOSTTY_API bool ghostty_surface_set_selection_endpoint_viewport(
+    ghostty_surface_t,
+    uint16_t,
+    uint16_t,
+    bool);
+GHOSTTY_API bool ghostty_surface_resolve_viewport_cell(
+    ghostty_surface_t,
+    uint16_t,
+    uint16_t,
+    uint16_t*,
+    uint16_t*,
+    uint16_t*);
+GHOSTTY_API bool ghostty_surface_selection_endpoint_viewport(
+    ghostty_surface_t,
+    uint16_t*,
+    uint16_t*);
 // cmux fork: set/query the active selection from inclusive absolute screen rows.
 // The setter updates Ghostty's tracked selection pins without writing clipboards.
 GHOSTTY_API bool ghostty_surface_select_screen_rows(ghostty_surface_t,

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -2471,6 +2471,144 @@ pub fn clearSelection(self: *Surface) !bool {
     return true;
 }
 
+fn viewportPin(
+    screen: *terminal.Screen,
+    column: u16,
+    row: u16,
+) ?terminal.Pin {
+    if (column >= screen.pages.cols or row >= screen.pages.rows) return null;
+    return screen.pages.pin(.{
+        .viewport = .{ .x = column, .y = row },
+    });
+}
+
+/// Resolve a visible viewport cell to the leading cell of its displayed glyph.
+fn canonicalSelectionCellViewport(
+    screen: *terminal.Screen,
+    column: u16,
+    row: u16,
+) ?terminal.Selection.CanonicalCell {
+    const pin = viewportPin(screen, column, row) orelse return null;
+    const cell = terminal.Selection.canonicalCell(pin) orelse return null;
+    const point = screen.pages.pointFromPin(.viewport, cell.pin) orelse
+        return null;
+    if (point.viewport.x >= screen.pages.cols or
+        point.viewport.y >= screen.pages.rows) return null;
+    return cell;
+}
+
+/// Select one visible cell using Ghostty's tracked terminal coordinates.
+pub fn selectViewportCell(
+    self: *Surface,
+    column: u16,
+    row: u16,
+) !bool {
+    self.renderer_state.lockDemand();
+    defer self.renderer_state.unlockDemand();
+
+    const screen: *terminal.Screen = self.io.terminal.screens.active;
+    const cell = canonicalSelectionCellViewport(screen, column, row) orelse
+        return false;
+
+    try self.setSelection(terminal.Selection.init(cell.pin, cell.pin, false));
+    return true;
+}
+
+/// Select inclusive visible rows using tracked full-line endpoints.
+pub fn selectViewportRows(
+    self: *Surface,
+    top_row: u16,
+    bottom_row: u16,
+) !bool {
+    self.renderer_state.lockDemand();
+    defer self.renderer_state.unlockDemand();
+
+    if (top_row > bottom_row) return false;
+    const screen: *terminal.Screen = self.io.terminal.screens.active;
+    if (screen.pages.cols == 0 or
+        top_row >= screen.pages.rows or
+        bottom_row >= screen.pages.rows) return false;
+
+    const top_left = viewportPin(screen, 0, top_row) orelse
+        return false;
+    const bottom_right = viewportPin(
+        screen,
+        screen.pages.cols - 1,
+        bottom_row,
+    ) orelse return false;
+
+    try self.setSelection(terminal.Selection.initLinewise(
+        top_left,
+        bottom_right,
+    ));
+    return true;
+}
+
+/// Move the active selection endpoint to one visible cell.
+pub fn setSelectionEndpointViewport(
+    self: *Surface,
+    column: u16,
+    row: u16,
+    linewise: bool,
+) !bool {
+    self.renderer_state.lockDemand();
+    defer self.renderer_state.unlockDemand();
+
+    const screen: *terminal.Screen = self.io.terminal.screens.active;
+    const pin = if (linewise)
+        viewportPin(screen, column, row) orelse return false
+    else
+        (canonicalSelectionCellViewport(screen, column, row) orelse
+            return false).pin;
+    if (!screen.setSelectionEndpoint(pin, linewise)) return false;
+
+    try self.queueRender();
+    return true;
+}
+
+/// Resolve a viewport coordinate to a displayed glyph's leading cell and width.
+pub fn resolveViewportCell(
+    self: *Surface,
+    column: u16,
+    row: u16,
+    resolved_column: *u16,
+    resolved_row: *u16,
+    width_cells: *u16,
+) bool {
+    self.renderer_state.lockDemand();
+    defer self.renderer_state.unlockDemand();
+
+    const screen: *terminal.Screen = self.io.terminal.screens.active;
+    const cell = canonicalSelectionCellViewport(screen, column, row) orelse
+        return false;
+    const point = screen.pages.pointFromPin(.viewport, cell.pin) orelse
+        return false;
+    if (point.viewport.x >= screen.pages.cols or
+        point.viewport.y >= screen.pages.rows) return false;
+
+    resolved_column.* = @intCast(point.viewport.x);
+    resolved_row.* = @intCast(point.viewport.y);
+    width_cells.* = cell.width_cells;
+    return true;
+}
+
+/// Query the logical endpoint of the active selection in viewport cells.
+pub fn selectionEndpointViewport(
+    self: *Surface,
+    column: *u16,
+    row: *u16,
+) bool {
+    self.renderer_state.lockDemand();
+    defer self.renderer_state.unlockDemand();
+
+    const screen: *terminal.Screen = self.io.terminal.screens.active;
+    const endpoint = screen.selectionEndpointViewport() orelse return false;
+
+    column.* = @intCast(endpoint.viewport.x);
+    row.* = @intCast(endpoint.viewport.y);
+    return true;
+}
+
 /// Select inclusive absolute screen rows without writing copy-on-select
 /// clipboards.
 pub fn selectScreenRows(self: *Surface, top_y: u32, bottom_y: u32) !bool {
@@ -2490,7 +2628,7 @@ pub fn selectScreenRows(self: *Surface, top_y: u32, bottom_y: u32) !bool {
         .screen = .{ .x = pages.cols -| 1, .y = bottom_y },
     }) orelse return false;
 
-    try screen.select(terminal.Selection.init(top_left, bottom_right, false));
+    try screen.select(terminal.Selection.initLinewise(top_left, bottom_right));
     screen.dirty.selection = true;
     try self.queueRender();
     return true;
@@ -4478,11 +4616,7 @@ pub fn mouseButtonCallback(
         if (self.config.copy_on_select != .false) {
             const prev_ = self.io.terminal.screens.active.selection;
             if (prev_) |prev| {
-                try self.setSelectionAndCopy(terminal.Selection.init(
-                    prev.start(),
-                    prev.end(),
-                    prev.rectangle,
-                ));
+                try self.setSelectionAndCopy(prev.snapshot());
             }
         }
 
@@ -6921,6 +7055,171 @@ fn presentSurface(self: *Surface) !void {
 /// not available on a particular platform.
 pub fn getProcessInfo(self: *Surface, comptime info: ProcessInfo) ?ProcessInfo.Type(info) {
     return self.io.getProcessInfo(info);
+}
+
+test "Surface: viewport selection canonicalizes wide glyph tails" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var t: terminal.Terminal = try .init(alloc, .{ .cols = 10, .rows = 3 });
+    defer t.deinit(alloc);
+    var stream = t.vtStream();
+    defer stream.deinit();
+    stream.nextSlice("A橋B");
+
+    const screen = t.screens.active;
+    const tail = canonicalSelectionCellViewport(screen, 2, 0).?;
+    try testing.expectEqual(
+        terminal.point.Point{ .viewport = .{ .x = 1, .y = 0 } },
+        screen.pages.pointFromPin(.viewport, tail.pin).?,
+    );
+    try testing.expectEqual(@as(u16, 2), tail.width_cells);
+    try screen.select(terminal.Selection.init(tail.pin, tail.pin, false));
+
+    var state: terminal.RenderState = .empty;
+    defer state.deinit(alloc);
+    try state.update(alloc, &t);
+    try testing.expectEqualSlices(
+        u16,
+        &.{ 1, 1 },
+        &state.row_data.items(.selection)[0].?,
+    );
+
+    const selected_wide = try screen.selectionString(alloc, .{
+        .sel = screen.selection.?,
+        .trim = false,
+    });
+    defer alloc.free(selected_wide);
+    try testing.expectEqualStrings("橋", selected_wide);
+
+    const anchor = canonicalSelectionCellViewport(screen, 0, 0).?;
+    try screen.select(terminal.Selection.init(anchor.pin, anchor.pin, false));
+    const endpoint = canonicalSelectionCellViewport(screen, 2, 0).?;
+    try testing.expect(screen.setSelectionEndpoint(endpoint.pin, false));
+    try testing.expectEqual(
+        terminal.point.Point{ .viewport = .{ .x = 1, .y = 0 } },
+        screen.selectionEndpointViewport().?,
+    );
+    try state.update(alloc, &t);
+    try testing.expectEqualSlices(
+        u16,
+        &.{ 0, 1 },
+        &state.row_data.items(.selection)[0].?,
+    );
+
+    const selected_range = try screen.selectionString(alloc, .{
+        .sel = screen.selection.?,
+        .trim = false,
+    });
+    defer alloc.free(selected_range);
+    try testing.expectEqualStrings("A橋", selected_range);
+
+    const raw_tail = screen.pages.pin(.{
+        .viewport = .{ .x = 2, .y = 0 },
+    }).?;
+    try screen.select(terminal.Selection.init(anchor.pin, raw_tail, false));
+    try testing.expectEqual(
+        terminal.point.Point{ .viewport = .{ .x = 1, .y = 0 } },
+        screen.selectionEndpointViewport().?,
+    );
+}
+
+test "Surface: viewport selection resolves a wrapped wide glyph head" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var t: terminal.Terminal = try .init(alloc, .{ .cols = 4, .rows = 3 });
+    defer t.deinit(alloc);
+    var stream = t.vtStream();
+    defer stream.deinit();
+    stream.nextSlice("ABC橋D");
+
+    const screen = t.screens.active;
+    const spacer_head = screen.pages.pin(.{
+        .viewport = .{ .x = 3, .y = 0 },
+    }).?;
+    try testing.expectEqual(
+        terminal.page.Cell.Wide.spacer_head,
+        spacer_head.rowAndCell().cell.wide,
+    );
+
+    const cell = canonicalSelectionCellViewport(screen, 3, 0).?;
+    try testing.expectEqual(@as(u16, 2), cell.width_cells);
+    try testing.expectEqual(
+        terminal.point.Point{ .viewport = .{ .x = 0, .y = 1 } },
+        screen.pages.pointFromPin(.viewport, cell.pin).?,
+    );
+    try screen.select(terminal.Selection.init(cell.pin, cell.pin, false));
+
+    var state: terminal.RenderState = .empty;
+    defer state.deinit(alloc);
+    try state.update(alloc, &t);
+    try testing.expectEqual(null, state.row_data.items(.selection)[0]);
+    try testing.expectEqualSlices(
+        u16,
+        &.{ 0, 0 },
+        &state.row_data.items(.selection)[1].?,
+    );
+
+    const selected = try screen.selectionString(alloc, .{
+        .sel = screen.selection.?,
+        .trim = false,
+    });
+    defer alloc.free(selected);
+    try testing.expectEqualStrings("橋", selected);
+}
+
+test "Surface: linewise viewport endpoint keeps its spacer-head row" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var t: terminal.Terminal = try .init(alloc, .{ .cols = 4, .rows = 3 });
+    defer t.deinit(alloc);
+    var stream = t.vtStream();
+    defer stream.deinit();
+    stream.nextSlice("ABC橋");
+
+    const screen = t.screens.active;
+    const start_pin = viewportPin(screen, 0, 0).?;
+    const end_pin = viewportPin(screen, 3, 0).?;
+    try testing.expectEqual(
+        terminal.page.Cell.Wide.spacer_head,
+        end_pin.rowAndCell().cell.wide,
+    );
+    try screen.select(terminal.Selection.initLinewise(start_pin, end_pin));
+    const selection = screen.selection.?;
+    try testing.expectEqual(
+        terminal.point.Point{ .viewport = .{ .x = 0, .y = 0 } },
+        screen.pages.pointFromPin(.viewport, selection.topLeft(screen)).?,
+    );
+    try testing.expectEqual(
+        terminal.point.Point{ .viewport = .{ .x = 3, .y = 0 } },
+        screen.pages.pointFromPin(.viewport, selection.bottomRight(screen)).?,
+    );
+    try testing.expectEqual(
+        terminal.point.Point{ .viewport = .{ .x = 3, .y = 0 } },
+        screen.selectionEndpointViewport().?,
+    );
+}
+
+test "Surface: viewport glyph resolution rejects an offscreen wrapped cell" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var t: terminal.Terminal = try .init(alloc, .{ .cols = 4, .rows = 2 });
+    defer t.deinit(alloc);
+    var stream = t.vtStream();
+    defer stream.deinit();
+    stream.nextSlice("pre\r\nABC橋\r\nlater\r\n");
+    t.scrollViewport(.top);
+
+    const screen = t.screens.active;
+    const bottom_right = viewportPin(screen, 3, 1).?;
+    try testing.expectEqual(
+        terminal.page.Cell.Wide.spacer_head,
+        bottom_right.rowAndCell().cell.wide,
+    );
+    try testing.expect(canonicalSelectionCellViewport(screen, 3, 1) == null);
 }
 
 test "Surface: mouseLinkRefreshAllowedState honors ctrl/super under mouse reporting" {

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -2063,6 +2063,73 @@ pub const CAPI = struct {
         cell_height_px: u32,
     };
 
+    const SurfaceGridMetrics = extern struct {
+        columns: u16,
+        rows: u16,
+        cursor_column: u16,
+        cursor_row: u16,
+        cursor_width_cells: u16,
+        cursor_in_viewport: bool,
+        cell_width: f64,
+        cell_height: f64,
+        padding_left: f64,
+        padding_top: f64,
+    };
+
+    fn surfaceGridMetricsSnapshot(
+        size: renderer.Size,
+        scale: apprt.ContentScale,
+        screen: *terminal.Screen,
+    ) ?SurfaceGridMetrics {
+        const size_grid = size.grid();
+        if (screen.pages.cols == 0 or
+            screen.pages.rows == 0 or
+            size_grid.columns != screen.pages.cols or
+            size_grid.rows != screen.pages.rows or
+            size.cell.width == 0 or
+            size.cell.height == 0 or
+            !std.math.isFinite(scale.x) or
+            !std.math.isFinite(scale.y) or
+            scale.x <= 0 or
+            scale.y <= 0) return null;
+
+        const cursor_cell = terminal.Selection.canonicalCell(
+            screen.cursor.page_pin.*,
+        );
+        const cursor = if (cursor_cell) |cell|
+            if (screen.pages.pointFromPin(.viewport, cell.pin)) |point|
+                if (point.viewport.x < screen.pages.cols and
+                    point.viewport.y < screen.pages.rows)
+                    point
+                else
+                    null
+            else
+                null
+        else
+            null;
+        return .{
+            .columns = @intCast(screen.pages.cols),
+            .rows = @intCast(screen.pages.rows),
+            .cursor_column = if (cursor) |point|
+                @intCast(point.viewport.x)
+            else
+                0,
+            .cursor_row = if (cursor) |point|
+                @intCast(point.viewport.y)
+            else
+                0,
+            .cursor_width_cells = if (cursor != null)
+                cursor_cell.?.width_cells
+            else
+                0,
+            .cursor_in_viewport = cursor != null,
+            .cell_width = @as(f64, @floatFromInt(size.cell.width)) / scale.x,
+            .cell_height = @as(f64, @floatFromInt(size.cell.height)) / scale.y,
+            .padding_left = @as(f64, @floatFromInt(size.padding.left)) / scale.x,
+            .padding_top = @as(f64, @floatFromInt(size.padding.top)) / scale.y,
+        };
+    }
+
     const SurfaceScrollbar = extern struct {
         total: u64,
         offset: u64,
@@ -2464,6 +2531,77 @@ pub const CAPI = struct {
         };
     }
 
+    /// Select one visible cell without synthesizing a mouse gesture.
+    export fn ghostty_surface_select_viewport_cell(
+        surface: *Surface,
+        column: u16,
+        row: u16,
+    ) bool {
+        return surface.core_surface.selectViewportCell(column, row) catch |err| {
+            log.warn("error selecting viewport cell err={}", .{err});
+            return false;
+        };
+    }
+
+    /// Select inclusive visible rows with tracked full-line endpoints.
+    export fn ghostty_surface_select_viewport_rows(
+        surface: *Surface,
+        top_row: u16,
+        bottom_row: u16,
+    ) bool {
+        return surface.core_surface.selectViewportRows(
+            top_row,
+            bottom_row,
+        ) catch |err| {
+            log.warn("error selecting viewport rows err={}", .{err});
+            return false;
+        };
+    }
+
+    /// Move the active tracked selection endpoint to a visible cell.
+    export fn ghostty_surface_set_selection_endpoint_viewport(
+        surface: *Surface,
+        column: u16,
+        row: u16,
+        linewise: bool,
+    ) bool {
+        return surface.core_surface.setSelectionEndpointViewport(
+            column,
+            row,
+            linewise,
+        ) catch |err| {
+            log.warn("error setting selection endpoint err={}", .{err});
+            return false;
+        };
+    }
+
+    /// Resolve a visible coordinate to its glyph's leading cell and width.
+    export fn ghostty_surface_resolve_viewport_cell(
+        surface: *Surface,
+        column: u16,
+        row: u16,
+        resolved_column: *u16,
+        resolved_row: *u16,
+        width_cells: *u16,
+    ) bool {
+        return surface.core_surface.resolveViewportCell(
+            column,
+            row,
+            resolved_column,
+            resolved_row,
+            width_cells,
+        );
+    }
+
+    /// Query the active selection's logical endpoint in viewport cells.
+    export fn ghostty_surface_selection_endpoint_viewport(
+        surface: *Surface,
+        column: *u16,
+        row: *u16,
+    ) bool {
+        return surface.core_surface.selectionEndpointViewport(column, row);
+    }
+
     /// Select inclusive absolute screen rows without writing clipboards
     /// (cmux-specific).
     export fn ghostty_surface_select_screen_rows(
@@ -2801,6 +2939,26 @@ pub const CAPI = struct {
     /// Return the size information a surface has.
     export fn ghostty_surface_size(surface: *Surface) SurfaceSize {
         return surfaceSize(surface);
+    }
+
+    /// Return exact renderer grid geometry in logical embedder coordinates.
+    export fn ghostty_surface_grid_metrics(
+        surface: *Surface,
+        result: *SurfaceGridMetrics,
+    ) bool {
+        surface.core_surface.renderer_state.lockDemand();
+        defer surface.core_surface.renderer_state.unlockDemand();
+        const screen = surface.core_surface
+            .renderer_state
+            .terminal
+            .screens
+            .active;
+        result.* = surfaceGridMetricsSnapshot(
+            surface.core_surface.size,
+            surface.content_scale,
+            screen,
+        ) orelse return false;
+        return true;
     }
 
     /// Set an authoritative grid and return the pixel size Ghostty resolved.
@@ -4421,6 +4579,124 @@ test "output sequence publishes only with successful VT tail snapshot" {
         &next_sequence,
     ));
     try std.testing.expectEqual(@as(u64, 42), next_sequence);
+}
+
+test "grid metrics reject resize skew and report an offscreen cursor" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    var term = try terminal.Terminal.init(alloc, .{
+        .cols = 10,
+        .rows = 2,
+    });
+    defer term.deinit(alloc);
+
+    var stream = term.vtStream();
+    defer stream.deinit();
+    stream.nextSlice("one\r\ntwo\r\nthree\r\nfour\r\n");
+    term.scrollViewport(.top);
+    const screen = term.screens.active;
+
+    const size: renderer.Size = .{
+        .screen = .{ .width = 83, .height = 37 },
+        .cell = .{ .width = 8, .height = 16 },
+        .padding = .{ .left = 3, .top = 5 },
+    };
+    const snapshot = CAPI.surfaceGridMetricsSnapshot(
+        size,
+        .{ .x = 2, .y = 2 },
+        screen,
+    ).?;
+    try testing.expectEqual(@as(u16, 10), snapshot.columns);
+    try testing.expectEqual(@as(u16, 2), snapshot.rows);
+    try testing.expect(!snapshot.cursor_in_viewport);
+    try testing.expectEqual(@as(u16, 0), snapshot.cursor_width_cells);
+    try testing.expectEqual(@as(f64, 4), snapshot.cell_width);
+    try testing.expectEqual(@as(f64, 8), snapshot.cell_height);
+    try testing.expectEqual(@as(f64, 1.5), snapshot.padding_left);
+    try testing.expectEqual(@as(f64, 2.5), snapshot.padding_top);
+
+    var mismatched_size = size;
+    mismatched_size.screen.width += size.cell.width;
+    try testing.expect(CAPI.surfaceGridMetricsSnapshot(
+        mismatched_size,
+        .{ .x = 2, .y = 2 },
+        screen,
+    ) == null);
+
+    term.scrollViewport(.bottom);
+    const active = CAPI.surfaceGridMetricsSnapshot(
+        size,
+        .{ .x = 2, .y = 2 },
+        screen,
+    ).?;
+    try testing.expect(active.cursor_in_viewport);
+    try testing.expectEqual(@as(u16, 1), active.cursor_width_cells);
+}
+
+test "grid metrics canonicalize a wide-tail cursor" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    var term = try terminal.Terminal.init(alloc, .{
+        .cols = 6,
+        .rows = 2,
+    });
+    defer term.deinit(alloc);
+
+    var stream = term.vtStream();
+    defer stream.deinit();
+    stream.nextSlice("A橋B\x1b[1;3H");
+    const cursor_pin = term.screens.active.cursor.page_pin.*;
+    try testing.expectEqual(
+        terminal.page.Cell.Wide.spacer_tail,
+        cursor_pin.rowAndCell().cell.wide,
+    );
+
+    const snapshot = CAPI.surfaceGridMetricsSnapshot(
+        .{
+            .screen = .{ .width = 51, .height = 37 },
+            .cell = .{ .width = 8, .height = 16 },
+            .padding = .{ .left = 3, .top = 5 },
+        },
+        .{ .x = 1, .y = 1 },
+        term.screens.active,
+    ).?;
+    try testing.expect(snapshot.cursor_in_viewport);
+    try testing.expectEqual(@as(u16, 1), snapshot.cursor_column);
+    try testing.expectEqual(@as(u16, 0), snapshot.cursor_row);
+    try testing.expectEqual(@as(u16, 2), snapshot.cursor_width_cells);
+}
+
+test "grid metrics resolve a spacer-head cursor to its wrapped glyph" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    var term = try terminal.Terminal.init(alloc, .{
+        .cols = 4,
+        .rows = 3,
+    });
+    defer term.deinit(alloc);
+
+    var stream = term.vtStream();
+    defer stream.deinit();
+    stream.nextSlice("ABC橋\x1b[1;4H");
+    const cursor_pin = term.screens.active.cursor.page_pin.*;
+    try testing.expectEqual(
+        terminal.page.Cell.Wide.spacer_head,
+        cursor_pin.rowAndCell().cell.wide,
+    );
+
+    const snapshot = CAPI.surfaceGridMetricsSnapshot(
+        .{
+            .screen = .{ .width = 35, .height = 53 },
+            .cell = .{ .width = 8, .height = 16 },
+            .padding = .{ .left = 3, .top = 5 },
+        },
+        .{ .x = 1, .y = 1 },
+        term.screens.active,
+    ).?;
+    try testing.expect(snapshot.cursor_in_viewport);
+    try testing.expectEqual(@as(u16, 0), snapshot.cursor_column);
+    try testing.expectEqual(@as(u16, 1), snapshot.cursor_row);
+    try testing.expectEqual(@as(u16, 2), snapshot.cursor_width_cells);
 }
 
 test "render grid preserves terminal color semantics" {

--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -587,6 +587,7 @@ pub fn clone(
                 .end = end_pin,
             } },
             .rectangle = sel.rectangle,
+            .linewise = sel.linewise,
         };
     } else null;
 
@@ -2679,11 +2680,63 @@ pub fn adjustSelection(
     adjustment: Selection.Adjustment,
 ) ?*Selection {
     const selection = if (self.selection) |*selection| selection else return null;
+    const previous_start = selection.start();
     const previous_end = selection.end();
     selection.adjust(self, adjustment);
     self.dirty.selection = true;
-    if (!previous_end.eql(selection.end())) self.advanceSelectionActivity();
+    if (!previous_start.eql(selection.start()) or
+        !previous_end.eql(selection.end()))
+    {
+        self.advanceSelectionActivity();
+    }
     return selection;
+}
+
+/// Move the logical endpoint of the active tracked selection to `pin`.
+///
+/// Linewise selections retain logical anchor and endpoint cells. Selection
+/// formatting and rendering derive full-row bounds without mutating them.
+pub fn setSelectionEndpoint(
+    self: *Screen,
+    pin: Pin,
+    linewise: bool,
+) bool {
+    const selection = if (self.selection) |*selection| selection else return false;
+    if (self.pages.cols == 0) return false;
+
+    const previous_start = selection.start();
+    const previous_end = selection.end();
+    const previous_rectangle = selection.rectangle;
+    const previous_linewise = selection.linewise;
+
+    selection.endPtr().* = pin;
+    selection.rectangle = false;
+    selection.linewise = linewise;
+
+    self.dirty.selection = true;
+    if (!previous_start.eql(selection.start()) or
+        !previous_end.eql(selection.end()) or
+        previous_rectangle != selection.rectangle or
+        previous_linewise != selection.linewise)
+    {
+        self.advanceSelectionActivity();
+    }
+    return true;
+}
+
+/// Return a valid active-selection endpoint in viewport coordinates.
+pub fn selectionEndpointViewport(self: *const Screen) ?point.Point {
+    const selection = self.selection orelse return null;
+    const endpoint = selection.end();
+    if (endpoint.garbage) return null;
+    const resolved = if (selection.linewise)
+        endpoint
+    else
+        (Selection.canonicalCell(endpoint) orelse return null).pin;
+    const result = self.pages.pointFromPin(.viewport, resolved) orelse return null;
+    if (result.viewport.x >= self.pages.cols or
+        result.viewport.y >= self.pages.rows) return null;
+    return result;
 }
 
 fn advanceSelectionActivity(self: *Screen) void {
@@ -8220,6 +8273,187 @@ test "Screen: selection activity tracks genuine transitions" {
     try testing.expectEqual(@as(u64, 5), s.selection_activity);
     s.clearSelection();
     try testing.expectEqual(@as(u64, 5), s.selection_activity);
+}
+
+test "Screen: linewise selection keeps logical cells and derives row bounds" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var s = try init(alloc, .{ .cols = 10, .rows = 10, .max_scrollback = 0 });
+    defer s.deinit();
+    try s.testWriteString("one\ntwo\nthree");
+
+    try s.select(Selection.init(
+        s.pages.pin(.{ .screen = .{ .x = 3, .y = 1 } }).?,
+        s.pages.pin(.{ .screen = .{ .x = 3, .y = 1 } }).?,
+        false,
+    ));
+
+    try testing.expect(s.setSelectionEndpoint(
+        s.pages.pin(.{ .screen = .{ .x = 4, .y = 2 } }).?,
+        true,
+    ));
+    var selection = s.selection.?;
+    try testing.expectEqual(point.Point{ .screen = .{
+        .x = 3,
+        .y = 1,
+    } }, s.pages.pointFromPin(.screen, selection.start()).?);
+    try testing.expectEqual(point.Point{ .screen = .{
+        .x = 4,
+        .y = 2,
+    } }, s.pages.pointFromPin(.screen, selection.end()).?);
+    try testing.expectEqual(point.Point{ .screen = .{
+        .x = 0,
+        .y = 1,
+    } }, s.pages.pointFromPin(.screen, selection.topLeft(&s)).?);
+    try testing.expectEqual(point.Point{ .screen = .{
+        .x = 9,
+        .y = 2,
+    } }, s.pages.pointFromPin(.screen, selection.bottomRight(&s)).?);
+    try testing.expectEqual(point.Point{ .viewport = .{
+        .x = 4,
+        .y = 2,
+    } }, s.selectionEndpointViewport().?);
+
+    _ = s.adjustSelection(.left).?;
+    try testing.expectEqual(point.Point{ .viewport = .{
+        .x = 3,
+        .y = 2,
+    } }, s.selectionEndpointViewport().?);
+
+    try testing.expect(s.setSelectionEndpoint(
+        s.pages.pin(.{ .screen = .{ .x = 4, .y = 0 } }).?,
+        true,
+    ));
+    selection = s.selection.?;
+    try testing.expectEqual(point.Point{ .screen = .{
+        .x = 3,
+        .y = 1,
+    } }, s.pages.pointFromPin(.screen, selection.start()).?);
+    try testing.expectEqual(point.Point{ .screen = .{
+        .x = 4,
+        .y = 0,
+    } }, s.pages.pointFromPin(.screen, selection.end()).?);
+    try testing.expectEqual(point.Point{ .screen = .{
+        .x = 0,
+        .y = 0,
+    } }, s.pages.pointFromPin(.screen, selection.topLeft(&s)).?);
+    try testing.expectEqual(point.Point{ .screen = .{
+        .x = 9,
+        .y = 1,
+    } }, s.pages.pointFromPin(.screen, selection.bottomRight(&s)).?);
+
+    try s.resize(.{ .cols = 15, .rows = 10, .reflow = false });
+    selection = s.selection.?;
+    try testing.expect(selection.linewise);
+    try testing.expectEqual(point.Point{ .screen = .{
+        .x = 3,
+        .y = 1,
+    } }, s.pages.pointFromPin(.screen, selection.start()).?);
+    try testing.expectEqual(point.Point{ .screen = .{
+        .x = 4,
+        .y = 0,
+    } }, s.pages.pointFromPin(.screen, selection.end()).?);
+    try testing.expectEqual(point.Point{ .screen = .{
+        .x = 0,
+        .y = 0,
+    } }, s.pages.pointFromPin(.screen, selection.topLeft(&s)).?);
+    try testing.expectEqual(point.Point{ .screen = .{
+        .x = 14,
+        .y = 1,
+    } }, s.pages.pointFromPin(.screen, selection.bottomRight(&s)).?);
+
+    try testing.expect(s.setSelectionEndpoint(
+        s.pages.pin(.{ .screen = .{ .x = 5, .y = 2 } }).?,
+        false,
+    ));
+    selection = s.selection.?;
+    try testing.expect(!selection.linewise);
+    try testing.expectEqual(point.Point{ .screen = .{
+        .x = 3,
+        .y = 1,
+    } }, s.pages.pointFromPin(.screen, selection.topLeft(&s)).?);
+    try testing.expectEqual(point.Point{ .screen = .{
+        .x = 5,
+        .y = 2,
+    } }, s.pages.pointFromPin(.screen, selection.bottomRight(&s)).?);
+}
+
+test "Screen: linewise bounds survive no-scrollback row shrink" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var s = try init(alloc, .{ .cols = 8, .rows = 5, .max_scrollback = 0 });
+    defer s.deinit();
+    try s.testWriteString("one\ntwo\nthree\nfour");
+
+    try s.select(Selection.initLinewise(
+        s.pages.pin(.{ .screen = .{ .x = 3, .y = 0 } }).?,
+        s.pages.pin(.{ .screen = .{ .x = 4, .y = 1 } }).?,
+    ));
+    try s.resize(.{ .cols = 8, .rows = 3, .reflow = false });
+
+    const selection = s.selection.?;
+    try testing.expect(selection.linewise);
+    const top_left = s.pages.pointFromPin(.screen, selection.topLeft(&s)).?.screen;
+    const bottom_right = s.pages.pointFromPin(.screen, selection.bottomRight(&s)).?.screen;
+    try testing.expectEqual(@as(size.CellCountInt, 0), top_left.x);
+    try testing.expectEqual(s.pages.cols - 1, bottom_right.x);
+}
+
+test "Screen: linewise endpoint clears rectangular mode" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var s = try init(alloc, .{ .cols = 10, .rows = 5, .max_scrollback = 0 });
+    defer s.deinit();
+
+    try s.select(Selection.init(
+        s.pages.pin(.{ .screen = .{ .x = 2, .y = 1 } }).?,
+        s.pages.pin(.{ .screen = .{ .x = 4, .y = 2 } }).?,
+        true,
+    ));
+    const activity = s.selection_activity;
+    try testing.expect(s.setSelectionEndpoint(
+        s.pages.pin(.{ .screen = .{ .x = 4, .y = 2 } }).?,
+        false,
+    ));
+    try testing.expect(!s.selection.?.linewise);
+    try testing.expect(!s.selection.?.rectangle);
+    try testing.expectEqual(activity + 1, s.selection_activity);
+
+    try s.select(Selection.init(
+        s.pages.pin(.{ .screen = .{ .x = 2, .y = 1 } }).?,
+        s.pages.pin(.{ .screen = .{ .x = 4, .y = 2 } }).?,
+        true,
+    ));
+    try testing.expect(s.setSelectionEndpoint(
+        s.pages.pin(.{ .screen = .{ .x = 5, .y = 3 } }).?,
+        true,
+    ));
+    try testing.expect(s.selection.?.linewise);
+    try testing.expect(!s.selection.?.rectangle);
+
+    try testing.expect(s.setSelectionEndpoint(
+        s.pages.pin(.{ .screen = .{ .x = 6, .y = 3 } }).?,
+        false,
+    ));
+    try testing.expect(!s.selection.?.linewise);
+    try testing.expect(!s.selection.?.rectangle);
+}
+
+test "Screen: selection endpoint rejects a garbage tracked pin" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var s = try init(alloc, .{ .cols = 10, .rows = 3, .max_scrollback = 0 });
+    defer s.deinit();
+    const pin = s.pages.pin(.{ .viewport = .{ .x = 2, .y = 1 } }).?;
+    try s.select(Selection.init(pin, pin, false));
+    try testing.expect(s.selectionEndpointViewport() != null);
+
+    s.selection.?.endPtr().garbage = true;
+    try testing.expect(s.selectionEndpointViewport() == null);
 }
 
 test "Screen: selectAll" {

--- a/src/terminal/Selection.zig
+++ b/src/terminal/Selection.zig
@@ -29,6 +29,10 @@ bounds: Bounds,
 /// bottom right of the rectangle, or vice versa if the selection is backwards.
 rectangle: bool = false,
 
+/// Whether this selection covers complete rows. The screen keeps the stored
+/// endpoints normalized to its current first and last columns across resizes.
+linewise: bool = false,
+
 /// The bounds of the selection. A selection bounds can be either tracked
 /// or untracked. Untracked bounds are unsafe beyond the point the terminal
 /// screen may be modified, since they may point to invalid memory. Tracked
@@ -51,6 +55,28 @@ pub const Bounds = union(enum) {
     },
 };
 
+/// A terminal cell normalized to the leading grid cell of its glyph.
+pub const CanonicalCell = struct {
+    pin: Pin,
+    width_cells: u16,
+};
+
+/// Normalize a pin for consumers that draw or navigate displayed glyphs.
+pub fn canonicalCell(pin: Pin) ?CanonicalCell {
+    return switch (pin.rowAndCell().cell.wide) {
+        .wide => .{ .pin = pin, .width_cells = 2 },
+        .spacer_tail => .{ .pin = pin.left(1), .width_cells = 2 },
+        .narrow => .{ .pin = pin, .width_cells = 1 },
+        .spacer_head => cell: {
+            var it = pin.cellIterator(.right_down, null);
+            _ = it.next();
+            const next = it.next() orelse return null;
+            if (next.rowAndCell().cell.wide != .wide) return null;
+            break :cell .{ .pin = next, .width_cells = 2 };
+        },
+    };
+}
+
 /// Initialize a new selection with the given start and end pins on
 /// the screen. The screen will be used for pin tracking.
 pub fn init(
@@ -58,12 +84,41 @@ pub fn init(
     end_pin: Pin,
     rect: bool,
 ) Selection {
+    return initWithMode(start_pin, end_pin, rect, false);
+}
+
+/// Initialize a full-row selection whose column boundaries follow grid resizes.
+pub fn initLinewise(
+    start_pin: Pin,
+    end_pin: Pin,
+) Selection {
+    return initWithMode(start_pin, end_pin, false, true);
+}
+
+/// Return an untracked copy that preserves endpoints and selection mode.
+pub fn snapshot(self: Selection) Selection {
+    return initWithMode(
+        self.start(),
+        self.end(),
+        self.rectangle,
+        self.linewise,
+    );
+}
+
+fn initWithMode(
+    start_pin: Pin,
+    end_pin: Pin,
+    rect: bool,
+    linewise: bool,
+) Selection {
+    assert(!rect or !linewise);
     return .{
         .bounds = .{ .untracked = .{
             .start = start_pin,
             .end = end_pin,
         } },
         .rectangle = rect,
+        .linewise = linewise,
     };
 }
 
@@ -85,7 +140,8 @@ pub fn deinit(
 pub fn eql(self: Selection, other: Selection) bool {
     return self.start().eql(other.start()) and
         self.end().eql(other.end()) and
-        self.rectangle == other.rectangle;
+        self.rectangle == other.rectangle and
+        self.linewise == other.linewise;
 }
 
 /// The starting pin of the selection. This is NOT ordered.
@@ -145,12 +201,13 @@ pub fn track(self: *const Selection, s: *Screen) Allocator.Error!Selection {
             .end = tracked_end,
         } },
         .rectangle = self.rectangle,
+        .linewise = self.linewise,
     };
 }
 
 /// Returns the top left point of the selection.
 pub fn topLeft(self: Selection, s: *const Screen) Pin {
-    return switch (self.order(s)) {
+    var result = switch (self.order(s)) {
         .forward => self.start(),
         .reverse => self.end(),
         .mirrored_forward => pin: {
@@ -164,11 +221,13 @@ pub fn topLeft(self: Selection, s: *const Screen) Pin {
             break :pin p;
         },
     };
+    if (self.linewise) result.x = 0;
+    return result;
 }
 
 /// Returns the bottom right point of the selection.
 pub fn bottomRight(self: Selection, s: *const Screen) Pin {
-    return switch (self.order(s)) {
+    var result = switch (self.order(s)) {
         .forward => self.end(),
         .reverse => self.start(),
         .mirrored_forward => pin: {
@@ -182,6 +241,8 @@ pub fn bottomRight(self: Selection, s: *const Screen) Pin {
             break :pin p;
         },
     };
+    if (self.linewise) result.x = s.pages.cols - 1;
+    return result;
 }
 
 /// The order of the selection:
@@ -206,6 +267,11 @@ pub const Order = lib.Enum(lib.target, &.{
 pub fn order(self: Selection, s: *const Screen) Order {
     const start_pt = s.pages.pointFromPin(.screen, self.start()).?.screen;
     const end_pt = s.pages.pointFromPin(.screen, self.end()).?.screen;
+
+    // Horizontal direction has no meaning for a full-row selection.
+    if (self.linewise) {
+        return if (start_pt.y <= end_pt.y) .forward else .reverse;
+    }
 
     if (self.rectangle) {
         // Reverse (also handles single-column)
@@ -235,18 +301,30 @@ pub fn order(self: Selection, s: *const Screen) Order {
 /// Note that only forward and reverse are useful desired orders for this
 /// function. All other orders act as if forward order was desired.
 pub fn ordered(self: Selection, s: *const Screen, desired: Order) Selection {
-    if (self.order(s) == desired) return .init(
-        self.start(),
-        self.end(),
-        self.rectangle,
-    );
+    const current = self.order(s);
+    if (current == desired) return self.snapshot();
+
+    // Preserve the logical columns of linewise endpoints. Rendering and
+    // formatting derive row-edge bounds through topLeft and bottomRight.
+    if (self.linewise) return switch (desired) {
+        .reverse => initWithMode(
+            self.end(),
+            self.start(),
+            false,
+            true,
+        ),
+        else => if (current == .forward)
+            initWithMode(self.start(), self.end(), false, true)
+        else
+            initWithMode(self.end(), self.start(), false, true),
+    };
 
     const tl = self.topLeft(s);
     const br = self.bottomRight(s);
     return switch (desired) {
-        .forward => .init(tl, br, self.rectangle),
-        .reverse => .init(br, tl, self.rectangle),
-        else => .init(tl, br, self.rectangle),
+        .forward => initWithMode(tl, br, self.rectangle, self.linewise),
+        .reverse => initWithMode(br, tl, self.rectangle, self.linewise),
+        else => initWithMode(tl, br, self.rectangle, self.linewise),
     };
 }
 
@@ -1372,6 +1450,49 @@ test "ordered" {
         try testing.expect(sel.ordered(&s, .reverse).eql(sel_reverse));
         try testing.expect(sel.ordered(&s, .mirrored_forward).eql(sel_forward));
     }
+    {
+        // linewise reverse preserves logical columns
+        const sel = Selection.initLinewise(
+            s.pages.pin(.{ .screen = .{ .x = 5, .y = 3 } }).?,
+            s.pages.pin(.{ .screen = .{ .x = 2, .y = 1 } }).?,
+        );
+        const sel_forward = Selection.initLinewise(
+            s.pages.pin(.{ .screen = .{ .x = 2, .y = 1 } }).?,
+            s.pages.pin(.{ .screen = .{ .x = 5, .y = 3 } }).?,
+        );
+        try testing.expect(sel.ordered(&s, .forward).eql(sel_forward));
+        try testing.expect(sel.ordered(&s, .reverse).eql(sel));
+
+        const forward = sel.ordered(&s, .forward);
+        try testing.expectEqual(@as(u16, 0), forward.topLeft(&s).x);
+        try testing.expectEqual(s.pages.cols - 1, forward.bottomRight(&s).x);
+    }
+}
+
+test "Selection: snapshot preserves linewise and rectangular modes" {
+    const testing = std.testing;
+
+    var s = try Screen.init(testing.allocator, .{
+        .cols = 10,
+        .rows = 4,
+        .max_scrollback = 0,
+    });
+    defer s.deinit();
+
+    const start_pin = s.pages.pin(.{ .screen = .{ .x = 3, .y = 1 } }).?;
+    const end_pin = s.pages.pin(.{ .screen = .{ .x = 4, .y = 2 } }).?;
+
+    const linewise = Selection.initLinewise(start_pin, end_pin);
+    const linewise_snapshot = linewise.snapshot();
+    try testing.expect(linewise_snapshot.eql(linewise));
+    try testing.expect(linewise_snapshot.linewise);
+    try testing.expect(!linewise_snapshot.rectangle);
+
+    const rectangle = Selection.init(start_pin, end_pin, true);
+    const rectangle_snapshot = rectangle.snapshot();
+    try testing.expect(rectangle_snapshot.eql(rectangle));
+    try testing.expect(rectangle_snapshot.rectangle);
+    try testing.expect(!rectangle_snapshot.linewise);
 }
 
 test "Selection: contains" {

--- a/src/terminal/render.zig
+++ b/src/terminal/render.zig
@@ -648,7 +648,7 @@ pub const RenderState = struct {
                 const tl_pin = sel.topLeft(s);
                 const br_pin = sel.bottomRight(s);
                 self.selection_cache = .{
-                    .selection = .init(tl_pin, br_pin, sel.rectangle),
+                    .selection = sel.snapshot(),
                     .tl_pin = tl_pin,
                     .br_pin = br_pin,
                 };
@@ -1937,6 +1937,36 @@ test "selection multiple lines" {
         &.{ 0, 2 },
         &sels[2].?,
     );
+}
+
+test "linewise selection cache preserves mode and direction" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var t: Terminal = try .init(alloc, .{
+        .cols = 10,
+        .rows = 3,
+    });
+    defer t.deinit(alloc);
+
+    const screen: *Screen = t.screens.active;
+    try screen.select(.initLinewise(
+        screen.pages.pin(.{ .active = .{ .x = 5, .y = 2 } }).?,
+        screen.pages.pin(.{ .active = .{ .x = 3, .y = 1 } }).?,
+    ));
+
+    var state: RenderState = .empty;
+    defer state.deinit(alloc);
+    try state.update(alloc, &t);
+
+    const cached = state.selection_cache.?.selection;
+    try testing.expect(cached.linewise);
+    try testing.expect(cached.eql(screen.selection.?));
+
+    const sels = state.row_data.items(.selection);
+    try testing.expectEqual(null, sels[0]);
+    try testing.expectEqualSlices(size.CellCountInt, &.{ 0, 9 }, &sels[1].?);
+    try testing.expectEqualSlices(size.CellCountInt, &.{ 0, 9 }, &sels[2].?);
 }
 
 test "linkCells" {


### PR DESCRIPTION
## Summary
- expose demand-safe grid metrics and tracked viewport selection APIs for cmux
- keep logical selection endpoints while deriving linewise render and copy bounds
- canonicalize wide and wrapped glyph cells across cursor metrics, navigation, rendering, and copy

## Verification
- focused Zig selection, linewise, viewport, and grid-metrics suites
- ReleaseFast universal GhosttyKit framework build
- canonical branch autoreview clean

Parent: https://github.com/manaflow-ai/cmux/pull/8995

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/154"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787745445&installation_model_id=21920&pr_number=154&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F154&signature=35f26bc856fa034a6a6110a4bd4bf835198635edaf24e556de5b87be8fc94d35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exposes exact grid metrics and tracked viewport selection APIs to enable native keyboard selection in `cmux`. Also canonicalizes wide/wrapped glyphs so cursor metrics, selection, rendering, and copy behave consistently, supporting `cmux` parent PR #8995.

- New Features
  - Added `ghostty_surface_grid_metrics` (with `ghostty_surface_grid_metrics_s`) to return authoritative grid geometry: columns, rows, cursor column/row/width, cell size, and padding in logical coordinates.
  - Added viewport selection C APIs: `ghostty_surface_select_viewport_cell`, `ghostty_surface_select_viewport_rows`, `ghostty_surface_set_selection_endpoint_viewport`, `ghostty_surface_resolve_viewport_cell`, `ghostty_surface_selection_endpoint_viewport`.

- Bug Fixes
  - Normalized wide and wrapped glyphs to their leading cell across cursor metrics, navigation, rendering, and copy; offscreen wrapped cells are rejected.
  - Kept logical selection endpoints and derived full-row bounds for linewise mode; preserved mode/direction in the render cache; advanced selection activity only on real changes.

<sup>Written for commit 3fbc88b488d6f424fb387ff3603d92c9ea83b309. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

