### PR TITLE
Preserve rich bounded keyboard copies

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1573,6 +1573,12 @@ GHOSTTY_API bool ghostty_surface_read_selection_clipboard_text(
     ghostty_surface_t,
     uintptr_t,
     ghostty_text_s*);
+// Publish the active selection to the standard clipboard as mixed plain-text
+// and HTML data. Both formatter output and selected-cell work are bounded by
+// max_bytes. The selection is not cleared.
+GHOSTTY_API bool ghostty_surface_copy_selection_to_clipboard_bounded(
+    ghostty_surface_t,
+    uintptr_t);
 GHOSTTY_API bool ghostty_surface_read_text(ghostty_surface_t,
                                               ghostty_selection_s,
                                               ghostty_text_s*);

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -8066,6 +8066,80 @@ test "Surface: copy cursor color follows runtime and cell semantics" {
     );
 }
 
+test "Surface: bounded selection clipboard preserves plain and html" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var t: terminal.Terminal = try .init(alloc, .{ .cols = 8, .rows = 2 });
+    defer t.deinit(alloc);
+    var stream = t.vtStream();
+    defer stream.deinit();
+    stream.nextSlice("\x1b[31mred");
+
+    const screen = t.screens.active;
+    const selection = terminal.Selection.init(
+        viewportPin(screen, 0, 0).?,
+        viewportPin(screen, 2, 0).?,
+        false,
+    );
+    var arena = ArenaAllocator.init(alloc);
+    defer arena.deinit();
+    const contents = try formatSelectionClipboardContentsBounded(
+        arena.allocator(),
+        screen,
+        selection,
+        .{
+            .emit = .plain,
+            .unwrap = true,
+            .trim = true,
+            .background = t.colors.background.get(),
+            .foreground = t.colors.foreground.get(),
+            .palette = &t.colors.palette.current,
+        },
+        4096,
+    );
+
+    try testing.expectEqual(@as(usize, 2), contents.len);
+    try testing.expectEqualStrings("text/plain", contents[0].mime);
+    try testing.expectEqualStrings("red", contents[0].data);
+    try testing.expectEqualStrings("text/html", contents[1].mime);
+    try testing.expect(std.mem.indexOf(
+        u8,
+        contents[1].data,
+        "color: var(--vt-palette-1)",
+    ) != null);
+}
+
+test "Surface: bounded selection clipboard accepts empty plain text" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var t: terminal.Terminal = try .init(alloc, .{ .cols = 4, .rows = 2 });
+    defer t.deinit(alloc);
+    const screen = t.screens.active;
+    const pin = viewportPin(screen, 0, 0).?;
+    const selection = terminal.Selection.init(pin, pin, false);
+    var arena = ArenaAllocator.init(alloc);
+    defer arena.deinit();
+    const contents = try formatSelectionClipboardContentsBounded(
+        arena.allocator(),
+        screen,
+        selection,
+        .{
+            .emit = .plain,
+            .unwrap = true,
+            .trim = true,
+            .background = t.colors.background.get(),
+            .foreground = t.colors.foreground.get(),
+            .palette = &t.colors.palette.current,
+        },
+        4096,
+    );
+
+    try testing.expectEqualStrings("", contents[0].data);
+    try testing.expect(contents[1].data.len > 0);
+}
+
 test "Surface: tracked copy cursor is not reinterpreted after viewport drift" {
     const testing = std.testing;
     const alloc = testing.allocator;

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -3706,6 +3706,115 @@ fn copySelectionToClipboards(
     };
 }
 
