### PR TITLE
renderer: thread-safe tokened forced draw for offscreen capture

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1391,6 +1391,19 @@ GHOSTTY_API bool ghostty_surface_set_font_size_action_callback(
 // size-discarded render has no callback.
 GHOSTTY_API void ghostty_surface_render_now_with_token(ghostty_surface_t,
                                                        uint64_t token);
+// cmux fork: queue a tokened forced render executed on the renderer thread.
+// Thread-safe while the renderer OS thread is live, unlike
+// ghostty_surface_render_now_with_token which renders on the calling thread
+// and requires embedder-owned renderer state. Deliberately ignores the
+// occlusion visibility gate so an occluded window still renders a fresh frame
+// (ground-truth capture). The installed render-presented callback fires only
+// after the exact frame is presented to the platform layer (Metal: after the
+// main-thread IOSurface assignment). Returns false when no render-presented
+// callback is installed or another tokened draw is still pending; a
+// successfully queued render whose draw is skipped (renderer unrealized,
+// zero-sized surface, or a size-discarded layer assignment) has no callback.
+GHOSTTY_API bool ghostty_surface_request_render_with_token(ghostty_surface_t,
+                                                           uint64_t token);
 GHOSTTY_API void ghostty_surface_set_content_scale(ghostty_surface_t, double, double);
 GHOSTTY_API void ghostty_surface_set_focus(ghostty_surface_t, bool);
 GHOSTTY_API void ghostty_surface_set_occlusion(ghostty_surface_t, bool);

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1411,6 +1411,23 @@ pub const Surface = struct {
         });
     }
 
