### PR TITLE
fix: make keyboard copy navigation atomic

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -638,6 +638,38 @@ typedef struct {
   uint64_t row_space_revision;
 } ghostty_surface_scrollbar_s;
 
+// cmux fork: semantic keyboard-selection movement kept inside Ghostty so
+// glyph canonicalization, tracked endpoints, and viewport scrolling are one
+// renderer-state transaction.
+typedef enum {
+  GHOSTTY_KEYBOARD_SELECTION_MOVE_LEFT,
+  GHOSTTY_KEYBOARD_SELECTION_MOVE_RIGHT,
+  GHOSTTY_KEYBOARD_SELECTION_MOVE_UP,
+  GHOSTTY_KEYBOARD_SELECTION_MOVE_DOWN,
+  GHOSTTY_KEYBOARD_SELECTION_MOVE_PAGE_UP,
+  GHOSTTY_KEYBOARD_SELECTION_MOVE_PAGE_DOWN,
+  GHOSTTY_KEYBOARD_SELECTION_MOVE_HOME,
+  GHOSTTY_KEYBOARD_SELECTION_MOVE_END,
+  GHOSTTY_KEYBOARD_SELECTION_MOVE_BEGINNING_OF_LINE,
+  GHOSTTY_KEYBOARD_SELECTION_MOVE_END_OF_LINE,
+} ghostty_keyboard_selection_move_e;
+
+// cmux fork: synchronous viewport mutations used by keyboard copy mode.
+typedef enum {
+  GHOSTTY_KEYBOARD_COPY_SCROLL_LINES,
+  GHOSTTY_KEYBOARD_COPY_SCROLL_PAGES,
+  GHOSTTY_KEYBOARD_COPY_SCROLL_HALF_PAGES,
+  GHOSTTY_KEYBOARD_COPY_SCROLL_TOP,
+  GHOSTTY_KEYBOARD_COPY_SCROLL_BOTTOM,
+  GHOSTTY_KEYBOARD_COPY_SCROLL_PROMPTS,
+} ghostty_keyboard_copy_scroll_e;
+
+typedef enum {
+  GHOSTTY_KEYBOARD_COPY_SELECTION_NONE,
+  GHOSTTY_KEYBOARD_COPY_SELECTION_CHARACTER,
+  GHOSTTY_KEYBOARD_COPY_SELECTION_LINE,
+} ghostty_keyboard_copy_selection_e;
+
 // Config types
 
 // config.Path
@@ -1480,6 +1512,42 @@ GHOSTTY_API bool ghostty_surface_selection_endpoint_viewport(
     ghostty_surface_t,
     uint16_t*,
     uint16_t*);
+GHOSTTY_API bool ghostty_surface_keyboard_copy_cursor_set(
+    ghostty_surface_t,
+    bool,
+    uint16_t*,
+    uint16_t*,
+    uint16_t*);
+GHOSTTY_API bool ghostty_surface_keyboard_copy_cursor_viewport(
+    ghostty_surface_t,
+    uint16_t*,
+    uint16_t*,
+    uint16_t*);
+GHOSTTY_API ghostty_keyboard_copy_selection_e
+ghostty_surface_keyboard_copy_selection_kind(ghostty_surface_t);
+GHOSTTY_API bool ghostty_surface_keyboard_copy_selection_start(
+    ghostty_surface_t,
+    bool,
+    uint16_t,
+    uint16_t*,
+    uint16_t*,
+    uint16_t*);
+GHOSTTY_API bool ghostty_surface_keyboard_selection_move(
+    ghostty_surface_t,
+    ghostty_keyboard_selection_move_e,
+    uint16_t,
+    bool,
+    bool,
+    uint16_t*,
+    uint16_t*,
+    uint16_t*);
+GHOSTTY_API bool ghostty_surface_keyboard_copy_scroll(
+    ghostty_surface_t,
+    ghostty_keyboard_copy_scroll_e,
+    int32_t,
+    uint16_t*,
+    uint16_t*,
+    uint16_t*);
 // cmux fork: set/query the active selection from inclusive absolute screen rows.
 // The setter updates Ghostty's tracked selection pins without writing clipboards.
 GHOSTTY_API bool ghostty_surface_select_screen_rows(ghostty_surface_t,
@@ -1489,6 +1557,10 @@ GHOSTTY_API bool ghostty_surface_selection_screen_rows(ghostty_surface_t,
                                                        uint32_t*,
                                                        uint32_t*);
 GHOSTTY_API bool ghostty_surface_read_selection(ghostty_surface_t, ghostty_text_s*);
+GHOSTTY_API bool ghostty_surface_read_selection_clipboard_text(
+    ghostty_surface_t,
+    uintptr_t,
+    ghostty_text_s*);
 GHOSTTY_API bool ghostty_surface_read_text(ghostty_surface_t,
                                               ghostty_selection_s,
                                               ghostty_text_s*);

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -7795,6 +7795,370 @@ test "Surface: viewport selection canonicalizes wide glyph tails" {
     );
 }
 
