### PR TITLE
Integrate mailbox turn bounds with renderer memory fixes

### DIFF
--- a/src/App.zig
+++ b/src/App.zig
@@ -372,7 +372,16 @@ pub fn needsConfirmQuit(self: *const App) bool {
 
 /// Drain the mailbox.
 fn drainMailbox(self: *App, rt_app: *apprt.App) !void {
-    while (self.mailbox.pop()) |message| {
+    // Process only the messages present at the start of this app turn.
+    // Producers can refill the queue as we pop, so draining until a transient
+    // empty state can monopolize a runtime's main thread indefinitely.
+    // Retain a later tick explicitly because runtime wakeups may coalesce with
+    // the turn currently being handled.
+    var remaining = self.mailbox.count();
+    defer if (self.mailbox.count() > 0) rt_app.wakeup();
+
+    while (remaining > 0) : (remaining -= 1) {
+        const message = self.mailbox.pop() orelse break;
         if (comptime std.log.logEnabled(.debug, .app)) {
             switch (message) {
                 // these tend to be way too verbose for normal debugging

--- a/src/App.zig
+++ b/src/App.zig
@@ -847,6 +847,78 @@ fn testAction(_: *apprt.App, _: apprt.Target.C, _: apprt.Action.C) callconv(.c) 
     return true;
 }
 
+test "app mailbox drain bounds a producer-refilled turn" {
+    if (comptime !@hasField(apprt.App, "opts")) return error.SkipZigTest;
+
+    const Context = struct {
+        app: *App,
+        action_calls: usize = 0,
+        refills_remaining: usize = 4,
+        wakeups: usize = 0,
+
+        fn action(
+            rt_app: *apprt.App,
+            _: apprt.Target.C,
+            _: apprt.Action.C,
+        ) callconv(.c) bool {
+            const self: *@This() = @ptrCast(@alignCast(
+                rt_app.opts.userdata.?,
+            ));
+            self.action_calls += 1;
+            if (self.refills_remaining > 0) {
+                self.refills_remaining -= 1;
+                const queued = self.app.mailbox.push(.open_config, .instant);
+                std.debug.assert(queued > 0);
+            }
+            return true;
+        }
+
+        fn wakeup(userdata: ?*anyopaque) callconv(.c) void {
+            const self: *@This() = @ptrCast(@alignCast(userdata.?));
+            self.wakeups += 1;
+        }
+    };
+
+    var app: App = undefined;
+    try app.init(std.testing.allocator);
+    defer {
+        app.surfaces.deinit(std.testing.allocator);
+        app.font_grid_set.deinit();
+    }
+
+    var context: Context = .{ .app = &app };
+    var rt_app: apprt.App = undefined;
+    rt_app.core_app = &app;
+    rt_app.opts = undefined;
+    rt_app.opts.userdata = &context;
+    rt_app.opts.action = Context.action;
+    rt_app.opts.wakeup = Context.wakeup;
+
+    try std.testing.expectEqual(
+        @as(Mailbox.Queue.Size, 1),
+        app.mailbox.push(.open_config, .instant),
+    );
+    try std.testing.expectEqual(
+        @as(Mailbox.Queue.Size, 2),
+        app.mailbox.push(.open_config, .instant),
+    );
+
+    try app.tick(&rt_app);
+    try std.testing.expectEqual(@as(usize, 2), context.action_calls);
+    try std.testing.expectEqual(@as(Mailbox.Queue.Size, 2), app.mailbox.count());
+    try std.testing.expectEqual(@as(usize, 1), context.wakeups);
+
+    try app.tick(&rt_app);
+    try std.testing.expectEqual(@as(usize, 4), context.action_calls);
+    try std.testing.expectEqual(@as(Mailbox.Queue.Size, 2), app.mailbox.count());
+    try std.testing.expectEqual(@as(usize, 2), context.wakeups);
+
+    try app.tick(&rt_app);
+    try std.testing.expectEqual(@as(usize, 6), context.action_calls);
+    try std.testing.expectEqual(@as(Mailbox.Queue.Size, 0), app.mailbox.count());
+    try std.testing.expectEqual(@as(usize, 2), context.wakeups);
+}
+
 test "external redraw rejects allocator-reused surface address" {
     if (comptime !@hasField(apprt.App, "opts")) return error.SkipZigTest;
     if (comptime !@hasField(apprt.Surface, "core_surface")) return error.SkipZigTest;


### PR DESCRIPTION
Integrates the mailbox-livelock fix currently pinned by cmux main with the renderer-memory fixes now on Ghostty main.

The only conflict was the Zig 0.16 blocking-queue API. The merge preserves bounded snapshot draining and passes global.io() to count, pop, and the regression test queue operations.

Validation:
- zig build test -Demit-macos-app=false -Dtest-filter="app mailbox drain bounds a producer-refilled turn"
- zig build test -Demit-macos-app=false -Dtest-filter="custom shader"
- canonical autoreview clean, thread 019fac16-fba6-70c0-9730-7fb353edc077

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/169"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787890910&installation_model_id=21920&pr_number=169&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F169&signature=4ca91ae7b83d46f6ad952d3db3d57e073be2a661ad982ac5e80ffc87e6eee1e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound mailbox draining to the messages present at the start of each app turn to prevent main-thread livelock when producers refill the queue. Also integrated renderer memory fixes from Ghostty main.

- **Bug Fixes**
  - Process a fixed count per turn using mailbox.count(global.io()) and a decrementing loop.
  - Schedule rt_app.wakeup when messages remain after the turn.
  - Use global.io() for count/pop with Zig 0.16’s blocking-queue API.
  - Added regression test: "app mailbox drain bounds a producer-refilled turn".

<sup>Written for commit 112faaa496f49cb3d7c74b82cbdc802929cc5a8d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/169?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mailbox processing so continuously arriving messages no longer monopolize a runtime tick.
  * Ensured remaining messages are handled during subsequent ticks, keeping application responsiveness predictable.
* **Tests**
  * Added coverage verifying bounded message processing and correct wakeup behavior across tick boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->