### PR TITLE
Do not join an unindented hard wrap after a short row

### DIFF
--- a/src/global.zig
+++ b/src/global.zig
@@ -258,10 +258,20 @@ pub fn init(opts: InitOpts) !void {
     std.log.info("renderer={}", .{renderer.Renderer});
     std.log.info("libxev default backend={t}", .{xev.backend});
 
+    // We need to make sure the process locale is set properly. Locale
+    // affects a lot of behaviors in a shell.
+    //
+    // Darwin's setlocale mutates global libc state. Do this before starting
+    // crash reporting, because that path initializes Sentry on a background
+    // thread and can otherwise race process-wide locale mutation during embed
+    // startup.
+    try internal_os.ensureLocale();
+    syncEnviron();
+
     // As early as possible, initialize our resource limits.
     self.rlimits = .init();
 
-    // Initialize our crash reporting.
+    // Initialize our crash reporting after locale is stable.
     crash.init(self.alloc) catch |err| {
         std.log.warn(
             "sentry init failed, no crash capture available err={}",
@@ -277,13 +287,6 @@ pub fn init(opts: InitOpts) !void {
     // ))) |uuid| {
     //     std.log.warn("uuid={s}", .{uuid.string()});
     // } else std.log.warn("failed to capture event", .{});
-
-    // We need to make sure the process locale is set properly. Locale
-    // affects a lot of behaviors in a shell.
-    //
-    // We need to re-sync the environment after this completes.
-    try internal_os.ensureLocale();
-    syncEnviron();
 
     // Initialize glslang for shader compilation
     try glslang.init();

--- a/src/link.zig
+++ b/src/link.zig
@@ -1338,6 +1338,17 @@ fn hardWrapBoundary(
 
     const semantic = upper_cells[upper_x].semantic_content;
 
+    // An unindented continuation is only credible when the upper row actually
+    // ran out of width: a UI that hard-wraps an unbroken token has no room
+    // left after the break punctuation. When the row still has blank columns,
+    // the newline was the program's own line ending, so the next row is
+    // unrelated output rather than the rest of one token. A trailing wide
+    // glyph that did not fit leaves its spacer head in the final column and
+    // still counts as full.
+    const upper_row_full = upper_x == upper_end.x or
+        (upper_x + 1 == upper_end.x and
+            upper_cells[upper_end.x].wide == .spacer_head);
+
     const lower_cells = lower_page.getCells(lower_page.getRow(lower_start.y));
     var lower_x: usize = lower_start.x;
     var indentation: usize = 0;
@@ -1357,6 +1368,7 @@ fn hardWrapBoundary(
             indentation,
             cp,
         ) orelse return false;
+        if (continuation == .unindented and !upper_row_full) return false;
 
         // Probe a bounded UTF-8 prefix without allocating under the terminal
         // lock. Filling the probe is ambiguous, so fail closed rather than

--- a/src/renderer/link.zig
+++ b/src/renderer/link.zig
@@ -1063,6 +1063,55 @@ test "renderPreparedHover keeps adjacent independent links separate" {
     }
 }
 
+test "renderPreparedHover does not join a short URL row ending in slash" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const url = @import("../config/url.zig");
+    const first = "https://google.com/";
+    const second = "foobar";
+
+    var t: terminal.Terminal = try .init(std.testing.io, alloc, .{ .cols = 80, .rows = 2 });
+    defer t.deinit(alloc);
+    var stream = t.vtStream();
+    defer stream.deinit();
+    stream.nextSlice(first ++ "\r\n" ++ second);
+
+    var set = try Set.fromConfig(alloc, &.{
+        .{
+            .regex = url.scheme_regex,
+            .action = .{ .open = {} },
+            .highlight = .{ .hover_mods = inputpkg.ctrlOrSuper(.{}) },
+            .candidate_scope = .bounded_logical,
+            .hard_wrap_continuations = true,
+        },
+        .{
+            .regex = url.path_regex,
+            .action = .{ .open = {} },
+            .highlight = .{ .hover_mods = inputpkg.ctrlOrSuper(.{}) },
+            .hard_wrap_continuations = true,
+            .hard_wrap_match_delimiter = true,
+        },
+    });
+    defer set.deinit(alloc);
+
+    var arena = std.heap.ArenaAllocator.init(alloc);
+    defer arena.deinit();
+    var result: terminal.RenderState.CellSet = .empty;
+    try renderHoverForTest(
+        &set,
+        arena.allocator(),
+        &t,
+        &result,
+        .{ .x = 10, .y = 0 },
+        inputpkg.ctrlOrSuper(.{}),
+    );
+
+    try testing.expectEqual(first.len, result.count());
+    for (0..first.len) |x| {
+        try testing.expect(result.contains(.{ .x = @intCast(x), .y = 0 }));
+    }
+}
+
 test "renderPreparedHover does not merge adjacent bare path after slash" {
     const testing = std.testing;
     const alloc = testing.allocator;


### PR DESCRIPTION
URL detection treated `https://google.com/` followed by an unrelated line as one token, so cmd+click opened `https://google.com/foobar`.

`hardWrapBoundary` accepted an unindented continuation whenever the upper row's last non-blank cell was break punctuation (`-`, `/`, `?`, `#`, `&`, `=`, `%`). The upper row's selection always ends at the final column, so the check had no evidence that the newline was width-forced rather than the program's own line ending.

An unindented continuation only occurs when the row ran out of width, so the fix requires the upper row's final column to be occupied (or to hold the spacer head of a wide glyph that did not fit). Indented continuations, where the formatter's padding is the evidence, are unchanged.

Fixes the ghostty side of https://github.com/manaflow-ai/cmux/issues/9456.

Note: this branch is based on the SHA cmux `main` currently pins, which is one commit ("Initialize locale before crash reporting") ahead of this fork's `main`; that commit rides along in this diff.

## Testing

- Commit 1 adds `renderPreparedHover does not join a short URL row ending in slash` only. Before the fix: `expected 19, found 25`.
- Commit 2 adds the fix. `zig build test -Dtest-filter=link --summary all` -> 197/197 passed; `-Dtest-filter=url` -> 82/82 passed.
- Confirmed against a tagged cmux dev build by running `echo "https://google.com/" && echo "foobar"` and cmd+clicking the URL.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/179"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788385160&installation_model_id=21920&pr_number=179&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F179&signature=d310434a1d5dfe7ccd151ee520c8bf6e2229199aed4273014dba5c844431b182"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent joining unindented hard wraps unless the upper row is width-filled, so short URL lines like `https://google.com/` aren’t merged with the next line. Fixes wrong URL detection when a URL ends with `/` (cmux issue 9456).

- **Bug Fixes**
  - Only join unindented continuations when the previous row’s final column is occupied (or a wide-glyph spacer). Indented continuations are unchanged.
  - Added a renderer test to ensure a URL line ending with `/` is not joined with the following line.

- **Refactors**
  - Initialize the process locale before starting crash reporting to avoid races, then re-sync the environment.

<sup>Written for commit 2022d20bbda0e9a846ad24f988200b6a5674100d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/179?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