+test "Surface: keyboard selection movement batches wide glyph navigation" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var t: terminal.Terminal = try .init(alloc, .{ .cols = 6, .rows = 2 });
+    defer t.deinit(alloc);
+    var stream = t.vtStream();
+    defer stream.deinit();
+    stream.nextSlice("A橋B");
+
+    const screen = t.screens.active;
+    const start = viewportPin(screen, 0, 0).?;
+    const wide = keyboardSelectionPin(
+        screen,
+        start,
+        .right,
+        1,
+    ).?;
+    try testing.expectEqual(@as(terminal.size.CellCountInt, 1), wide.pin.x);
+    try testing.expectEqual(@as(u16, 2), wide.width_cells);
+
+    const after_wide = keyboardSelectionPin(
+        screen,
+        start,
+        .right,
+        2,
+    ).?;
+    try testing.expectEqual(@as(terminal.size.CellCountInt, 3), after_wide.pin.x);
+    try testing.expectEqual(@as(u16, 1), after_wide.width_cells);
+
+    const boundary = keyboardSelectionPin(
+        screen,
+        start,
+        .right,
+        9999,
+    ).?;
+    try testing.expectEqual(@as(terminal.size.CellCountInt, 5), boundary.pin.x);
+
+    const wide_tail = viewportPin(screen, 2, 0).?;
+    const before_wide = keyboardSelectionPin(
+        screen,
+        wide_tail,
+        .left,
+        1,
+    ).?;
+    try testing.expectEqual(@as(terminal.size.CellCountInt, 0), before_wide.pin.x);
+}
+
+test "Surface: wrapped wide glyph horizontal movement is reversible" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var t: terminal.Terminal = try .init(alloc, .{ .cols = 4, .rows = 3 });
+    defer t.deinit(alloc);
+    var stream = t.vtStream();
+    defer stream.deinit();
+    stream.nextSlice("ABC橋D");
+
+    const screen = t.screens.active;
+    const before_wrap = viewportPin(screen, 2, 0).?;
+    const wrapped = keyboardSelectionPin(
+        screen,
+        before_wrap,
+        .right,
+        1,
+    ).?;
+    try testing.expectEqual(
+        terminal.point.Point{ .viewport = .{ .x = 0, .y = 1 } },
+        screen.pages.pointFromPin(.viewport, wrapped.pin).?,
+    );
+    try testing.expectEqual(@as(u16, 2), wrapped.width_cells);
+
+    const restored = keyboardSelectionPin(
+        screen,
+        wrapped.pin,
+        .left,
+        1,
+    ).?;
+    try testing.expectEqual(
+        terminal.point.Point{ .viewport = .{ .x = 2, .y = 0 } },
+        screen.pages.pointFromPin(.viewport, restored.pin).?,
+    );
+}
+
+test "Surface: counted horizontal movement crosses multiple wide wraps" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var t: terminal.Terminal = try .init(alloc, .{ .cols = 4, .rows = 4 });
+    defer t.deinit(alloc);
+    var stream = t.vtStream();
+    defer stream.deinit();
+    stream.nextSlice("ABC橋X橋");
+
+    const screen = t.screens.active;
+    const start = viewportPin(screen, 0, 0).?;
+    const moved = keyboardSelectionPin(screen, start, .right, 5).?;
+    try testing.expectEqual(
+        terminal.point.Point{ .viewport = .{ .x = 0, .y = 2 } },
+        screen.pages.pointFromPin(.viewport, moved.pin).?,
+    );
+    try testing.expectEqual(@as(u16, 2), moved.width_cells);
+}
+
+test "Surface: tracked copy cursor is not reinterpreted after viewport drift" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var t: terminal.Terminal = try .init(alloc, .{ .cols = 8, .rows = 2 });
+    defer t.deinit(alloc);
+    var stream = t.vtStream();
+    defer stream.deinit();
+    stream.nextSlice("one\r\ntwo");
+
+    const screen = t.screens.active;
+    const original = viewportPin(screen, 0, 0).?;
+    const original_y = screen.pages.pointFromPin(.screen, original).?.screen.y;
+    const tracked = try screen.pages.trackPin(original);
+    defer screen.pages.untrackPin(tracked);
+
+    stream.nextSlice("\r\nthree\r\nfour\r\nfive");
+    const tracked_y = screen.pages.pointFromPin(.screen, tracked.*).?.screen.y;
+    const current_row_zero = viewportPin(screen, 0, 0).?;
+    const current_row_zero_y = screen.pages
+        .pointFromPin(.screen, current_row_zero).?
+        .screen
+        .y;
+    try testing.expectEqual(original_y, tracked_y);
+    try testing.expect(tracked_y != current_row_zero_y);
+
+    const resolved = resolveTrackedKeyboardCopyCursor(screen, tracked).?;
+    try testing.expect(resolved.changed);
+    try testing.expectEqual(
+        terminal.point.Point{ .viewport = .{ .x = 0, .y = 0 } },
+        screen.pages.pointFromPin(.viewport, resolved.cell.pin).?,
+    );
+}
+
+test "Surface: tracked copy cursor recovery clears garbage state" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var t: terminal.Terminal = try .init(alloc, .{ .cols = 8, .rows = 2 });
+    defer t.deinit(alloc);
+
+    const screen = t.screens.active;
+    const tracked = try screen.pages.trackPin(viewportPin(screen, 3, 1).?);
+    defer screen.pages.untrackPin(tracked);
+    screen.pages.reset();
+    try testing.expect(tracked.garbage);
+
+    const resolved = resolveTrackedKeyboardCopyCursor(screen, tracked).?;
+    try testing.expect(resolved.changed);
+    try testing.expect(!tracked.garbage);
+    try testing.expectEqual(
+        terminal.point.Point{ .viewport = .{ .x = 0, .y = 0 } },
+        screen.pages.pointFromPin(.viewport, resolved.cell.pin).?,
+    );
+}
+
+test "Surface: stale alternate-screen copy cursor skips untracking" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var screens: terminal.ScreenSet = try .init(alloc, .default);
+    defer screens.deinit(alloc);
+    const alternate = try screens.getInit(alloc, .alternate, .default);
+    const tracked = try alternate.pages.trackPin(
+        alternate.pages.getTopLeft(.screen),
+    );
+    const cursor: KeyboardCopyCursor = .{
+        .screen_key = .alternate,
+        .screen_generation = screens.generation(.alternate),
+        .pin = tracked,
+    };
+
+    screens.remove(alloc, .alternate);
+    try testing.expect(!untrackKeyboardCopyCursor(&screens, cursor));
+    try testing.expect(screens.get(.alternate) == null);
+}
+
+test "Surface: copy cursor teardown reports cleared owned selection" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var screens: terminal.ScreenSet = try .init(alloc, .default);
+    defer screens.deinit(alloc);
+    const screen = screens.active;
+    const pin = screen.pages.getTopLeft(.screen);
+    const tracked = try screen.pages.trackPin(pin);
+    try screen.select(terminal.Selection.init(pin, pin, false));
+    const cursor: KeyboardCopyCursor = .{
+        .screen_key = .primary,
+        .screen_generation = screens.generation(.primary),
+        .pin = tracked,
+        .selection = .{
+            .linewise = false,
+            .activity = screen.selection_activity,
+        },
+    };
+
+    try testing.expect(untrackKeyboardCopyCursor(&screens, cursor));
+    try testing.expect(screen.selection == null);
+}
+
+test "Surface: keyboard selection ownership rejects replacement selection" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var t: terminal.Terminal = try .init(alloc, .{ .cols = 8, .rows = 2 });
+    defer t.deinit(alloc);
+    const screen = t.screens.active;
+    const pin = viewportPin(screen, 1, 0).?;
+    const tracked = try screen.pages.trackPin(pin);
+    defer screen.pages.untrackPin(tracked);
+
+    try screen.select(terminal.Selection.init(pin, pin, false));
+    var cursor: KeyboardCopyCursor = .{
+        .screen_key = .primary,
+        .screen_generation = t.screens.generation(.primary),
+        .pin = tracked,
+        .selection = .{
+            .linewise = false,
+            .activity = screen.selection_activity,
+        },
+    };
+    try testing.expectEqual(
+        false,
+        validateKeyboardCopySelection(&cursor, screen).?,
+    );
+
+    const foreign_endpoint = viewportPin(screen, 4, 1).?;
+    try screen.select(terminal.Selection.init(pin, foreign_endpoint, true));
+    try testing.expect(
+        validateKeyboardCopySelection(&cursor, screen) == null,
+    );
+    try testing.expect(cursor.selection == null);
+    try testing.expect(screen.selection.?.rectangle);
+    try testing.expect(screen.selection.?.end().eql(foreign_endpoint));
+}
+
+test "Surface: linewise keyboard movement includes blank physical rows" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var t: terminal.Terminal = try .init(alloc, .{
+        .cols = 8,
+        .rows = 2,
+    });
+    defer t.deinit(alloc);
+    var stream = t.vtStream();
+    defer stream.deinit();
+    stream.nextSlice("one\r\n\r\nthree\r\nfour\r\n");
+    t.scrollViewport(.top);
+
+    const screen = t.screens.active;
+    const start = viewportPin(screen, 0, 0).?;
+    const start_point = screen.pages.pointFromPin(.screen, start).?.screen;
+    const next = keyboardSelectionPin(
+        screen,
+        start,
+        .down,
+        1,
+    ).?;
+    const next_point = screen.pages.pointFromPin(.screen, next.pin).?.screen;
+    try testing.expectEqual(start_point.y + 1, next_point.y);
+
+    const end = keyboardSelectionPin(
+        screen,
+        start,
+        .end,
+        1,
+    ).?;
+    scrollPinIntoViewport(screen, end.pin);
+    const visible = screen.pages.pointFromPin(.viewport, end.pin).?.viewport;
+    try testing.expectEqual(@as(u32, screen.pages.rows - 1), visible.y);
+}
+
+test "Surface: counted linewise movement extends beyond the viewport" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var t: terminal.Terminal = try .init(alloc, .{ .cols = 8, .rows = 2 });
+    defer t.deinit(alloc);
+    var stream = t.vtStream();
+    defer stream.deinit();
+    stream.nextSlice("one\r\ntwo\r\nthree\r\nfour\r\nfive");
+    t.scrollViewport(.top);
+
+    const screen = t.screens.active;
+    const start = viewportPin(screen, 0, 1).?;
+    const start_y = screen.pages.pointFromPin(.screen, start).?.screen.y;
+    const endpoint = keyboardSelectionPin(screen, start, .down, 3).?;
+    const endpoint_y = screen.pages
+        .pointFromPin(.screen, endpoint.pin).?
+        .screen
+        .y;
+    try testing.expectEqual(start_y + 3, endpoint_y);
+
+    scrollPinIntoViewport(screen, endpoint.pin);
+    try testing.expectEqual(
+        @as(u32, screen.pages.rows - 1),
+        screen.pages.pointFromPin(.viewport, endpoint.pin).?.viewport.y,
+    );
+}
+
+test "Surface: linewise keyboard movement preserves the copy cursor column" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var t: terminal.Terminal = try .init(alloc, .{ .cols = 8, .rows = 4 });
+    defer t.deinit(alloc);
+
+    const screen = t.screens.active;
+    const anchor = viewportPin(screen, 0, 0).?;
+    const row_edge = viewportPin(screen, 7, 1).?;
+    try screen.select(terminal.Selection.initLinewise(anchor, row_edge));
+
+    var start = row_edge;
+    start.x = 3;
+    const start_point = screen.pages.pointFromPin(.viewport, start).?.viewport;
+    try testing.expectEqual(@as(u32, 3), start_point.x);
+    try testing.expectEqual(@as(u32, 1), start_point.y);
+
+    const moved = keyboardSelectionPin(
+        screen,
+        start,
+        .down,
+        1,
+    ).?;
+    const moved_point = screen.pages.pointFromPin(.viewport, moved.pin).?.viewport;
+    try testing.expectEqual(@as(u32, 3), moved_point.x);
+    try testing.expectEqual(@as(u32, 2), moved_point.y);
+}
+
+test "Surface: linewise horizontal movement skips wide glyph tails" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var t: terminal.Terminal = try .init(alloc, .{ .cols = 6, .rows = 2 });
+    defer t.deinit(alloc);
+    var stream = t.vtStream();
+    defer stream.deinit();
+    stream.nextSlice("A橋B");
+
+    const screen = t.screens.active;
+    const anchor = viewportPin(screen, 0, 0).?;
+    const wide = viewportPin(screen, 1, 0).?;
+    try screen.select(terminal.Selection.initLinewise(anchor, wide));
+
+    const start = wide;
+    const moved = keyboardSelectionPin(screen, start, .right, 1).?;
+    try testing.expectEqual(
+        terminal.point.Point{ .viewport = .{ .x = 3, .y = 0 } },
+        screen.pages.pointFromPin(.viewport, moved.pin).?,
+    );
+    try testing.expectEqual(@as(u16, 1), moved.width_cells);
+    try testing.expect(screen.setSelectionEndpoint(moved.pin, true));
+    try testing.expectEqual(
+        terminal.point.Point{ .viewport = .{ .x = 3, .y = 0 } },
+        screen.selectionEndpointViewport().?,
+    );
+}
+
 test "Surface: viewport selection resolves a wrapped wide glyph head" {
     const testing = std.testing;
     const alloc = testing.allocator;
@@ -7891,6 +8255,39 @@ test "Surface: viewport glyph resolution rejects an offscreen wrapped cell" {
         bottom_right.rowAndCell().cell.wide,
     );
     try testing.expect(canonicalSelectionCellViewport(screen, 3, 1) == null);
+
+    const start = bottom_right;
+    const left = keyboardSelectionPin(screen, start, .left, 1).?;
+    const left_point = screen.pages.pointFromPin(.viewport, left.pin).?.viewport;
+    try testing.expectEqual(
+        terminal.point.Point{ .viewport = .{ .x = 2, .y = 1 } },
+        terminal.point.Point{ .viewport = left_point },
+    );
+
+    const right = keyboardSelectionPin(screen, start, .right, 1).?;
+    scrollPinIntoViewport(screen, right.pin);
+    const right_point = screen.pages.pointFromPin(.viewport, right.pin).?.viewport;
+    try testing.expect(right_point.x < screen.pages.cols);
+    try testing.expect(right_point.y < screen.pages.rows);
+}
+
+test "Surface: vertical keyboard movement stays on a spacer-head row" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var t: terminal.Terminal = try .init(alloc, .{ .cols = 4, .rows = 3 });
+    defer t.deinit(alloc);
+    var stream = t.vtStream();
+    defer stream.deinit();
+    stream.nextSlice("ABC橋");
+
+    const screen = t.screens.active;
+    const start = viewportPin(screen, 3, 1).?;
+    const moved = keyboardSelectionPin(screen, start, .up, 1).?;
+    try testing.expectEqual(
+        terminal.point.Point{ .viewport = .{ .x = 2, .y = 0 } },
+        screen.pages.pointFromPin(.viewport, moved.pin).?,
+    );
 }
 
 test "Surface: mouseLinkRefreshAllowedState honors ctrl/super under mouse reporting" {

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -101,6 +101,9 @@ mouse: Mouse,
 /// Keyboard input state.
 keyboard: Keyboard,
 
+/// Ghostty-owned cursor for cmux keyboard copy mode.
+keyboard_copy_cursor: ?KeyboardCopyCursor = null,
+
 /// A currently pressed key. This is used so that we can send a keyboard
 /// release event when the surface is unfocused. Note that when the surface
 /// is refocused, a key press event may not be sent again -- this depends
@@ -214,6 +217,18 @@ const Search = struct {
         // Now it is safe to deinit the state
         self.state.deinit();
     }
+};
+
+const KeyboardCopyCursor = struct {
+    screen_key: terminal.ScreenSet.Key,
+    screen_generation: usize,
+    pin: *terminal.Pin,
+    selection: ?KeyboardCopySelectionState = null,
+};
+
+const KeyboardCopySelectionState = struct {
+    linewise: bool,
+    activity: u64,
 };
 
 /// Mouse state for the surface.
