### PR TITLE
Bound embedded surface process teardown

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1339,6 +1339,11 @@ GHOSTTY_API ghostty_surface_t ghostty_surface_new_with_scrollback_limit(
     ghostty_app_t,
     const ghostty_surface_config_s*,
     size_t scrollback_limit_bytes);
+// cmux fork: retire the surface from Ghostty app routing and begin bounded
+// child-process termination without joining or freeing native surface state.
+// After this call, the embedder must make no other surface API calls and must
+// eventually call ghostty_surface_free. Safe to call repeatedly before free.
+GHOSTTY_API void ghostty_surface_request_process_termination(ghostty_surface_t);
 GHOSTTY_API void ghostty_surface_free(ghostty_surface_t);
 GHOSTTY_API void* ghostty_surface_userdata(ghostty_surface_t);
 GHOSTTY_API ghostty_app_t ghostty_surface_app(ghostty_surface_t);

--- a/include/ghostty/vt/terminal.h
+++ b/include/ghostty/vt/terminal.h
@@ -1496,6 +1496,22 @@ GHOSTTY_API void ghostty_terminal_vt_write(GhosttyTerminal terminal,
                                 size_t len);
 
 /**
+ * Return whether the VT stream has no incomplete parser or UTF-8 state.
+ *
+ * A true result means a formatter snapshot can be loaded into a fresh
+ * terminal and followed by later VT bytes without losing an unfinished
+ * escape sequence or Unicode codepoint. The caller must serialize this query
+ * and its snapshot with ghostty_terminal_vt_write().
+ *
+ * @param terminal The terminal handle (NULL returns false)
+ * @return true when both the VT parser and UTF-8 decoder are in ground state
+ *
+ * @ingroup terminal
+ */
+GHOSTTY_API bool ghostty_terminal_vt_stream_is_ground(
+    GhosttyTerminal terminal);
+
+/**
  * Scroll the terminal viewport.
  *
  * Scrolls the terminal's viewport according to the given behavior.

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -1070,13 +1070,15 @@ pub fn init(
 }
 
 pub fn deinit(self: *Surface) void {
-    // Stop search thread
-    if (self.search) |*s| s.deinit();
-
+    // Start renderer and child-process shutdown before waiting on any one
+    // owned thread. Embedded hosts may already have requested IO shutdown;
+    // xev async notifications are safe to repeat before Thread.deinit.
     self.renderer_thread.stop.notify() catch |err|
         log.err("error notifying renderer thread to stop, may stall err={}", .{err});
-    self.io_thread.stop.notify() catch |err|
-        log.err("error notifying io thread to stop, may stall err={}", .{err});
+    self.requestProcessTermination();
+
+    // Stop search thread
+    if (self.search) |*s| s.deinit();
 
     // Stop rendering thread
     {
@@ -1119,6 +1121,13 @@ pub fn deinit(self: *Surface) void {
     self.config.deinit();
 
     log.info("surface closed addr={x}", .{@intFromPtr(self)});
+}
+
+/// Ask the IO owner to terminate and reap this surface's child process without
+/// waiting for surface destruction. Safe to call repeatedly before deinit.
+pub fn requestProcessTermination(self: *Surface) void {
+    self.io_thread.stop.notify() catch |err|
+        log.err("error notifying io thread to stop, may stall err={}", .{err});
 }
 
 /// Signal that the app-thread mailbox has capacity for a retained renderer

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -807,6 +807,7 @@ test "embedded surface teardown completes before a retained action returns" {
     surface.userdata = &teardown_completed;
     surface.core_surface.id = 22;
     surface.app_action_lifetime = .{};
+    surface.process_termination_requested = .{ .raw = false };
     try core_app.surfaces.append(std.testing.allocator, &surface);
 
     surface.retainForAppAction();
@@ -826,6 +827,7 @@ pub const Surface = struct {
     userdata: ?*anyopaque = null,
     core_surface: CoreSurface,
     app_action_lifetime: SurfaceActionLifetime = .{},
+    process_termination_requested: std.atomic.Value(bool) = .{ .raw = false },
     content_scale: apprt.ContentScale,
     size: apprt.SurfaceSize,
     cursor_pos: apprt.CursorPos,
@@ -1129,7 +1131,19 @@ pub const Surface = struct {
     }
 
     pub fn deinit(self: *Surface) void {
+        self.requestProcessTermination();
         self.deinitWith(destroyContents);
+    }
+
+    /// Retire the surface from app routing and ask its IO thread to terminate
+    /// the owned child process without waiting for the native surface free.
+    pub fn requestProcessTermination(self: *Surface) void {
+        if (self.process_termination_requested.swap(true, .acq_rel)) return;
+
+        // Registry removal and redraw-lease acquisition share one lock, so no
+        // new app action can retain this surface after deletion returns.
+        self.app.core_app.deleteSurface(self);
+        self.core_surface.requestProcessTermination();
     }
 
     fn deinitWith(
@@ -1138,10 +1152,16 @@ pub const Surface = struct {
     ) void {
         const alloc = self.app.core_app.alloc;
 
-        // Stop new app actions first. Wait for an action on another thread;
-        // a reentrant action on this thread retains the outer allocation while
-        // the live renderer, IO, and callback state are torn down.
-        self.app.core_app.deleteSurface(self);
+        // requestProcessTermination normally removed the surface already.
+        // deinitWith is also used by a focused lifetime test, so preserve the
+        // standalone removal behavior when no process request preceded it.
+        if (!self.process_termination_requested.load(.acquire)) {
+            self.app.core_app.deleteSurface(self);
+        }
+
+        // Wait for an action on another thread; a reentrant action on this
+        // thread retains the outer allocation while renderer, IO, and callback
+        // state are torn down.
         self.app_action_lifetime.waitForActionsBeforeTeardown();
         deinit_contents(self);
         if (self.app_action_lifetime.releaseOwner()) alloc.destroy(self);
@@ -2453,6 +2473,11 @@ pub const CAPI = struct {
 
     export fn ghostty_surface_free(ptr: *Surface) void {
         ptr.app.closeSurface(ptr);
+    }
+
+    /// Begin child-process shutdown without waiting for surface destruction.
+    export fn ghostty_surface_request_process_termination(ptr: *Surface) void {
+        ptr.requestProcessTermination();
     }
 
     /// Returns the userdata associated with the surface.

--- a/src/lib_vt.zig
+++ b/src/lib_vt.zig
@@ -266,6 +266,7 @@ comptime {
         @export(&c.terminal_resize, .{ .name = "ghostty_terminal_resize" });
         @export(&c.terminal_set, .{ .name = "ghostty_terminal_set" });
         @export(&c.terminal_vt_write, .{ .name = "ghostty_terminal_vt_write" });
+        @export(&c.terminal_vt_stream_is_ground, .{ .name = "ghostty_terminal_vt_stream_is_ground" });
         @export(&c.terminal_scroll_viewport, .{ .name = "ghostty_terminal_scroll_viewport" });
         @export(&c.terminal_compression_activity, .{ .name = "ghostty_terminal_compression_activity" });
         @export(&c.terminal_compress, .{ .name = "ghostty_terminal_compress" });

--- a/src/terminal/c/main.zig
+++ b/src/terminal/c/main.zig
@@ -188,6 +188,7 @@ pub const terminal_reset = terminal.reset;
 pub const terminal_resize = terminal.resize;
 pub const terminal_set = terminal.set;
 pub const terminal_vt_write = terminal.vt_write;
+pub const terminal_vt_stream_is_ground = terminal.vt_stream_is_ground;
 pub const terminal_scroll_viewport = terminal.scroll_viewport;
 pub const terminal_compression_activity = terminal.compression_activity;
 pub const terminal_compress = terminal.compress;

--- a/src/terminal/c/terminal.zig
+++ b/src/terminal/c/terminal.zig
@@ -411,6 +411,14 @@ pub fn vt_write(
     wrapper.stream.nextSlice(ptr[0..len]);
 }
 
+pub fn vt_stream_is_ground(
+    terminal_: Terminal,
+) callconv(lib.calling_conv) bool {
+    const wrapper = terminal_ orelse return false;
+    return wrapper.stream.parser.state == .ground and
+        wrapper.stream.utf8decoder.state == 0;
+}
+
 pub fn compression_activity(
     terminal_: Terminal,
     out_activity_: ?*u64,
@@ -1838,6 +1846,43 @@ test "vt_write split escape sequence" {
     defer testing.allocator.free(str);
     // If the escape sequence leaked, we'd see "[1mBold" as literal text.
     try testing.expectEqualStrings("Hello Bold", str);
+}
+
+test "vt stream ground requires complete parser and UTF-8 state" {
+    var t: Terminal = null;
+    try testing.expectEqual(Result.success, new(
+        &lib.alloc.test_allocator,
+        &t,
+        .{
+            .cols = 80,
+            .rows = 24,
+            .max_scrollback = 10_000,
+        },
+    ));
+    defer free(t);
+
+    try testing.expect(vt_stream_is_ground(t));
+    vt_write(t, "plain ", 6);
+    try testing.expect(vt_stream_is_ground(t));
+
+    vt_write(t, "\xce", 1);
+    try testing.expect(!vt_stream_is_ground(t));
+    vt_write(t, "\xbb", 1);
+    try testing.expect(vt_stream_is_ground(t));
+
+    vt_write(t, "\x1b", 1);
+    try testing.expect(!vt_stream_is_ground(t));
+    vt_write(t, "[31", 3);
+    try testing.expect(!vt_stream_is_ground(t));
+    vt_write(t, "m", 1);
+    try testing.expect(vt_stream_is_ground(t));
+
+    vt_write(t, "\x1b]0;title", 9);
+    try testing.expect(!vt_stream_is_ground(t));
+    vt_write(t, "\x1b", 1);
+    try testing.expect(!vt_stream_is_ground(t));
+    vt_write(t, "\\", 1);
+    try testing.expect(vt_stream_is_ground(t));
 }
 
 test "vt_write split combining mark after base at right edge" {

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -1120,9 +1120,9 @@ const Subprocess = struct {
         self.process = null;
     }
 
-    /// Stop the subprocess. This is safe to call anytime. This will wait
-    /// for the subprocess to register that it has been signalled, but not
-    /// for it to terminate, so it will not block.
+    /// Stop the subprocess. This is safe to call anytime. POSIX teardown
+    /// allows the process group a bounded SIGHUP grace period, then escalates
+    /// to SIGKILL and bounds that reap wait as well.
     /// This does not close the pty.
     pub fn stop(self: *Subprocess) void {
         switch (self.process orelse return) {
@@ -1130,7 +1130,7 @@ const Subprocess = struct {
                 // Note: this will also wait for the command to exit, so
                 // DO NOT call cmd.wait
                 killCommand(cmd) catch |err|
-                    log.err("error sending SIGHUP to command, may hang: {}", .{err});
+                    log.err("error stopping command: {}", .{err});
             },
 
             .flatpak => |*cmd| if (comptime build_config.flatpak) {
@@ -1167,9 +1167,8 @@ const Subprocess = struct {
         }
     }
 
-    /// Kill the underlying subprocess. This sends a SIGHUP to the child
-    /// process. This also waits for the command to exit and will return the
-    /// exit code.
+    /// Kill the underlying subprocess. POSIX process groups receive SIGHUP
+    /// first and SIGKILL if they outlive the graceful shutdown budget.
     fn killCommand(command: *Command) !void {
         if (command.pid) |pid| {
             switch (builtin.os.tag) {
@@ -1186,7 +1185,19 @@ const Subprocess = struct {
         }
     }
 
+    const KillTimeouts = struct {
+        // Claude's injected SessionEnd hook has a 10-second timeout. Leave
+        // enough room for that hook plus process shutdown bookkeeping.
+        sighup_grace: std.Io.Duration = .fromSeconds(12),
+        sigkill_grace: std.Io.Duration = .fromSeconds(3),
+        poll_interval: std.Io.Duration = .fromMilliseconds(10),
+    };
+
     fn killPid(pid: c.pid_t) !void {
+        return killPidWithTimeouts(pid, .{});
+    }
+
+    fn killPidWithTimeouts(pid: c.pid_t, timeouts: KillTimeouts) !void {
         const pgid = getpgid(pid) orelse {
             // Darwin no longer exposes a process group for an exited child,
             // even while its wait status is still pending. The process
@@ -1199,12 +1210,20 @@ const Subprocess = struct {
         // our child process calls setsid but before or simultaneous
         // to calling execve. In this case, the direct child dies
         // but grandchildren survive. To work around this, we loop
-        // and repeatedly kill the process group until all
-        // descendents are well and truly dead. We will not rest
-        // until the entire family tree is obliterated.
+        // and repeatedly signal the process group until the direct child is
+        // reaped. A child that ignores SIGHUP is escalated to SIGKILL, and the
+        // final wait is bounded so a pathological kernel/process state cannot
+        // hold a surface teardown worker forever.
+        var signal: c_int = c.SIGHUP;
+        var deadline = std.Io.Timestamp.now(global.io(), .awake).addDuration(
+            timeouts.sighup_grace,
+        );
         while (true) {
-            switch (posix.errno(c.killpg(pgid, c.SIGHUP))) {
-                .SUCCESS => log.debug("process group killed pgid={}", .{pgid}),
+            switch (posix.errno(c.killpg(pgid, signal))) {
+                .SUCCESS => log.debug(
+                    "process group signalled pgid={} signal={}",
+                    .{ pgid, signal },
+                ),
                 .SRCH => {
                     // The child may have exited between getpgid and killpg.
                     // Consume its wait status if the process watcher has not.
@@ -1219,7 +1238,7 @@ const Subprocess = struct {
                         break :killpg;
                     }
 
-                    log.warn("error killing process group pgid={} err={}", .{ pgid, err });
+                    log.warn("error signalling process group pgid={} err={}", .{ pgid, err });
                     return error.KillFailed;
                 },
             }
@@ -1228,8 +1247,29 @@ const Subprocess = struct {
             // The gist is that it lets us detect when children
             // are still alive without blocking so that we can
             // kill them again.
-            if (try reapExitedChild(pid)) break;
-            try std.Io.sleep(global.io(), .fromMilliseconds(10), .awake);
+            if (try reapExitedChild(pid)) return;
+
+            const now = std.Io.Timestamp.now(global.io(), .awake);
+            if (now.toNanoseconds() >= deadline.toNanoseconds()) {
+                if (signal == c.SIGHUP) {
+                    signal = c.SIGKILL;
+                    deadline = now.addDuration(timeouts.sigkill_grace);
+                    log.warn(
+                        "process group exceeded SIGHUP grace; escalating " ++
+                            "pgid={}",
+                        .{pgid},
+                    );
+                    continue;
+                }
+
+                log.err(
+                    "process group did not reap after SIGKILL pgid={} pid={}",
+                    .{ pgid, pid },
+                );
+                return error.ProcessTerminationTimedOut;
+            }
+
+            try std.Io.sleep(global.io(), timeouts.poll_interval, .awake);
         }
     }
 

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -2108,6 +2108,63 @@ test "subprocess stop reaps an already-exited child on Darwin" {
     try testing.expectEqual(posix.E.CHILD, wait_err);
 }
 
+test "subprocess stop escalates ignored SIGHUP to SIGKILL" {
+    if (comptime builtin.os.tag == .windows) return error.SkipZigTest;
+
+    const testing = std.testing;
+    const c = Subprocess.c;
+    const ready_pipe = try internal_os.pipe();
+    defer {
+        _ = posix.system.close(ready_pipe[0]);
+        _ = posix.system.close(ready_pipe[1]);
+    }
+
+    const pid: posix.pid_t = pid: {
+        const rc = posix.system.fork();
+        switch (posix.errno(rc)) {
+            .SUCCESS => break :pid @intCast(rc),
+            .AGAIN, .NOMEM => return error.SystemResources,
+            else => |err| return posix.unexpectedErrno(err),
+        }
+    };
+    if (pid == 0) {
+        _ = posix.system.close(ready_pipe[0]);
+        if (c.setsid() < 0) c._exit(1);
+        var action: posix.Sigaction = .{
+            .handler = .{ .handler = posix.SIG.IGN },
+            .mask = posix.sigemptyset(),
+            .flags = 0,
+        };
+        posix.sigaction(posix.SIG.HUP, &action, null);
+        if (posix.system.write(ready_pipe[1], "r", 1) != 1) c._exit(1);
+        while (true) _ = c.pause();
+    }
+
+    var reaped = false;
+    defer if (!reaped) {
+        _ = c.killpg(pid, c.SIGKILL);
+        var status: c_int = 0;
+        _ = posix.system.waitpid(pid, &status, 0);
+    };
+    _ = posix.system.close(ready_pipe[1]);
+    var ready: [1]u8 = undefined;
+    try testing.expectEqual(@as(usize, 1), try posix.read(ready_pipe[0], &ready));
+
+    try Subprocess.killPidWithTimeouts(pid, .{
+        .sighup_grace = .fromMilliseconds(20),
+        .sigkill_grace = .fromSeconds(1),
+    });
+
+    var status: c_int = 0;
+    const wait_result = posix.system.waitpid(pid, &status, std.c.W.NOHANG);
+    const wait_err = posix.errno(wait_result);
+    reaped = wait_result == pid or
+        (wait_result < 0 and wait_err == .CHILD);
+
+    try testing.expectEqual(@as(c.pid_t, -1), wait_result);
+    try testing.expectEqual(posix.E.CHILD, wait_err);
+}
+
 /// Builds the argv array for the process we should exec for the
 /// configured command. This isn't as straightforward as it seems since
 /// we deal with shell-wrapping, macOS login shells, etc.


### PR DESCRIPTION
## Summary

- expose a pre-free embedded API that retires a surface from app routing and wakes its Ghostty-owned IO teardown
- preserve a 12-second SIGHUP grace period, then escalate to SIGKILL and cap the final reap wait at 3 seconds
- cover subprocesses that ignore SIGHUP while preserving the existing embedded action-lifetime regression
- reapply the VT stream-boundary API required by the current cmux parent pin

Supports manaflow-ai/cmux#9573.

## Verification

- focused ignored-SIGHUP escalation test: 73/73 passed
- subprocess stop filter: 74/74 passed
- embedded retained-action teardown filter: 73/73 passed
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/184"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788683442&installation_model_id=21920&pr_number=184&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F184&signature=c06b406d5d052fd67cf1cd165c670fdcc3526555c53259e3366a1543da7035b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound embedded surface teardown to avoid hangs and provide a pre-free API to retire a surface and shut down its child process. Adds a VT stream “ground” check for safe snapshot boundaries, meeting the needs in `manaflow-ai/cmux#9573`.

- **New Features**
  - `ghostty_surface_request_process_termination()` retires a surface from app routing and starts child-process shutdown; idempotent; still call `ghostty_surface_free()`.
  - Bounded process shutdown: send SIGHUP with a 12s grace, then SIGKILL; cap final reap at 3s; handles subprocesses that ignore SIGHUP.
  - `ghostty_terminal_vt_stream_is_ground()` reports parser/UTF‑8 ground state to snapshot VT safely (required by the current cmux parent pin).

- **Migration**
  - On embedded surface close, call `ghostty_surface_request_process_termination(surface)` before `ghostty_surface_free(surface)`; safe to call multiple times.
  - If snapshotting VT output, only snapshot when `ghostty_terminal_vt_stream_is_ground(terminal)` returns true.

<sup>Written for commit 5b20c62297aca8289b400cb7f5583f65a5c759bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/184?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an API to request child-process termination before a surface is destroyed.
  * Added an API to report whether terminal input processing is complete and has no partial sequences.

* **Bug Fixes**
  * Improved process shutdown by retrying termination signals, escalating when necessary, and reporting failures if the process cannot be reaped.
  * Improved surface teardown reliability by coordinating renderer, process, and thread shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->