### PR TITLE
lib-vt: expose Kitty replay image ID cursors

### DIFF
--- a/include/ghostty/vt/terminal.h
+++ b/include/ghostty/vt/terminal.h
@@ -294,6 +294,32 @@ typedef enum GHOSTTY_ENUM_TYPED {
 } GhosttyTerminalScreen;
 
 /**
+ * Automatic Kitty image-ID cursors for both terminal screens.
+ *
+ * @ingroup terminal
+ */
+typedef struct {
+  uint32_t primary;
+  uint32_t alternate;
+} GhosttyTerminalKittyImageIdCursors;
+
+/**
+ * Replay and steady-state Kitty image-ID cursors.
+ *
+ * Replay cursors are installed immediately before image replay bytes that can
+ * allocate an automatic ID. Replay prefixes containing terminal reset
+ * sequences must be applied first. Replay cursors can point at IDs already
+ * reserved by in-flight multipart uploads. Next cursors are restored after
+ * replay.
+ *
+ * @ingroup terminal
+ */
+typedef struct {
+  GhosttyTerminalKittyImageIdCursors replay;
+  GhosttyTerminalKittyImageIdCursors next;
+} GhosttyTerminalKittyImageIdCursorState;
+
+/**
  * Visual style of the terminal cursor.
  *
  * @ingroup terminal
@@ -780,6 +806,17 @@ typedef enum GHOSTTY_ENUM_TYPED {
    */
   GHOSTTY_TERMINAL_OPT_KITTY_PLACEMENT_COUNT_LIMIT = 27,
 
+  /**
+   * Restore automatic Kitty image-ID cursors for both terminal screens.
+   *
+   * Every cursor must be nonzero. The alternate screen is initialized only
+   * when its supplied cursors differ from their defaults. A NULL value is
+   * invalid.
+   *
+   * Input type: GhosttyTerminalKittyImageIdCursors*
+   */
+  GHOSTTY_TERMINAL_OPT_KITTY_IMAGE_ID_CURSORS = 28,
+
   GHOSTTY_TERMINAL_OPT_MAX_VALUE = GHOSTTY_ENUM_MAX_VALUE,
 } GhosttyTerminalOption;
 
@@ -1156,6 +1193,16 @@ typedef enum GHOSTTY_ENUM_TYPED {
    * Output type: uint64_t *
    */
   GHOSTTY_TERMINAL_DATA_KITTY_PLACEMENT_COUNT_LIMIT = 38,
+
+  /**
+   * Exact automatic Kitty image-ID replay and steady-state cursors for both
+   * terminal screens. A cursor can identify an occupied image because
+   * allocation probes forward at use time. An uninitialized alternate screen
+   * reports defaults.
+   *
+   * Output type: GhosttyTerminalKittyImageIdCursorState*
+   */
+  GHOSTTY_TERMINAL_DATA_KITTY_IMAGE_ID_CURSORS = 39,
 
   GHOSTTY_TERMINAL_DATA_MAX_VALUE = GHOSTTY_ENUM_MAX_VALUE,
 } GhosttyTerminalData;

--- a/src/terminal/c/terminal.zig
+++ b/src/terminal/c/terminal.zig
@@ -10,6 +10,7 @@ const ScreenSet = @import("../ScreenSet.zig");
 const PageList = @import("../PageList.zig");
 const apc = @import("../apc.zig");
 const kitty = @import("../kitty/key.zig");
+const kitty_graphics_storage = @import("../kitty/graphics_storage.zig");
 const kitty_gfx_c = @import("kitty_graphics.zig");
 const modes = @import("../modes.zig");
 const point = @import("../point.zig");