@@ -973,6 +988,7 @@ pub fn deinit(self: *Surface) void {
     self.renderer.deinit();
     self.io_thread.deinit();
     self.mouse.selection_gesture.deinit(&self.io.terminal);
+    _ = self.clearKeyboardCopyCursor();
     self.io.deinit();
 
     if (self.inspector) |v| {
@@ -2460,10 +2476,16 @@ pub fn selectCursorLine(self: *Surface) !bool {
 
 /// Clear the active selection (cmux-specific).
 pub fn clearSelection(self: *Surface) !bool {
-    self.renderer_state.mutex.lock();
-    defer self.renderer_state.mutex.unlock();
+    self.renderer_state.lockDemand();
+    defer self.renderer_state.unlockDemand();
 
     const screen: *terminal.Screen = self.io.terminal.screens.active;
+    if (self.keyboard_copy_cursor) |*cursor| {
+        const screens = &self.io.terminal.screens;
+        if (cursor.screen_key == screens.active_key and
+            cursor.screen_generation == screens.generation(screens.active_key))
+            cursor.selection = null;
+    }
     if (screen.selection == null) return false;
     try self.setSelection(null);
     screen.dirty.selection = true;
@@ -2495,6 +2517,645 @@ fn canonicalSelectionCellViewport(
     if (point.viewport.x >= screen.pages.cols or
         point.viewport.y >= screen.pages.rows) return null;
     return cell;
+}
+
+pub const KeyboardSelectionMove = enum(c_int) {
+    left,
+    right,
+    up,
+    down,
+    page_up,
+    page_down,
+    home,
+    end,
+    beginning_of_line,
+    end_of_line,
+};
+
+pub const KeyboardCopyScroll = enum(c_int) {
+    lines,
+    pages,
+    half_pages,
+    top,
+    bottom,
+    prompts,
+};
+
+pub const KeyboardCopySelectionKind = enum(c_int) {
+    none,
+    character,
+    line,
+};
+
+const KeyboardSelectionCell = struct {
+    pin: terminal.Pin,
+    width_cells: u16,
+};
+
+fn canonicalKeyboardSelectionResult(
+    pin: terminal.Pin,
+) ?terminal.Selection.CanonicalCell {
+    if (pin.rowAndCell().cell.wide != .spacer_head)
+        return terminal.Selection.canonicalCell(pin);
+
+    // A spacer head represents unused space before a wide glyph wraps to the
+    // next physical row. Vertical and row-edge movement must remain on the
+    // requested row, so resolve to the preceding displayed glyph.
+    if (pin.x == 0) return null;
+    const cell = terminal.Selection.canonicalCell(pin.left(1)) orelse
+        return null;
+    if (cell.pin.node != pin.node or cell.pin.y != pin.y) return null;
+    return cell;
+}
+
+fn keyboardSelectionHorizontalStep(
+    cell: terminal.Selection.CanonicalCell,
+    movement: KeyboardSelectionMove,
+) ?terminal.Selection.CanonicalCell {
+    return switch (movement) {
+        .left => left: {
+            if (cell.pin.x > 0)
+                break :left terminal.Selection.canonicalCell(cell.pin.left(1));
+
+            // A wide glyph at column zero can be preceded by a spacer head on
+            // the previous physical row. Cross only that wrapped-glyph
+            // boundary; ordinary row starts still clamp.
+            var previous_row = cell.pin.up(1) orelse return null;
+            previous_row.x = previous_row.node.cols() - 1;
+            if (previous_row.rowAndCell().cell.wide != .spacer_head)
+                return null;
+            const wrapped = terminal.Selection.canonicalCell(previous_row) orelse
+                return null;
+            if (!wrapped.pin.eql(cell.pin)) return null;
+            break :left canonicalKeyboardSelectionResult(previous_row);
+        },
+        .right => right: {
+            const next_x = @as(usize, cell.pin.x) + cell.width_cells;
+            if (next_x >= cell.pin.node.cols()) return null;
+            break :right terminal.Selection.canonicalCell(
+                cell.pin.right(cell.width_cells),
+            );
+        },
+        else => unreachable,
+    };
+}
+
+fn keyboardSelectionPin(
+    screen: *terminal.Screen,
+    start_pin: terminal.Pin,
+    movement: KeyboardSelectionMove,
+    count: u16,
+) ?KeyboardSelectionCell {
+    if (screen.pages.cols == 0 or screen.pages.rows == 0 or count == 0)
+        return null;
+
+    var result = start_pin;
+    const steps: usize = count;
+
+    switch (movement) {
+        .left, .right => {
+            var remaining = steps;
+            var cell = terminal.Selection.canonicalCell(result) orelse
+                return null;
+            if (result.rowAndCell().cell.wide == .spacer_head) {
+                remaining -= 1;
+                cell = if (movement == .left)
+                    canonicalKeyboardSelectionResult(result) orelse return null
+                else
+                    terminal.Selection.canonicalCell(result) orelse return null;
+            }
+
+            for (0..remaining) |_| {
+                const next = keyboardSelectionHorizontalStep(
+                    cell,
+                    movement,
+                ) orelse break;
+                if (next.pin.eql(cell.pin)) break;
+                cell = next;
+            }
+            result = cell.pin;
+        },
+        .up, .down, .page_up, .page_down => {
+            const row_multiplier: usize = switch (movement) {
+                .page_up, .page_down => screen.pages.rows,
+                else => 1,
+            };
+            const distance = std.math.mul(usize, steps, row_multiplier) catch
+                std.math.maxInt(usize);
+            result = switch (movement) {
+                .up, .page_up => switch (result.upOverflow(distance)) {
+                    .offset => |pin| pin,
+                    .overflow => |overflow| overflow.end,
+                },
+                .down, .page_down => switch (result.downOverflow(distance)) {
+                    .offset => |pin| pin,
+                    .overflow => |overflow| overflow.end,
+                },
+                else => unreachable,
+            };
+        },
+        .home => result = screen.pages.getTopLeft(.screen),
+        .end => result = screen.pages.getBottomRight(.screen) orelse return null,
+        .beginning_of_line => result.x = 0,
+        .end_of_line => result.x = result.node.cols() - 1,
+    }
+
+    result.x = @min(result.x, result.node.cols() - 1);
+    const cell = canonicalKeyboardSelectionResult(result) orelse return null;
+    return .{ .pin = cell.pin, .width_cells = cell.width_cells };
+}
+
+fn scrollPinIntoViewport(
+    screen: *terminal.Screen,
+    pin: terminal.Pin,
+) void {
+    const viewport_tl = screen.pages.getTopLeft(.viewport);
+    const viewport_br = screen.pages.getBottomRight(.viewport) orelse return;
+    if (pin.isBetween(viewport_tl, viewport_br)) return;
+
+    const target = if (pin.before(viewport_tl))
+        pin
+    else
+        pin.up(screen.pages.rows - 1) orelse pin;
+    screen.scroll(.{ .pin = target });
+}
+
+const KeyboardCopyCursorResolution = struct {
+    cell: KeyboardSelectionCell,
+    changed: bool,
+};
+
+fn keyboardSelectionCellOnViewportRow(
+    screen: *terminal.Screen,
+    row: usize,
+    preferred_column: usize,
+) ?terminal.Selection.CanonicalCell {
+    if (row >= screen.pages.rows or screen.pages.cols == 0) return null;
+    const preferred = @min(preferred_column, screen.pages.cols - 1);
+
+    var x = preferred + 1;
+    while (x > 0) {
+        x -= 1;
+        const pin = viewportPin(screen, @intCast(x), @intCast(row)) orelse
+            continue;
+        const cell = canonicalKeyboardSelectionResult(pin) orelse continue;
+        const point = screen.pages.pointFromPin(.viewport, cell.pin) orelse
+            continue;
+        if (point.viewport.y == row and
+            point.viewport.x < screen.pages.cols) return cell;
+    }
+
+    x = preferred + 1;
+    while (x < screen.pages.cols) : (x += 1) {
+        const pin = viewportPin(screen, @intCast(x), @intCast(row)) orelse
+            continue;
+        const cell = canonicalKeyboardSelectionResult(pin) orelse continue;
+        const point = screen.pages.pointFromPin(.viewport, cell.pin) orelse
+            continue;
+        if (point.viewport.y == row and
+            point.viewport.x < screen.pages.cols) return cell;
+    }
+    return null;
+}
+
+fn keyboardCopyCursorInitialCell(
+    screen: *terminal.Screen,
+) ?terminal.Selection.CanonicalCell {
+    if (terminal.Selection.canonicalCell(screen.cursor.page_pin.*)) |cell| {
+        if (screen.pages.pointFromPin(.viewport, cell.pin)) |point| {
+            if (point.viewport.x < screen.pages.cols and
+                point.viewport.y < screen.pages.rows) return cell;
+        }
+    }
+
+    var row = screen.pages.rows;
+    while (row > 0) {
+        row -= 1;
+        if (keyboardSelectionCellOnViewportRow(screen, row, 0)) |cell|
+            return cell;
+    }
+    return null;
+}
+
+fn untrackKeyboardCopyCursor(
+    screens: *terminal.ScreenSet,
+    cursor: KeyboardCopyCursor,
+) bool {
+    if (screens.generation(cursor.screen_key) != cursor.screen_generation)
+        return false;
+    var cleared_selection = false;
+    if (screens.get(cursor.screen_key)) |screen| {
+        if (cursor.selection) |state| {
+            if (screen.selection) |selection| {
+                if (screen.selection_activity == state.activity and
+                    selection.linewise == state.linewise and
+                    !selection.rectangle)
+                {
+                    screen.clearSelection();
+                    cleared_selection = true;
+                }
+            }
+        }
+        screen.pages.untrackPin(cursor.pin);
+    }
+    return cleared_selection;
+}
+
+fn clearKeyboardCopyCursor(self: *Surface) bool {
+    var cleared_selection = false;
+    if (self.keyboard_copy_cursor) |cursor|
+        cleared_selection = untrackKeyboardCopyCursor(
+            &self.io.terminal.screens,
+            cursor,
+        );
+    self.keyboard_copy_cursor = null;
+    return cleared_selection;
+}
+
+fn initializeKeyboardCopyCursor(
+    self: *Surface,
+    screen: *terminal.Screen,
+) !?*KeyboardCopyCursor {
+    const cell = keyboardCopyCursorInitialCell(screen) orelse return null;
+    const tracked = try screen.pages.trackPin(cell.pin);
+    self.keyboard_copy_cursor = .{
+        .screen_key = self.io.terminal.screens.active_key,
+        .screen_generation = self.io.terminal.screens.generation(
+            self.io.terminal.screens.active_key,
+        ),
+        .pin = tracked,
+    };
+    return if (self.keyboard_copy_cursor) |*cursor| cursor else null;
+}
+
+fn ensureKeyboardCopyCursor(
+    self: *Surface,
+    screen: *terminal.Screen,
+) !?*KeyboardCopyCursor {
+    const cursor = if (self.keyboard_copy_cursor) |*value| value else return null;
+    const screens = &self.io.terminal.screens;
+    if (cursor.screen_key == screens.active_key and
+        cursor.screen_generation == screens.generation(screens.active_key))
+        return cursor;
+
+    const cleared_selection = self.clearKeyboardCopyCursor();
+    const next = try self.initializeKeyboardCopyCursor(screen);
+    if (cleared_selection) try self.queueRender();
+    return next;
+}
+
+fn resolveTrackedKeyboardCopyCursor(
+    screen: *terminal.Screen,
+    tracked_pin: *terminal.Pin,
+) ?KeyboardCopyCursorResolution {
+    const original = tracked_pin.*;
+    var cell: terminal.Selection.CanonicalCell = cell: {
+        if (!original.garbage) {
+            if (terminal.Selection.canonicalCell(original)) |candidate| {
+                if (screen.pages.pointFromPin(.viewport, candidate.pin)) |point| {
+                    if (point.viewport.x < screen.pages.cols and
+                        point.viewport.y < screen.pages.rows)
+                        break :cell candidate;
+                }
+            }
+
+            if (screen.pages.pointFromPin(.viewport, original)) |point| {
+                if (point.viewport.x < screen.pages.cols and
+                    point.viewport.y < screen.pages.rows)
+                    break :cell keyboardSelectionCellOnViewportRow(
+                        screen,
+                        point.viewport.y,
+                        point.viewport.x,
+                    ) orelse return null;
+            }
+        }
+
+        const viewport_tl = screen.pages.getTopLeft(.viewport);
+        const above = original.garbage or original.before(viewport_tl);
+        const preferred_column = @min(original.x, screen.pages.cols - 1);
+        var row = if (above) @as(usize, 0) else screen.pages.rows - 1;
+        while (true) {
+            if (keyboardSelectionCellOnViewportRow(
+                screen,
+                row,
+                preferred_column,
+            )) |candidate| break :cell candidate;
+            if (above) {
+                if (row + 1 >= screen.pages.rows) return null;
+                row += 1;
+            } else {
+                if (row == 0) return null;
+                row -= 1;
+            }
+        }
+    };
+
+    const changed = !cell.pin.eql(original);
+    if (changed) tracked_pin.* = cell.pin;
+
+    // Re-read after assigning the tracked pin so callers always receive the
+    // cursor's authoritative value.
+    cell = terminal.Selection.canonicalCell(tracked_pin.*) orelse return null;
+    return .{
+        .cell = .{ .pin = cell.pin, .width_cells = cell.width_cells },
+        .changed = changed,
+    };
+}
+
+fn validateKeyboardCopySelection(
+    cursor: *KeyboardCopyCursor,
+    screen: *terminal.Screen,
+) ?bool {
+    const state = cursor.selection orelse return null;
+    const selection = screen.selection orelse {
+        cursor.selection = null;
+        return null;
+    };
+    if (screen.selection_activity != state.activity or
+        selection.linewise != state.linewise or
+        selection.rectangle)
+    {
+        cursor.selection = null;
+        return null;
+    }
+    return state.linewise;
+}
+
+fn resolveKeyboardCopyCursor(
+    self: *Surface,
+    screen: *terminal.Screen,
+) !?KeyboardCopyCursorResolution {
+    const cursor = try self.ensureKeyboardCopyCursor(screen) orelse return null;
+    const resolution = resolveTrackedKeyboardCopyCursor(
+        screen,
+        cursor.pin,
+    ) orelse return null;
+    if (validateKeyboardCopySelection(cursor, screen)) |linewise| {
+        if (resolution.changed) {
+            _ = screen.setSelectionEndpoint(resolution.cell.pin, linewise);
+            cursor.selection.?.activity = screen.selection_activity;
+        }
+    }
+
+    return resolution;
+}
+
+fn writeKeyboardCopyCursorViewport(
+    screen: *terminal.Screen,
+    resolution: KeyboardCopyCursorResolution,
+    resolved_column: *u16,
+    resolved_row: *u16,
+    width_cells: *u16,
+) bool {
+    const point = screen.pages.pointFromPin(
+        .viewport,
+        resolution.cell.pin,
+    ) orelse return false;
+    if (point.viewport.x >= screen.pages.cols or
+        point.viewport.y >= screen.pages.rows) return false;
+
+    resolved_column.* = @intCast(point.viewport.x);
+    resolved_row.* = @intCast(point.viewport.y);
+    width_cells.* = resolution.cell.width_cells;
+    return true;
+}
+
+/// Start or stop Ghostty's tracked keyboard-copy cursor.
+pub fn keyboardCopyCursorSet(
+    self: *Surface,
+    active: bool,
+    resolved_column: *u16,
+    resolved_row: *u16,
+    width_cells: *u16,
+) !bool {
+    self.renderer_state.lockDemand();
+    defer self.renderer_state.unlockDemand();
+
+    if (!active) {
+        if (self.clearKeyboardCopyCursor()) try self.queueRender();
+        resolved_column.* = 0;
+        resolved_row.* = 0;
+        width_cells.* = 0;
+        return true;
+    }
+
+    if (self.clearKeyboardCopyCursor()) try self.queueRender();
+    const screen: *terminal.Screen = self.io.terminal.screens.active;
+    try self.setSelection(null);
+    _ = try self.initializeKeyboardCopyCursor(screen) orelse return false;
+    const resolution = try self.resolveKeyboardCopyCursor(screen) orelse
+        return false;
+    return writeKeyboardCopyCursorViewport(
+        screen,
+        resolution,
+        resolved_column,
+        resolved_row,
+        width_cells,
+    );
+}
+
+/// Return the tracked keyboard-copy cursor in the current viewport.
+pub fn keyboardCopyCursorViewport(
+    self: *Surface,
+    resolved_column: *u16,
+    resolved_row: *u16,
+    width_cells: *u16,
+) !bool {
+    self.renderer_state.lockDemand();
+    defer self.renderer_state.unlockDemand();
+
+    const screen: *terminal.Screen = self.io.terminal.screens.active;
+    const resolution = try self.resolveKeyboardCopyCursor(screen) orelse
+        return false;
+    if (resolution.changed) try self.queueRender();
+    return writeKeyboardCopyCursorViewport(
+        screen,
+        resolution,
+        resolved_column,
+        resolved_row,
+        width_cells,
+    );
+}
+
+/// Return the kind of selection still owned by keyboard copy mode.
+pub fn keyboardCopySelectionKind(
+    self: *Surface,
+) !KeyboardCopySelectionKind {
+    self.renderer_state.lockDemand();
+    defer self.renderer_state.unlockDemand();
+
+    const screen: *terminal.Screen = self.io.terminal.screens.active;
+    const cursor = try self.ensureKeyboardCopyCursor(screen) orelse
+        return .none;
+    const linewise = validateKeyboardCopySelection(cursor, screen) orelse
+        return .none;
+    return if (linewise) .line else .character;
+}
+
+/// Start a characterwise or linewise selection at the tracked copy cursor.
+pub fn keyboardCopySelectionStart(
+    self: *Surface,
+    linewise: bool,
+    line_count: u16,
+    resolved_column: *u16,
+    resolved_row: *u16,
+    width_cells: *u16,
+) !bool {
+    self.renderer_state.lockDemand();
+    defer self.renderer_state.unlockDemand();
+
+    if (line_count == 0) return false;
+    const screen: *terminal.Screen = self.io.terminal.screens.active;
+    const start = try self.resolveKeyboardCopyCursor(screen) orelse
+        return false;
+    const cursor = try self.ensureKeyboardCopyCursor(screen) orelse return false;
+    var endpoint = start.cell;
+
+    if (linewise) {
+        if (line_count > 1) {
+            endpoint = keyboardSelectionPin(
+                screen,
+                start.cell.pin,
+                .down,
+                line_count - 1,
+            ) orelse return false;
+        }
+        try self.setSelection(terminal.Selection.initLinewise(
+            start.cell.pin,
+            endpoint.pin,
+        ));
+        cursor.pin.* = endpoint.pin;
+        scrollPinIntoViewport(screen, endpoint.pin);
+    } else {
+        try self.setSelection(terminal.Selection.init(
+            start.cell.pin,
+            start.cell.pin,
+            false,
+        ));
+    }
+    cursor.selection = .{
+        .linewise = linewise,
+        .activity = screen.selection_activity,
+    };
+
+    const resolution: KeyboardCopyCursorResolution = .{
+        .cell = endpoint,
+        .changed = !endpoint.pin.eql(start.cell.pin),
+    };
+    return writeKeyboardCopyCursorViewport(
+        screen,
+        resolution,
+        resolved_column,
+        resolved_row,
+        width_cells,
+    );
+}
+
+/// Move the tracked copy-mode cursor and optional selection endpoint.
+pub fn keyboardSelectionMove(
+    self: *Surface,
+    movement: KeyboardSelectionMove,
+    count: u16,
+    extend_selection: bool,
+    linewise: bool,
+    resolved_column: *u16,
+    resolved_row: *u16,
+    width_cells: *u16,
+) !bool {
+    self.renderer_state.lockDemand();
+    defer self.renderer_state.unlockDemand();
+
+    const screen: *terminal.Screen = self.io.terminal.screens.active;
+    const start = try self.resolveKeyboardCopyCursor(screen) orelse
+        return false;
+    const cursor = try self.ensureKeyboardCopyCursor(screen) orelse return false;
+    if (extend_selection) {
+        const owned_linewise = validateKeyboardCopySelection(
+            cursor,
+            screen,
+        ) orelse return false;
+        if (owned_linewise != linewise) return false;
+    } else if (validateKeyboardCopySelection(cursor, screen) != null) {
+        return false;
+    }
+
+    const moved = keyboardSelectionPin(
+        screen,
+        start.cell.pin,
+        movement,
+        count,
+    ) orelse return false;
+    cursor.pin.* = moved.pin;
+    scrollPinIntoViewport(screen, moved.pin);
+    const resolution = try self.resolveKeyboardCopyCursor(screen) orelse
+        return false;
+    if (extend_selection) {
+        if (!screen.setSelectionEndpoint(resolution.cell.pin, linewise))
+            return false;
+        cursor.selection.?.activity = screen.selection_activity;
+    }
+
+    try self.queueRender();
+    return writeKeyboardCopyCursorViewport(
+        screen,
+        resolution,
+        resolved_column,
+        resolved_row,
+        width_cells,
+    );
+}
+
+/// Apply a copy-mode viewport mutation while holding renderer state.
+pub fn keyboardCopyScroll(
+    self: *Surface,
+    action: KeyboardCopyScroll,
+    amount: i32,
+    resolved_column: *u16,
+    resolved_row: *u16,
+    width_cells: *u16,
+) !bool {
+    self.renderer_state.lockDemand();
+    defer self.renderer_state.unlockDemand();
+
+    const screen: *terminal.Screen = self.io.terminal.screens.active;
+    _ = try self.resolveKeyboardCopyCursor(screen) orelse return false;
+    const rows: i64 = screen.pages.rows;
+    const signed_amount: i64 = amount;
+    const line_delta: i64 = switch (action) {
+        .lines => signed_amount,
+        .pages => std.math.mul(i64, signed_amount, rows) catch
+            if (signed_amount < 0) std.math.minInt(i64) else std.math.maxInt(i64),
+        .half_pages => std.math.mul(
+            i64,
+            signed_amount,
+            @divTrunc(rows, 2),
+        ) catch if (signed_amount < 0) std.math.minInt(i64) else std.math.maxInt(i64),
+        .prompts => signed_amount,
+        .top, .bottom => 0,
+    };
+    const delta = std.math.cast(isize, line_delta) orelse
+        if (line_delta < 0)
+            @as(isize, std.math.minInt(isize))
+        else
+            @as(isize, std.math.maxInt(isize));
+
+    switch (action) {
+        .lines, .pages, .half_pages => screen.scroll(.{ .delta_row = delta }),
+        .top => screen.scroll(.{ .top = {} }),
+        .bottom => screen.scroll(.{ .active = {} }),
+        .prompts => screen.scroll(.{ .delta_prompt = delta }),
+    }
+
+    const resolution = try self.resolveKeyboardCopyCursor(screen) orelse
+        return false;
+    try self.queueRender();
+    return writeKeyboardCopyCursorViewport(
+        screen,
+        resolution,
+        resolved_column,
+        resolved_row,
+        width_cells,
+    );
 }
 
 /// Select one visible cell using Ghostty's tracked terminal coordinates.
@@ -2937,8 +3598,18 @@ fn copySelectionToClipboards(
 ///
 /// This must be called with the renderer mutex held.
 fn setSelection(self: *Surface, sel_: ?terminal.Selection) !void {
+    var invalidate_keyboard_selection = false;
+    if (self.keyboard_copy_cursor) |*cursor| {
+        const screens = &self.io.terminal.screens;
+        if (cursor.screen_key == screens.active_key and
+            cursor.screen_generation == screens.generation(screens.active_key))
+            invalidate_keyboard_selection = true;
+    }
     const activity = self.io.terminal.screens.active.selection_activity;
     try self.io.terminal.screens.active.select(sel_);
+    if (invalidate_keyboard_selection) {
+        if (self.keyboard_copy_cursor) |*cursor| cursor.selection = null;
+    }
 
     // Some selection callers return without otherwise scheduling a render.
     // Always wake the renderer after a genuine transition so it can deliver

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -2850,7 +2850,7 @@ fn resolveTrackedKeyboardCopyCursor(
         }
     };
 
-    const changed = !cell.pin.eql(original);
+    const changed = original.garbage or !cell.pin.eql(original);
     if (changed) tracked_pin.* = cell.pin;
 
     // Re-read after assigning the tracked pin so callers always receive the

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -2602,6 +2602,119 @@ pub const CAPI = struct {
         return surface.core_surface.selectionEndpointViewport(column, row);
     }
 
+    /// Start or stop Ghostty's tracked keyboard-copy cursor.
+    export fn ghostty_surface_keyboard_copy_cursor_set(
+        surface: *Surface,
+        active: bool,
+        resolved_column: *u16,
+        resolved_row: *u16,
+        width_cells: *u16,
+    ) bool {
+        return surface.core_surface.keyboardCopyCursorSet(
+            active,
+            resolved_column,
+            resolved_row,
+            width_cells,
+        ) catch |err| {
+            log.warn("error setting keyboard copy cursor err={}", .{err});
+            return false;
+        };
+    }
+
+    /// Query Ghostty's tracked keyboard-copy cursor in viewport cells.
+    export fn ghostty_surface_keyboard_copy_cursor_viewport(
+        surface: *Surface,
+        resolved_column: *u16,
+        resolved_row: *u16,
+        width_cells: *u16,
+    ) bool {
+        return surface.core_surface.keyboardCopyCursorViewport(
+            resolved_column,
+            resolved_row,
+            width_cells,
+        ) catch |err| {
+            log.warn("error querying keyboard copy cursor err={}", .{err});
+            return false;
+        };
+    }
+
+    /// Return the selection still owned by keyboard copy mode.
+    export fn ghostty_surface_keyboard_copy_selection_kind(
+        surface: *Surface,
+    ) CoreSurface.KeyboardCopySelectionKind {
+        return surface.core_surface.keyboardCopySelectionKind() catch |err| {
+            log.warn("error querying keyboard copy selection err={}", .{err});
+            return .none;
+        };
+    }
+
+    /// Start a selection at Ghostty's tracked keyboard-copy cursor.
+    export fn ghostty_surface_keyboard_copy_selection_start(
+        surface: *Surface,
+        linewise: bool,
+        line_count: u16,
+        resolved_column: *u16,
+        resolved_row: *u16,
+        width_cells: *u16,
+    ) bool {
+        return surface.core_surface.keyboardCopySelectionStart(
+            linewise,
+            line_count,
+            resolved_column,
+            resolved_row,
+            width_cells,
+        ) catch |err| {
+            log.warn("error starting keyboard copy selection err={}", .{err});
+            return false;
+        };
+    }
+
+    /// Move the tracked copy cursor and optional selection endpoint.
+    export fn ghostty_surface_keyboard_selection_move(
+        surface: *Surface,
+        movement: CoreSurface.KeyboardSelectionMove,
+        count: u16,
+        extend_selection: bool,
+        linewise: bool,
+        resolved_column: *u16,
+        resolved_row: *u16,
+        width_cells: *u16,
+    ) bool {
+        return surface.core_surface.keyboardSelectionMove(
+            movement,
+            count,
+            extend_selection,
+            linewise,
+            resolved_column,
+            resolved_row,
+            width_cells,
+        ) catch |err| {
+            log.warn("error moving keyboard selection err={}", .{err});
+            return false;
+        };
+    }
+
+    /// Apply a synchronous copy-mode viewport mutation.
+    export fn ghostty_surface_keyboard_copy_scroll(
+        surface: *Surface,
+        action: CoreSurface.KeyboardCopyScroll,
+        amount: i32,
+        resolved_column: *u16,
+        resolved_row: *u16,
+        width_cells: *u16,
+    ) bool {
+        return surface.core_surface.keyboardCopyScroll(
+            action,
+            amount,
+            resolved_column,
+            resolved_row,
+            width_cells,
+        ) catch |err| {
+            log.warn("error scrolling keyboard copy viewport err={}", .{err});
+            return false;
+        };
+    }
+
     /// Select inclusive absolute screen rows without writing clipboards
     /// (cmux-specific).
     export fn ghostty_surface_select_screen_rows(
@@ -2640,6 +2753,22 @@ pub const CAPI = struct {
 
         // Read the text from the selection.
         return readTextLocked(surface, core_sel, result);
+    }
+
+    /// Read clipboard-formatted plain text from the active selection while
+    /// bounding both temporary and returned allocation size.
+    export fn ghostty_surface_read_selection_clipboard_text(
+        surface: *Surface,
+        max_bytes: usize,
+        result: *Text,
+    ) bool {
+        const core_surface = &surface.core_surface;
+        core_surface.renderer_state.lockDemand();
+        defer core_surface.renderer_state.unlockDemand();
+
+        const core_sel = core_surface.io.terminal.screens.active.selection orelse
+            return false;
+        return readClipboardTextLocked(surface, core_sel, max_bytes, result);
     }
 
     /// Read some arbitrary text from the surface.


### PR DESCRIPTION
Follow-up to https://github.com/manaflow-ai/ghostty/pull/154.

Ghostty now owns the keyboard copy cursor as a tracked terminal pin, owns selection identity, applies counted movement and scrolling under one terminal lock, and exposes authoritative cursor and selection state to embedded hosts. Copy reads are bounded to 2 MiB.

Tests cover wide glyphs, wrapped rows, output drift, reset recovery, alternate-screen teardown, foreign selection replacement, offscreen movement, and history-spanning counts.

Verification:
- zig build test -Dtest-filter=Surface: -j1
- xcrun clang -fsyntax-only -x c include/ghostty.h

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/156"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787759588&installation_model_id=21920&pr_number=156&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F156&signature=9b140826a796dc5bdad1deab0b07892c38deeaab2a5c8cc5c215bf5395a16363"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes keyboard copy navigation atomic by tracking the cursor and selection inside Ghostty and batching movement/scroll under one renderer lock. Embedded hosts can query authoritative cursor/selection; clipboard text reads are bounded to 2 MiB.

- New Features
  - Ghostty-owned keyboard copy cursor and selection (tracked pins).
  - New C API for copy mode: `ghostty_surface_keyboard_copy_cursor_set`, `ghostty_surface_keyboard_copy_cursor_viewport`, `ghostty_surface_keyboard_copy_selection_kind`, `ghostty_surface_keyboard_copy_selection_start`, `ghostty_surface_keyboard_selection_move`, `ghostty_surface_keyboard_copy_scroll`, `ghostty_surface_read_selection_clipboard_text`.
  - Navigation enums: `ghostty_keyboard_selection_move_e`, `ghostty_keyboard_copy_scroll_e`, `ghostty_keyboard_copy_selection_e`.

- Bug Fixes
  - Atomic movement/scroll prevents cursor/selection desync.
  - Correct handling for wide glyphs, wrapped rows, offscreen movement, and history-spanning counts.
  - Resilient recovery on reset and alternate-screen teardown; owned selections cleared when cursor is untracked.

<sup>Written for commit a8e997f6bc6a973f227715cbff834140f317318b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/156?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyboard copy mode with cursor navigation, viewport scrolling, and character- or line-based selection.
  * Added support for extending selections with directional and counted movement.
  * Added an API for reading selected text as clipboard-formatted plain text.
* **Bug Fixes**
  * Improved selection handling around wrapped lines and wide characters.
  * Preserved cursor and selection consistency during terminal scrolling and selection changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->