+    /// cmux fork: queue one tokened forced render executed on the renderer
+    /// thread. Safe to call from any thread while the renderer OS thread is
+    /// live (unlike `renderNowWithToken`, which renders on the calling thread
+    /// and requires embedder-owned renderer state). The installed
+    /// render-presented callback fires only after the exact frame is
+    /// presented to the platform layer (Metal: after the main-thread
+    /// IOSurface assignment). Returns false when no callback is installed or
+    /// another tokened draw is still pending.
+    pub fn requestRenderWithToken(self: *Surface, token: u64) bool {
+        const callback = self.render_presented_cb orelse return false;
+        return self.core_surface.renderer_thread.requestDrawWithPresentation(.{
+            .callback = callback,
+            .userdata = self.render_presented_userdata,
+            .token = token,
+        });
+    }
+
     pub fn updateContentScale(self: *Surface, x: f64, y: f64) void {
         // We are an embedded API so the caller can send us all sorts of
         // garbage. We want to make sure that the float values are valid
@@ -3127,6 +3144,15 @@ pub const CAPI = struct {
     /// caller-provided token.
     export fn ghostty_surface_render_now_with_token(surface: *Surface, token: u64) void {
         surface.renderNowWithToken(token);
+    }
+
+    /// Queue a tokened forced render executed on the renderer thread. See
+    /// `Surface.requestRenderWithToken`.
+    export fn ghostty_surface_request_render_with_token(
+        surface: *Surface,
+        token: u64,
+    ) bool {
+        return surface.requestRenderWithToken(token);
     }
 
     /// Update the size of a surface. This will trigger resize notifications

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -756,6 +756,16 @@ draw_active: bool = false,
 draw_now: xev.Async,
 draw_now_c: xev.Completion = .{},
 
+/// cmux fork: single-slot pending presentation for an embedder-requested
+/// tokened draw executed on the renderer thread. Producers on any thread fill
+/// the slot through `requestDrawWithPresentation` and the renderer thread's
+/// `drawNowCallback` consumes it. One slot keeps the contract honest: every
+/// accepted request gets its own forced update+draw whose backend
+/// presentation carries the exact token, and a concurrent second request is
+/// refused instead of silently sharing or dropping a frame.
+pending_draw_presentation_mutex: std.Thread.Mutex = .{},
+pending_draw_presentation: ?rendererpkg.FramePresentation = null,
+
 /// Dedicated, coalescing retry signal for a retained visibility submission.
 /// Keeping this separate from `draw_now` makes stale capacity notifications
 /// no-op instead of turning them into duplicate forced draws.
@@ -1003,6 +1013,43 @@ pub fn renderNowWithPresentation(
         &self.instrumentation,
         presentation,
     );
+}
+
+/// cmux fork: queue one tokened forced render executed on the renderer
+/// thread. Unlike `renderNowWithPresentation`, which performs the whole
+/// render cycle on the calling thread (safe only when the embedder owns
+/// renderer state, i.e. iOS external-drain mode), this is safe to call from
+/// any thread while the renderer OS thread is live: it only fills the pending
+/// slot and rings the existing `draw_now` async. Returns false when another
+/// tokened draw is still pending or the wakeup could not be delivered; the
+/// caller may retry.
+pub fn requestDrawWithPresentation(
+    self: *Thread,
+    presentation: rendererpkg.FramePresentation,
+) bool {
+    {
+        self.pending_draw_presentation_mutex.lock();
+        defer self.pending_draw_presentation_mutex.unlock();
+        if (self.pending_draw_presentation != null) return false;
+        self.pending_draw_presentation = presentation;
+    }
+    self.draw_now.notify() catch |err| {
+        log.warn("requestDrawWithPresentation: notify failed err={}", .{err});
+        self.pending_draw_presentation_mutex.lock();
+        defer self.pending_draw_presentation_mutex.unlock();
+        self.pending_draw_presentation = null;
+        return false;
+    };
+    return true;
+}
+
+/// cmux fork: take the pending tokened presentation, if any.
+fn takePendingDrawPresentation(self: *Thread) ?rendererpkg.FramePresentation {
+    self.pending_draw_presentation_mutex.lock();
+    defer self.pending_draw_presentation_mutex.unlock();
+    const presentation = self.pending_draw_presentation;
+    self.pending_draw_presentation = null;
+    return presentation;
 }
 
 /// Finish a forced draw before delivering a synchronous backend presentation.
@@ -1789,10 +1836,49 @@ fn drawNowCallback(
     // this remains a pure display-link draw and cannot consume stale retries.
     const t = self_.?;
     if (t.externalDrainActive()) return .rearm;
+
+    // cmux fork: a queued tokened draw takes this wake. It rebuilds frame data
+    // from current terminal state and skips the `flags.visible` gate on
+    // purpose (drawFrame's early-return): the whole point of the tokened path
+    // is ground-truth capture of a window the compositor considers occluded.
+    // The renderer-realized gate still applies (drawing unrealized GPU state
+    // is invalid); an unconsumed presentation is dropped and its callback
+    // never fires, which the embedder surfaces as a timeout.
+    if (t.takePendingDrawPresentation()) |presentation| {
+        drawPendingTokenedFrame(t, presentation);
+        return .rearm;
+    }
+
     if (t.visibility_regain.isPending()) return .rearm;
     _ = t.drawFrame(true);
 
     return .rearm;
+}
+
+/// cmux fork: renderer-thread half of `requestDrawWithPresentation`. Rebuilds
+/// frame data from the current terminal state, then draws one forced frame
+/// whose backend presentation carries the embedder token. On Metal the
+/// presentation is captured into the command-buffer completion and delivered
+/// after the main-thread IOSurface assignment; synchronous backends return it
+/// here and it is delivered as the final operation (delivery may reentrantly
+/// destroy Thread).
+fn drawPendingTokenedFrame(
+    t: *Thread,
+    presentation: rendererpkg.FramePresentation,
+) void {
+    if (!t.renderer_realized) {
+        log.warn("tokened draw skipped: renderer unrealized", .{});
+        return;
+    }
+    t.updateFrame(t.effectiveCursorBlinkVisible()) catch |err| {
+        log.warn("tokened draw: error updating frame err={}", .{err});
+        return;
+    };
+    finishRenderNowWithPresentation(
+        t.renderer,
+        &t.instrumentation,
+        presentation,
+    );
 }
 
 fn visibilityRetryCallback(

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -763,7 +763,7 @@ draw_now_c: xev.Completion = .{},
 /// accepted request gets its own forced update+draw whose backend
 /// presentation carries the exact token, and a concurrent second request is
 /// refused instead of silently sharing or dropping a frame.
-pending_draw_presentation_mutex: std.Thread.Mutex = .{},
+pending_draw_presentation_mutex: std.Io.Mutex = .init,
 pending_draw_presentation: ?rendererpkg.FramePresentation = null,
 
 /// Dedicated, coalescing retry signal for a retained visibility submission.
@@ -1028,15 +1028,15 @@ pub fn requestDrawWithPresentation(
     presentation: rendererpkg.FramePresentation,
 ) bool {
     {
-        self.pending_draw_presentation_mutex.lock();
-        defer self.pending_draw_presentation_mutex.unlock();
+        self.pending_draw_presentation_mutex.lockUncancelable(global.io());
+        defer self.pending_draw_presentation_mutex.unlock(global.io());
         if (self.pending_draw_presentation != null) return false;
         self.pending_draw_presentation = presentation;
     }
     self.draw_now.notify() catch |err| {
         log.warn("requestDrawWithPresentation: notify failed err={}", .{err});
-        self.pending_draw_presentation_mutex.lock();
-        defer self.pending_draw_presentation_mutex.unlock();
+        self.pending_draw_presentation_mutex.lockUncancelable(global.io());
+        defer self.pending_draw_presentation_mutex.unlock(global.io());
         self.pending_draw_presentation = null;
         return false;
     };
@@ -1045,8 +1045,8 @@ pub fn requestDrawWithPresentation(
 
 /// cmux fork: take the pending tokened presentation, if any.
 fn takePendingDrawPresentation(self: *Thread) ?rendererpkg.FramePresentation {
-    self.pending_draw_presentation_mutex.lock();
-    defer self.pending_draw_presentation_mutex.unlock();
+    self.pending_draw_presentation_mutex.lockUncancelable(global.io());
+    defer self.pending_draw_presentation_mutex.unlock(global.io());
     const presentation = self.pending_draw_presentation;
     self.pending_draw_presentation = null;
     return presentation;


### PR DESCRIPTION
Adds `ghostty_surface_request_render_with_token`: queues one forced update+draw executed on the renderer thread via the existing `draw_now` async, acknowledged through the render-presented callback after the exact frame's main-thread IOSurface assignment.

Mechanism: a single-slot mutex-guarded pending `FramePresentation` on `renderer.Thread`; `drawNowCallback` consumes it, rebuilds frame data from current terminal state (`updateFrame`), and draws with `drawFrameWithPresentation(sync=true)`. On Metal the presentation rides the command-buffer completion and is delivered on main in the same block that assigns the frame's IOSurface to the layer, so an embedder reading `layer.contents` from the callback observes at least that frame.

Why a new entry point: `ghostty_surface_render_now_with_token` performs the whole render cycle on the calling thread and is only safe when the embedder owns renderer state (iOS external-drain mode). On macOS the renderer OS thread is live, and draining the mailbox from a foreign thread mutates libxev loop timers unsafely. This API only fills the slot and rings `draw_now`, so it is safe from any thread.

The forced draw deliberately skips the `flags.visible` occlusion gate (but keeps the `renderer_realized` gate): its purpose is ground-truth capture of a surface whose window is occluded, on another Space, or never ordered front. cmux uses it for the `debug.surface.screenshot` debug-socket RPC (cmux PR to follow; the cmux submodule pointer bump depends on this PR merging first).

Note: branch is based on the SHA cmux main currently pins (19d03fa4d), which is itself ahead of this fork's main via a pending PR; the extra commits below mine will disappear from this diff once that lands.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/181"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788604270&installation_model_id=21920&pr_number=181&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F181&signature=e86dca22c150a635b9fab14e7e4fb938d3ed1aef477a41360a3608dc75aa709f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a thread-safe API to request a tokened offscreen render on the renderer thread, enabling ground-truth screenshots even when the window is occluded. Also reduces noisy opener logs and fixes a startup locale race.

- New Features
  - Added `ghostty_surface_request_render_with_token(...)` to queue one forced update+draw on the renderer thread.
  - Uses `draw_now` and delivers the exact frame’s token via the render-presented callback after IOSurface assignment.
  - Ignores occlusion; rejects requests with no callback or while one is pending. If the renderer is unrealized or the surface is zero-sized/size-discarded, the draw is skipped and no callback fires.

- Bug Fixes
  - `drainStderr`: ignore blank lines and bound repeats; tests for EOF and repeated blank output.
  - Initialize locale before crash reporting to avoid races during embed startup.
  - Use `std.Io.Mutex` for the pending presentation slot for Zig 0.16 compatibility.

<sup>Written for commit a52417bdc1bc40b2392f5f4129d3bdae3d2a201b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/181?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an API for requesting an asynchronous, forced render with a unique token.
  * Render completion callbacks now report only after the requested frame is presented.
  * Requests safely skip unavailable or already-pending renders and do not trigger callbacks when rendering is skipped.

* **Documentation**
  * Clarified locale initialization requirements to improve crash-reporting reliability on macOS.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->