### PR TITLE
os/open: guard against tight loop in stderr streaming

### DIFF
--- a/src/os/open.zig
+++ b/src/os/open.zig
@@ -77,21 +77,32 @@ fn openThread(exe_: std.process.Child) void {
     // requires a mutable reference and we can't have one as a thread
     // param.
     var exe = exe_;
+    // Always reap the child, even if the stderr loop exits early.
+    defer _ = exe.wait() catch {};
+
     if (exe.stderr) |stderr| {
         var buffer: [256]u8 = undefined;
         var stream = stderr.readerStreaming(&buffer);
         const reader = &stream.interface;
+        // Guard against a tight loop when the reader returns zero-length
+        // slices without signaling EndOfStream (observed under EOF races
+        // in std.Io.Reader on Zig 0.15). After a short run of empty reads
+        // we assume the stream is done and exit.
+        var empty_streak: u32 = 0;
         while (true) {
             const line = reader.takeDelimiterExclusive('\n') catch |outer| switch (outer) {
-                error.EndOfStream => break,
-                error.ReadFailed => break,
+                error.EndOfStream, error.ReadFailed => break,
                 error.StreamTooLong => reader.take(buffer.len) catch |inner| switch (inner) {
-                    error.ReadFailed => break,
-                    error.EndOfStream => break,
+                    error.ReadFailed, error.EndOfStream => break,
                 },
             };
+            if (line.len == 0) {
+                empty_streak += 1;
+                if (empty_streak >= 16) break;
+                continue;
+            }
+            empty_streak = 0;
             log.warn("open stderr={s}", .{line});
         }
     }
-    _ = exe.wait() catch {};
 }

--- a/src/os/open.zig
+++ b/src/os/open.zig
@@ -84,11 +84,11 @@ fn openThread(exe_: std.process.Child) void {
         var buffer: [256]u8 = undefined;
         var stream = stderr.readerStreaming(&buffer);
         const reader = &stream.interface;
-        // Guard against a tight loop when the reader returns zero-length
-        // slices without signaling EndOfStream (observed under EOF races
-        // in std.Io.Reader on Zig 0.15). After a short run of empty reads
-        // we assume the stream is done and exit.
-        var empty_streak: u32 = 0;
+        // Safety net against a pathological reader that neither errors
+        // nor advances. peek() below is the primary termination check;
+        // this counter only trips if peek() itself is stuck (should
+        // never happen in practice).
+        var no_progress: u32 = 0;
         while (true) {
             const line = reader.takeDelimiterExclusive('\n') catch |outer| switch (outer) {
                 error.EndOfStream, error.ReadFailed => break,
@@ -97,11 +97,18 @@ fn openThread(exe_: std.process.Child) void {
                 },
             };
             if (line.len == 0) {
-                empty_streak += 1;
-                if (empty_streak >= 16) break;
+                // Empty line: distinguish a legitimate blank stderr
+                // record from a reader stuck at EOF. An underlying
+                // std.Io.Reader can return zero-length slices without
+                // signaling error.EndOfStream on some pipe EOF races,
+                // which would previously loop and flood the log; peek()
+                // surfaces the real termination.
+                _ = reader.peek(1) catch break;
+                no_progress += 1;
+                if (no_progress > 4096) break;
                 continue;
             }
-            empty_streak = 0;
+            no_progress = 0;
             log.warn("open stderr={s}", .{line});
         }
     }


### PR DESCRIPTION
## Summary

Fixes a runaway loop in `openThread` that spams tens of thousands of empty `open stderr=` log warnings per second and pins the parent process at 300%+ CPU indefinitely.

## Reproducer (cmux 1.3.x, Ghostty 1.3.2-dev, macOS)

Observed on a running cmux instance:

- **~45,000 log lines/sec** all reading `[com.mitchellh.ghostty:os-open] os-open: open stderr=` (empty payload)
- `log stream --process cmux` reports `Messages dropped during live streaming` — flood exceeds `os_log` throughput
- Parent process at 300–400 % CPU across 5 threads, each producing ~9,000 lines/sec
- Log-flood survives surface / workspace teardown; only killing cmux stops it

`sample <pid>` top-of-stack was dominated by `os_log_impl_flatten_and_send`, `os_log_create`, `_os_log`, and `zig_os_log_with_type`, confirming the hot path is the `log.warn` inside `openThread`.

## Root cause

Introduced in bb375a2f ("deal with large outputs from xdg-open/rundll32/open"), which replaced the batched `collectOutput` with a streaming reader loop.

Under Zig 0.15.2's new `std.Io.Reader`, `takeDelimiterExclusive('\n')` can return **zero-length slices without throwing `EndOfStream`** when the underlying pipe has reached EOF but the reader has not yet fully drained its state. On macOS, once `/usr/bin/open <url>` exits, its stderr pipe enters this state and every subsequent call returns an empty slice — no error variant of the outer `switch` matches, so the loop never `break`s and `log.warn("open stderr={s}", .{line})` fires every iteration with an empty string.

Because `openThread` is `.detach()`'d, each leaked instance runs forever. The five leaks in the reproducer corresponded to five prior `open()` calls over the lifetime of the process.

A secondary issue: the pre-patch code calls `_ = exe.wait() catch {};` **after** the stderr block, so any of the existing `break` paths that leave the loop early skip the reap.

## Fix

1. **Empty-read guard**: count consecutive zero-length lines and break after 16. This tolerates legitimate blank lines in child output (unlikely from `open`/`xdg-open`/`rundll32` but future-proof) while providing a hard ceiling that prevents the tight loop.
2. **`defer exe.wait()`**: unconditional reap regardless of which branch exits the loop.
3. **Coalesce identical error arms** in the switch for readability (no behavior change).

## Verification

- Manual repro: cmux with 5 leaked `openThread`s was pinning 3–4 cores at 100 % and flooding `os_log` at ~45k lines/sec; after applying this patch and rebuilding, CPU is idle and no `os-open` messages are emitted after each child exits.
- No behavioral change on the happy path (child writes finite stderr, terminates, loop exits via `EndOfStream`).

## Notes

- The upstream `ghostty-org/ghostty` `main` branch carries the same bb375a2f, so this fix applies there as well; happy to open a parallel PR upstream if desired.
- `takeDelimiterExclusive` returning an empty slice at EOF instead of `EndOfStream` may itself be a `std.Io.Reader` bug worth reporting to Zig, but a defensive guard here is the right call regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/155"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787748892&installation_model_id=21920&pr_number=155&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F155&signature=dc033d048157c9459b049a1a937b228ed8a77990519fa0a19ad3c5a7ef3a26a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents a tight loop in `openThread` stderr streaming that spammed empty logs and pegged CPU after `/usr/bin/open` exited. Uses `peek()` to detect EOF on blank reads and always reaps the child process.

- **Bug Fixes**
  - After zero-length reads, call `reader.peek(1)` and only break on EOF/read error; add a 4096 no-progress cap as a safety net.
  - Move `exe.wait()` to `defer` so the child is reaped on all exits.
  - Coalesce identical error arms for clearer control flow (no behavior change).

<sup>Written for commit fb2ea98dd2389356e3b5a0b284dd800af823e131. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/155?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when launching and monitoring external processes.
  * Prevented hangs during stderr reading, including EOF races and repeated empty reads.
  * Ensured child processes are properly reaped after execution.
  * Improved handling of oversized or failed output streams.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->