### PR TITLE
Fix trailing-slash URL detection across hard newlines

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -9054,16 +9054,20 @@ test "Surface: path link selection spans an indented hard newline" {
     )) == null);
 }
 
-test "Surface: markdown path spans unindented hard newlines" {
+test "Surface: markdown path spans width-filled unindented hard newlines" {
     if (comptime !@import("terminal_options").oniguruma) return error.SkipZigTest;
 
     const testing = std.testing;
     const alloc = testing.allocator;
     const prefix = "##  ";
     const first = "/Users/austinwang/Library/Developer/Xcode/DerivedData/";
-    const second = "cmux-fix-split-resize/Build/Products/Debug/cmux DEV fix-";
+    const second = "cmux-fix-split-resize/Build/Products/Debug/cmux DEV fix-x-";
     const third = "split-resize.app";
     const value = first ++ second ++ third;
+
+    comptime {
+        std.debug.assert(prefix.len + first.len == second.len);
+    }
 
     try oni.testing.ensureInit();
     var config = try configpkg.Config.default(alloc);
@@ -9072,7 +9076,7 @@ test "Surface: markdown path spans unindented hard newlines" {
     defer derived.deinit();
 
     var screen = try terminal.Screen.init(std.testing.io, alloc, .{
-        .cols = 80,
+        .cols = second.len,
         .rows = 4,
         .max_scrollback = 0,
     });
@@ -9080,7 +9084,7 @@ test "Surface: markdown path spans unindented hard newlines" {
 
     screen.cursorSetSemanticContent(.output);
     try screen.testWriteString(
-        prefix ++ first ++ "\r\n" ++ second ++ "\r\n" ++ third,
+        prefix ++ first ++ "\n" ++ second ++ "\n" ++ third,
     );
 
     for ([_]terminal.point.Coordinate{
@@ -9101,15 +9105,21 @@ test "Surface: markdown path spans unindented hard newlines" {
     }
 }
 
-test "Surface: URL spans unindented hard newlines" {
+test "Surface: URL spans width-filled unindented hard newlines" {
     if (comptime !@import("terminal_options").oniguruma) return error.SkipZigTest;
 
     const testing = std.testing;
     const alloc = testing.allocator;
-    const first = "https://github.com/manaflow-ai/cmux/issues/8583#issuecomment-";
-    const second = "0123456789-";
+    const first = "https://github.com/manaflow-ai/cmux/issues/8583#issuecomment-xy-";
+    const second = "01234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-";
     const third = "abcdefghijklmnopqrstuvwxyz";
     const value = first ++ second ++ third;
+
+    comptime {
+        // An unindented real newline is only an unambiguous wrap when the
+        // preceding physical row ran out of columns.
+        std.debug.assert(first.len == second.len);
+    }
 
     try oni.testing.ensureInit();
     var config = try configpkg.Config.default(alloc);
@@ -9118,13 +9128,13 @@ test "Surface: URL spans unindented hard newlines" {
     defer derived.deinit();
 
     var screen = try terminal.Screen.init(std.testing.io, alloc, .{
-        .cols = 96,
+        .cols = first.len,
         .rows = 4,
         .max_scrollback = 0,
     });
     defer screen.deinit();
     screen.cursorSetSemanticContent(.output);
-    try screen.testWriteString(first ++ "\r\n" ++ second ++ "\r\n" ++ third);
+    try screen.testWriteString(first ++ "\n" ++ second ++ "\n" ++ third);
 
     for ([_]terminal.point.Coordinate{
         .{ .x = 20, .y = 0 },

--- a/src/link.zig
+++ b/src/link.zig
@@ -1338,6 +1338,17 @@ fn hardWrapBoundary(
 
     const semantic = upper_cells[upper_x].semantic_content;
 
+    // An unindented continuation is only credible when the upper row actually
+    // ran out of width: a UI that hard-wraps an unbroken token has no room
+    // left after the break punctuation. When the row still has blank columns,
+    // the newline was the program's own line ending, so the next row is
+    // unrelated output rather than the rest of one token. A trailing wide
+    // glyph that did not fit leaves its spacer head in the final column and
+    // still counts as full.
+    const upper_row_full = upper_x == upper_end.x or
+        (upper_x + 1 == upper_end.x and
+            upper_cells[upper_end.x].wide == .spacer_head);
+
     const lower_cells = lower_page.getCells(lower_page.getRow(lower_start.y));
     var lower_x: usize = lower_start.x;
     var indentation: usize = 0;
@@ -1357,6 +1368,7 @@ fn hardWrapBoundary(
             indentation,
             cp,
         ) orelse return false;
+        if (continuation == .unindented and !upper_row_full) return false;
 
         // Probe a bounded UTF-8 prefix without allocating under the terminal
         // lock. Filling the probe is ambiguous, so fail closed rather than

--- a/src/renderer/link.zig
+++ b/src/renderer/link.zig
@@ -1063,6 +1063,55 @@ test "renderPreparedHover keeps adjacent independent links separate" {
     }
 }
 
+test "renderPreparedHover does not join a short URL row ending in slash" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const url = @import("../config/url.zig");
+    const first = "https://google.com/";
+    const second = "foobar";
+
+    var t: terminal.Terminal = try .init(std.testing.io, alloc, .{ .cols = 80, .rows = 2 });
+    defer t.deinit(alloc);
+    var stream = t.vtStream();
+    defer stream.deinit();
+    stream.nextSlice(first ++ "\r\n" ++ second);
+
+    var set = try Set.fromConfig(alloc, &.{
+        .{
+            .regex = url.scheme_regex,
+            .action = .{ .open = {} },
+            .highlight = .{ .hover_mods = inputpkg.ctrlOrSuper(.{}) },
+            .candidate_scope = .bounded_logical,
+            .hard_wrap_continuations = true,
+        },
+        .{
+            .regex = url.path_regex,
+            .action = .{ .open = {} },
+            .highlight = .{ .hover_mods = inputpkg.ctrlOrSuper(.{}) },
+            .hard_wrap_continuations = true,
+            .hard_wrap_match_delimiter = true,
+        },
+    });
+    defer set.deinit(alloc);
+
+    var arena = std.heap.ArenaAllocator.init(alloc);
+    defer arena.deinit();
+    var result: terminal.RenderState.CellSet = .empty;
+    try renderHoverForTest(
+        &set,
+        arena.allocator(),
+        &t,
+        &result,
+        .{ .x = 10, .y = 0 },
+        inputpkg.ctrlOrSuper(.{}),
+    );
+
+    try testing.expectEqual(first.len, result.count());
+    for (0..first.len) |x| {
+        try testing.expect(result.contains(.{ .x = @intCast(x), .y = 0 }));
+    }
+}
+
 test "renderPreparedHover does not merge adjacent bare path after slash" {
     const testing = std.testing;
     const alloc = testing.allocator;


### PR DESCRIPTION
Fixes manaflow-ai/cmux#9456.

## Root cause

Ghostty's canonical grid resolver treated punctuation, the following row, and semantic-region equality as sufficient evidence for an unindented hard-newline continuation. It did not verify that the upper physical row actually ran out of columns, so a short complete URL or path ending in `-`, `_`, `/`, `?`, `#`, `&`, `=`, or `%` could absorb unrelated output from the next row.

## Change

- Require the upper row to be width-filled before accepting an unindented hard-newline continuation.
- Preserve indented hard-newline continuations and terminal soft wraps unchanged.
- Keep the decision in grid expansion, the layer that owns terminal-column evidence; normalization continues to share the punctuation classifier.
- Preserve full-width unindented URL and path coverage, including the Screen test helper's newline semantics.

The branch deliberately has two commits: the first adds the failing behavioral regression, and the second adds the fix.

## Verification

- Red, test-only SHA `28baa8649`: [focused run](https://github.com/manaflow-ai/ghostty/actions/runs/31149151450) failed with `expected 19, found 25`, proving the exact `https://google.com/` + `foobar` reproduction joined all 25 cells.
- Green runtime fix: [focused run](https://github.com/manaflow-ai/ghostty/actions/runs/31149529107) passed the same regression.
- Final source tree: [full headless Ghostty suite](https://github.com/manaflow-ai/ghostty/actions/runs/31151725380) passed with `-Dapp-runtime=none`.
- `zig fmt` and `git diff --check` pass on the changed Zig files.
