### PR TITLE
os/open: stop the stderr drain from spinning and leaking zombies

### DIFF
--- a/src/os/open.zig
+++ b/src/os/open.zig
@@ -72,26 +72,93 @@ pub fn open(
     thread.detach();
 }
 
+/// Maximum stderr lines reported for a single `open`. A failing `open` says
+/// what went wrong in a line or two; anything past this is a malfunctioning
+/// child, and logging it at full speed throttles the whole process's unified
+/// logging firehose (`__FIREHOSE_CLIENT_THROTTLED_DUE_TO_HEAVY_LOGGING__`),
+/// which makes every other os_log call in the process expensive.
+const max_open_stderr_lines = 32;
+
 fn openThread(exe_: std.process.Child) void {
     // Copy the exe so it is non-const. This is necessary because wait()
     // requires a mutable reference and we can't have one as a thread
     // param.
     var exe = exe_;
-    if (exe.stderr) |stderr| {
-        var buffer: [256]u8 = undefined;
-        var stream = stderr.readerStreaming(&buffer);
-        const reader = &stream.interface;
-        while (true) {
-            const line = reader.takeDelimiterExclusive('\n') catch |outer| switch (outer) {
-                error.EndOfStream => break,
-                error.ReadFailed => break,
-                error.StreamTooLong => reader.take(buffer.len) catch |inner| switch (inner) {
-                    error.ReadFailed => break,
-                    error.EndOfStream => break,
-                },
-            };
+
+    // Always reap the child. Previously `wait()` was only reachable by falling
+    // out of the drain loop below, so a loop that never terminated leaked this
+    // thread AND left the child as a zombie forever.
+    defer _ = exe.wait() catch {};
+
+    const stderr = exe.stderr orelse return;
+    var buffer: [256]u8 = undefined;
+    var stream = stderr.readerStreaming(&buffer);
+    const reader = &stream.interface;
+
+    _ = drainStderr(reader);
+}
+
+/// Drain `reader` to end-of-stream, reporting at most `max_open_stderr_lines`
+/// lines. Returns how many were reported.
+///
+/// Split out from `openThread` so the property that actually matters -- this
+/// loop consumes its input and terminates -- can be tested without spawning a
+/// child process.
+fn drainStderr(reader: *std.Io.Reader) usize {
+    var logged: usize = 0;
+    while (true) {
+        // `takeDelimiter` consumes the delimiter and reports end-of-stream as
+        // null. `takeDelimiterExclusive` (used here previously) advances only up
+        // to the delimiter, so once the seek position sits on a '\n' it returns
+        // a zero-length slice forever without progressing and without erroring.
+        // That made this loop spin at 100% CPU after the very first stderr line,
+        // emitting empty `open stderr=` records until macOS throttled the
+        // process-wide logging firehose, and it never reached `wait()`.
+        const line = (reader.takeDelimiter('\n') catch |outer| switch (outer) {
+            error.ReadFailed => break,
+            error.StreamTooLong => reader.take(reader.buffer.len) catch break,
+        }) orelse break;
+
+        // Keep draining after the cap so a child blocked writing into a full
+        // pipe can still finish and exit; only the reporting is capped.
+        if (logged < max_open_stderr_lines) {
+            logged += 1;
             log.warn("open stderr={s}", .{line});
+            if (logged == max_open_stderr_lines) {
+                log.warn("open stderr truncated after {d} lines", .{logged});
+            }
         }
     }
-    _ = exe.wait() catch {};
+    return logged;
+}
+
+test "drainStderr reports every line and terminates" {
+    var r: std.Io.Reader = .fixed("first\nsecond\nthird\n");
+    try std.testing.expectEqual(@as(usize, 3), drainStderr(&r));
+}
+
+test "drainStderr terminates on blank lines" {
+    // The old `takeDelimiterExclusive` loop spun forever here: the seek position
+    // parks on the delimiter and every subsequent read returns an empty slice.
+    var r: std.Io.Reader = .fixed("\n\n\n");
+    try std.testing.expectEqual(@as(usize, 3), drainStderr(&r));
+}
+
+test "drainStderr reports a final line with no trailing newline" {
+    var r: std.Io.Reader = .fixed("only");
+    try std.testing.expectEqual(@as(usize, 1), drainStderr(&r));
+}
+
+test "drainStderr caps reporting but still drains to end of stream" {
+    const line_count = max_open_stderr_lines + 8;
+    var buf: [line_count * 2]u8 = undefined;
+    for (0..line_count) |i| {
+        buf[i * 2] = 'x';
+        buf[i * 2 + 1] = '\n';
+    }
+    var r: std.Io.Reader = .fixed(&buf);
+    try std.testing.expectEqual(@as(usize, max_open_stderr_lines), drainStderr(&r));
+    // Draining must continue past the reporting cap, otherwise a child blocked
+    // writing into a full pipe can never exit and `wait()` parks forever.
+    try std.testing.expectEqual(@as(usize, 0), r.end - r.seek);
 }


### PR DESCRIPTION
`openThread` drained a spawned child's stderr with `std.Io.Reader.takeDelimiterExclusive`, which advances *up to but not past* the delimiter. Once the seek position sits on a `\n` it returns a zero-length slice forever — no progress, no error. Verified on zig 0.15.2:

```
input "aaa\nbbb\nccc\n"
iter 0: len=3 'aaa'
iter 1: len=0 ''      <- parked on the newline
iter 2..inf: len=0 ''
```

So **any single line of stderr wedges the thread permanently**. The loop spun at 100% CPU emitting empty `open stderr=` records until macOS throttled the process-wide logging firehose (`__FIREHOSE_CLIENT_THROTTLED_DUE_TO_HEAVY_LOGGING__`, which then makes *every* `os_log` call in the process expensive). `exe.wait()` was only reachable by exiting that loop, so the child was never reaped either.

Measured on cmux 0.64.20 after ~1 day uptime: **11 zombie children matched one-for-one by 11 threads at ~12.4% CPU each — ~95% of the process's 500-600% total**, every one 94-97% of its stack inside `zig_os_log_with_type`. The pairing is causal: all 11 zombies spawned in a 16-second burst, and thread-id against zombie-pid regresses at R² = 0.999927, the signature of `exe.spawn()` immediately followed by `std.Thread.spawn()` eleven times.

## Change

- Use `takeDelimiter`, which consumes the delimiter and reports end-of-stream as `null`, so the loop advances and terminates.
- `defer _ = exe.wait() catch {}` so the child is reaped unconditionally, including on early exits.
- Cap reporting at 32 lines **while still draining**, so a child blocked writing into a full pipe can finish and exit.
- Extract the loop as `drainStderr` and test it: every line reported, all-blank-lines input terminates (the case that used to hang), a final line with no trailing newline, and cap-still-drains-to-EOF.

Affects Linux too — the GTK apprt reaches this via `OpenURI.zig` whenever the XDG portal is unavailable, which is a more common path than the macOS one.

`zig build` clean and `zig build test -Dtest-filter=drainStderr` green on zig 0.15.2.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/161"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787790152&installation_model_id=21920&pr_number=161&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F161&signature=7f343aa2bf16deeb612b5fd8ccf7cb5bccc6d97bfd7214f0218d05a8dbc08f18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug in `os/open` where draining a child’s stderr could spin at 100% CPU and leave zombie processes. Always reaps the child and limits log spam while still draining to EOF.

- **Bug Fixes**
  - Switched to `takeDelimiter` so the loop advances and terminates on EOF.
  - Reap the child unconditionally via `defer _ = exe.wait() catch {}` to prevent zombies.
  - Cap stderr reporting at 32 lines while continuing to drain to avoid pipe backpressure and log throttling.
  - Extracted `drainStderr` and added tests for blank lines, no trailing newline, full-cap drain, and normal line reporting.

<sup>Written for commit 8f31fb57cde291e7b8fecb46203bc398c44459f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/161?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of application launch errors to prevent hangs when reading process output.
  * Ensured launched processes are properly completed and cleaned up.
  * Added safeguards to limit excessive error messages while continuing to process all output.
  * Improved handling of blank lines and final messages without trailing line breaks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->