### PR TITLE
Initialize locale before crash reporting

### DIFF
--- a/src/global.zig
+++ b/src/global.zig
@@ -258,10 +258,20 @@ pub fn init(opts: InitOpts) !void {
     std.log.info("renderer={}", .{renderer.Renderer});
     std.log.info("libxev default backend={t}", .{xev.backend});
 
+    // We need to make sure the process locale is set properly. Locale
+    // affects a lot of behaviors in a shell.
+    //
+    // Darwin's setlocale mutates global libc state. Do this before starting
+    // crash reporting, because that path initializes Sentry on a background
+    // thread and can otherwise race process-wide locale mutation during embed
+    // startup.
+    try internal_os.ensureLocale();
+    syncEnviron();
+
     // As early as possible, initialize our resource limits.
     self.rlimits = .init();
 
-    // Initialize our crash reporting.
+    // Initialize our crash reporting after locale is stable.
     crash.init(self.alloc) catch |err| {
         std.log.warn(
             "sentry init failed, no crash capture available err={}",
@@ -277,13 +287,6 @@ pub fn init(opts: InitOpts) !void {
     // ))) |uuid| {
     //     std.log.warn("uuid={s}", .{uuid.string()});
     // } else std.log.warn("failed to capture event", .{});
-
-    // We need to make sure the process locale is set properly. Locale
-    // affects a lot of behaviors in a shell.
-    //
-    // We need to re-sync the environment after this completes.
-    try internal_os.ensureLocale();
-    syncEnviron();
 
     // Initialize glslang for shader compilation
     try glslang.init();


### PR DESCRIPTION
Summary:
- moves Darwin locale setup before Ghostty crash reporting starts Sentry background initialization
- fixes the cmux INTERNAL TestFlight startup crash where the main thread was in setlocale while a Ghostty-created thread crashed in ghostty_init

Evidence:
- ASC crashes ABcW9SkjM5N2hVaFZE0YBsM and AIvdoBLmrBQfVpYrycr3lg8 on cmux INTERNAL build 20260801151612, local date 2026-08-02
- evidence saved locally under out/perf-incident-20260802-211649 in cmuxterm-hq

Testing:
- zig fmt src/global.zig
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/178"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788324102&installation_model_id=21920&pr_number=178&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F178&signature=765045a0e487ba8836d20ee67d00589aaa32b236bea2ca8f9c36352925c60851"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Initialize the process locale before starting crash reporting on macOS to prevent a startup race between `setlocale` and Sentry’s background init. Fixes the cmux INTERNAL TestFlight crash on launch.

- **Bug Fixes**
  - Moved `internal_os.ensureLocale()` and `syncEnviron()` before crash reporting init in `src/global.zig`.
  - Prevents Darwin race where crash reporter thread starts while `setlocale` mutates global libc state.

<sup>Written for commit f0f8273b700e754b3f0052cea033789aab902fd1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/178?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup locale initialization and synchronization.
  * Ensured crash reporting starts only after the process locale and resource limits are configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->