### PR TITLE
Integrate current cmux Ghostty fixes with cached logging

### DIFF
--- a/src/global.zig
+++ b/src/global.zig
@@ -258,10 +258,20 @@ pub fn init(opts: InitOpts) !void {
     std.log.info("renderer={}", .{renderer.Renderer});
     std.log.info("libxev default backend={t}", .{xev.backend});
 
+    // We need to make sure the process locale is set properly. Locale
+    // affects a lot of behaviors in a shell.
+    //
+    // Darwin's setlocale mutates global libc state. Do this before starting
+    // crash reporting, because that path initializes Sentry on a background
+    // thread and can otherwise race process-wide locale mutation during embed
+    // startup.
+    try internal_os.ensureLocale();
+    syncEnviron();
+
     // As early as possible, initialize our resource limits.
     self.rlimits = .init();
 
-    // Initialize our crash reporting.
+    // Initialize our crash reporting after locale is stable.
     crash.init(self.alloc) catch |err| {
         std.log.warn(
             "sentry init failed, no crash capture available err={}",
@@ -277,13 +287,6 @@ pub fn init(opts: InitOpts) !void {
     // ))) |uuid| {
     //     std.log.warn("uuid={s}", .{uuid.string()});
     // } else std.log.warn("failed to capture event", .{});
-
-    // We need to make sure the process locale is set properly. Locale
-    // affects a lot of behaviors in a shell.
-    //
-    // We need to re-sync the environment after this completes.
-    try internal_os.ensureLocale();
-    syncEnviron();
 
     // Initialize glslang for shader compilation
     try glslang.init();

--- a/src/os/open.zig
+++ b/src/os/open.zig
@@ -104,6 +104,11 @@ fn drainStderr(reader: *std.Io.Reader) usize {
             error.StreamTooLong => reader.take(reader.buffer.len) catch break,
         }) orelse break;
 
+        // Blank lines contain no diagnostic information. Keep consuming them
+        // so the child can exit, but do not emit repeated `open stderr=`
+        // records if an opener writes blank output.
+        if (line.len == 0) continue;
+
         // Keep draining after the cap so a child blocked writing into a full
         // pipe can still finish and exit; only the reporting is capped.
         if (logged < max_open_stderr_lines) {
@@ -122,11 +127,11 @@ test "drainStderr reports every line and terminates" {
     try std.testing.expectEqual(@as(usize, 3), drainStderr(&r));
 }
 
-test "drainStderr terminates on blank lines" {
+test "drainStderr drains blank lines without reporting" {
     // The old `takeDelimiterExclusive` loop spun forever here: the seek position
     // parks on the delimiter and every subsequent read returns an empty slice.
     var r: std.Io.Reader = .fixed("\n\n\n");
-    try std.testing.expectEqual(@as(usize, 3), drainStderr(&r));
+    try std.testing.expectEqual(@as(usize, 0), drainStderr(&r));
 }
 
 test "drainStderr reports a final line with no trailing newline" {

--- a/src/os/open.zig
+++ b/src/os/open.zig
@@ -147,3 +147,48 @@ test "drainStderr caps reporting but still drains to end of stream" {
     // writing into a full pipe can never exit and `wait()` parks forever.
     try std.testing.expectEqual(@as(usize, 0), r.end - r.seek);
 }
+
+test "open stderr reader exits after blank lines and bounds repeated logs" {
+    if (comptime builtin.os.tag == .windows) return error.SkipZigTest;
+
+    const testing = std.testing;
+    const io = testing.io;
+    const child = try std.process.spawn(io, .{
+        .argv = &.{
+            "/bin/sh",
+            "-c",
+            "i=0; while [ \"$i\" -lt 40 ]; do printf '\\n' >&2; i=$((i + 1)); done",
+        },
+        .stdout = .ignore,
+        .stderr = .pipe,
+    });
+
+    var logged: usize = 0;
+    var returned: std.Io.Event = .unset;
+    const thread = try std.Thread.spawn(.{}, struct {
+        fn run(
+            thread_io: std.Io,
+            child_: std.process.Child,
+            logged_: *usize,
+            returned_: *std.Io.Event,
+        ) void {
+            var child_copy = child_;
+            defer _ = child_copy.wait(thread_io) catch {};
+
+            const stderr = child_copy.stderr orelse return;
+            var buffer: [256]u8 = undefined;
+            var stream = stderr.readerStreaming(thread_io, &buffer);
+            logged_.* = drainStderr(&stream.interface);
+            returned_.set(thread_io);
+        }
+    }.run, .{ io, child, &logged, &returned });
+
+    returned.waitTimeout(io, .{ .duration = .{
+        .clock = .awake,
+        .raw = .fromSeconds(1),
+    } }) catch @panic("open stderr reader did not exit after EOF");
+    thread.join();
+
+    // A short burst of identical blank lines must not become a log flood.
+    try testing.expect(logged < 10);
+}


### PR DESCRIPTION
The cmux parent PR now needs one Ghostty commit that contains both the cached, enablement-gated macOS logger fix from #177 and the current cmux locale/opener fixes from `19d03fa4d`.

This PR publishes merge commit `754c95d4f286ff7a0cebbc5d5b198818ebf80cf1` on the protected tracked `main` branch. The merge resolves `src/global.zig` by preserving one locale initialization before crash reporting. Ghostty package and focused logger/opener integration tests pass, and the universal ReleaseFast GhosttyKit artifact was published and independently validated by manaflow-ai/cmux Actions run 31135442829.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/182"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788656471&installation_model_id=21920&pr_number=182&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F182&signature=93957039a87bd46473d2d2d7ccc49415f4c519d254ed104c753e3baf77865ee7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Integrates the latest cmux Ghostty locale/opener fixes with the cached, enablement‑gated macOS logger. Prevents stderr log floods and ensures crash reporting starts after the locale is stable.

- **Bug Fixes**
  - Initialize locale before crash reporting, resync the environment, then set resource limits to avoid environ reallocation races during crash init.
  - Harden opener stderr handling: skip blank lines, bound repeated logs, and still drain to EOF to avoid child hangs; added tests for blank-line loops and a spawned child case.

<sup>Written for commit 754c95d4f286ff7a0cebbc5d5b198818ebf80cf1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/182?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of blank lines in process error output to prevent unnecessary log entries.
  * Ensured repeated blank output is drained promptly and does not exceed reporting limits.
  * Improved startup sequencing so locale setup is completed before resource-limit and crash-reporting initialization.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->