### PR TITLE
Preserve plain bounded clipboard copies

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1573,9 +1573,10 @@ GHOSTTY_API bool ghostty_surface_read_selection_clipboard_text(
     ghostty_surface_t,
     uintptr_t,
     ghostty_text_s*);
-// Publish the active selection to the standard clipboard as mixed plain-text
-// and HTML data. Both formatter output and selected-cell work are bounded by
-// max_bytes. The selection is not cleared.
+// Publish the active selection to the standard clipboard as plain text plus
+// HTML when the HTML fits. Both formatter output and selected-cell work are
+// bounded by max_bytes; plain text is still published when only HTML exceeds
+// that bound. The selection is not cleared.
 GHOSTTY_API bool ghostty_surface_copy_selection_to_clipboard_bounded(
     ghostty_surface_t,
     uintptr_t);

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -8219,6 +8219,47 @@ test "Surface: bounded selection clipboard preserves plain and html" {
     ) != null);
 }
 
+test "Surface: bounded selection clipboard falls back to plain when html exceeds budget" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var t: terminal.Terminal = try .init(alloc, .{ .cols = 8, .rows = 2 });
+    defer t.deinit(alloc);
+    var stream = t.vtStream();
+    defer stream.deinit();
+    stream.nextSlice(
+        "\x1b[31ma\x1b[32mb\x1b[33mc\x1b[34md" ++
+            "\x1b[35me\x1b[36mf\x1b[37mg\x1b[31mh",
+    );
+
+    const screen = t.screens.active;
+    const selection = terminal.Selection.init(
+        viewportPin(screen, 0, 0).?,
+        viewportPin(screen, 7, 0).?,
+        false,
+    );
+    var arena = ArenaAllocator.init(alloc);
+    defer arena.deinit();
+    const contents = try formatSelectionClipboardContentsBounded(
+        arena.allocator(),
+        screen,
+        selection,
+        .{
+            .emit = .plain,
+            .unwrap = true,
+            .trim = true,
+            .background = t.colors.background.get(),
+            .foreground = t.colors.foreground.get(),
+            .palette = &t.colors.palette.current,
+        },
+        64,
+    );
+
+    try testing.expectEqual(@as(usize, 1), contents.len);
+    try testing.expectEqualStrings("text/plain", contents[0].mime);
+    try testing.expectEqualStrings("abcdefgh", contents[0].data);
+}
+
 test "Surface: bounded selection clipboard accepts empty plain text" {
     const testing = std.testing;
     const alloc = testing.allocator;

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -3735,7 +3735,7 @@ fn formatSelectionClipboardContentsBounded(
     selection: terminal.Selection,
     opts_: terminal.formatter.Options,
     max_bytes: usize,
-) ![2]apprt.ClipboardContent {
+) ![]apprt.ClipboardContent {
     if (max_bytes == 0 or
         !selectionWithinClipboardWorkBudget(
             screen,
@@ -3757,6 +3757,9 @@ fn formatSelectionClipboardContentsBounded(
     try formatter.format(&writer);
     const plain = try alloc.dupeZ(u8, writer.buffered());
     errdefer alloc.free(plain);
+    const contents = try alloc.alloc(apprt.ClipboardContent, 2);
+    errdefer alloc.free(contents);
+    contents[0] = .{ .mime = "text/plain", .data = plain };
 
     opts.emit = .html;
     opts.background = null;
@@ -3764,16 +3767,18 @@ fn formatSelectionClipboardContentsBounded(
     formatter = .init(screen, opts);
     formatter.content = .{ .selection = selection };
     writer = .fixed(scratch);
-    try formatter.format(&writer);
-    const html = try alloc.dupeZ(u8, writer.buffered());
-
-    return .{
-        .{ .mime = "text/plain", .data = plain },
-        .{ .mime = "text/html", .data = html },
+    formatter.format(&writer) catch |err| switch (err) {
+        error.WriteFailed => return contents[0..1],
+        else => |other| return other,
     };
+    const html = try alloc.dupeZ(u8, writer.buffered());
+    contents[1] = .{ .mime = "text/html", .data = html };
+
+    return contents;
 }
 
-/// Publish the active selection as bounded plain-text and HTML clipboard data.
+/// Publish the active selection as bounded plain text plus HTML when it fits.
+/// Plain text remains available when only rich formatting exceeds the bound.
 ///
 /// This intentionally does not clear the selection. The caller owns the
 /// keyboard-copy transaction and clears it only after publication succeeds.
@@ -3806,7 +3811,7 @@ pub fn copySelectionToClipboardBounded(
 
     self.rt_surface.setClipboard(
         .standard,
-        &contents,
+        contents,
         false,
     ) catch |err| {
         log.err("error setting bounded clipboard selection err={}", .{err});

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -2784,7 +2784,7 @@ pub const CAPI = struct {
         return readClipboardTextLocked(surface, core_sel, max_bytes, result);
     }
 
-    /// Publish bounded mixed plain-text and HTML data for the active selection.
+    /// Publish bounded plain text plus HTML when rich formatting fits.
     export fn ghostty_surface_copy_selection_to_clipboard_bounded(
         surface: *Surface,
         max_bytes: usize,

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -2784,7 +2784,8 @@ pub const CAPI = struct {
         return readClipboardTextLocked(surface, core_sel, max_bytes, result);
     }
 
-    /// Publish bounded plain text plus HTML when rich formatting fits.
+    /// Always publish bounded plain text and add HTML when rich formatting fits.
+    /// Plain text remains published when HTML exceeds max_bytes.
     export fn ghostty_surface_copy_selection_to_clipboard_bounded(
         surface: *Surface,
         max_bytes: usize,


### PR DESCRIPTION
Follow-up to https://github.com/manaflow-ai/ghostty/pull/159.

If HTML formatting exceeds `max_bytes` after plain-text formatting succeeds, publish the bounded plain-text representation instead of failing the entire copy. The first commit adds the failing regression test; the second implements the fallback and documents the C API contract.

Tests: `/opt/homebrew/Cellar/zig/0.15.2_1/bin/zig build test -Dtest-filter="Surface:"`; Zig format check; C header parse.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/160"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787770481&installation_model_id=21920&pr_number=160&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F160&signature=c529e4ec9c46c8270dedbe9a2c684b8e3e6edbd982b9baab1aa18b06da8e6e33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures bounded clipboard copies always include plain text, adding HTML only when it fits the size limit. Prevents copy failures and keeps the selection intact, with C API docs now clearly stating the fallback.

- **Bug Fixes**
  - Implemented plain-text fallback in bounded copy; only add `text/html` when within budget.
  - Clarified behavior in `include/ghostty.h` and embedded C API comments; added a regression test for the plain-only case.

<sup>Written for commit 4063577c9a92d58ff20d4dcfb78106c29a98d416. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/160?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bounded clipboard copying for selected content.
  * Plain text is always copied, while HTML is included only when it fits within the configured size limit.
  * Selections are preserved when copied.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->