### PR TITLE
Fix sentry-init racing environ mutation during global init

### DIFF
--- a/src/crash/sentry.zig
+++ b/src/crash/sentry.zig
@@ -56,6 +56,22 @@ pub fn init(gpa: Allocator) !void {
     // Must only start once
     assert(init_thread == null);
 
+    // Resolve the Sentry cache directory BEFORE spawning the init thread.
+    // The resolution reads the process environment, and the global environ
+    // snapshot/map have no concurrency control (see global.syncEnviron), so
+    // reading them from the spawned thread races any setenv on another
+    // thread. That exact race crashed iOS during ghostty_init: initThread
+    // walked the environ block that ensureLocale's setenv had just
+    // realloc'd and freed on the main thread (cmux INTERNAL builds
+    // 20260730090940 and 20260730213932). Resolving here, on the spawning
+    // thread, keeps the spawned thread free of shared environ access.
+    const cache_dir = cache_dir: {
+        var environ_map = try global.environMap();
+        defer environ_map.deinit();
+        break :cache_dir try resolveCacheDir(gpa, &environ_map);
+    };
+    errdefer gpa.free(cache_dir);
+
     // We use a thread for initializing Sentry because initialization takes
     // ~2k ns on my M3 Max. That's not a LOT of time but it's enough to be
     // 90% of our pre-App startup time. Everything Sentry is doing initially
@@ -64,14 +80,42 @@ pub fn init(gpa: Allocator) !void {
     const thr = try std.Thread.spawn(
         .{},
         initThread,
-        .{gpa},
+        .{ gpa, cache_dir },
     );
     thr.setName(global.io(), "sentry-init") catch {};
     init_thread = thr;
 }
 
-fn initThread(gpa: Allocator) !void {
+/// Determine the Sentry cache directory from the given environment map.
+/// This takes the environment as an explicit map rather than reading the
+/// global process state so the caller can resolve it on a thread that owns
+/// the data (the spawning thread, not the sentry-init thread), and so the
+/// resolution is testable without touching the live environment.
+fn resolveCacheDir(
+    alloc: Allocator,
+    environ_map: *const std.process.Environ.Map,
+) ![]const u8 {
+    // On macOS, we prefer to use the NSCachesDirectory value to be
+    // a more idiomatic macOS application. But if XDG env vars are set
+    // we will respect them.
+    if (comptime builtin.os.tag == .macos) {
+        const xdg_cache_home = environ_map.get("XDG_CACHE_HOME") orelse "";
+        if (xdg_cache_home.len == 0) return try internal_os.macos.cacheDir(
+            alloc,
+            "sentry",
+        );
+    }
+
+    return try internal_os.xdg.cache(
+        alloc,
+        environ_map,
+        .{ .subdir = "ghostty/sentry" },
+    );
+}
+
+fn initThread(gpa: Allocator, cache_dir: []const u8) !void {
     if (comptime !build_options.sentry) return;
+    defer gpa.free(cache_dir);
 
     // Right now, on Darwin, `std.Thread.setName` can only name the current
     // thread, and we have no way to get the current thread from within it,
@@ -79,10 +123,6 @@ fn initThread(gpa: Allocator) !void {
     if (builtin.os.tag.isDarwin()) {
         internal_os.macos.pthread_setname_np(&"sentry-init".*);
     }
-
-    var arena = std.heap.ArenaAllocator.init(gpa);
-    defer arena.deinit();
-    const alloc = arena.allocator();
 
     const transport = sentry.Transport.init(&Transport.send);
     // This will crash if the transport was never used so we avoid
@@ -104,27 +144,10 @@ fn initThread(gpa: Allocator) !void {
     // do here and why we use this.
     sentry.c.sentry_options_set_before_send(opts, beforeSend, null);
 
-    // Determine the Sentry cache directory.
-    const cache_dir = cache_dir: {
-        // On macOS, we prefer to use the NSCachesDirectory value to be
-        // a more idiomatic macOS application. But if XDG env vars are set
-        // we will respect them.
-        if (comptime builtin.os.tag == .macos) macos: {
-            if (global.environ().containsUnemptyConstant("XDG_CACHE_HOME")) break :macos;
-            break :cache_dir try internal_os.macos.cacheDir(
-                alloc,
-                "sentry",
-            );
-        }
-
-        var environ_map = try global.environMap();
-        defer environ_map.deinit();
-        break :cache_dir try internal_os.xdg.cache(
-            alloc,
-            &environ_map,
-            .{ .subdir = "ghostty/sentry" },
-        );
-    };
+    // The Sentry cache directory was resolved by init() on the spawning
+    // thread (sentry copies the string into its options). Do NOT read the
+    // global environ from this thread; that raced setenv during startup
+    // and crashed (see init).
     sentry.c.sentry_options_set_database_path_n(
         opts,
         cache_dir.ptr,
@@ -310,3 +333,51 @@ pub const Transport = struct {
         return true;
     }
 };
+
+test "sentry cache dir resolves from the caller-provided environ map" {
+    // Regression test for the iOS startup crash (cmux INTERNAL builds
+    // 20260730090940 and 20260730213932): initThread used to read the
+    // GLOBAL environ snapshot from the spawned sentry-init thread, racing
+    // ensureLocale's setenv on the main thread and walking a freed environ
+    // block. The fix resolves the cache dir on the SPAWNING thread from an
+    // explicit map. This pins the seam: resolution must consume the
+    // caller's map (whose value does not exist in the live process
+    // environment), so it fails if the resolution ever reaches back into
+    // global process state.
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var environ_map = try testing.environ.createMap(alloc);
+    defer environ_map.deinit();
+    try environ_map.put("XDG_CACHE_HOME", "/tmp/ghostty-sentry-race-test");
+
+    const cache_dir = try resolveCacheDir(alloc, &environ_map);
+    defer alloc.free(cache_dir);
+
+    try testing.expectEqualStrings(
+        "/tmp/ghostty-sentry-race-test/ghostty/sentry",
+        cache_dir,
+    );
+}
+
+test "sentry cache dir prefers NSCachesDirectory on macOS without XDG" {
+    // Pins the behavior the refactor preserved from the old thread-side
+    // code: on macOS an unset OR empty XDG_CACHE_HOME falls back to the
+    // NSCachesDirectory-based path instead of the XDG path.
+    if (comptime builtin.os.tag != .macos) return error.SkipZigTest;
+
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var environ_map = try testing.environ.createMap(alloc);
+    defer environ_map.deinit();
+    try environ_map.put("XDG_CACHE_HOME", "");
+
+    const cache_dir = try resolveCacheDir(alloc, &environ_map);
+    defer alloc.free(cache_dir);
+
+    try testing.expect(std.mem.indexOf(u8, cache_dir, "Caches") != null);
+    try testing.expect(std.mem.endsWith(u8, cache_dir, "sentry"));
+}

--- a/src/global.zig
+++ b/src/global.zig
@@ -261,6 +261,21 @@ pub fn init(opts: InitOpts) !void {
     // As early as possible, initialize our resource limits.
     self.rlimits = .init();
 
+    // We need to make sure the process locale is set properly. Locale
+    // affects a lot of behaviors in a shell.
+    //
+    // We need to re-sync the environment after this completes.
+    //
+    // This MUST happen before crash.init below: ensureLocale mutates the
+    // process environment (setenv can realloc the environ array, freeing
+    // the block our environ snapshot points at), and crash.init spawns the
+    // sentry-init thread. Spawning that thread first left a concurrent
+    // environ reader alive across the realloc, which crashed iOS with a
+    // SIGSEGV in the sentry-init thread during the first ghostty_init of a
+    // session (cmux INTERNAL builds 20260730090940 and 20260730213932).
+    try internal_os.ensureLocale();
+    syncEnviron();
+
     // Initialize our crash reporting.
     crash.init(self.alloc) catch |err| {
         std.log.warn(
@@ -277,13 +292,6 @@ pub fn init(opts: InitOpts) !void {
     // ))) |uuid| {
     //     std.log.warn("uuid={s}", .{uuid.string()});
     // } else std.log.warn("failed to capture event", .{});
-
-    // We need to make sure the process locale is set properly. Locale
-    // affects a lot of behaviors in a shell.
-    //
-    // We need to re-sync the environment after this completes.
-    try internal_os.ensureLocale();
-    syncEnviron();
 
     // Initialize glslang for shader compilation
     try glslang.init();


### PR DESCRIPTION
Fixes the iOS crash that hit cmux INTERNAL three times on 2026-07-30 (builds `20260730090940` and `20260730213932`, twice back-to-back): EXC_BAD_ACCESS byte read on the sentry-init thread while the main thread was inside `ghostty_init -> ensureLocale -> setlocale` during the first terminal-surface mount of a session.

Mechanism: `ghostty_init` snapshots the raw C `environ` pointer array. `global.init` spawned the sentry-init thread (`crash.init`) BEFORE `ensureLocale()`, whose `setenv("LANG"/"LANGUAGE")` can realloc the environ array and free the snapshotted block; `syncEnviron()` re-syncs only after. On iOS (non-macOS branch), sentry-init then walked the freed snapshot via `global.environMap()` (`src/crash/sentry.zig`), which has no concurrency control, and byte-scanned a garbage entry pointer (near-null `0x2fb1` in one crash, wild pointers in the other two, matching freed-block reuse).

Fix, two layers:
- `global.init` runs `ensureLocale()` + `syncEnviron()` before `crash.init`, so no other thread exists while init mutates the environment.
- `sentry.init` resolves the Sentry cache directory on the spawning thread from an explicit `Environ.Map` and passes it into `initThread`; the spawned thread no longer touches the shared environ snapshot at all, so this crash class stays dead even if some later code calls `setenv` after startup.

The regression test pins the seam: cache-dir resolution must consume the caller-provided map (whose test value does not exist in the live process environment), so it fails if resolution ever reaches back into global process state; a mutation check confirmed the test executes and fails when broken (`73 pass, 1 fail`). A second macOS-gated test pins the preserved NSCachesDirectory fallback for unset/empty `XDG_CACHE_HOME`. A red/green two-commit structure is not applicable here: the defect is a data race whose pre-fix failure mode is undefined behavior, and the testable seam does not exist pre-fix.

Verified with `zig build test -Dtest-filter="sentry cache dir"` on zig 0.16.0 (86/86 steps, 74/74 tests).

Full triage with the crash evidence and most-likely-cause ranking lives in cmuxterm-hq `out/crash-20260730/triage.md`; the cmux submodule bump PR follows and must merge only after this lands on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/174"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788043307&installation_model_id=21920&pr_number=174&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F174&signature=ab5a6ccf3c319da5ba97dde5a0e4e39a0412f3ba93dd504c32e2b8bce1f511ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes an iOS startup crash caused by the `sentry-init` thread reading a freed `environ` snapshot during locale setup. We now finish locale/env setup before spawning Sentry and avoid reading the global env from the Sentry thread.

- **Bug Fixes**
  - Run `ensureLocale()` + `syncEnviron()` before `crash.init` so no thread reads the environment while it’s being mutated.
  - Resolve the Sentry cache directory on the spawning thread from an explicit `Environ.Map`, pass it into `initThread`, and stop touching `global.environ` in the spawned thread.
  - Add regression tests to ensure cache-dir resolution uses the caller-provided map and to keep the macOS fallback to NSCachesDirectory when `XDG_CACHE_HOME` is unset or empty.

<sup>Written for commit abcf5697d4fcd05e29a83ccfc090d6e234952849. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/174?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