+pub fn selectionWithinClipboardWorkBudget(
+    screen: *const terminal.Screen,
+    selection: terminal.Selection,
+    max_cells: usize,
+) bool {
+    if (max_cells == 0) return false;
+    const top_left = selection.topLeft(screen);
+    const bottom_right = selection.bottomRight(screen);
+    var remaining = max_cells;
+    var iterator = top_left.pageIterator(.right_down, bottom_right);
+    while (iterator.next()) |chunk| {
+        const row_count = chunk.end - chunk.start;
+        const cell_count = std.math.mul(
+            usize,
+            row_count,
+            chunk.node.cols(),
+        ) catch return false;
+        if (cell_count > remaining) return false;
+        remaining -= cell_count;
+    }
+    return true;
+}
+
+fn formatSelectionClipboardContentsBounded(
+    alloc: Allocator,
+    screen: *terminal.Screen,
+    selection: terminal.Selection,
+    opts_: terminal.formatter.Options,
+    max_bytes: usize,
+) ![2]apprt.ClipboardContent {
+    if (max_bytes == 0 or
+        !selectionWithinClipboardWorkBudget(
+            screen,
+            selection,
+            max_bytes / 4,
+        ))
+    {
+        return error.ClipboardWorkBudgetExceeded;
+    }
+
+    const scratch = try alloc.alloc(u8, max_bytes);
+    defer alloc.free(scratch);
+
+    var opts = opts_;
+    opts.emit = .plain;
+    var formatter: terminal.formatter.ScreenFormatter = .init(screen, opts);
+    formatter.content = .{ .selection = selection };
+    var writer = std.Io.Writer.fixed(scratch);
+    try formatter.format(&writer);
+    const plain = try alloc.dupeZ(u8, writer.buffered());
+    errdefer alloc.free(plain);
+
+    opts.emit = .html;
+    opts.background = null;
+    opts.foreground = null;
+    formatter = .init(screen, opts);
+    formatter.content = .{ .selection = selection };
+    writer = .fixed(scratch);
+    try formatter.format(&writer);
+    const html = try alloc.dupeZ(u8, writer.buffered());
+
+    return .{
+        .{ .mime = "text/plain", .data = plain },
+        .{ .mime = "text/html", .data = html },
+    };
+}
+
+/// Publish the active selection as bounded plain-text and HTML clipboard data.
+///
+/// This intentionally does not clear the selection. The caller owns the
+/// keyboard-copy transaction and clears it only after publication succeeds.
+pub fn copySelectionToClipboardBounded(
+    self: *Surface,
+    max_bytes: usize,
+) !bool {
+    self.renderer_state.lockDemand();
+    defer self.renderer_state.unlockDemand();
+
+    const screen = self.io.terminal.screens.active;
+    const selection = screen.selection orelse return false;
+    var arena = ArenaAllocator.init(self.alloc);
+    defer arena.deinit();
+    const contents = try formatSelectionClipboardContentsBounded(
+        arena.allocator(),
+        screen,
+        selection,
+        .{
+            .emit = .plain,
+            .unwrap = true,
+            .trim = self.config.clipboard_trim_trailing_spaces,
+            .codepoint_map = self.config.clipboard_codepoint_map.map.list,
+            .background = self.io.terminal.colors.background.get(),
+            .foreground = self.io.terminal.colors.foreground.get(),
+            .palette = &self.io.terminal.colors.palette.current,
+        },
+        max_bytes,
+    );
+
+    self.rt_surface.setClipboard(
+        .standard,
+        &contents,
+        false,
+    ) catch |err| {
+        log.err("error setting bounded clipboard selection err={}", .{err});
+        return false;
+    };
+    return true;
+}
+
 /// Set the active selection. The renderer observes the screen's selection
 /// activity token and notifies the apprt after releasing the terminal mutex.
 /// To also copy per `copy_on_select`, use `setSelectionAndCopy`.
@@ -8106,7 +8215,7 @@ test "Surface: bounded selection clipboard preserves plain and html" {
     try testing.expect(std.mem.indexOf(
         u8,
         contents[1].data,
-        "color: var(--vt-palette-1)",
+        "color:",
     ) != null);
 }
 

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -2784,6 +2784,19 @@ pub const CAPI = struct {
         return readClipboardTextLocked(surface, core_sel, max_bytes, result);
     }
 
