### PR TITLE
terminal: clear stale prompt marks on output overwrite

### DIFF
--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -645,6 +645,19 @@ inline fn printSliceEligible(cp: u32, comptime width: PrintSliceWidth) bool {
     });
 }
 
+/// Output replaces the prompt lifecycle for any row it writes. Keeping a
+/// prompt mark here would let later prompt-aware operations treat application
+/// output as a live shell prompt even though the cells no longer are one.
+inline fn clearSemanticPromptRowForOutput(self: *Terminal) void {
+    const cursor = &self.screens.active.cursor;
+    if (cursor.page_row.semantic_prompt != .none and
+        cursor.semantic_content == .output)
+    {
+        @branchHint(.unlikely);
+        cursor.page_row.semantic_prompt = .none;
+    }
+}
+
 /// Store a run of narrow codepoint cells built from a bit template:
 /// for each `idx` in `[from, to)`, `cells[idx]` is assigned the bits
 /// `template_bits | (cps[idx] << cp_shift)`.
@@ -859,6 +872,7 @@ fn printSliceFill(
                 }
                 cursor.page_row.dirty = true;
                 if (style_id != style.default_id) cursor.page_row.styled = true;
+                self.clearSemanticPromptRowForOutput();
                 cells[0] = spacer;
                 try self.printWrap();
                 continue :outer;
@@ -1061,6 +1075,7 @@ fn printSliceFill(
             assert(k % cells_per_cp == 0);
             cursor.page_row.dirty = true;
             if (style_id != style.default_id) cursor.page_row.styled = true;
+            self.clearSemanticPromptRowForOutput();
             self.previous_char = @intCast(cps[printed + k / cells_per_cp - 1]);
             printed += k / cells_per_cp;
 
@@ -1490,6 +1505,7 @@ fn printCell(
     };
 
     const cell = self.screens.active.cursor.page_cell;
+    self.clearSemanticPromptRowForOutput();
 
     // If the wide property of this cell is the same, then we don't
     // need to do the special handling here because the structure will

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -14477,6 +14477,48 @@ test "Terminal: semantic prompt" {
     }
 }
 
+test "Terminal: scalar output overwrite clears semantic prompt row mark" {
+    const alloc = testing.allocator;
+    const io_impl = testing.io;
+    var t = try init(io_impl, alloc, .{ .cols = 20, .rows = 5 });
+    defer t.deinit(alloc);
+
+    try t.semanticPrompt(.init(.prompt_start));
+    for ("$ claude") |c| try t.print(c);
+    try t.semanticPrompt(.init(.end_input_start_output));
+
+    t.carriageReturn();
+    for ("Claude Code") |c| try t.print(c);
+
+    const list_cell = t.screens.active.pages.getCell(.{ .active = .{
+        .x = 0,
+        .y = 0,
+    } }).?;
+    try testing.expectEqual(.output, list_cell.cell.semantic_content);
+    try testing.expectEqual(.none, list_cell.row.semantic_prompt);
+}
+
+test "Terminal: batched output overwrite clears semantic prompt row mark" {
+    const alloc = testing.allocator;
+    const io_impl = testing.io;
+    var t = try init(io_impl, alloc, .{ .cols = 20, .rows = 5 });
+    defer t.deinit(alloc);
+
+    try t.semanticPrompt(.init(.prompt_start));
+    try t.printSlice(&.{ '$', ' ', 'c', 'l', 'a', 'u', 'd', 'e' });
+    try t.semanticPrompt(.init(.end_input_start_output));
+
+    t.carriageReturn();
+    try t.printSlice(&.{ 'C', 'l', 'a', 'u', 'd', 'e', ' ', 'C', 'o', 'd', 'e' });
+
+    const list_cell = t.screens.active.pages.getCell(.{ .active = .{
+        .x = 0,
+        .y = 0,
+    } }).?;
+    try testing.expectEqual(.output, list_cell.cell.semantic_content);
+    try testing.expectEqual(.none, list_cell.row.semantic_prompt);
+}
+
 test "Terminal: semantic prompt continuations" {
     const alloc = testing.allocator;
     const io_impl = testing.io;


### PR DESCRIPTION
## Summary

- add red regression coverage for scalar and batched output overwriting an OSC 133 prompt-marked row
- clear row-level prompt metadata when printable output actually writes that row
- preserve historical prompt marks unless output overwrites their row

This closes the stale semantic-prompt lifecycle defect behind manaflow-ai/cmux#9268. A stale prompt row could make CSI 2J take the prompt-aware scroll-clear path after an inline TUI had already replaced the shell prompt.

## Tests

- Zig 0.16: Terminal: output overwrite clears semantic prompt row mark (red before fix, green after)
- Zig 0.16: Terminal: semantic prompt

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/176"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788070961&installation_model_id=21920&pr_number=176&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F176&signature=71715efef8229e8911bdc7dcb7ae704ef42c7b664b54f93ee8563b5a22e483ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale semantic prompt rows by clearing the prompt mark when output overwrites that row. Addresses Linear issue 9268 so prompt-aware clears don't run after a TUI replaces the shell prompt.

- **Bug Fixes**
  - Clear the row’s prompt metadata on output writes (scalar and batched) via a helper called in `printSliceFill` and `printCell`.
  - Preserve older prompt marks unless their rows are overwritten by output.

<sup>Written for commit 2d6e944e31a32f7be501715a744c33a1ba06642d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed prompt markers remaining visible when terminal output overwrites their row.
  * Ensured consistent behavior for single-character, batched, and cell-based output.
* **Tests**
  * Added coverage for prompt-row cleanup during scalar and batched output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->