### PR TITLE
fix: bound copy work and expose runtime cursor style

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -670,6 +670,15 @@ typedef enum {
   GHOSTTY_KEYBOARD_COPY_SELECTION_LINE,
 } ghostty_keyboard_copy_selection_e;
 
+typedef struct {
+  uint16_t column;
+  uint16_t row;
+  uint16_t width_cells;
+  uint8_t color_red;
+  uint8_t color_green;
+  uint8_t color_blue;
+} ghostty_keyboard_copy_cursor_s;
+
 // Config types
 
 // config.Path
@@ -1523,6 +1532,9 @@ GHOSTTY_API bool ghostty_surface_keyboard_copy_cursor_viewport(
     uint16_t*,
     uint16_t*,
     uint16_t*);
+GHOSTTY_API bool ghostty_surface_keyboard_copy_cursor_snapshot(
+    ghostty_surface_t,
+    ghostty_keyboard_copy_cursor_s*);
 GHOSTTY_API ghostty_keyboard_copy_selection_e
 ghostty_surface_keyboard_copy_selection_kind(ghostty_surface_t);
 GHOSTTY_API bool ghostty_surface_keyboard_copy_selection_start(

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -415,8 +415,6 @@ const DerivedConfig = struct {
     middle_click_action: configpkg.MiddleClickAction,
     confirm_close_surface: configpkg.ConfirmCloseSurface,
     cursor_click_to_move: bool,
-    cursor_color: ?configpkg.Config.TerminalColor,
-    bold_color: ?terminal.Style.BoldColor,
     desktop_notifications: bool,
     font: font.SharedGridSet.DerivedConfig,
     mouse_interval: u64,
@@ -502,11 +500,6 @@ const DerivedConfig = struct {
             .middle_click_action = config.@"middle-click-action",
             .confirm_close_surface = config.@"confirm-close-surface",
             .cursor_click_to_move = config.@"cursor-click-to-move",
-            .cursor_color = config.@"cursor-color",
-            .bold_color = if (config.@"bold-color") |color|
-                color.toTerminal()
-            else
-                null,
             .desktop_notifications = config.@"desktop-notifications",
             .font = try font.SharedGridSet.DerivedConfig.init(alloc, config),
             .mouse_interval = config.@"click-repeat-interval" * 1_000_000, // 500ms
@@ -3003,11 +2996,11 @@ fn writeKeyboardCopyCursorSnapshot(
         std.mem.swap(terminal.color.RGB, &foreground, &background);
     const color = effectiveKeyboardCopyCursorColor(
         self.io.terminal.colors.cursor.override,
-        self.config.cursor_color,
+        self.io.config.cursor_color,
         foreground,
         background,
         &self.io.terminal.colors.palette.current,
-        self.config.bold_color,
+        self.io.config.bold_color,
         resolution.cell.pin,
     );
     snapshot.* = .{

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -415,6 +415,8 @@ const DerivedConfig = struct {
     middle_click_action: configpkg.MiddleClickAction,
     confirm_close_surface: configpkg.ConfirmCloseSurface,
     cursor_click_to_move: bool,
+    cursor_color: ?configpkg.Config.TerminalColor,
+    bold_color: ?terminal.Style.BoldColor,
     desktop_notifications: bool,
     font: font.SharedGridSet.DerivedConfig,
     mouse_interval: u64,
@@ -500,6 +502,11 @@ const DerivedConfig = struct {
             .middle_click_action = config.@"middle-click-action",
             .confirm_close_surface = config.@"confirm-close-surface",
             .cursor_click_to_move = config.@"cursor-click-to-move",
+            .cursor_color = config.@"cursor-color",
+            .bold_color = if (config.@"bold-color") |color|
+                color.toTerminal()
+            else
+                null,
             .desktop_notifications = config.@"desktop-notifications",
             .font = try font.SharedGridSet.DerivedConfig.init(alloc, config),
             .mouse_interval = config.@"click-repeat-interval" * 1_000_000, // 500ms
@@ -2547,6 +2554,15 @@ pub const KeyboardCopySelectionKind = enum(c_int) {
     line,
 };
 
+pub const KeyboardCopyCursorSnapshot = extern struct {
+    column: u16,
+    row: u16,
+    width_cells: u16,
+    color_red: u8,
+    color_green: u8,
+    color_blue: u8,
+};
+
 const KeyboardSelectionCell = struct {
     pin: terminal.Pin,
     width_cells: u16,
@@ -2920,6 +2936,91 @@ fn writeKeyboardCopyCursorViewport(
     return true;
 }
 
+fn effectiveKeyboardCopyCursorColor(
+    runtime_override: ?terminal.color.RGB,
+    configured: ?configpkg.Config.TerminalColor,
+    foreground: terminal.color.RGB,
+    background: terminal.color.RGB,
+    palette: *const terminal.color.Palette,
+    bold_color: ?terminal.Style.BoldColor,
+    pin: terminal.Pin,
+) terminal.color.RGB {
+    if (runtime_override) |color| return color;
+    const configured_color = configured orelse return foreground;
+    return switch (configured_color) {
+        .color => |color| color.toTerminalRGB(),
+        inline .@"cell-foreground",
+        .@"cell-background",
+        => |_, tag| {
+            const cell = pin.rowAndCell().cell;
+            const style = pin.style(cell);
+            const cell_foreground = style.fg(.{
+                .default = foreground,
+                .palette = palette,
+                .bold = bold_color,
+            });
+            const cell_background = style.bg(
+                cell,
+                palette,
+            ) orelse background;
+            return switch (tag) {
+                .color => unreachable,
+                .@"cell-foreground" => if (style.flags.inverse)
+                    cell_background
+                else
+                    cell_foreground,
+                .@"cell-background" => if (style.flags.inverse)
+                    cell_foreground
+                else
+                    cell_background,
+            };
+        },
+    };
+}
+
+fn writeKeyboardCopyCursorSnapshot(
+    self: *Surface,
+    screen: *terminal.Screen,
+    resolution: KeyboardCopyCursorResolution,
+    snapshot: *KeyboardCopyCursorSnapshot,
+) bool {
+    var column: u16 = 0;
+    var row: u16 = 0;
+    var width_cells: u16 = 0;
+    if (!writeKeyboardCopyCursorViewport(
+        screen,
+        resolution,
+        &column,
+        &row,
+        &width_cells,
+    )) return false;
+
+    var foreground = self.io.terminal.colors.foreground.get() orelse
+        self.io.config.foreground.toTerminalRGB();
+    var background = self.io.terminal.colors.background.get() orelse
+        self.io.config.background.toTerminalRGB();
+    if (self.io.terminal.modes.get(.reverse_colors))
+        std.mem.swap(terminal.color.RGB, &foreground, &background);
+    const color = effectiveKeyboardCopyCursorColor(
+        self.io.terminal.colors.cursor.override,
+        self.config.cursor_color,
+        foreground,
+        background,
+        &self.io.terminal.colors.palette.current,
+        self.config.bold_color,
+        resolution.cell.pin,
+    );
+    snapshot.* = .{
+        .column = column,
+        .row = row,
+        .width_cells = width_cells,
+        .color_red = color.r,
+        .color_green = color.g,
+        .color_blue = color.b,
+    };
+    return true;
+}
+
 /// Start or stop Ghostty's tracked keyboard-copy cursor.
 pub fn keyboardCopyCursorSet(
     self: *Surface,
@@ -2974,6 +3075,26 @@ pub fn keyboardCopyCursorViewport(
         resolved_column,
         resolved_row,
         width_cells,
+    );
+}
+
+/// Return tracked copy cursor geometry and its effective runtime color.
+pub fn keyboardCopyCursorSnapshot(
+    self: *Surface,
+    snapshot: *KeyboardCopyCursorSnapshot,
+) !bool {
+    self.renderer_state.lockDemand();
+    defer self.renderer_state.unlockDemand();
+
+    const screen: *terminal.Screen = self.io.terminal.screens.active;
+    const resolution = try self.resolveKeyboardCopyCursor(screen) orelse
+        return false;
+    if (resolution.changed) try self.queueRender();
+    return writeKeyboardCopyCursorSnapshot(
+        self,
+        screen,
+        resolution,
+        snapshot,
     );
 }
 

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -7899,6 +7899,59 @@ test "Surface: counted horizontal movement crosses multiple wide wraps" {
     try testing.expectEqual(@as(u16, 2), moved.width_cells);
 }
 
+test "Surface: copy cursor color follows runtime and cell semantics" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var t: terminal.Terminal = try .init(alloc, .{ .cols = 4, .rows = 2 });
+    defer t.deinit(alloc);
+    var stream = t.vtStream();
+    defer stream.deinit();
+    stream.nextSlice("\x1b[38;2;10;20;30;48;2;40;50;60mX");
+
+    const screen = t.screens.active;
+    const pin = viewportPin(screen, 0, 0).?;
+    const foreground: terminal.color.RGB = .{ .r = 1, .g = 2, .b = 3 };
+    const background: terminal.color.RGB = .{ .r = 4, .g = 5, .b = 6 };
+
+    try testing.expectEqual(
+        terminal.color.RGB{ .r = 10, .g = 20, .b = 30 },
+        effectiveKeyboardCopyCursorColor(
+            null,
+            .@"cell-foreground",
+            foreground,
+            background,
+            &t.colors.palette.current,
+            null,
+            pin,
+        ),
+    );
+    try testing.expectEqual(
+        terminal.color.RGB{ .r = 40, .g = 50, .b = 60 },
+        effectiveKeyboardCopyCursorColor(
+            null,
+            .@"cell-background",
+            foreground,
+            background,
+            &t.colors.palette.current,
+            null,
+            pin,
+        ),
+    );
+    try testing.expectEqual(
+        terminal.color.RGB{ .r = 90, .g = 80, .b = 70 },
+        effectiveKeyboardCopyCursorColor(
+            .{ .r = 90, .g = 80, .b = 70 },
+            .@"cell-foreground",
+            foreground,
+            background,
+            &t.colors.palette.current,
+            null,
+            pin,
+        ),
+    );
+}
+
 test "Surface: tracked copy cursor is not reinterpreted after viewport drift" {
     const testing = std.testing;
     const alloc = testing.allocator;

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -2638,6 +2638,19 @@ pub const CAPI = struct {
         };
     }
 
+    /// Query tracked copy cursor geometry and effective runtime color.
+    export fn ghostty_surface_keyboard_copy_cursor_snapshot(
+        surface: *Surface,
+        snapshot: *CoreSurface.KeyboardCopyCursorSnapshot,
+    ) bool {
+        return surface.core_surface.keyboardCopyCursorSnapshot(
+            snapshot,
+        ) catch |err| {
+            log.warn("error querying keyboard copy cursor snapshot err={}", .{err});
+            return false;
+        };
+    }
+
     /// Return the selection still owned by keyboard copy mode.
     export fn ghostty_surface_keyboard_copy_selection_kind(
         surface: *Surface,
@@ -2958,6 +2971,19 @@ pub const CAPI = struct {
         result: *Text,
     ) bool {
         const core_surface = &surface.core_surface;
+        const screen = core_surface.io.terminal.screens.active;
+        const max_work_cells = max_bytes / 4;
+        if (!selectionWithinClipboardWorkBudget(
+            screen,
+            core_sel,
+            max_work_cells,
+        )) {
+            log.warn(
+                "clipboard selection exceeds work budget max_cells={}",
+                .{max_work_cells},
+            );
+            return false;
+        }
         const opts: terminal.formatter.Options = .{
             .emit = .plain,
             .unwrap = true,
@@ -2969,7 +2995,7 @@ pub const CAPI = struct {
         };
 
         var formatter: terminal.formatter.ScreenFormatter = .init(
-            core_surface.io.terminal.screens.active,
+            screen,
             opts,
         );
         formatter.content = .{ .selection = core_sel };
@@ -2999,6 +3025,29 @@ pub const CAPI = struct {
             .text_len = formatted.len,
         };
 
+        return true;
+    }
+
+    fn selectionWithinClipboardWorkBudget(
+        screen: *const terminal.Screen,
+        selection: terminal.Selection,
+        max_cells: usize,
+    ) bool {
+        if (max_cells == 0) return false;
+        const top_left = selection.topLeft(screen);
+        const bottom_right = selection.bottomRight(screen);
+        var remaining = max_cells;
+        var iterator = top_left.pageIterator(.right_down, bottom_right);
+        while (iterator.next()) |chunk| {
+            const row_count = chunk.end - chunk.start;
+            const cell_count = std.math.mul(
+                usize,
+                row_count,
+                chunk.node.cols(),
+            ) catch return false;
+            if (cell_count > remaining) return false;
+            remaining -= cell_count;
+        }
         return true;
     }
 

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -4710,6 +4710,36 @@ test "output sequence publishes only with successful VT tail snapshot" {
     try std.testing.expectEqual(@as(u64, 42), next_sequence);
 }
 
+test "clipboard selection work budget rejects blank history" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    var term = try terminal.Terminal.init(alloc, .{
+        .cols = 4,
+        .rows = 2,
+    });
+    defer term.deinit(alloc);
+
+    var stream = term.vtStream();
+    defer stream.deinit();
+    stream.nextSlice("\r\n\r\n\r\n\r\n");
+
+    const screen = term.screens.active;
+    const selection = terminal.Selection.initLinewise(
+        screen.pages.getTopLeft(.screen),
+        screen.pages.getBottomRight(.screen).?,
+    );
+    try testing.expect(!CAPI.selectionWithinClipboardWorkBudget(
+        screen,
+        selection,
+        8,
+    ));
+    try testing.expect(CAPI.selectionWithinClipboardWorkBudget(
+        screen,
+        selection,
+        64,
+    ));
+}
+
 test "grid metrics reject resize skew and report an offscreen cursor" {
     const testing = std.testing;
     const alloc = testing.allocator;

--- a/src/termio/Termio.zig
+++ b/src/termio/Termio.zig
@@ -245,6 +245,28 @@ pub const DerivedConfig = struct {
     }
 };
 
+test "Termio: theme config updates cursor semantics" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var base_config = try configpkg.Config.default(alloc);
+    defer base_config.deinit();
+    var target = try DerivedConfig.init(alloc, &base_config);
+    defer target.deinit();
+
+    var theme_config = try configpkg.Config.default(alloc);
+    defer theme_config.deinit();
+    theme_config.@"cursor-color" = .@"cell-background";
+    theme_config.@"bold-color" = .bright;
+    var theme = try DerivedConfig.init(alloc, &theme_config);
+    defer theme.deinit();
+
+    updateThemeColorSemantics(&target, &theme);
+
+    try testing.expect(std.meta.eql(theme.cursor_color, target.cursor_color));
+    try testing.expect(std.meta.eql(theme.bold_color, target.bold_color));
+}
+
 /// Initialize the termio state.
 ///
 /// This will also start the child process if the termio is configured

--- a/src/termio/Termio.zig
+++ b/src/termio/Termio.zig
@@ -191,6 +191,7 @@ pub const DerivedConfig = struct {
     cursor_style: terminalpkg.CursorStyle,
     cursor_blink: ?bool,
     cursor_color: ?configpkg.Config.TerminalColor,
+    bold_color: ?terminalpkg.Style.BoldColor,
     foreground: configpkg.Config.Color,
     background: configpkg.Config.Color,
     osc_color_report_format: configpkg.Config.OSCColorReportFormat,
@@ -227,6 +228,10 @@ pub const DerivedConfig = struct {
             .cursor_style = config.@"cursor-style",
             .cursor_blink = config.@"cursor-style-blink",
             .cursor_color = config.@"cursor-color",
+            .bold_color = if (config.@"bold-color") |color|
+                color.toTerminal()
+            else
+                null,
             .foreground = config.foreground,
             .background = config.background,
             .osc_color_report_format = config.@"osc-color-report-format",
@@ -244,6 +249,14 @@ pub const DerivedConfig = struct {
         self.arena.deinit();
     }
 };
+
+fn updateThemeColorSemantics(
+    target: *DerivedConfig,
+    source: *const DerivedConfig,
+) void {
+    target.cursor_color = source.cursor_color;
+    target.bold_color = source.bold_color;
+}
 
 test "Termio: theme config updates cursor semantics" {
     const testing = std.testing;
@@ -607,6 +620,7 @@ pub fn changeColorConfig(self: *Termio, config: *const DerivedConfig) void {
     self.renderer_state.mutex.lock();
     defer self.renderer_state.mutex.unlock();
 
+    updateThemeColorSemantics(&self.config, config);
     self.terminal.colors.palette.changeDefault(config.palette);
     self.terminal.colors.background.default = config.background.toTerminalRGB();
     self.terminal.colors.foreground.default = config.foreground.toTerminalRGB();


### PR DESCRIPTION
Follow-up to https://github.com/manaflow-ai/ghostty/pull/156.

Clipboard formatting now rejects selections whose physical cell work exceeds the input budget before any compressed page is decoded. A new atomic keyboard-copy cursor snapshot returns Ghostty-owned glyph geometry and effective runtime cursor color, including OSC 12 overrides and cell-relative semantics.

The first commit adds failing regressions. The second implements the fixes.

Verification:
- zig build test -Dtest-filter=Surface: -j1
- zig build test -Dtest-filter=clipboard selection work budget rejects blank history -j1
- xcrun clang -fsyntax-only -x c include/ghostty.h

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/157"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787762030&installation_model_id=21920&pr_number=157&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F157&signature=4588637f47710344ee4982aaab919e1f74054e9f93de16ef2f68c36723867b98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds clipboard copy work to avoid heavy history scans and adds a C API to snapshot the keyboard-copy cursor geometry and color, which now updates live with theme changes. This prevents heavy copy operations and lets UIs draw the cursor with the exact runtime color.

- **New Features**
  - Added `ghostty_surface_keyboard_copy_cursor_snapshot` and `ghostty_keyboard_copy_cursor_s` to return cursor column, row, width (cells), and RGB color resolved from runtime override, `cursor-color`, cell fg/bg, bold/inverse, palette, and reverse-colors.
  - `cursor-color` and `bold-color` are now part of the derived config and apply live; the snapshot reflects theme changes without restart.

- **Bug Fixes**
  - Clipboard formatting now rejects selections when physical cell work exceeds the budget (`max_bytes / 4`) before any compressed page is decoded, avoiding expensive history scans and blank-history edge cases.
  - Copy cursor color semantics refresh on config/theme updates so the snapshot always returns the current effective color.

<sup>Written for commit dfa4bcec8d1abdfc4fad2d72cea33677bd78413d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/157?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

