### PR TITLE
font: resolve NFD Hangul clusters via canonical composition

### DIFF
--- a/src/font/hangul.zig
+++ b/src/font/hangul.zig
@@ -1,0 +1,131 @@
+//! Algorithmic Hangul canonical composition (The Unicode Standard,
+//! chapter 3.12, "Conjoining Jamo Behavior").
+//!
+//! A decomposed (NFD) Hangul grapheme cluster — a leading consonant,
+//! a vowel, and optionally a trailing consonant — is canonically
+//! equivalent to a single precomposed syllable in the U+AC00–U+D7A3
+//! block. The mapping is fully algorithmic: no tables are required and
+//! it is complete for the modern jamo ranges, so composing a cluster
+//! here yields exactly its NFC form.
+//!
+//! Font selection uses this to resolve canonically equivalent NFC and
+//! NFD text to the same face (issue: canonically equivalent Korean
+//! NFC/NFD text selecting different fallback fonts). Terminal cell
+//! contents are never rewritten; only the resolver query changes.
+
+const std = @import("std");
+
+/// First leading consonant (choseong) jamo, U+1100.
+const l_base: u21 = 0x1100;
+/// First vowel (jungseong) jamo, U+1161.
+const v_base: u21 = 0x1161;
+/// One before the first trailing consonant (jongseong) jamo, U+11A7.
+/// Trailing index 0 means "no trailing consonant".
+const t_base: u21 = 0x11A7;
+/// First precomposed syllable (가), U+AC00.
+const s_base: u21 = 0xAC00;
+const l_count: u21 = 19;
+const v_count: u21 = 21;
+const t_count: u21 = 28;
+const n_count: u21 = v_count * t_count; // 588
+const s_count: u21 = l_count * n_count; // 11172
+
+fn isL(cp: u21) bool {
+    return cp >= l_base and cp < l_base + l_count;
+}
+
+fn isV(cp: u21) bool {
+    return cp >= v_base and cp < v_base + v_count;
+}
+
+fn isT(cp: u21) bool {
+    return cp > t_base and cp < t_base + t_count;
+}
+
+/// A precomposed syllable with no trailing consonant (an "LV" syllable).
+fn isLV(cp: u21) bool {
+    return cp >= s_base and cp < s_base + s_count and
+        (cp - s_base) % t_count == 0;
+}
+
+/// Returns the precomposed Hangul syllable canonically equivalent to the
+/// grapheme cluster formed by `primary` followed by `rest`, or null when
+/// the cluster has no precomposed equivalent. Null covers non-Hangul
+/// clusters, archaic jamo (outside the modern L/V/T ranges), partial
+/// clusters such as a lone jamo, and clusters carrying any additional
+/// codepoints.
+pub fn composedSyllable(primary: u21, rest: []const u21) ?u21 {
+    // L + V, optionally + T
+    if (isL(primary)) {
+        if (rest.len < 1 or rest.len > 2) return null;
+        if (!isV(rest[0])) return null;
+        const lv = s_base +
+            (primary - l_base) * n_count +
+            (rest[0] - v_base) * t_count;
+        if (rest.len == 1) return lv;
+        if (!isT(rest[1])) return null;
+        return lv + (rest[1] - t_base);
+    }
+
+    // An already-precomposed LV syllable + T composes to LVT.
+    if (isLV(primary)) {
+        if (rest.len != 1) return null;
+        if (!isT(rest[0])) return null;
+        return primary + (rest[0] - t_base);
+    }
+
+    return null;
+}
+
+test "composedSyllable composes modern jamo clusters" {
+    const testing = std.testing;
+
+    // 회 = ᄒ + ᅬ (L + V)
+    try testing.expectEqual(@as(?u21, 0xD68C), composedSyllable(0x1112, &.{0x116C}));
+    // 법 = ᄇ + ᅥ + ᆸ (L + V + T)
+    try testing.expectEqual(@as(?u21, 0xBC95), composedSyllable(0x1107, &.{ 0x1165, 0x11B8 }));
+    // 인 = ᄋ + ᅵ + ᆫ (L + V + T)
+    try testing.expectEqual(@as(?u21, 0xC778), composedSyllable(0x110B, &.{ 0x1175, 0x11AB }));
+    // 법 = 버 (LV syllable) + ᆸ (T)
+    try testing.expectEqual(@as(?u21, 0xBC95), composedSyllable(0xBC84, &.{0x11B8}));
+}
+
+test "composedSyllable round-trips every precomposed syllable" {
+    const testing = std.testing;
+
+    var s: u21 = s_base;
+    while (s < s_base + s_count) : (s += 1) {
+        const index = s - s_base;
+        const l = l_base + index / n_count;
+        const v = v_base + (index % n_count) / t_count;
+        const t_index = index % t_count;
+
+        if (t_index == 0) {
+            try testing.expectEqual(@as(?u21, s), composedSyllable(l, &.{v}));
+        } else {
+            const t = t_base + t_index;
+            try testing.expectEqual(@as(?u21, s), composedSyllable(l, &.{ v, t }));
+            // LV + T form of the same syllable.
+            try testing.expectEqual(@as(?u21, s), composedSyllable(s - t_index, &.{t}));
+        }
+    }
+}
+
+test "composedSyllable rejects clusters without a precomposed equivalent" {
+    const testing = std.testing;
+
+    // Lone jamo and wrong ordering.
+    try testing.expectEqual(@as(?u21, null), composedSyllable(0x1112, &.{}));
+    try testing.expectEqual(@as(?u21, null), composedSyllable(0x116C, &.{0x1112}));
+    // V where T is required and vice versa.
+    try testing.expectEqual(@as(?u21, null), composedSyllable(0x1112, &.{ 0x116C, 0x116C }));
+    try testing.expectEqual(@as(?u21, null), composedSyllable(0x1112, &.{0x11B8}));
+    // Archaic jamo outside the modern ranges (e.g. choseong filler).
+    try testing.expectEqual(@as(?u21, null), composedSyllable(0x115F, &.{0x1161}));
+    // LVT syllable cannot take another trailing consonant.
+    try testing.expectEqual(@as(?u21, null), composedSyllable(0xBC95, &.{0x11B8}));
+    // Extra codepoints beyond a full LVT cluster.
+    try testing.expectEqual(@as(?u21, null), composedSyllable(0x1107, &.{ 0x1165, 0x11B8, 0x11B8 }));
+    // Non-Hangul cluster (e + combining acute).
+    try testing.expectEqual(@as(?u21, null), composedSyllable('e', &.{0x0301}));
+}