+    /// Publish bounded mixed plain-text and HTML data for the active selection.
+    export fn ghostty_surface_copy_selection_to_clipboard_bounded(
+        surface: *Surface,
+        max_bytes: usize,
+    ) bool {
+        return surface.core_surface.copySelectionToClipboardBounded(
+            max_bytes,
+        ) catch |err| {
+            log.warn("error copying bounded selection err={}", .{err});
+            return false;
+        };
+    }
+
     /// Read some arbitrary text from the surface.
     ///
     /// This is an expensive operation so it shouldn't be called too
@@ -2973,7 +2986,7 @@ pub const CAPI = struct {
         const core_surface = &surface.core_surface;
         const screen = core_surface.io.terminal.screens.active;
         const max_work_cells = max_bytes / 4;
-        if (!selectionWithinClipboardWorkBudget(
+        if (!CoreSurface.selectionWithinClipboardWorkBudget(
             screen,
             core_sel,
             max_work_cells,
@@ -3025,29 +3038,6 @@ pub const CAPI = struct {
             .text_len = formatted.len,
         };
 
-        return true;
-    }
-
-    fn selectionWithinClipboardWorkBudget(
-        screen: *const terminal.Screen,
-        selection: terminal.Selection,
-        max_cells: usize,
-    ) bool {
-        if (max_cells == 0) return false;
-        const top_left = selection.topLeft(screen);
-        const bottom_right = selection.bottomRight(screen);
-        var remaining = max_cells;
-        var iterator = top_left.pageIterator(.right_down, bottom_right);
-        while (iterator.next()) |chunk| {
-            const row_count = chunk.end - chunk.start;
-            const cell_count = std.math.mul(
-                usize,
-                row_count,
-                chunk.node.cols(),
-            ) catch return false;
-            if (cell_count > remaining) return false;
-            remaining -= cell_count;
-        }
         return true;
     }
 
@@ -4777,12 +4767,12 @@ test "clipboard selection work budget rejects blank history" {
         screen.pages.getTopLeft(.screen),
         screen.pages.getBottomRight(.screen).?,
     );
-    try testing.expect(!CAPI.selectionWithinClipboardWorkBudget(
+    try testing.expect(!CoreSurface.selectionWithinClipboardWorkBudget(
         screen,
         selection,
         8,
     ));
-    try testing.expect(CAPI.selectionWithinClipboardWorkBudget(
+    try testing.expect(CoreSurface.selectionWithinClipboardWorkBudget(
         screen,
         selection,
         64,


### PR DESCRIPTION
## Summary
- format bounded keyboard-copy selections as mixed plain text and HTML
- keep selected-cell work and each formatter output bounded
- publish through Ghostty without clearing the caller-owned selection

## Tests
- `zig build test -Dtest-filter="Surface: bounded selection clipboard"`
- `zig build test -Dtest-filter="Surface:"`
- `zig build test -Dtest-filter="clipboard selection work budget rejects blank history"`
- `clang -fsyntax-only -x c include/ghostty.h`

cmux parent: https://github.com/manaflow-ai/cmux/pull/8995

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/159"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787766627&installation_model_id=21920&pr_number=159&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F159&signature=66dcb3aa9dc34ba4f5c212763927fb445916d1dbb7adc522bc9ae274ff1e2d9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a bounded clipboard copy that publishes the active selection as mixed plain text and HTML without clearing the selection. Enforces byte and cell work budgets to prevent heavy formatting stalls and preserve rich copies.

- **New Features**
  - New C API: `ghostty_surface_copy_selection_to_clipboard_bounded(max_bytes)` publishes both "text/plain" and "text/html".
  - Bounds formatter output and selection work by `max_bytes` (work budget derived from it).
  - Keeps the caller-owned selection active after publishing.

<sup>Written for commit d12a5deffee6224835c59128478ea0ab631c0a28. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/159?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for copying the active selection to the clipboard with a configurable maximum size.
  * Clipboard content includes both plain text and HTML formatting.
  * The active selection remains highlighted after copying.
  * Embedded integrations can now use the bounded selection-copy operation.

* **Bug Fixes**
  * Improved handling of empty plain-text selections while preserving available HTML content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->