### PR TITLE
font: expose surface font resolution and rasterization query API (cmux fork)

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1456,6 +1456,38 @@ GHOSTTY_API ghostty_string_s ghostty_surface_render_grid_json_v2(
     uintptr_t,
     bool,
     bool);
+// cmux fork: resolve a UTF-8 grapheme cluster (ptr, len) with style
+// (bold, italic) and a constraint width (1 or 2) through this surface's
+// LIVE font pipeline: the shared grid's CodepointResolver/Collection
+// (including fallback faces added by dynamic CoreText discovery this
+// session) and a private CoreText shaper with the surface's font
+// features. Returns a JSON document (format "cmux.font-query.v1") with
+// one entry per shaper run: PostScript name, family, source
+// ("primary" | "embedded" | "discovered" | "asset" | "sprite"), color
+// flag, and per-cell glyph indices/offsets. Free the result with
+// ghostty_string_free; empty string (ptr == NULL) on failure.
+GHOSTTY_API ghostty_string_s ghostty_surface_font_resolve_json(
+    ghostty_surface_t,
+    const char* cluster,
+    uintptr_t cluster_len,
+    bool bold,
+    bool italic,
+    uint8_t constraint_width);
+// cmux fork: like ghostty_surface_font_resolve_json, but additionally
+// rasterizes every resolved glyph through the app's own render path
+// (CoreText Face.renderGlyph or the sprite face) into a private atlas.
+// Each glyph object gains width/height/glyph_offset_x/glyph_offset_y,
+// pixel_format ("coverage16-le" for monochrome — the pipeline's 8-bit
+// coverage widened losslessly, v16 = v8 * 257 — or "bgra8-premul-p3"
+// for color glyphs, premultiplied Display P3 BGRA verbatim), and
+// data_b64. Free with ghostty_string_free; empty string on failure.
+GHOSTTY_API ghostty_string_s ghostty_surface_font_rasterize_json(
+    ghostty_surface_t,
+    const char* cluster,
+    uintptr_t cluster_len,
+    bool bold,
+    bool italic,
+    uint8_t constraint_width);
 GHOSTTY_API void ghostty_surface_set_color_scheme(ghostty_surface_t,
                                                      ghostty_color_scheme_e);
 GHOSTTY_API ghostty_input_mods_e ghostty_surface_key_translation_mods(ghostty_surface_t,

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1463,9 +1463,11 @@ GHOSTTY_API ghostty_string_s ghostty_surface_render_grid_json_v2(
 // session) and a private CoreText shaper with the surface's font
 // features. Returns a JSON document (format "cmux.font-query.v1") with
 // one entry per shaper run: PostScript name, family, source
-// ("primary" | "embedded" | "discovered" | "asset" | "sprite"), color
-// flag, and per-cell glyph indices/offsets. Free the result with
-// ghostty_string_free; empty string (ptr == NULL) on failure.
+// ("primary" | "embedded" | "discovered" | "asset" | "sprite" |
+// "codepoint-map", the last when a config font-codepoint-map entry
+// decided the face), color flag, and per-cell glyph indices/offsets.
+// Free the result with ghostty_string_free; empty string (ptr == NULL)
+// on failure.
 GHOSTTY_API ghostty_string_s ghostty_surface_font_resolve_json(
     ghostty_surface_t,
     const char* cluster,

--- a/include/ghostty/vt/terminal.h
+++ b/include/ghostty/vt/terminal.h
@@ -1496,6 +1496,22 @@ GHOSTTY_API void ghostty_terminal_vt_write(GhosttyTerminal terminal,
                                 size_t len);
 
 /**
+ * Return whether the VT stream has no incomplete parser or UTF-8 state.
+ *
+ * A true result means a formatter snapshot can be loaded into a fresh
+ * terminal and followed by later VT bytes without losing an unfinished
+ * escape sequence or Unicode codepoint. The caller must serialize this query
+ * and its snapshot with ghostty_terminal_vt_write().
+ *
+ * @param terminal The terminal handle (NULL returns false)
+ * @return true when both the VT parser and UTF-8 decoder are in ground state
+ *
+ * @ingroup terminal
+ */
+GHOSTTY_API bool ghostty_terminal_vt_stream_is_ground(
+    GhosttyTerminal terminal);
+
+/**
  * Scroll the terminal viewport.
  *
  * Scrolls the terminal's viewport according to the given behavior.

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -4277,6 +4277,18 @@ pub const CAPI = struct {
                 try jw.objectField("family");
                 try jw.write("");
             } else {
+                // A config-driven `font-codepoint-map` entry (e.g. cmux's
+                // auto-injected CJK mappings) wins over every fallback path
+                // in CodepointResolver.getIndex, and its face is added as a
+                // NON-fallback entry, so classify it explicitly instead of
+                // letting it masquerade as the primary family. The map is
+                // immutable after grid creation; no lock needed.
+                const codepoint_map_hit: bool = hit: {
+                    const map = grid.resolver.codepoint_map orelse break :hit false;
+                    const first_cell = cells_raw[run.offset];
+                    const cp0 = std.math.cast(u21, first_cell.codepoint()) orelse break :hit false;
+                    break :hit map.get(cp0) != null;
+                };
                 grid.lock.lockSharedUncancelable(global.io());
                 defer grid.lock.unlockShared(global.io());
                 // Safe: the run iterator resolved this index through
@@ -4306,7 +4318,10 @@ pub const CAPI = struct {
                 }
 
                 try jw.objectField("source");
-                try jw.write(fontFaceSourceLabel(entry.fallback, url_path));
+                try jw.write(if (codepoint_map_hit)
+                    "codepoint-map"
+                else
+                    fontFaceSourceLabel(entry.fallback, url_path));
                 try jw.objectField("ps_name");
                 try jw.write(ps_name);
                 try jw.objectField("family");

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -4137,6 +4137,394 @@ pub const CAPI = struct {
         };
     }
 
+    // ------------------------------------------------------------------
+    // cmux fork: font resolution / rasterization debug API (ghostty-web
+    // parity D3 service). Given a UTF-8 grapheme cluster and a style, run
+    // the surface's REAL font pipeline — a scratch terminal for grapheme
+    // clustering and SGR styling, the surface's live SharedGrid
+    // (CodepointResolver + Collection, including any fallback faces that
+    // dynamic CoreText discovery already added this session), and a
+    // private CoreText shaper with the surface's font features — and
+    // report the resolved face identity and glyph indices, optionally
+    // rasterizing each glyph through the app's own Face/sprite render
+    // path. Everything here is read-mostly against the shared grid (its
+    // own RwLock protects it, exactly as concurrent renderer threads for
+    // split surfaces do) and safe to call from any thread.
+
+    /// Classify where a resolved collection entry came from. Embedded
+    /// faces are loaded from in-binary bytes and have no CTFont URL
+    /// attribute; discovered faces come from CoreText descriptors with a
+    /// file URL; on-demand OS font assets live under /AssetsV2/.
+    fn fontFaceSourceLabel(
+        fallback: bool,
+        url_path: ?[]const u8,
+    ) []const u8 {
+        if (!fallback) return "primary";
+        const path = url_path orelse return "embedded";
+        if (std.mem.indexOf(u8, path, "/AssetsV2/") != null) return "asset";
+        return "discovered";
+    }
+
+    fn fontClusterQueryJson(
+        surface: *Surface,
+        cluster: []const u8,
+        bold: bool,
+        italic: bool,
+        constraint_width_raw: u8,
+        include_pixels: bool,
+    ) !String {
+        const getConstraint = @import("../font/nerd_font_attributes.zig").getConstraint;
+        const cellpkg = @import("../renderer/cell.zig");
+
+        const alloc = global.alloc();
+        const core = &surface.core_surface;
+        const constraint_width: u2 = switch (constraint_width_raw) {
+            1 => 1,
+            2 => 2,
+            else => return error.InvalidConstraintWidth,
+        };
+        if (cluster.len == 0 or cluster.len > 128) return error.InvalidCluster;
+
+        // The identical SharedGrid the renderer uses: SharedGridSet is
+        // keyed by font config, so ref() returns the same grid and holds
+        // a reference for the duration of the query.
+        const key, const grid = try core.app.font_grid_set.ref(
+            &core.config.font,
+            core.font_size,
+        );
+        defer core.app.font_grid_set.deref(key);
+
+        // Scratch terminal: the app's real grapheme clustering, wide char
+        // and spacer handling, isolated from the surface's terminal.
+        var t: terminal.Terminal = try .init(global.io(), alloc, .{
+            .cols = 16,
+            .rows = 2,
+        });
+        defer t.deinit(alloc);
+        {
+            var s = t.vtStream();
+            defer s.deinit();
+            if (bold) s.nextSlice("\x1b[1m");
+            if (italic) s.nextSlice("\x1b[3m");
+            s.nextSlice(cluster);
+        }
+
+        var state: terminal.RenderState = .empty;
+        defer state.deinit(alloc);
+        try state.update(alloc, &t);
+
+        // Private shaper with the surface's shaping features; the
+        // renderer-owned shaper must never be touched from here.
+        var shaper = try font.Shaper.init(alloc, .{
+            .features = core.renderer.config.font_features.items,
+        });
+        defer shaper.deinit();
+        defer shaper.endFrame();
+
+        const row = state.row_data.get(0);
+        const cells_slice = row.cells.slice();
+        const cells_raw = cells_slice.items(.raw);
+
+        var buf: std.Io.Writer.Allocating = .init(alloc);
+        errdefer buf.deinit();
+        var jw: std.json.Stringify = .{ .writer = &buf.writer };
+
+        try jw.beginObject();
+        try jw.objectField("format");
+        try jw.write("cmux.font-query.v1");
+        try jw.objectField("cluster");
+        try jw.write(cluster);
+        try jw.objectField("bold");
+        try jw.write(bold);
+        try jw.objectField("italic");
+        try jw.write(italic);
+        try jw.objectField("constraint_width");
+        try jw.write(constraint_width);
+        try jw.objectField("metrics");
+        try jw.beginObject();
+        try jw.objectField("cell_width");
+        try jw.write(grid.metrics.cell_width);
+        try jw.objectField("cell_height");
+        try jw.write(grid.metrics.cell_height);
+        try jw.objectField("cell_baseline");
+        try jw.write(grid.metrics.cell_baseline);
+        try jw.endObject();
+        try jw.objectField("runs");
+        try jw.beginArray();
+
+        var it = shaper.runIterator(.{
+            .grid = grid,
+            .cells = cells_slice,
+        });
+        while (try it.next(alloc)) |run| {
+            const shaped = try shaper.shape(run);
+            try jw.beginObject();
+            try jw.objectField("offset");
+            try jw.write(run.offset);
+            try jw.objectField("cells_covered");
+            try jw.write(run.cells);
+            try jw.objectField("font_index");
+            try jw.write(run.font_index.int());
+            try jw.objectField("style");
+            try jw.write(@tagName(run.font_index.style));
+
+            var run_is_color = false;
+            if (run.font_index.special()) |special| {
+                try jw.objectField("source");
+                try jw.write(@tagName(special));
+                try jw.objectField("ps_name");
+                try jw.write("");
+                try jw.objectField("family");
+                try jw.write("");
+            } else {
+                grid.lock.lockSharedUncancelable(global.io());
+                defer grid.lock.unlockShared(global.io());
+                // Safe: the run iterator resolved this index through
+                // SharedGrid.getIndex, which force-loads deferred faces
+                // under the exclusive lock.
+                const entry = try grid.resolver.collection.getEntry(run.font_index);
+                const face = try grid.resolver.collection.getFace(run.font_index);
+
+                var ps_buf: [256]u8 = undefined;
+                const ps_name: []const u8 = blk: {
+                    const s = face.font.copyPostScriptName();
+                    defer s.release();
+                    break :blk s.cstring(&ps_buf, .utf8) orelse "";
+                };
+                var family_buf: [256]u8 = undefined;
+                const family: []const u8 = face.name(&family_buf) catch "";
+                var url_buf: [1024]u8 = undefined;
+                const url_path: ?[]const u8 = blk: {
+                    const url = face.font.copyAttribute(.url) orelse break :blk null;
+                    defer url.release();
+                    const path = url.copyPath() orelse break :blk null;
+                    defer path.release();
+                    break :blk path.cstring(&url_buf, .utf8);
+                };
+                if (shaped.len > 0) {
+                    run_is_color = face.isColorGlyph(shaped[0].glyph_index);
+                }
+
+                try jw.objectField("source");
+                try jw.write(fontFaceSourceLabel(entry.fallback, url_path));
+                try jw.objectField("ps_name");
+                try jw.write(ps_name);
+                try jw.objectField("family");
+                try jw.write(family);
+                if (url_path) |path| {
+                    try jw.objectField("url_path");
+                    try jw.write(path);
+                }
+            }
+            try jw.objectField("color");
+            try jw.write(run_is_color);
+
+            try jw.objectField("glyphs");
+            try jw.beginArray();
+            for (shaped) |shaper_cell| {
+                const abs_x: usize = @as(usize, run.offset) + shaper_cell.x;
+                if (abs_x >= cells_raw.len) continue;
+                const raw_cell = cells_raw[abs_x];
+                const cp = raw_cell.codepoint();
+
+                try jw.beginObject();
+                try jw.objectField("x");
+                try jw.write(shaper_cell.x);
+                try jw.objectField("glyph_index");
+                try jw.write(shaper_cell.glyph_index);
+                try jw.objectField("x_offset");
+                try jw.write(shaper_cell.x_offset);
+                try jw.objectField("y_offset");
+                try jw.write(shaper_cell.y_offset);
+                try jw.objectField("cp");
+                try jw.write(cp);
+                try jw.objectField("grid_width");
+                try jw.write(raw_cell.gridWidth());
+
+                if (include_pixels) {
+                    const render_opts: font.Glyph.RenderOptions = .{
+                        .grid_metrics = grid.metrics,
+                        .thicken = core.renderer.config.font_thicken,
+                        .thicken_strength = core.renderer.config.font_thicken_strength,
+                        .cell_width = raw_cell.gridWidth(),
+                        .constraint = getConstraint(@intCast(cp)) orelse
+                            if (cellpkg.isSymbol(@intCast(cp)))
+                                .{ .size = .fit }
+                            else
+                                .none,
+                        .constraint_width = constraint_width,
+                    };
+                    try fontEmitGlyphPixels(
+                        &jw,
+                        alloc,
+                        grid,
+                        run.font_index,
+                        shaper_cell.glyph_index,
+                        render_opts,
+                    );
+                }
+                try jw.endObject();
+            }
+            try jw.endArray();
+            try jw.endObject();
+        }
+        try jw.endArray();
+        try jw.endObject();
+        return .fromSlice(try buf.toOwnedSlice());
+    }
+
+    /// Rasterize one glyph through the app's own pipeline into a PRIVATE
+    /// atlas (never the shared one, so the renderer's glyph cache cannot
+    /// be poisoned by caller-supplied constraint variants) and append the
+    /// pixel fields to the currently open JSON object. Monochrome glyphs
+    /// come out of the exact CoreText render path as 8-bit coverage and
+    /// are emitted losslessly widened to 16-bit (v16 = v8 * 257,
+    /// little-endian), matching the sprite convention used by atlasgen;
+    /// color glyphs (Apple Color Emoji) are premultiplied BGRA in
+    /// Display P3, emitted verbatim.
+    fn fontEmitGlyphPixels(
+        jw: *std.json.Stringify,
+        alloc: Allocator,
+        grid: *font.SharedGrid,
+        index: font.Collection.Index,
+        glyph_index: u32,
+        opts: font.Glyph.RenderOptions,
+    ) !void {
+        var glyph: font.Glyph = undefined;
+        var is_color = false;
+        var atlas: font.Atlas = undefined;
+        var atlas_ready = false;
+        defer if (atlas_ready) atlas.deinit(alloc);
+
+        if (index.special() != null) {
+            const sprite = grid.resolver.sprite orelse return error.SpriteFaceUnavailable;
+            atlas = try font.Atlas.init(alloc, 512, .grayscale);
+            atlas_ready = true;
+            glyph = sprite.renderGlyph(alloc, &atlas, glyph_index, opts) catch |err| switch (err) {
+                error.AtlasFull => blk: {
+                    try atlas.grow(alloc, 2048);
+                    break :blk try sprite.renderGlyph(alloc, &atlas, glyph_index, opts);
+                },
+                else => return err,
+            };
+        } else {
+            grid.lock.lockSharedUncancelable(global.io());
+            defer grid.lock.unlockShared(global.io());
+            const face = try grid.resolver.collection.getFace(index);
+            is_color = face.isColorGlyph(glyph_index);
+            atlas = try font.Atlas.init(alloc, 512, if (is_color) .bgra else .grayscale);
+            atlas_ready = true;
+            glyph = face.renderGlyph(alloc, &atlas, glyph_index, opts) catch |err| switch (err) {
+                error.AtlasFull => blk: {
+                    try atlas.grow(alloc, 2048);
+                    break :blk try face.renderGlyph(alloc, &atlas, glyph_index, opts);
+                },
+                else => return err,
+            };
+        }
+
+        try jw.objectField("width");
+        try jw.write(glyph.width);
+        try jw.objectField("height");
+        try jw.write(glyph.height);
+        try jw.objectField("glyph_offset_x");
+        try jw.write(glyph.offset_x);
+        try jw.objectField("glyph_offset_y");
+        try jw.write(glyph.offset_y);
+        try jw.objectField("pixel_format");
+        try jw.write(if (is_color) "bgra8-premul-p3" else "coverage16-le");
+
+        if (glyph.width == 0 or glyph.height == 0) {
+            try jw.objectField("data_b64");
+            try jw.write("");
+            return;
+        }
+
+        const depth: usize = if (is_color) 4 else 1;
+        const out_depth: usize = if (is_color) 4 else 2;
+        const out = try alloc.alloc(u8, glyph.width * glyph.height * out_depth);
+        defer alloc.free(out);
+        var y: u32 = 0;
+        while (y < glyph.height) : (y += 1) {
+            const src_off = ((@as(usize, glyph.atlas_y + y) * atlas.size) + glyph.atlas_x) * depth;
+            const src_row = atlas.data[src_off..][0 .. @as(usize, glyph.width) * depth];
+            if (is_color) {
+                @memcpy(out[y * glyph.width * 4 ..][0 .. glyph.width * 4], src_row);
+            } else {
+                var x: usize = 0;
+                while (x < glyph.width) : (x += 1) {
+                    const v16: u16 = @as(u16, src_row[x]) * 257;
+                    const dst = (@as(usize, y) * glyph.width + x) * 2;
+                    out[dst] = @truncate(v16);
+                    out[dst + 1] = @truncate(v16 >> 8);
+                }
+            }
+        }
+
+        const b64_len = std.base64.standard.Encoder.calcSize(out.len);
+        const b64 = try alloc.alloc(u8, b64_len);
+        defer alloc.free(b64);
+        try jw.objectField("data_b64");
+        try jw.write(std.base64.standard.Encoder.encode(b64, out));
+    }
+
+    /// cmux fork: resolve a UTF-8 grapheme cluster + style through this
+    /// surface's live font pipeline (CodepointResolver, collection with
+    /// session fallback state, CoreText shaper). Returns a JSON document
+    /// (`cmux.font-query.v1`) with the resolved face identity per shaper
+    /// run: PostScript name, source (primary / embedded / discovered /
+    /// asset / sprite), glyph indices and shaper offsets. Free the result
+    /// with ghostty_string_free. Empty string on failure.
+    export fn ghostty_surface_font_resolve_json(
+        surface: *Surface,
+        cluster_ptr: [*]const u8,
+        cluster_len: usize,
+        bold: bool,
+        italic: bool,
+        constraint_width: u8,
+    ) String {
+        return fontClusterQueryJson(
+            surface,
+            cluster_ptr[0..cluster_len],
+            bold,
+            italic,
+            constraint_width,
+            false,
+        ) catch |err| {
+            log.warn("font resolve failed err={}", .{err});
+            return .empty;
+        };
+    }
+
+    /// cmux fork: like ghostty_surface_font_resolve_json, but additionally
+    /// rasterizes every resolved glyph through the app's own render path
+    /// (CoreText Face.renderGlyph or the sprite face) into a private
+    /// atlas, returning per-glyph pixels base64-encoded in the JSON:
+    /// 16-bit little-endian coverage for monochrome glyphs (losslessly
+    /// widened from the pipeline's 8-bit coverage, v16 = v8 * 257) or
+    /// premultiplied Display-P3 BGRA for color glyphs. Free the result
+    /// with ghostty_string_free. Empty string on failure.
+    export fn ghostty_surface_font_rasterize_json(
+        surface: *Surface,
+        cluster_ptr: [*]const u8,
+        cluster_len: usize,
+        bold: bool,
+        italic: bool,
+        constraint_width: u8,
+    ) String {
+        return fontClusterQueryJson(
+            surface,
+            cluster_ptr[0..cluster_len],
+            bold,
+            italic,
+            constraint_width,
+            true,
+        ) catch |err| {
+            log.warn("font rasterize failed err={}", .{err});
+            return .empty;
+        };
+    }
+
     /// Returns the PID of the foreground process for the surface PTY.
     export fn ghostty_surface_foreground_pid(surface: *Surface) u64 {
         return surface.core_surface.getProcessInfo(.foreground_pid) orelse 0;

--- a/src/lib_vt.zig
+++ b/src/lib_vt.zig
@@ -266,6 +266,7 @@ comptime {
         @export(&c.terminal_resize, .{ .name = "ghostty_terminal_resize" });
         @export(&c.terminal_set, .{ .name = "ghostty_terminal_set" });
         @export(&c.terminal_vt_write, .{ .name = "ghostty_terminal_vt_write" });
+        @export(&c.terminal_vt_stream_is_ground, .{ .name = "ghostty_terminal_vt_stream_is_ground" });
         @export(&c.terminal_scroll_viewport, .{ .name = "ghostty_terminal_scroll_viewport" });
         @export(&c.terminal_compression_activity, .{ .name = "ghostty_terminal_compression_activity" });
         @export(&c.terminal_compress, .{ .name = "ghostty_terminal_compress" });

--- a/src/terminal/c/main.zig
+++ b/src/terminal/c/main.zig
@@ -188,6 +188,7 @@ pub const terminal_reset = terminal.reset;
 pub const terminal_resize = terminal.resize;
 pub const terminal_set = terminal.set;
 pub const terminal_vt_write = terminal.vt_write;
+pub const terminal_vt_stream_is_ground = terminal.vt_stream_is_ground;
 pub const terminal_scroll_viewport = terminal.scroll_viewport;
 pub const terminal_compression_activity = terminal.compression_activity;
 pub const terminal_compress = terminal.compress;

--- a/src/terminal/c/terminal.zig
+++ b/src/terminal/c/terminal.zig
@@ -411,6 +411,14 @@ pub fn vt_write(
     wrapper.stream.nextSlice(ptr[0..len]);
 }
 
+pub fn vt_stream_is_ground(
+    terminal_: Terminal,
+) callconv(lib.calling_conv) bool {
+    const wrapper = terminal_ orelse return false;
+    return wrapper.stream.parser.state == .ground and
+        wrapper.stream.utf8decoder.state == 0;
+}
+
 pub fn compression_activity(
     terminal_: Terminal,
     out_activity_: ?*u64,
@@ -1838,6 +1846,43 @@ test "vt_write split escape sequence" {
     defer testing.allocator.free(str);
     // If the escape sequence leaked, we'd see "[1mBold" as literal text.
     try testing.expectEqualStrings("Hello Bold", str);
+}
+
+test "vt stream ground requires complete parser and UTF-8 state" {
+    var t: Terminal = null;
+    try testing.expectEqual(Result.success, new(
+        &lib.alloc.test_allocator,
+        &t,
+        .{
+            .cols = 80,
+            .rows = 24,
+            .max_scrollback = 10_000,
+        },
+    ));
+    defer free(t);
+
+    try testing.expect(vt_stream_is_ground(t));
+    vt_write(t, "plain ", 6);
+    try testing.expect(vt_stream_is_ground(t));
+
+    vt_write(t, "\xce", 1);
+    try testing.expect(!vt_stream_is_ground(t));
+    vt_write(t, "\xbb", 1);
+    try testing.expect(vt_stream_is_ground(t));
+
+    vt_write(t, "\x1b", 1);
+    try testing.expect(!vt_stream_is_ground(t));
+    vt_write(t, "[31", 3);
+    try testing.expect(!vt_stream_is_ground(t));
+    vt_write(t, "m", 1);
+    try testing.expect(vt_stream_is_ground(t));
+
+    vt_write(t, "\x1b]0;title", 9);
+    try testing.expect(!vt_stream_is_ground(t));
+    vt_write(t, "\x1b", 1);
+    try testing.expect(!vt_stream_is_ground(t));
+    vt_write(t, "\\", 1);
+    try testing.expect(vt_stream_is_ground(t));
 }
 
 test "vt_write split combining mark after base at right edge" {


### PR DESCRIPTION
Adds the D3 app-side font resolution service of the ghostty-web pixel-parity project (cmux `docs/ghostty-web-parity.md`): two `// cmux fork` C exports that let an embedder ask a LIVE surface how its real font pipeline resolves and rasterizes a grapheme cluster.

`ghostty_surface_font_resolve_json(surface, cluster, len, bold, italic, constraint_width)` replays the cluster into a scratch terminal (real mode-2027 grapheme clustering, SGR styling, wide/spacer classification), resolves it against the surface's shared font grid — the identical `SharedGrid`/`CodepointResolver`/`Collection` instance the renderer uses, taken via `SharedGridSet.ref/deref`, including fallback faces added by dynamic CoreText discovery earlier in the session — and shapes it with a private CoreText `font.Shaper` carrying the surface's font features. Returns JSON (`cmux.font-query.v1`) with, per shaper run: PostScript name (`CTFontCopyPostScriptName`), family, source classification (`primary` = non-fallback entry, `embedded` = fallback with no `kCTFontURLAttribute`, `discovered` = fallback with a file URL, `asset` = URL under `/AssetsV2/`, `sprite` = special index), color flag, and per-cell glyph indices/offsets.

`ghostty_surface_font_rasterize_json(...)` additionally renders every resolved glyph through the app's own render path (`Face.renderGlyph` for text/color glyphs, the sprite face for box drawing etc.) into a PRIVATE atlas — never the shared one, so the renderer's `GlyphKey`-packed glyph cache cannot be poisoned by caller-supplied constraint variants — and emits pixels base64-encoded: 16-bit little-endian coverage for monochrome (the pipeline's 8-bit coverage widened losslessly, v16 = v8 * 257, the same convention atlasgen uses for sprites) or premultiplied Display-P3 BGRA verbatim for color glyphs.

Threading: everything is safe from any thread. `SharedGrid` methods take the grid's own RwLock (the multi-surface renderer-thread contract); the scratch terminal and shaper are private per call; face identity reads hold the grid lock shared. Allocation uses `global.alloc()`; the returned string is freed with the existing `ghostty_string_free`.

Consumer: cmux debug socket verbs `debug.font.resolve` / `debug.font.rasterize` (cmux PR, linked after open). Those replace the parity harness's two loudly-flagged empirical font-selection pins (asset-font exclusion, CJK face overrides) and its warmup-replay hack with answers from the app itself.

Base: the currently-pinned `11aa609d7` plus a merge of fork `main` (`1d111a072`), following the submodule-ancestry rule; merge this before the cmux PR that bumps the pointer.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/186"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788684288&installation_model_id=21920&pr_number=186&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F186&signature=be060b84cdd41079271e1498013f8ea727f2bdd51d5d26598409b834e4f93b2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds C APIs to inspect and rasterize how a surface’s live font pipeline resolves a grapheme cluster, plus a VT-stream ground check for safe snapshot boundaries. Powers cmux’s ghostty-web pixel-parity debugging with real selection, shaping, and pixels.

- **New Features**
  - `ghostty_surface_font_resolve_json(surface, cluster, len, bold, italic, constraint_width)` returns `cmux.font-query.v1` JSON with per-run font identity (PostScript name, family, source: `primary` | `embedded` | `discovered` | `asset` | `sprite` | `codepoint-map`), color flag, per-cell glyph indices/offsets, and cell metrics; includes `url_path` when available. Uses the surface’s live `SharedGrid` and a private shaper. Free with `ghostty_string_free`.
  - `ghostty_surface_font_rasterize_json(...)` also renders each glyph into a private atlas and includes base64 pixels (`coverage16-le` for monochrome, `bgra8-premul-p3` for color) alongside glyph metrics.
  - `ghostty_terminal_vt_stream_is_ground(terminal)` reports when both the VT parser and UTF‑8 decoder are in ground state for safe snapshot serialization.

<sup>Written for commit 93ef76df051abf9217479a815dc0da3c94d99eb6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/186?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added font inspection APIs that return structured information about font selection, shaping, glyph metrics, and cell coverage for UTF-8 text.
  - Added optional glyph rasterization output, including pixel data and rendering metrics.
  - Added an API to determine whether terminal input processing is complete and ready for safe state snapshots.

- **Bug Fixes**
  - Improved handling and validation of incomplete UTF-8, control sequences, and font inspection failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->