### PR TITLE
Integrate font action callbacks with renderer reclamation

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1378,8 +1378,9 @@ GHOSTTY_API bool ghostty_surface_set_render_presented_callback(
     void* userdata);
 // cmux fork: install a per-surface callback for successfully performed font
 // binding actions. Call once after construction. The callback is synchronous
-// on the GUI thread, is not inherited by child surfaces, and its userdata must
-// remain valid until ghostty_surface_free returns.
+// on the GUI thread, must not destroy or otherwise reenter the surface, is not
+// inherited by child surfaces, and its userdata must remain valid until
+// ghostty_surface_free returns.
 GHOSTTY_API bool ghostty_surface_set_font_size_action_callback(
     ghostty_surface_t,
     ghostty_font_size_action_cb,

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -568,6 +568,22 @@ typedef void (*ghostty_pty_tee_cb)(void* userdata,
 // main thread. Synchronous backends deliver on the rendering caller's thread.
 typedef void (*ghostty_render_presented_cb)(void*, uint64_t);
 
+// cmux fork: semantic font binding actions emitted after the native mutation
+// succeeds. The callback runs synchronously on the surface's GUI thread.
+typedef enum {
+  GHOSTTY_FONT_SIZE_ACTION_INCREASE = 0,
+  GHOSTTY_FONT_SIZE_ACTION_DECREASE = 1,
+  GHOSTTY_FONT_SIZE_ACTION_RESET = 2,
+  GHOSTTY_FONT_SIZE_ACTION_SET = 3,
+} ghostty_font_size_action_e;
+typedef void (*ghostty_font_size_action_cb)(
+    void* userdata,
+    ghostty_font_size_action_e action,
+    float previous_points,
+    float current_points,
+    bool previous_adjusted,
+    bool current_adjusted);
+
 // Content-free renderer activity events emitted only when a surface installs
 // ghostty_renderer_event_cb. Begin/end pairs run on the renderer thread.
 typedef enum {
@@ -1359,6 +1375,14 @@ GHOSTTY_API void ghostty_surface_render_now(ghostty_surface_t);
 GHOSTTY_API bool ghostty_surface_set_render_presented_callback(
     ghostty_surface_t,
     ghostty_render_presented_cb,
+    void* userdata);
+// cmux fork: install a per-surface callback for successfully performed font
+// binding actions. Call once after construction. The callback is synchronous
+// on the GUI thread, is not inherited by child surfaces, and its userdata must
+// remain valid until ghostty_surface_free returns.
+GHOSTTY_API bool ghostty_surface_set_font_size_action_callback(
+    ghostty_surface_t,
+    ghostty_font_size_action_cb,
     void* userdata);
 // cmux fork: submit a forced render associated with `token`. When successful,
 // the installed callback fires after the backend presents the exact rendered

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -199,6 +199,51 @@ pub const InputEffect = enum {
     closed,
 };
 
+test "font size action event preserves semantic mutation" {
+    const absolute = fontSizeActionEvent(
+        .{ .set_font_size = 400 },
+        12,
+        255,
+        false,
+        true,
+    ).?;
+    try std.testing.expectEqual(
+        FontSizeActionKind.set,
+        absolute.kind,
+    );
+    try std.testing.expectEqual(@as(f32, 12), absolute.previous_points);
+    try std.testing.expectEqual(@as(f32, 255), absolute.current_points);
+    try std.testing.expect(!absolute.previous_adjusted);
+    try std.testing.expect(absolute.current_adjusted);
+
+    const clamped_relative = fontSizeActionEvent(
+        .{ .increase_font_size = 1 },
+        255,
+        255,
+        false,
+        true,
+    ).?;
+    try std.testing.expectEqual(
+        FontSizeActionKind.increase,
+        clamped_relative.kind,
+    );
+    try std.testing.expectEqual(
+        clamped_relative.previous_points,
+        clamped_relative.current_points,
+    );
+    try std.testing.expect(clamped_relative.current_adjusted);
+
+    try std.testing.expect(
+        fontSizeActionEvent(
+            .copy_title_to_clipboard,
+            12,
+            12,
+            false,
+            false,
+        ) == null,
+    );
+}
+
 /// The search state for the surface.
 const Search = struct {
     state: terminal.search.Thread,

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -199,6 +199,67 @@ pub const InputEffect = enum {
     closed,
 };
 
+/// The semantic font mutation performed by one binding action.
+pub const FontSizeActionKind = enum(c_int) {
+    increase = 0,
+    decrease = 1,
+    reset = 2,
+    set = 3,
+};
+
+/// The resolved native state surrounding one performed font binding action.
+pub const FontSizeActionEvent = struct {
+    kind: FontSizeActionKind,
+    previous_points: f32,
+    current_points: f32,
+    previous_adjusted: bool,
+    current_adjusted: bool,
+};
+
+fn fontSizeActionEvent(
+    action: input.Binding.Action,
+    previous_points: f32,
+    current_points: f32,
+    previous_adjusted: bool,
+    current_adjusted: bool,
+) ?FontSizeActionEvent {
+    const kind: FontSizeActionKind = switch (action) {
+        .increase_font_size => .increase,
+        .decrease_font_size => .decrease,
+        .reset_font_size => .reset,
+        .set_font_size => .set,
+        else => return null,
+    };
+    return .{
+        .kind = kind,
+        .previous_points = previous_points,
+        .current_points = current_points,
+        .previous_adjusted = previous_adjusted,
+        .current_adjusted = current_adjusted,
+    };
+}
+
+fn fontSizeActionDidPerform(
+    self: *Surface,
+    action: input.Binding.Action,
+    previous_points: f32,
+    previous_adjusted: bool,
+) void {
+    if (comptime @hasDecl(
+        apprt.runtime.Surface,
+        "fontSizeActionDidPerform",
+    )) {
+        const event = fontSizeActionEvent(
+            action,
+            previous_points,
+            self.font_size.points,
+            previous_adjusted,
+            self.font_size_adjusted,
+        ) orelse return;
+        self.rt_surface.fontSizeActionDidPerform(event);
+    }
+}
+
 test "font size action event preserves semantic mutation" {
     const absolute = fontSizeActionEvent(
         .{ .set_font_size = 400 },
@@ -7001,6 +7062,9 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
         ),
 
         .increase_font_size => |delta| {
+            const previous_points = self.font_size.points;
+            const previous_adjusted = self.font_size_adjusted;
+
             // Max delta is somewhat arbitrary.
             const clamped_delta = @max(0, @min(255, delta));
 
@@ -7013,9 +7077,17 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
 
             // Mark that we manually adjusted the font size
             self.font_size_adjusted = true;
+            self.fontSizeActionDidPerform(
+                action,
+                previous_points,
+                previous_adjusted,
+            );
         },
 
         .decrease_font_size => |delta| {
+            const previous_points = self.font_size.points;
+            const previous_adjusted = self.font_size_adjusted;
+
             // Max delta is somewhat arbitrary.
             const clamped_delta = @max(0, @min(255, delta));
 
@@ -7027,9 +7099,17 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
 
             // Mark that we manually adjusted the font size
             self.font_size_adjusted = true;
+            self.fontSizeActionDidPerform(
+                action,
+                previous_points,
+                previous_adjusted,
+            );
         },
 
         .reset_font_size => {
+            const previous_points = self.font_size.points;
+            const previous_adjusted = self.font_size_adjusted;
+
             log.debug("reset font size", .{});
 
             var size = self.font_size;
@@ -7038,9 +7118,17 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
 
             // Reset font size also resets the manual adjustment state
             self.font_size_adjusted = false;
+            self.fontSizeActionDidPerform(
+                action,
+                previous_points,
+                previous_adjusted,
+            );
         },
 
         .set_font_size => |points| {
+            const previous_points = self.font_size.points;
+            const previous_adjusted = self.font_size_adjusted;
+
             log.debug("set font size={d}", .{points});
 
             var size = self.font_size;
@@ -7049,6 +7137,11 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
 
             // Mark that we manually adjusted the font size
             self.font_size_adjusted = true;
+            self.fontSizeActionDidPerform(
+                action,
+                previous_points,
+                previous_adjusted,
+            );
         },
 
         .prompt_surface_title => return try self.rt_app.performAction(

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -4952,3 +4952,71 @@ test "render presentation callback setter is per surface" {
         parent.render_presented_userdata,
     );
 }
+
+test "font size action callback preserves resolved action events" {
+    const Observation = struct {
+        calls: usize = 0,
+        kind: CoreSurface.FontSizeActionKind = .reset,
+        previous_points: f32 = 0,
+        current_points: f32 = 0,
+        previous_adjusted: bool = false,
+        current_adjusted: bool = false,
+    };
+    const Callbacks = struct {
+        fn fontSizeAction(
+            userdata: ?*anyopaque,
+            kind: CoreSurface.FontSizeActionKind,
+            previous_points: f32,
+            current_points: f32,
+            previous_adjusted: bool,
+            current_adjusted: bool,
+        ) callconv(.c) void {
+            const observation: *Observation =
+                @ptrCast(@alignCast(userdata.?));
+            observation.* = .{
+                .calls = observation.calls + 1,
+                .kind = kind,
+                .previous_points = previous_points,
+                .current_points = current_points,
+                .previous_adjusted = previous_adjusted,
+                .current_adjusted = current_adjusted,
+            };
+        }
+    };
+
+    var observation: Observation = .{};
+    var surface: Surface = undefined;
+    surface.font_size_action_cb = null;
+    surface.font_size_action_userdata = null;
+
+    try std.testing.expect(
+        CAPI.ghostty_surface_set_font_size_action_callback(
+            &surface,
+            Callbacks.fontSizeAction,
+            &observation,
+        ),
+    );
+    surface.fontSizeActionDidPerform(.{
+        .kind = .set,
+        .previous_points = 12,
+        .current_points = 255,
+        .previous_adjusted = false,
+        .current_adjusted = true,
+    });
+
+    try std.testing.expectEqual(@as(usize, 1), observation.calls);
+    try std.testing.expectEqual(
+        CoreSurface.FontSizeActionKind.set,
+        observation.kind,
+    );
+    try std.testing.expectEqual(
+        @as(f32, 12),
+        observation.previous_points,
+    );
+    try std.testing.expectEqual(
+        @as(f32, 255),
+        observation.current_points,
+    );
+    try std.testing.expect(!observation.previous_adjusted);
+    try std.testing.expect(observation.current_adjusted);
+}

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -662,6 +662,14 @@ pub const IoWriteCallback = *const fn (?*anyopaque, [*]const u8, usize) callconv
 pub const PtyTeeCallback = *const fn (?*anyopaque, [*]const u8, usize) callconv(.c) void;
 pub const RendererEventCallback = renderer.InstrumentationCallback;
 pub const RenderPresentedCallback = *const fn (?*anyopaque, u64) callconv(.c) void;
+pub const FontSizeActionCallback = *const fn (
+    ?*anyopaque,
+    CoreSurface.FontSizeActionKind,
+    f32,
+    f32,
+    bool,
+    bool,
+) callconv(.c) void;
 
 const SurfaceActionLifetime = struct {
     const ReleasePauseForTesting = struct {
@@ -837,6 +845,10 @@ pub const Surface = struct {
     // the public by-value Options ABI.
     render_presented_cb: ?RenderPresentedCallback = null,
     render_presented_userdata: ?*anyopaque = null,
+    // Binding callbacks run on the GUI thread. These fields belong to this
+    // exact embedded surface and are never inherited by child surfaces.
+    font_size_action_cb: ?FontSizeActionCallback = null,
+    font_size_action_userdata: ?*anyopaque = null,
 
     /// The current title of the surface. The embedded apprt saves this so
     /// that getTitle works without the implementer needing to save it.
@@ -1052,6 +1064,21 @@ pub const Surface = struct {
             font_size.points = opts.font_size;
             try self.core_surface.setFontSize(font_size);
         }
+    }
+
+    pub fn fontSizeActionDidPerform(
+        self: *Surface,
+        event: CoreSurface.FontSizeActionEvent,
+    ) void {
+        const callback = self.font_size_action_cb orelse return;
+        callback(
+            self.font_size_action_userdata,
+            event.kind,
+            event.previous_points,
+            event.current_points,
+            event.previous_adjusted,
+            event.current_adjusted,
+        );
     }
 
     /// Applies an optional embedder cap without ever raising the user's
@@ -3077,6 +3104,22 @@ pub const CAPI = struct {
 
         surface.render_presented_cb = registered_callback;
         surface.render_presented_userdata = userdata;
+        return true;
+    }
+
+    /// Install a callback for resolved font binding actions on this surface.
+    /// Registration is one-shot and the embedder keeps userdata alive until
+    /// surface destruction returns.
+    export fn ghostty_surface_set_font_size_action_callback(
+        surface: *Surface,
+        callback: ?FontSizeActionCallback,
+        userdata: ?*anyopaque,
+    ) bool {
+        const registered_callback = callback orelse return false;
+        if (surface.font_size_action_cb != null) return false;
+
+        surface.font_size_action_cb = registered_callback;
+        surface.font_size_action_userdata = userdata;
         return true;
     }
 


### PR DESCRIPTION
Integrates the two resolved font-binding callback commits from `task-font-size-action-callback` on top of current fork `main`, which already contains the hidden-renderer reclamation and retry-deadline work.

This resolves the Ghostty gitlink divergence encountered while updating cmux PR #8998 from current cmux `main` without dropping either behavior.

Validation:
- both commits cherry-picked cleanly
- `git diff --check`
- `zig fmt --check src/Surface.zig src/apprt/embedded.zig`

Parent cmux PR: https://github.com/manaflow-ai/cmux/pull/8998

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/171"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787960623&installation_model_id=21920&pr_number=171&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F171&signature=510b5b104590ba944b4243dd8a4bc12f76bf96dc5701de3c7e9e08cc003dcc73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-surface font size action callbacks that run on the GUI thread after a successful font binding change. Provides previous/current point sizes and manual-adjust flags, and remains compatible with renderer reclamation.

- **New Features**
  - C API: `ghostty_font_size_action_e`, `ghostty_font_size_action_cb`, `ghostty_surface_set_font_size_action_callback` (synchronous on GUI thread, one-shot, per-surface/not inherited, non-reentrant—do not destroy or reenter the surface; keep userdata alive until `ghostty_surface_free`).
  - Core: emits events from `performBindingAction` for `increase`, `decrease`, `reset`, `set`, including `previous_points`, `current_points`, `previous_adjusted`, `current_adjusted`.
  - Embedded runtime: forwards events to the registered C callback; tests cover payload correctness and per-surface registration.

<sup>Written for commit 2803ccfe1c1e146e25be90af3387822a3ae17c83. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/171?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an embedding API to receive notifications when font size changes are performed.
  - Notifications include the action type, previous and current font sizes, and adjustment status.
  - Supported actions include increase, decrease, reset, and set.
  - Callbacks can be registered per surface and run synchronously after successful changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->