### PR TITLE
Fix theme picker hanging on launch after vaxis 0.6 upgrade

### DIFF
--- a/src/cli/list_themes.zig
+++ b/src/cli/list_themes.zig
@@ -630,6 +630,11 @@ const Preview = struct {
         };
 
         var loop: vaxis.Loop(Event) = .init(global.io(), &self.tty, &self.vx);
+        // vaxis 0.6 moved the reader task and the SIGWINCH handler out of
+        // Loop.init into start/installResizeHandler. Without them nothing ever
+        // pushes to the event queue and pollEvent below blocks forever.
+        try loop.start();
+
         const writer = self.tty.writer();
 
         try self.vx.enterAltScreen(writer);
@@ -640,6 +645,8 @@ const Preview = struct {
         if (self.cmux == null) {
             try self.vx.queryTerminal(writer, .fromSeconds(1));
         }
+        // Only needed when the terminal does not report resizes in band.
+        if (!self.vx.state.in_band_resize) try loop.installResizeHandler();
         try self.vx.setMouseMode(writer, true);
         if (self.cmux == null and self.vx.caps.color_scheme_updates)
             try self.vx.subscribeToColorSchemeUpdates(writer);


### PR DESCRIPTION
## What breaks

`ghostty +list-themes` hangs immediately on launch. It enters the alt screen, sets the title, enables mouse tracking, and then blocks forever with an empty screen and no way to type anything. Reproduces 3/3, not intermittent.

Captured output from the hung process is 55 bytes and nothing else, ever:

```
\x1b[?1049h\x1b]2;cmux Theme Preview\x1b\\\x1b[?1002;1003;1004;1006h
```

## Cause

vaxis 0.6 split `Loop.init` into three pieces. `init` is now a plain constructor; the tty reader task moved to `Loop.start` and the SIGWINCH handler moved to `Loop.installResizeHandler`.

The Zig 0.16 migration in e8525c0fd rewrote the construction here:

```zig
-        var loop: vaxis.Loop(Event) = .{
-            .tty = &self.tty,
-            .vaxis = &self.vx,
-        };
-        try loop.init();
-        try loop.start();
+        var loop: vaxis.Loop(Event) = .init(global.io(), &self.tty, &self.vx);
```

Neither `start` nor `installResizeHandler` was added back. `Loop.start` is the only thing that spawns `ttyRun`, and `ttyRun` is the only producer of events: it posts the initial winsize and every key press. `installResizeHandler` is the only caller of `Tty.notifyWinsize`. With neither called, nothing can ever push to the queue, so the `loop.pollEvent()` at the top of the render loop waits on a condvar that is never signalled. The first `draw`/`render` sits after that call, which is why not even one frame is painted.

`sample` on the hung process shows the main thread parked in the queue wait with the reader never started.

## Fix

Restore both calls, following the ordering `vxfw/App.zig` uses: `start` before the terminal writes, `installResizeHandler` after `queryTerminal` and only when the terminal does not report resizes in band.

`Loop.stop` is deliberately **not** added, even though `vxfw/App.zig` defers it. `stop` wakes the reader by writing a device status report and then awaiting the task, which only works if the terminal answers. Under a piped or scripted terminal nothing answers, the reader stays parked in `readv`, and the await never returns. Measured directly: with `defer loop.stop()` the picker hangs at exit 3/3 after applying the theme; without it, it exits cleanly in under 0.1s. This also matches the pre-regression behaviour, which had no `stop` call.

## Verification

Built the CLI helper at this branch and at the parent commit with zig 0.16.0 and drove both through a scripted PTY:

| build | result |
| --- | --- |
| parent (36a46414a) | hangs 3/3, 55 bytes of output, no footer, no config written |
| this branch | passes 3/3, renders in <0.1s, Enter applies and the process exits 0 |

cmux's `tests/test_bundled_ghostty_theme_picker_helper.sh` covers all four scenarios (normal, search, Ctrl-N, Ctrl-P). Against the parent build it fails on the first scenario; against this branch it prints `PASS`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/173"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787985428&installation_model_id=21920&pr_number=173&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F173&signature=573e45c3b741ee3141a31609f96374e0ea5e79bc6571daa716251bfb2946841f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the theme picker hang introduced by the `vaxis 0.6` upgrade by starting the TTY reader and installing the resize handler. The picker now renders immediately and accepts input.

- **Bug Fixes**
  - Call `loop.start()` before terminal writes to spawn the reader and post the initial winsize.
  - Call `loop.installResizeHandler()` only when `in_band_resize` is false.
  - Intentionally omit `loop.stop()` to prevent exit hangs in piped/scripted terminals.

<sup>Written for commit 6143bac777724854e5a3bab8c7a4e47735f17113. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/173?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal preview responsiveness by ensuring events are processed correctly.
  * Added resize handling for terminals that do not report window size changes automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->