--- a/src/font/main.zig
+++ b/src/font/main.zig
@@ -16,6 +16,7 @@ pub const DeferredFace = @import("DeferredFace.zig");
 pub const Face = face.Face;
 pub const Glyph = @import("Glyph.zig");
 pub const glyf_rasterize = @import("glyf_rasterize.zig");
+pub const hangul = @import("hangul.zig");
 pub const Metrics = @import("Metrics.zig");
 pub const opentype = @import("opentype.zig");
 pub const shape = @import("shape.zig");

--- a/src/font/shaper/coretext.zig
+++ b/src/font/shaper/coretext.zig
@@ -1116,6 +1116,78 @@ test "run iterator: empty cells with background set" {
     }
 }
 
+test "run iterator: canonically equivalent NFC and NFD Hangul use the same font" {
+    // https://github.com/manaflow-ai/cmux/issues/9583
+    // Korean typed in a terminal is usually NFC while macOS filenames are
+    // decomposed NFD jamo clusters. Both encodings of the same text must
+    // resolve to the same face. We pin the precomposed syllable block (and
+    // only that block) to a specific system font via a codepoint map, the
+    // exact `font-codepoint-map = U+AC00-U+D7A3=...` setup from the issue:
+    // a decomposed cluster is canonically equivalent to a codepoint in the
+    // mapped range, so it must resolve through the same mapping instead of
+    // per-jamo fallback discovery.
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var testdata = try testShaperWithFont(alloc, .jetbrains_mono);
+    defer testdata.deinit();
+
+    // Enable discovery: the codepoint map resolves its descriptor through
+    // discovery, and pre-fix jamo take the fallback discovery path.
+    var disco = font.Discover.init(testdata.lib);
+    defer disco.deinit();
+    testdata.grid.resolver.discover = &disco;
+
+    // Ships with every macOS and covers Hangul syllables.
+    var map: font.CodepointMap = .{};
+    defer map.deinit(alloc);
+    try map.add(alloc, .{
+        .range = .{ 0xAC00, 0xD7A3 },
+        .descriptor = .{ .family = "Apple SD Gothic Neo" },
+    });
+    testdata.grid.resolver.codepoint_map = map;
+
+    const inputs = [_][]const u8{
+        // NFD first so its resolution cannot reuse faces that the NFC row
+        // loaded into the collection. Covers both L+V (회, 계) and L+V+T
+        // (법, 인) cluster shapes.
+        "\u{1112}\u{116C}\u{1100}\u{1168}\u{1107}\u{1165}\u{11B8}\u{110B}\u{1175}\u{11AB}",
+        // NFC: U+D68C U+ACC4 U+BC95 U+C778 (회계법인)
+        "\u{D68C}\u{ACC4}\u{BC95}\u{C778}",
+    };
+
+    var indexes: [inputs.len]font.Collection.Index = undefined;
+    for (inputs, 0..) |input, i| {
+        var t = try terminal.Terminal.init(testing.io, alloc, .{ .cols = 20, .rows = 3 });
+        defer t.deinit(alloc);
+
+        var s = t.vtStream();
+        defer s.deinit();
+        s.nextSlice(input);
+
+        var state: terminal.RenderState = .empty;
+        defer state.deinit(alloc);
+        try state.update(alloc, &t);
+
+        var shaper = &testdata.shaper;
+        var it = shaper.runIterator(.{
+            .grid = testdata.grid,
+            .cells = state.row_data.get(0).cells.slice(),
+        });
+        const run = (try it.next(alloc)).?;
+
+        // The whole line must be a single run backed by a real (non-sprite)
+        // face, not the replacement-character fallback path.
+        try testing.expect(run.font_index.special() == null);
+        try testing.expect(try it.next(alloc) == null);
+        indexes[i] = run.font_index;
+    }
+
+    // Canonically equivalent clusters must select the same face (and with
+    // it the same metrics, since metrics derive from the face).
+    try testing.expectEqual(indexes[1], indexes[0]);
+}
+
 test "shape" {
     const testing = std.testing;
     const alloc = testing.allocator;

--- a/src/font/shaper/run.zig
+++ b/src/font/shaper/run.zig
@@ -394,6 +394,27 @@ pub const RunIterator = struct {
             );
         }
 