@@ -375,6 +376,7 @@ pub const Option = enum(c_int) {
     pwd_changed = 25,
     kitty_image_count_limit = 26,
     kitty_placement_count_limit = 27,
+    kitty_image_id_cursors = 28,
 
     /// Input type expected for setting the option.
     pub fn InType(comptime self: Option) type {
@@ -396,6 +398,7 @@ pub const Option = enum(c_int) {
             .kitty_image_count_limit,
             .kitty_placement_count_limit,
             => ?*const u64,
+            .kitty_image_id_cursors => ?*const KittyImageIdCursors,
             .kitty_image_medium_file,
             .kitty_image_medium_temp_file,
             .kitty_image_medium_shared_mem,
@@ -502,6 +505,22 @@ fn setTyped(
                 0;
             if (!wrapper.terminal.setKittyGraphicsPlacementCountLimit(limit)) {
                 return .invalid_value;
+            }
+        },
+        .kitty_image_id_cursors => {
+            if (comptime !build_options.kitty_graphics) return .success;
+            const cursors = (value orelse return .invalid_value).*;
+            if (cursors.primary == 0 or cursors.alternate == 0) {
+                return .invalid_value;
+            }
+            const t = wrapper.terminal;
+            const alternate = t.screens.get(.alternate) orelse if (cursors.alternate != kitty_default_image_id)
+                initAlternateScreen(t) catch return .out_of_memory
+            else
+                null;
+            t.screens.get(.primary).?.kitty_images.next_image_id = cursors.primary;
+            if (alternate) |screen| {
+                screen.kitty_images.next_image_id = cursors.alternate;
             }
         },
         .kitty_image_medium_file,
@@ -689,6 +708,48 @@ pub const KittyGraphics = kitty_gfx_c.KittyGraphics;
 /// C: GhosttyTerminalScreen
 pub const TerminalScreen = ScreenSet.Key;
 
+/// C: GhosttyTerminalKittyImageIdCursors
+pub const KittyImageIdCursors = extern struct {
+    primary: u32,
+    alternate: u32,
+};
+
+/// C: GhosttyTerminalKittyImageIdCursorState
+pub const KittyImageIdCursorState = extern struct {
+    replay: KittyImageIdCursors,
+    next: KittyImageIdCursors,
+};
+
+const kitty_default_image_id = kitty_graphics_storage.default_image_id;
+
+fn initAlternateScreen(t: *ZigTerminal) !*Screen {
+    const primary = t.screens.get(.primary).?;
+    return t.screens.getInit(
+        primary.alloc,
+        .alternate,
+        .{
+            .cols = t.cols,
+            .rows = t.rows,
+            .max_scrollback = 0,
+            .kitty_image_storage_limit = if (comptime build_options.kitty_graphics)
+                primary.kitty_images.total_limit
+            else
+                0,
+            .kitty_image_count_limit = if (comptime build_options.kitty_graphics)
+                primary.kitty_images.image_count_limit
+            else
+                0,
+            .kitty_placement_count_limit = if (comptime build_options.kitty_graphics)
+                primary.kitty_images.placement_count_limit
+            else
+                0,
+            .kitty_image_loading_limits = if (comptime build_options.kitty_graphics)
+                primary.kitty_images.image_limits
+            else {},
+        },
+    );
+}
+
 /// C: GhosttyTerminalScrollbar
 pub const TerminalScrollbar = PageList.Scrollbar.C;
 
@@ -733,6 +794,7 @@ pub const TerminalData = enum(c_int) {
     cursor_activity = 36,
     kitty_image_count_limit = 37,
     kitty_placement_count_limit = 38,
+    kitty_image_id_cursors = 39,
 
     /// Output type expected for querying the data of the given kind.
     pub fn OutType(comptime self: TerminalData) type {
@@ -766,6 +828,7 @@ pub const TerminalData = enum(c_int) {
             .kitty_image_count_limit,
             .kitty_placement_count_limit,
             => u64,
+            .kitty_image_id_cursors => KittyImageIdCursorState,
             .kitty_image_medium_file,
             .kitty_image_medium_temp_file,
             .kitty_image_medium_shared_mem,
@@ -873,6 +936,34 @@ fn getTyped(
         .kitty_placement_count_limit => {
             if (comptime !build_options.kitty_graphics) return .no_value;
             out.* = @intCast(t.screens.active.kitty_images.placement_count_limit);
+        },
+        .kitty_image_id_cursors => {
+            if (comptime !build_options.kitty_graphics) return .no_value;
+            const primary = &t.screens.get(.primary).?.kitty_images;
+            const alternate = if (t.screens.get(.alternate)) |screen|
+                &screen.kitty_images
+            else
+                null;
+            const primary_replay = primary.replayNextImageId() orelse return .no_value;
+            const primary_next = primary.imageIdCursor();
+            const alternate_replay = if (alternate) |storage|
+                storage.replayNextImageId() orelse return .no_value
+            else
+                kitty_default_image_id;
+            const alternate_next = if (alternate) |storage|
+                storage.imageIdCursor()
+            else
+                kitty_default_image_id;
+            out.* = .{
+                .replay = .{
+                    .primary = primary_replay,
+                    .alternate = alternate_replay,
+                },
+                .next = .{
+                    .primary = primary_next,
+                    .alternate = alternate_next,
+                },
+            };
         },
         .kitty_image_medium_file => {
             if (comptime !build_options.kitty_graphics) return .no_value;
@@ -1188,6 +1279,89 @@ test "scroll_viewport row alt screen" {
     try testing.expectEqual(@as(u64, 2), scrollbar_data.total);
     try testing.expectEqual(@as(u64, 0), scrollbar_data.offset);
     try testing.expectEqual(@as(u64, 2), scrollbar_data.len);
+}
+
+test "Kitty automatic image ID cursors cover both screens" {
+    if (comptime !build_options.kitty_graphics) return error.SkipZigTest;
+
+    var t: Terminal = null;
+    try testing.expectEqual(Result.success, new(
+        &lib.alloc.test_allocator,
+        &t,
+        .{ .cols = 5, .rows = 2, .max_scrollback = 0 },
+    ));
+    defer free(t);
+
+    const primary = "\x1b_Ga=t,t=d,f=24,I=1,s=1,v=1;////\x1b\\";
+    vt_write(t, primary.ptr, primary.len);
+    const enter_alt = "\x1b[?1049h";
+    vt_write(t, enter_alt.ptr, enter_alt.len);
+    const alternate = "\x1b_Ga=t,t=d,f=24,I=2,s=1,v=2,m=1;////\x1b\\";
+    vt_write(t, alternate.ptr, alternate.len);
+
+    var state: KittyImageIdCursorState = undefined;
+    try testing.expectEqual(
+        Result.success,
+        get(t, .kitty_image_id_cursors, @ptrCast(&state)),
+    );
+    try testing.expectEqual(@as(u32, kitty_default_image_id + 1), state.replay.primary);
+    try testing.expectEqual(@as(u32, kitty_default_image_id + 1), state.next.primary);
+    try testing.expectEqual(@as(u32, kitty_default_image_id), state.replay.alternate);
+    try testing.expectEqual(@as(u32, kitty_default_image_id + 1), state.next.alternate);
+
+    var restored: Terminal = null;
+    try testing.expectEqual(Result.success, new(
+        &lib.alloc.test_allocator,
+        &restored,
+        .{ .cols = 5, .rows = 2, .max_scrollback = 0 },
+    ));
+    defer free(restored);
+    const cursors: KittyImageIdCursors = .{ .primary = 41, .alternate = 42 };
+    try testing.expectEqual(
+        Result.success,
+        set(restored, .kitty_image_id_cursors, @ptrCast(&cursors)),
+    );
+    try testing.expectEqual(
+        Result.success,
+        get(restored, .kitty_image_id_cursors, @ptrCast(&state)),
+    );
+    try testing.expectEqual(cursors, state.replay);
+    try testing.expectEqual(cursors, state.next);
+
+    const invalid: KittyImageIdCursors = .{ .primary = 0, .alternate = 42 };
+    try testing.expectEqual(
+        Result.invalid_value,
+        set(restored, .kitty_image_id_cursors, @ptrCast(&invalid)),
+    );
+
+    var collision: Terminal = null;
+    try testing.expectEqual(Result.success, new(
+        &lib.alloc.test_allocator,
+        &collision,
+        .{ .cols = 5, .rows = 2, .max_scrollback = 0 },
+    ));
+    defer free(collision);
+    const explicit_probe =
+        "\x1b_Ga=t,t=d,f=24,i=2147483647,s=1,v=1;////\x1b\\";
+    vt_write(collision, explicit_probe.ptr, explicit_probe.len);
+    try testing.expectEqual(
+        Result.success,
+        get(collision, .kitty_image_id_cursors, @ptrCast(&state)),
+    );
+    try testing.expectEqual(@as(u32, kitty_default_image_id), state.replay.primary);
+    try testing.expectEqual(@as(u32, kitty_default_image_id), state.next.primary);
+
+    const delete_probe =
+        "\x1b_Ga=d,d=I,i=2147483647,q=2;\x1b\\";
+    vt_write(collision, delete_probe.ptr, delete_probe.len);
+    const automatic_after_delete =
+        "\x1b_Ga=t,t=d,f=24,I=3,s=1,v=1;////\x1b\\";
+    vt_write(collision, automatic_after_delete.ptr, automatic_after_delete.len);
+    try testing.expectEqual(
+        Result.success,
+        get(collision, .kitty_image_id_cursors, @ptrCast(&state)),
+    );
+    try testing.expectEqual(@as(u32, kitty_default_image_id + 1), state.next.primary);
 }
 
 test "scroll_viewport null" {

--- a/src/terminal/c/types.zig
+++ b/src/terminal/c/types.zig
@@ -66,6 +66,8 @@ pub const structs: std.StaticStringMap(StructInfo) = structs: {
         .{ "GhosttySurfacePosition", StructInfo.init(SurfacePosition) },
         .{ "GhosttyStyle", StructInfo.init(style_c.Style) },
         .{ "GhosttyStyleColor", StructInfo.init(style_c.Color) },
+        .{ "GhosttyTerminalKittyImageIdCursors", StructInfo.init(terminal.KittyImageIdCursors) },
+        .{ "GhosttyTerminalKittyImageIdCursorState", StructInfo.init(terminal.KittyImageIdCursorState) },
         .{ "GhosttyTerminalOptions", StructInfo.init(terminal.Options) },
         .{ "GhosttyTerminalScrollbar", StructInfo.init(terminal.TerminalScrollbar) },
         .{ "GhosttyTerminalScrollViewport", StructInfo.init(terminal.ScrollViewport) },
@@ -214,6 +216,16 @@ test "json parses" {
     // Verify we have all expected structs
     try std.testing.expect(root.contains("GhosttyTerminalOptions"));
     try std.testing.expect(root.contains("GhosttyFormatterTerminalOptions"));
+    try std.testing.expect(root.contains("GhosttyTerminalKittyImageIdCursors"));
+    try std.testing.expect(root.contains("GhosttyTerminalKittyImageIdCursorState"));
+    const kitty_cursors =
+        root.get("GhosttyTerminalKittyImageIdCursors").?.object.get("fields").?.object;
+    try std.testing.expect(kitty_cursors.contains("primary"));
+    try std.testing.expect(kitty_cursors.contains("alternate"));
+    const kitty_cursor_state =
+        root.get("GhosttyTerminalKittyImageIdCursorState").?.object.get("fields").?.object;
+    try std.testing.expect(kitty_cursor_state.contains("replay"));
+    try std.testing.expect(kitty_cursor_state.contains("next"));
 
     // Verify GhosttyTerminalOptions fields
     const term_opts = root.get("GhosttyTerminalOptions").?.object;

--- a/src/terminal/kitty/graphics_storage.zig
+++ b/src/terminal/kitty/graphics_storage.zig
@@ -19,6 +19,7 @@ const log = std.log.scoped(.kitty_gfx);
 
 pub const default_image_count_limit: usize = 4096;
 pub const default_placement_count_limit: usize = 16384;
+pub const default_image_id: u32 = 2147483647;
 
 /// Process-global counter backing all generation stamps (see
 /// ImageStorage.generation and Image.generation). This is global rather
@@ -109,7 +110,7 @@ pub const ImageStorage = struct {
     /// TODO: This isn't good enough, it's perfectly legal for programs
     ///       to use IDs in the latter half of the range and collisions
     ///       are not gracefully handled.
-    next_image_id: u32 = 2147483647,
+    next_image_id: u32 = default_image_id,
 
     /// This is the next automatically assigned placement ID. This is never
     /// user-facing so we can start at 0. This is 32-bits because we use
@@ -175,6 +176,15 @@ pub const ImageStorage = struct {
     /// The search spans the full non-zero u32 range and returns null only
     /// when every assignable ID is occupied.
     pub fn allocateImageId(self: *ImageStorage) ?u32 {
+        const candidate = self.nextImageId() orelse return null;
+        self.next_image_id = candidate +% 1;
+        if (self.next_image_id == 0) self.next_image_id = 1;
+        return candidate;
+    }
+
+    /// Returns the ID that the next automatic allocation would receive
+    /// without advancing the cursor.
+    pub fn nextImageId(self: *const ImageStorage) ?u32 {
         var candidate = if (self.next_image_id == 0)
             @as(u32, 1)
         else
@@ -186,10 +196,26 @@ pub const ImageStorage = struct {
             if (candidate == 0) candidate = 1;
             if (candidate == first) return null;
         }
-
-        self.next_image_id = candidate +% 1;
-        if (self.next_image_id == 0) self.next_image_id = 1;
         return candidate;
+    }
+
+    /// Returns the exact cursor that the next automatic allocation probes
+    /// first. Unlike nextImageId, this preserves an occupied probe so a later
+    /// deletion can make that ID eligible again.
+    pub fn imageIdCursor(self: *const ImageStorage) u32 {
+        return if (self.next_image_id == 0) 1 else self.next_image_id;
+    }
+
+    /// Cursor to install before replaying this storage's serialized state.
+    /// A multipart upload reserves an automatic ID as soon as its first
+    /// chunk arrives, so replay must begin from that reserved ID rather than
+    /// the already-advanced steady-state cursor.
+    pub fn replayNextImageId(self: *const ImageStorage) ?u32 {
+        const loading = self.loading orelse return self.imageIdCursor();
+        if (loading.image.number != 0 or loading.image.implicit_id) {
+            return loading.image.id;
+        }
+        return self.imageIdCursor();
     }
 
     /// Record a content mutation: marks the storage dirty and assigns a


### PR DESCRIPTION
Expose exact per-screen Kitty automatic image-ID cursors through the lib-vt C API, including the cursor required before replaying an in-flight multipart upload. Embedders can restore both primary and alternate storage after rebuilding a terminal mirror without changing later number-only transmissions.

The getter preserves Ghostty’s raw allocation cursor even when its current probe is occupied, while allocation continues to scan for a free ID at use time. The setter validates both cursors before mutating either screen and initializes alternate-screen storage only when needed.

Validation: `zig build test-lib-vt -Demit-lib-vt=true`; canonical autoreview clean.