### PR TITLE
Cache and gate macOS unified loggers

### DIFF
--- a/pkg/macos/os.zig
+++ b/pkg/macos/os.zig
@@ -4,6 +4,7 @@ pub const c = @import("os/c.zig");
 pub const signpost = @import("os/signpost.zig");
 pub const Log = log.Log;
 pub const LogType = log.LogType;
+pub const ScopedLog = log.ScopedLog;
 
 test {
     @import("std").testing.refAllDecls(@This());

--- a/pkg/macos/os/log.zig
+++ b/pkg/macos/os/log.zig
@@ -32,6 +32,8 @@ pub const Log = opaque {
         comptime format: []const u8,
         args: anytype,
     ) void {
+        if (!self.typeEnabled(typ)) return;
+
         const str = nosuspend std.fmt.allocPrintSentinel(
             alloc,
             format,
@@ -44,6 +46,39 @@ pub const Log = opaque {
 
     extern "c" fn zig_os_log_with_type(*Log, LogType, [*c]const u8) void;
 };
+
+/// Returns a process-lifetime logger for a compile-time subsystem and category.
+/// The first caller initializes it; subsequent calls only take dispatch_once's
+/// already-complete fast path. Unified log handles are safe to share between
+/// threads.
+pub fn ScopedLog(
+    comptime subsystem: [:0]const u8,
+    comptime category: [:0]const u8,
+) type {
+    const Init = struct {
+        fn create() *Log {
+            return Log.create(subsystem, category);
+        }
+    };
+
+    return Lazy(*Log, Init.create);
+}
+
+fn Lazy(comptime T: type, comptime initializer: fn () T) type {
+    return struct {
+        var once: c.dispatch_once_t = 0;
+        var value: ?T = null;
+
+        pub fn get() T {
+            c.dispatch_once_f(&once, null, initialize);
+            return value.?;
+        }
+
+        fn initialize(_: ?*anyopaque) callconv(.c) void {
+            value = initializer();
+        }
+    };
+}
 
 /// https://developer.apple.com/documentation/os/os_log_type_t?language=objc
 pub const LogType = enum(c.os_log_type_t) {
@@ -87,4 +122,22 @@ test "disabled log skips formatting" {
         .{FormattingProbe{ .formatted = &formatted }},
     );
     try testing.expect(!formatted);
+}
+
+test "scoped log cache initializes once" {
+    const testing = std.testing;
+
+    const Counter = struct {
+        var calls: usize = 0;
+
+        fn initialize() usize {
+            calls += 1;
+            return calls;
+        }
+    };
+
+    const cache = Lazy(usize, Counter.initialize);
+    try testing.expectEqual(@as(usize, 1), cache.get());
+    try testing.expectEqual(@as(usize, 1), cache.get());
+    try testing.expectEqual(@as(usize, 1), Counter.calls);
 }

--- a/pkg/macos/os/log.zig
+++ b/pkg/macos/os/log.zig
@@ -63,3 +63,28 @@ test {
     try testing.expect(log.typeEnabled(.fault));
     log.log(testing.allocator, .default, "hello {d}", .{12});
 }
+
+test "disabled log skips formatting" {
+    const testing = std.testing;
+
+    const FormattingProbe = struct {
+        formatted: *bool,
+
+        pub fn format(self: @This(), writer: *std.Io.Writer) std.Io.Writer.Error!void {
+            self.formatted.* = true;
+            try writer.writeAll("formatted");
+        }
+    };
+
+    var formatted = false;
+    const disabled: *Log = @ptrCast(&c._os_log_disabled);
+    try testing.expect(!disabled.typeEnabled(.debug));
+
+    disabled.log(
+        testing.allocator,
+        .debug,
+        "{f}",
+        .{FormattingProbe{ .formatted = &formatted }},
+    );
+    try testing.expect(!formatted);
+}

--- a/src/main_ghostty.zig
+++ b/src/main_ghostty.zig
@@ -143,10 +143,10 @@ fn logFn(
             .err => .fault,
         };
 
-        // Initialize a logger. This is slow to do on every operation
-        // but we shouldn't be logging too much.
-        const logger = macos.os.Log.create(build_config.bundle_id, @tagName(scope));
-        defer logger.release();
+        const logger = macos.os.ScopedLog(
+            build_config.bundle_id,
+            @tagName(scope),
+        ).get();
         logger.log(std.heap.c_allocator, mac_level, prefix ++ format, args);
     }
 


### PR DESCRIPTION
## Context

cmux [#8919](https://github.com/manaflow-ai/cmux/issues/8919) captured a thread spending every one of 3,030 samples in `os_log_create` with no wait. Turning the category off did not help because Ghostty created and released a unified-log handle for every `std.log` event, then allocated and formatted the message before the OS decided whether that type was enabled.

The Instruments capture in related cmux [#8935](https://github.com/manaflow-ai/cmux/issues/8935) has the same Ghostty path (`zig_os_log_with_type -> _os_log_impl`). This PR owns that shared fix; it does not attribute the stack to PostHog.

## Root cause and fix

- Add one lazy, process-lifetime `os_log_t` per compile-time subsystem/category using `dispatch_once_f`. Repeated events take the already-complete fast path instead of calling `os_log_create` and `os_release`.
- Check `os_log_type_enabled` before allocation or formatting at the shared `Log.log` boundary, so every caller gets the correct ordering.
- Keep the cache scoped by Ghostty's compile-time `std.log` scope rather than adding a synchronized runtime category dictionary to every event.

## Regression coverage

The first commit is intentionally red: Apple's always-disabled log handle still invokes an observable formatting probe on the old implementation (53/54 tests pass). The fix makes that test green and adds a counter-backed cache test proving two lookups initialize exactly once.

- `cd pkg/macos && zig build test --summary all`: 55/55 pass
- `zig build test -Dtest-filter='disabled log skips formatting' -Demit-macos-app=false -Demit-xcframework=false --summary all`: 72/72 pass and compiles the `main_ghostty.logFn` integration

## Profile

ReleaseFast harness, identical fixed-rate workload on macOS 26: 25 million disabled debug events targeted over five seconds. Normalized cores are `(user + sys) / real`; three direct-binary trials per revision.

| Revision | Median normalized cores | Median CPU seconds / million events |
| --- | ---: | ---: |
| Per-call create/format | 0.904 | 0.2072 |
| Cached + enablement-gated | 0.123 | 0.0248 |

That is an 86.4% reduction in sustained core cost and 8.35x less CPU work per event. The before revision missed the five-second schedule (5.65-6.62 seconds internal elapsed); the fixed revision completed on schedule.

## Related firehose sources

The independently-fixable transitioned hot states from cmux #8919 are already repaired on current fork/main and are not duplicated here:

- renderer realization is renderer-thread-owned and gates update/draw paths (manaflow-ai/ghostty#153, integrated by manaflow-ai/cmux#8998);
- the `os-open` delimiter non-progress, child reaping, and bounded reporting fixes landed in manaflow-ai/cmux#9000.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/177"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788156281&installation_model_id=21920&pr_number=177&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F177&signature=b91e0ecc31a07d84ea4885945af4b436583117ffbfc19631ba5c8cea5f8a66da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cache macOS unified loggers and gate formatting by enablement. This removes per-call `os_log_create`/`os_release` work and cuts CPU for disabled logs by ~8x.

- **Bug Fixes**
  - Added `macos.os.ScopedLog`: one process-lifetime logger per subsystem/category via `dispatch_once_f`.
  - `Log.log` now checks `typeEnabled` before allocating/formatting to skip disabled work.
  - Updated `main_ghostty.logFn` to use the cached logger; no per-call create/release.
  - Added tests for disabled formatting and one-time init; benchmark shows ~86% less sustained CPU on disabled events.

<sup>Written for commit d782c8c5c0a2031030b089b7a0813e08df5b14bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/177?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved macOS logging efficiency by avoiding unnecessary message formatting when a log level is disabled.
  * Reused initialized scoped loggers for consistent, lower-overhead logging.

* **Bug Fixes**
  * Preserved existing logging behavior and message output while improving logger lifecycle handling.

* **Tests**
  * Added coverage for disabled-log formatting and one-time logger initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->