+        // A decomposed (NFD) Hangul jamo cluster is canonically equivalent
+        // to a precomposed syllable. Resolve the font through the composed
+        // codepoint so both encodings produce the identical resolver query
+        // and therefore the same face; per-jamo resolution below would pick
+        // whichever fallback happens to cover the jamo blocks. The cell
+        // contents are untouched (copy/paste still returns the original
+        // codepoints) and both CoreText and HarfBuzz compose the cluster
+        // during shaping when the face carries the precomposed glyph.
+        if (cell.hasGrapheme()) hangul: {
+            const composed = font.hangul.composedSyllable(
+                cell.codepoint(),
+                graphemes,
+            ) orelse break :hangul;
+            if (try self.opts.grid.getIndex(
+                alloc,
+                composed,
+                style,
+                presentation,
+            )) |idx| return idx;
+        }
+
         // Get the font index for the primary codepoint.
         const primary_cp: u32 = cell.codepoint();
         const primary = try self.opts.grid.getIndex(


### PR DESCRIPTION
Canonically equivalent Korean NFC/NFD text selected different fallback font faces because font selection keyed on the raw stored codepoints of a grapheme cluster: decomposed jamo clusters queried the resolver with the leading jamo while equivalent precomposed syllables queried with the syllable codepoint.

Hangul canonical composition is algorithmic (The Unicode Standard ch. 3.12) and complete for the modern jamo ranges. `src/font/hangul.zig` composes L+V, L+V+T, and LV+T clusters to their precomposed syllable, and `RunIterator.indexForCell` resolves the face through the composed codepoint first, so both encodings produce the identical resolver query. Cell contents and shaper input are unchanged, preserving copy/paste of the original NFD codepoints.

Commit 1 adds the failing regression test; commit 2 adds the fix.

For https://github.com/manaflow-ai/cmux/issues/9583 (cmux PR: https://github.com/manaflow-ai/cmux/pull/9808)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/185"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788684152&installation_model_id=21920&pr_number=185&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F185&signature=1cbf4dfe6feeb11c825d6d9cd422ab264dcd9e6473f1d5186e4f57d8444d6d6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix font selection for Korean so NFC and NFD Hangul resolve to the same fallback face. We compose jamo clusters to their precomposed syllable for resolver queries to avoid mismatched fonts. Addresses cmux#9583.

- Bug Fixes
  - Added algorithmic Hangul composition (`L+V`, `L+V+T`, `LV+T`) in `src/font/hangul.zig` per Unicode ch. 3.12.
  - Updated run iterator to resolve via the composed codepoint first; cell contents and shaper input stay unchanged.
  - Added a regression test that pins U+AC00–U+D7A3 to "Apple SD Gothic Neo" and verifies NFC/NFD select the same face.
  - Falls back to the existing per-codepoint path when clusters have no precomposed equivalent.

<sup>Written for commit 3fbdd078dfc499134710d3cf9ce2c5e06fa101aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/185?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

