### PR TITLE
Fix initial cmux theme picker render

### DIFF
--- a/src/cli/list_themes.zig
+++ b/src/cli/list_themes.zig
@@ -644,6 +644,27 @@ const Preview = struct {
         if (self.cmux == null and self.vx.caps.color_scheme_updates)
             try self.vx.subscribeToColorSchemeUpdates(writer);
 
+        // cmux mode skips the capability query above, so there may be no
+        // terminal response to establish the initial size or wake pollEvent.
+        // Initialize both explicitly so the picker is visible before input.
+        if (self.cmux != null) {
+            var arena = std.heap.ArenaAllocator.init(self.allocator);
+            defer arena.deinit();
+            const winsize: vaxis.Winsize = switch (builtin.os.tag) {
+                .windows => .{
+                    .rows = 24,
+                    .cols = 120,
+                    .x_pixel = 1024,
+                    .y_pixel = 768,
+                },
+                else => try self.tty.getWinsize(),
+            };
+            try self.vx.resize(self.allocator, writer, winsize);
+            try self.draw(arena.allocator());
+            try self.vx.render(writer);
+            try writer.flush();
+        }
+
         while (!self.should_quit) {
             var arena = std.heap.ArenaAllocator.init(self.allocator);
             defer arena.deinit();

--- a/src/crash/sentry.zig
+++ b/src/crash/sentry.zig
@@ -56,6 +56,22 @@ pub fn init(gpa: Allocator) !void {
     // Must only start once
     assert(init_thread == null);
 
+    // Resolve the Sentry cache directory BEFORE spawning the init thread.
+    // The resolution reads the process environment, and the global environ
+    // snapshot/map have no concurrency control (see global.syncEnviron), so
+    // reading them from the spawned thread races any setenv on another
+    // thread. That exact race crashed iOS during ghostty_init: initThread
+    // walked the environ block that ensureLocale's setenv had just
+    // realloc'd and freed on the main thread (cmux INTERNAL builds
+    // 20260730090940 and 20260730213932). Resolving here, on the spawning
+    // thread, keeps the spawned thread free of shared environ access.
+    const cache_dir = cache_dir: {
+        var environ_map = try global.environMap();
+        defer environ_map.deinit();
+        break :cache_dir try resolveCacheDir(gpa, &environ_map);
+    };
+    errdefer gpa.free(cache_dir);
+
     // We use a thread for initializing Sentry because initialization takes
     // ~2k ns on my M3 Max. That's not a LOT of time but it's enough to be
     // 90% of our pre-App startup time. Everything Sentry is doing initially
@@ -64,14 +80,42 @@ pub fn init(gpa: Allocator) !void {
     const thr = try std.Thread.spawn(
         .{},
         initThread,
-        .{gpa},
+        .{ gpa, cache_dir },
     );
     thr.setName(global.io(), "sentry-init") catch {};
     init_thread = thr;
 }
 
-fn initThread(gpa: Allocator) !void {
+/// Determine the Sentry cache directory from the given environment map.
+/// This takes the environment as an explicit map rather than reading the
+/// global process state so the caller can resolve it on a thread that owns
+/// the data (the spawning thread, not the sentry-init thread), and so the
+/// resolution is testable without touching the live environment.
+fn resolveCacheDir(
+    alloc: Allocator,
+    environ_map: *const std.process.Environ.Map,
+) ![]const u8 {
+    // On macOS, we prefer to use the NSCachesDirectory value to be
+    // a more idiomatic macOS application. But if XDG env vars are set
+    // we will respect them.
+    if (comptime builtin.os.tag == .macos) {
+        const xdg_cache_home = environ_map.get("XDG_CACHE_HOME") orelse "";
+        if (xdg_cache_home.len == 0) return try internal_os.macos.cacheDir(
+            alloc,
+            "sentry",
+        );
+    }
+
+    return try internal_os.xdg.cache(
+        alloc,
+        environ_map,
+        .{ .subdir = "ghostty/sentry" },
+    );
+}
+
+fn initThread(gpa: Allocator, cache_dir: []const u8) !void {
     if (comptime !build_options.sentry) return;
+    defer gpa.free(cache_dir);
 
     // Right now, on Darwin, `std.Thread.setName` can only name the current
     // thread, and we have no way to get the current thread from within it,
@@ -79,10 +123,6 @@ fn initThread(gpa: Allocator) !void {
     if (builtin.os.tag.isDarwin()) {
         internal_os.macos.pthread_setname_np(&"sentry-init".*);
     }
-
-    var arena = std.heap.ArenaAllocator.init(gpa);
-    defer arena.deinit();
-    const alloc = arena.allocator();
 
     const transport = sentry.Transport.init(&Transport.send);
     // This will crash if the transport was never used so we avoid
@@ -104,27 +144,10 @@ fn initThread(gpa: Allocator) !void {
     // do here and why we use this.
     sentry.c.sentry_options_set_before_send(opts, beforeSend, null);
 
-    // Determine the Sentry cache directory.
-    const cache_dir = cache_dir: {
-        // On macOS, we prefer to use the NSCachesDirectory value to be
-        // a more idiomatic macOS application. But if XDG env vars are set
-        // we will respect them.
-        if (comptime builtin.os.tag == .macos) macos: {
-            if (global.environ().containsUnemptyConstant("XDG_CACHE_HOME")) break :macos;
-            break :cache_dir try internal_os.macos.cacheDir(
-                alloc,
-                "sentry",
-            );
-        }
-
-        var environ_map = try global.environMap();
-        defer environ_map.deinit();
-        break :cache_dir try internal_os.xdg.cache(
-            alloc,
-            &environ_map,
-            .{ .subdir = "ghostty/sentry" },
-        );
-    };
+    // The Sentry cache directory was resolved by init() on the spawning
+    // thread (sentry copies the string into its options). Do NOT read the
+    // global environ from this thread; that raced setenv during startup
+    // and crashed (see init).
     sentry.c.sentry_options_set_database_path_n(
         opts,
         cache_dir.ptr,
@@ -310,3 +333,51 @@ pub const Transport = struct {
         return true;
     }
 };
+
+test "sentry cache dir resolves from the caller-provided environ map" {
+    // Regression test for the iOS startup crash (cmux INTERNAL builds
+    // 20260730090940 and 20260730213932): initThread used to read the
+    // GLOBAL environ snapshot from the spawned sentry-init thread, racing
+    // ensureLocale's setenv on the main thread and walking a freed environ
+    // block. The fix resolves the cache dir on the SPAWNING thread from an
+    // explicit map. This pins the seam: resolution must consume the
+    // caller's map (whose value does not exist in the live process
+    // environment), so it fails if the resolution ever reaches back into
+    // global process state.
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var environ_map = try testing.environ.createMap(alloc);
+    defer environ_map.deinit();
+    try environ_map.put("XDG_CACHE_HOME", "/tmp/ghostty-sentry-race-test");
+
+    const cache_dir = try resolveCacheDir(alloc, &environ_map);
+    defer alloc.free(cache_dir);
+
+    try testing.expectEqualStrings(
+        "/tmp/ghostty-sentry-race-test/ghostty/sentry",
+        cache_dir,
+    );
+}
+
+test "sentry cache dir prefers NSCachesDirectory on macOS without XDG" {
+    // Pins the behavior the refactor preserved from the old thread-side
+    // code: on macOS an unset OR empty XDG_CACHE_HOME falls back to the
+    // NSCachesDirectory-based path instead of the XDG path.
+    if (comptime builtin.os.tag != .macos) return error.SkipZigTest;
+
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var environ_map = try testing.environ.createMap(alloc);
+    defer environ_map.deinit();
+    try environ_map.put("XDG_CACHE_HOME", "");
+
+    const cache_dir = try resolveCacheDir(alloc, &environ_map);
+    defer alloc.free(cache_dir);
+
+    try testing.expect(std.mem.indexOf(u8, cache_dir, "Caches") != null);
+    try testing.expect(std.mem.endsWith(u8, cache_dir, "sentry"));
+}

--- a/src/global.zig
+++ b/src/global.zig
@@ -261,6 +261,21 @@ pub fn init(opts: InitOpts) !void {
     // As early as possible, initialize our resource limits.
     self.rlimits = .init();
 
+    // We need to make sure the process locale is set properly. Locale
+    // affects a lot of behaviors in a shell.
+    //
+    // We need to re-sync the environment after this completes.
+    //
+    // This MUST happen before crash.init below: ensureLocale mutates the
+    // process environment (setenv can realloc the environ array, freeing
+    // the block our environ snapshot points at), and crash.init spawns the
+    // sentry-init thread. Spawning that thread first left a concurrent
+    // environ reader alive across the realloc, which crashed iOS with a
+    // SIGSEGV in the sentry-init thread during the first ghostty_init of a
+    // session (cmux INTERNAL builds 20260730090940 and 20260730213932).
+    try internal_os.ensureLocale();
+    syncEnviron();
+
     // Initialize our crash reporting.
     crash.init(self.alloc) catch |err| {
         std.log.warn(
@@ -277,13 +292,6 @@ pub fn init(opts: InitOpts) !void {
     // ))) |uuid| {
     //     std.log.warn("uuid={s}", .{uuid.string()});
     // } else std.log.warn("failed to capture event", .{});
-
-    // We need to make sure the process locale is set properly. Locale
-    // affects a lot of behaviors in a shell.
-    //
-    // We need to re-sync the environment after this completes.
-    try internal_os.ensureLocale();
-    syncEnviron();
 
     // Initialize glslang for shader compilation
     try glslang.init();


### PR DESCRIPTION
In cmux mode, `+list-themes` skips the terminal capability query. The event loop then blocks before receiving the initial size event, leaving the picker blank until a resize.

Initialize the terminal size and render the first frame before waiting for input. Standard Ghostty mode keeps its existing query-driven path.

Verified by building the macOS CLI helper and launching `cmux themes` in a tagged cmux app.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/175"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788049679&installation_model_id=21920&pr_number=175&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F175&signature=b54cd33bf60ad23b94b0be2b0213e855ac8becb1d8afdceb1975298a1b6374a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes blank initial render of the theme picker in `cmux` mode by initializing terminal size and rendering the first frame before input. Also prevents startup crashes by resolving the Sentry cache directory on the spawning thread and running locale setup before crash init.

<sup>Written for commit 59f2b5d2ec67a5f9dfe9138f6e5a4353b75d238e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/175?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cmux preview mode so the theme picker appears immediately with the correct terminal size.
  * Ensured the initial picker display is rendered and flushed before interaction begins.
  * Improved crash-reporting initialization across different environments, including macOS and systems using XDG cache locations.
  * Improved locale and environment setup to support more reliable application startup and diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->