### PR TITLE
Add Kitty replay restore for embedded surfaces

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1480,6 +1480,41 @@ GHOSTTY_API void ghostty_surface_preedit(ghostty_surface_t, const char*, uintptr
 // C bridge when upstream exports an equivalent surface output API.
 GHOSTTY_API void ghostty_surface_process_output(ghostty_surface_t, const char*, uintptr_t);
 
+typedef struct {
+  uint32_t primary;
+  uint32_t alternate;
+} ghostty_surface_kitty_image_id_cursors;
+
+typedef struct {
+  ghostty_surface_kitty_image_id_cursors replay;
+  ghostty_surface_kitty_image_id_cursors next;
+} ghostty_surface_kitty_image_id_cursor_state;
+
+typedef struct {
+  uint64_t image_bytes;
+  uint64_t inflight_bytes;
+  uint64_t images;
+  uint64_t placements;
+} ghostty_surface_kitty_graphics_limits;
+
+typedef struct {
+  uint32_t image_id;
+  uint32_t image_number;
+} ghostty_surface_kitty_image_alias;
+
+// Restore non-VT Kitty state around a replay. The surface applies limits,
+// replay cursors, the replay prefix/suffix, aliases on the active screen, and
+// final cursors as one ordered operation.
+GHOSTTY_API bool ghostty_surface_restore_kitty_replay(
+    ghostty_surface_t,
+    const char*,
+    uintptr_t,
+    uint32_t,
+    ghostty_surface_kitty_graphics_limits,
+    ghostty_surface_kitty_image_id_cursor_state,
+    const ghostty_surface_kitty_image_alias*,
+    uintptr_t);
+
 // cmux fork: PTY tee callback. Fires for every byte slice the read thread
 // produces before the VT parser sees it. Used by the Mac sync server to
 // broadcast raw bytes to a paired iPhone. Set cb=NULL to clear. Callback

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1557,7 +1557,8 @@ typedef struct {
 // Restore non-VT Kitty state around a replay on a new surface before it has
 // received other output. The surface applies limits, replay cursors, the replay
 // prefix/suffix, aliases on the active screen, and final cursors under one
-// terminal lock. On false, discard the surface; restore state can be partial.
+// terminal lock. alias_count must not exceed 65,536. On false, discard the
+// surface; restore state can be partial.
 GHOSTTY_API bool ghostty_surface_restore_kitty_replay(
     ghostty_surface_t,
     const char*,

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1554,9 +1554,10 @@ typedef struct {
   uint32_t image_number;
 } ghostty_surface_kitty_image_alias;
 
-// Restore non-VT Kitty state around a replay. The surface applies limits,
-// replay cursors, the replay prefix/suffix, aliases on the active screen, and
-// final cursors as one ordered operation.
+// Restore non-VT Kitty state around a replay on a new surface before it has
+// received other output. The surface applies limits, replay cursors, the replay
+// prefix/suffix, aliases on the active screen, and final cursors under one
+// terminal lock. On false, discard the surface; restore state can be partial.
 GHOSTTY_API bool ghostty_surface_restore_kitty_replay(
     ghostty_surface_t,
     const char*,

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1544,6 +1544,8 @@ typedef struct {
 
 typedef struct {
   uint64_t image_bytes;
+  // Producer-side limit for retained encoded replay bytes. The restore input
+  // is already bounded; this is not a decoded-image storage limit.
   uint64_t inflight_bytes;
   uint64_t images;
   uint64_t placements;

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -2095,17 +2095,31 @@ pub const Inspector = struct {
 
 // C API
 pub const CAPI = struct {
+    const max_kitty_replay_aliases: usize = 65_536;
+
     const KittyReplayAlias = extern struct {
         image_id: u32,
         image_number: u32,
     };
 
-    fn kittyReplayAliasesAreValid(aliases: []const KittyReplayAlias) bool {
-        for (aliases, 0..) |alias, i| {
+    fn kittyReplayAliasesAreValid(
+        alloc: Allocator,
+        aliases: []const KittyReplayAlias,
+    ) bool {
+        if (aliases.len > max_kitty_replay_aliases) return false;
+
+        var image_ids: std.AutoHashMapUnmanaged(u32, void) = .empty;
+        defer image_ids.deinit(alloc);
+        image_ids.ensureTotalCapacity(
+            alloc,
+            @intCast(aliases.len),
+        ) catch return false;
+
+        for (aliases) |alias| {
             if (alias.image_id == 0 or alias.image_number == 0) return false;
-            for (aliases[0..i]) |previous| {
-                if (previous.image_id == alias.image_id) return false;
-            }
+            const result = image_ids.getOrPutAssumeCapacity(alias.image_id);
+            if (result.found_existing) return false;
+            result.value_ptr.* = {};
         }
         return true;
     }
@@ -4787,6 +4801,7 @@ pub const CAPI = struct {
         if (replay_cursor_offset > replay_len) return false;
         if (replay_len != 0 and replay_ptr == null) return false;
         if (alias_count != 0 and aliases == null) return false;
+        if (alias_count > max_kitty_replay_aliases) return false;
         const replay: []const u8 = if (replay_len == 0) &[_]u8{} else replay_ptr.?[0..replay_len];
         const core_surface = &surface.core_surface;
         core_surface.renderer_state.mutex.lockUncancelable(global.io());
@@ -4806,11 +4821,11 @@ pub const CAPI = struct {
         if (replay_cursor_offset > std.math.maxInt(usize)) return false;
         if (cursors.replay.primary == 0 or cursors.replay.alternate == 0 or
             cursors.next.primary == 0 or cursors.next.alternate == 0) return false;
+        const t = &io.terminal;
         if (alias_count > 0) {
             const items = aliases.?[0..alias_count];
-            if (!kittyReplayAliasesAreValid(items)) return false;
+            if (!kittyReplayAliasesAreValid(t.gpa(), items)) return false;
         }
-        const t = &io.terminal;
         t.setKittyGraphicsSizeLimit(t.gpa(), @intCast(limits.image_bytes)) catch return false;
         t.setKittyGraphicsImageCountLimit(t.gpa(), @intCast(limits.images)) catch return false;
         if (!t.setKittyGraphicsPlacementCountLimit(@intCast(limits.placements))) return false;
@@ -5340,7 +5355,10 @@ test "kitty replay aliases preserve duplicate image numbers in assignment order"
         .{ .image_id = 11, .image_number = 7 },
         .{ .image_id = 12, .image_number = 7 },
     };
-    try std.testing.expect(CAPI.kittyReplayAliasesAreValid(&aliases));
+    try std.testing.expect(CAPI.kittyReplayAliasesAreValid(
+        std.testing.allocator,
+        &aliases,
+    ));
 }
 
 test "kitty replay aliases reject duplicate image IDs" {
@@ -5348,7 +5366,23 @@ test "kitty replay aliases reject duplicate image IDs" {
         .{ .image_id = 11, .image_number = 7 },
         .{ .image_id = 11, .image_number = 8 },
     };
-    try std.testing.expect(!CAPI.kittyReplayAliasesAreValid(&aliases));
+    try std.testing.expect(!CAPI.kittyReplayAliasesAreValid(
+        std.testing.allocator,
+        &aliases,
+    ));
+}
+
+test "kitty replay aliases reject counts above the restore bound" {
+    const aliases = try std.testing.allocator.alloc(
+        CAPI.KittyReplayAlias,
+        CAPI.max_kitty_replay_aliases + 1,
+    );
+    defer std.testing.allocator.free(aliases);
+
+    try std.testing.expect(!CAPI.kittyReplayAliasesAreValid(
+        std.testing.allocator,
+        aliases,
+    ));
 }
 
 test "clipboard selection work budget rejects blank history" {

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -4816,6 +4816,9 @@ pub const CAPI = struct {
             tracking_replay = false;
             return replay_succeeded;
         }
+        // inflight_bytes is the producer's encoded replay-retention bound.
+        // Validate its platform representation, but do not apply it to
+        // Ghostty's decoded LoadingImage storage, which image_bytes governs.
         if (limits.image_bytes > std.math.maxInt(usize) or limits.inflight_bytes > std.math.maxInt(usize) or
             limits.images > std.math.maxInt(usize) or limits.placements > std.math.maxInt(usize)) return false;
         if (replay_cursor_offset > std.math.maxInt(usize)) return false;

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -2104,7 +2104,8 @@ pub const CAPI = struct {
         for (aliases, 0..) |alias, i| {
             if (alias.image_id == 0 or alias.image_number == 0) return false;
             for (aliases[0..i]) |previous| {
-                if (previous.image_id == alias.image_id) return false;
+                if (previous.image_id == alias.image_id or
+                    previous.image_number == alias.image_number) return false;
             }
         }
         return true;
@@ -4823,8 +4824,13 @@ pub const CAPI = struct {
         primary.kitty_images.next_image_id = cursors.replay.primary;
         if (t.screens.get(.alternate)) |alternate| alternate.kitty_images.next_image_id = cursors.replay.alternate;
         surface.core_surface.io.processOutput(replay[replay_cursor_offset..]);
-        if (t.screens.active.kitty_images.loading) |loading| {
+        if (primary.kitty_images.loading) |loading| {
             if (!loading.setByteLimit(@intCast(limits.inflight_bytes))) return false;
+        }
+        if (t.screens.get(.alternate)) |alternate| {
+            if (alternate.kitty_images.loading) |loading| {
+                if (!loading.setByteLimit(@intCast(limits.inflight_bytes))) return false;
+            }
         }
         if (aliases) |items| {
             // Validate every active-screen image before changing any alias, so a

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -6,6 +6,8 @@
 
 const std = @import("std");
 const builtin = @import("builtin");
+const terminal_options = @import("terminal_options");
+const kitty_graphics = @import("../terminal/kitty/graphics_storage.zig");
 const assert = @import("../quirks.zig").inlineAssert;
 const Allocator = std.mem.Allocator;
 const objc = @import("objc");
@@ -4298,6 +4300,73 @@ pub const CAPI = struct {
     ) void {
         if (len == 0) return;
         surface.core_surface.io.processOutput(ptr[0..len]);
+    }
+
+    export fn ghostty_surface_restore_kitty_replay(
+        surface: *Surface,
+        replay_ptr: [*]const u8,
+        replay_len: usize,
+        replay_cursor_offset: u32,
+        limits: extern struct { image_bytes: u64, inflight_bytes: u64, images: u64, placements: u64 },
+        cursors: extern struct {
+            replay: extern struct { primary: u32, alternate: u32 },
+            next: extern struct { primary: u32, alternate: u32 },
+        },
+        aliases: ?[*]const extern struct { image_id: u32, image_number: u32 },
+        alias_count: usize,
+    ) bool {
+        if (replay_cursor_offset > replay_len) return false;
+        if (alias_count != 0 and aliases == null) return false;
+        if (comptime !terminal_options.kitty_graphics) {
+            surface.core_surface.io.processOutput(replay_ptr[0..replay_len]);
+            return true;
+        }
+        if (limits.image_bytes > std.math.maxInt(usize) or limits.inflight_bytes > std.math.maxInt(usize) or
+            limits.images > std.math.maxInt(usize) or limits.placements > std.math.maxInt(usize)) return false;
+        if (replay_cursor_offset > std.math.maxInt(usize)) return false;
+        if (cursors.replay.primary == 0 or cursors.replay.alternate == 0 or
+            cursors.next.primary == 0 or cursors.next.alternate == 0) return false;
+        if (alias_count > 0) {
+            const items = aliases.?[0..alias_count];
+            for (items, 0..) |alias, i| {
+                if (alias.image_id == 0 or alias.image_number == 0) return false;
+                for (items[0..i]) |previous| {
+                    if (previous.image_id == alias.image_id) return false;
+                }
+            }
+        }
+        const t = &surface.core_surface.io.terminal;
+        t.setKittyGraphicsSizeLimit(t.gpa(), @intCast(limits.image_bytes)) catch return false;
+        t.setKittyGraphicsImageCountLimit(t.gpa(), @intCast(limits.images)) catch return false;
+        if (!t.setKittyGraphicsPlacementCountLimit(@intCast(limits.placements))) return false;
+        const primary = t.screens.get(.primary) orelse return false;
+        const replay = replay_ptr[0..replay_len];
+        surface.core_surface.io.processOutput(replay[0..replay_cursor_offset]);
+        if (cursors.replay.alternate != kitty_graphics.default_image_id and t.screens.get(.alternate) == null) {
+            _ = t.screens.getInit(t.io(), primary.alloc, .alternate, .{
+                .cols = t.cols,
+                .rows = t.rows,
+                .max_scrollback = 0,
+                .kitty_image_storage_limit = primary.kitty_images.total_limit,
+                .kitty_image_count_limit = primary.kitty_images.image_count_limit,
+                .kitty_placement_count_limit = primary.kitty_images.placement_count_limit,
+                .kitty_image_loading_limits = primary.kitty_images.image_limits,
+            }) catch return false;
+        }
+        primary.kitty_images.next_image_id = cursors.replay.primary;
+        if (t.screens.get(.alternate)) |alternate| alternate.kitty_images.next_image_id = cursors.replay.alternate;
+        surface.core_surface.io.processOutput(replay[replay_cursor_offset..]);
+        if (t.screens.active.kitty_images.loading) |loading| {
+            if (!loading.setByteLimit(@intCast(limits.inflight_bytes))) return false;
+        }
+        if (aliases) |items| {
+            for (items[0..alias_count]) |alias| {
+                if (!t.screens.active.kitty_images.setImageNumber(alias.image_id, alias.image_number)) return false;
+            }
+        }
+        primary.kitty_images.next_image_id = cursors.next.primary;
+        if (t.screens.get(.alternate)) |alternate| alternate.kitty_images.next_image_id = cursors.next.alternate;
+        return true;
     }
 
     /// Install a callback that fires on every PTY-output byte slice

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -4788,9 +4788,18 @@ pub const CAPI = struct {
         if (replay_len != 0 and replay_ptr == null) return false;
         if (alias_count != 0 and aliases == null) return false;
         const replay: []const u8 = if (replay_len == 0) &[_]u8{} else replay_ptr.?[0..replay_len];
+        const core_surface = &surface.core_surface;
+        core_surface.renderer_state.mutex.lockUncancelable(global.io());
+        defer core_surface.renderer_state.mutex.unlock(global.io());
+        const io = &core_surface.io;
+        if (!io.beginKittyReplayRestoreLocked()) return false;
+        var tracking_replay = true;
+        defer if (tracking_replay) io.cancelKittyReplayRestoreLocked();
         if (comptime !terminal_options.kitty_graphics) {
-            surface.core_surface.io.processOutput(replay);
-            return true;
+            io.processKittyReplayOutputLocked(replay);
+            const replay_succeeded = io.finishKittyReplayRestoreLocked();
+            tracking_replay = false;
+            return replay_succeeded;
         }
         if (limits.image_bytes > std.math.maxInt(usize) or limits.inflight_bytes > std.math.maxInt(usize) or
             limits.images > std.math.maxInt(usize) or limits.placements > std.math.maxInt(usize)) return false;
@@ -4801,12 +4810,12 @@ pub const CAPI = struct {
             const items = aliases.?[0..alias_count];
             if (!kittyReplayAliasesAreValid(items)) return false;
         }
-        const t = &surface.core_surface.io.terminal;
+        const t = &io.terminal;
         t.setKittyGraphicsSizeLimit(t.gpa(), @intCast(limits.image_bytes)) catch return false;
         t.setKittyGraphicsImageCountLimit(t.gpa(), @intCast(limits.images)) catch return false;
         if (!t.setKittyGraphicsPlacementCountLimit(@intCast(limits.placements))) return false;
         const primary = t.screens.get(.primary) orelse return false;
-        surface.core_surface.io.processOutput(replay[0..replay_cursor_offset]);
+        io.processKittyReplayOutputLocked(replay[0..replay_cursor_offset]);
         if ((cursors.replay.alternate != kitty_graphics.default_image_id or
             cursors.next.alternate != kitty_graphics.default_image_id) and t.screens.get(.alternate) == null)
         {
@@ -4822,7 +4831,10 @@ pub const CAPI = struct {
         }
         primary.kitty_images.next_image_id = cursors.replay.primary;
         if (t.screens.get(.alternate)) |alternate| alternate.kitty_images.next_image_id = cursors.replay.alternate;
-        surface.core_surface.io.processOutput(replay[replay_cursor_offset..]);
+        io.processKittyReplayOutputLocked(replay[replay_cursor_offset..]);
+        const replay_succeeded = io.finishKittyReplayRestoreLocked();
+        tracking_replay = false;
+        if (!replay_succeeded) return false;
         if (primary.kitty_images.loading) |loading| {
             if (!loading.setByteLimit(@intCast(limits.inflight_bytes))) return false;
         }

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -4367,7 +4367,8 @@ pub const CAPI = struct {
         const primary = t.screens.get(.primary) orelse return false;
         const replay = replay_ptr[0..replay_len];
         surface.core_surface.io.processOutput(replay[0..replay_cursor_offset]);
-        if (cursors.replay.alternate != kitty_graphics.default_image_id and t.screens.get(.alternate) == null) {
+        if ((cursors.replay.alternate != kitty_graphics.default_image_id or
+            cursors.next.alternate != kitty_graphics.default_image_id) and t.screens.get(.alternate) == null) {
             _ = t.screens.getInit(t.io(), primary.alloc, .alternate, .{
                 .cols = t.cols,
                 .rows = t.rows,
@@ -4385,6 +4386,11 @@ pub const CAPI = struct {
             if (!loading.setByteLimit(@intCast(limits.inflight_bytes))) return false;
         }
         if (aliases) |items| {
+            // Validate every active-screen image before changing any alias, so a
+            // malformed sidecar cannot leave a partially restored mapping.
+            for (items[0..alias_count]) |alias| {
+                if (t.screens.active.kitty_images.images.getPtr(alias.image_id) == null) return false;
+            }
             for (items[0..alias_count]) |alias| {
                 if (!t.screens.active.kitty_images.setImageNumber(alias.image_id, alias.image_number)) return false;
             }

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -5324,10 +5324,18 @@ test "output sequence publishes only with successful VT tail snapshot" {
     try std.testing.expectEqual(@as(u64, 42), next_sequence);
 }
 
-test "kitty replay aliases reject duplicate image numbers" {
+test "kitty replay aliases preserve duplicate image numbers in assignment order" {
     const aliases = [_]CAPI.KittyReplayAlias{
         .{ .image_id = 11, .image_number = 7 },
         .{ .image_id = 12, .image_number = 7 },
+    };
+    try std.testing.expect(CAPI.kittyReplayAliasesAreValid(&aliases));
+}
+
+test "kitty replay aliases reject duplicate image IDs" {
+    const aliases = [_]CAPI.KittyReplayAlias{
+        .{ .image_id = 11, .image_number = 7 },
+        .{ .image_id = 11, .image_number = 8 },
     };
     try std.testing.expect(!CAPI.kittyReplayAliasesAreValid(&aliases));
 }

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -2104,8 +2104,7 @@ pub const CAPI = struct {
         for (aliases, 0..) |alias, i| {
             if (alias.image_id == 0 or alias.image_number == 0) return false;
             for (aliases[0..i]) |previous| {
-                if (previous.image_id == alias.image_id or
-                    previous.image_number == alias.image_number) return false;
+                if (previous.image_id == alias.image_id) return false;
             }
         }
         return true;

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -2095,6 +2095,21 @@ pub const Inspector = struct {
 
 // C API
 pub const CAPI = struct {
+    const KittyReplayAlias = extern struct {
+        image_id: u32,
+        image_number: u32,
+    };
+
+    fn kittyReplayAliasesAreValid(aliases: []const KittyReplayAlias) bool {
+        for (aliases, 0..) |alias, i| {
+            if (alias.image_id == 0 or alias.image_number == 0) return false;
+            for (aliases[0..i]) |previous| {
+                if (previous.image_id == alias.image_id) return false;
+            }
+        }
+        return true;
+    }
+
     /// This is the same as Surface.KeyEvent but this is the raw C API version.
     const KeyEvent = extern struct {
         action: input.Action,
@@ -4766,7 +4781,7 @@ pub const CAPI = struct {
             replay: extern struct { primary: u32, alternate: u32 },
             next: extern struct { primary: u32, alternate: u32 },
         },
-        aliases: ?[*]const extern struct { image_id: u32, image_number: u32 },
+        aliases: ?[*]const KittyReplayAlias,
         alias_count: usize,
     ) bool {
         if (replay_cursor_offset > replay_len) return false;
@@ -4784,12 +4799,7 @@ pub const CAPI = struct {
             cursors.next.primary == 0 or cursors.next.alternate == 0) return false;
         if (alias_count > 0) {
             const items = aliases.?[0..alias_count];
-            for (items, 0..) |alias, i| {
-                if (alias.image_id == 0 or alias.image_number == 0) return false;
-                for (items[0..i]) |previous| {
-                    if (previous.image_id == alias.image_id) return false;
-                }
-            }
+            if (!kittyReplayAliasesAreValid(items)) return false;
         }
         const t = &surface.core_surface.io.terminal;
         t.setKittyGraphicsSizeLimit(t.gpa(), @intCast(limits.image_bytes)) catch return false;
@@ -4798,7 +4808,8 @@ pub const CAPI = struct {
         const primary = t.screens.get(.primary) orelse return false;
         surface.core_surface.io.processOutput(replay[0..replay_cursor_offset]);
         if ((cursors.replay.alternate != kitty_graphics.default_image_id or
-            cursors.next.alternate != kitty_graphics.default_image_id) and t.screens.get(.alternate) == null) {
+            cursors.next.alternate != kitty_graphics.default_image_id) and t.screens.get(.alternate) == null)
+        {
             _ = t.screens.getInit(t.io(), primary.alloc, .alternate, .{
                 .cols = t.cols,
                 .rows = t.rows,
@@ -5305,6 +5316,14 @@ test "output sequence publishes only with successful VT tail snapshot" {
         &next_sequence,
     ));
     try std.testing.expectEqual(@as(u64, 42), next_sequence);
+}
+
+test "kitty replay aliases reject duplicate image numbers" {
+    const aliases = [_]CAPI.KittyReplayAlias{
+        .{ .image_id = 11, .image_number = 7 },
+        .{ .image_id = 12, .image_number = 7 },
+    };
+    try std.testing.expect(!CAPI.kittyReplayAliasesAreValid(&aliases));
 }
 
 test "clipboard selection work budget rejects blank history" {

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -4329,7 +4329,7 @@ pub const CAPI = struct {
 
     export fn ghostty_surface_restore_kitty_replay(
         surface: *Surface,
-        replay_ptr: [*]const u8,
+        replay_ptr: ?[*]const u8,
         replay_len: usize,
         replay_cursor_offset: u32,
         limits: extern struct { image_bytes: u64, inflight_bytes: u64, images: u64, placements: u64 },
@@ -4341,9 +4341,11 @@ pub const CAPI = struct {
         alias_count: usize,
     ) bool {
         if (replay_cursor_offset > replay_len) return false;
+        if (replay_len != 0 and replay_ptr == null) return false;
         if (alias_count != 0 and aliases == null) return false;
+        const replay: []const u8 = if (replay_len == 0) &[_]u8{} else replay_ptr.?[0..replay_len];
         if (comptime !terminal_options.kitty_graphics) {
-            surface.core_surface.io.processOutput(replay_ptr[0..replay_len]);
+            surface.core_surface.io.processOutput(replay);
             return true;
         }
         if (limits.image_bytes > std.math.maxInt(usize) or limits.inflight_bytes > std.math.maxInt(usize) or
@@ -4365,7 +4367,6 @@ pub const CAPI = struct {
         t.setKittyGraphicsImageCountLimit(t.gpa(), @intCast(limits.images)) catch return false;
         if (!t.setKittyGraphicsPlacementCountLimit(@intCast(limits.placements))) return false;
         const primary = t.screens.get(.primary) orelse return false;
-        const replay = replay_ptr[0..replay_len];
         surface.core_surface.io.processOutput(replay[0..replay_cursor_offset]);
         if ((cursors.replay.alternate != kitty_graphics.default_image_id or
             cursors.next.alternate != kitty_graphics.default_image_id) and t.screens.get(.alternate) == null) {

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -4850,14 +4850,6 @@ pub const CAPI = struct {
         const replay_succeeded = io.finishKittyReplayRestoreLocked();
         tracking_replay = false;
         if (!replay_succeeded) return false;
-        if (primary.kitty_images.loading) |loading| {
-            if (!loading.setByteLimit(@intCast(limits.inflight_bytes))) return false;
-        }
-        if (t.screens.get(.alternate)) |alternate| {
-            if (alternate.kitty_images.loading) |loading| {
-                if (!loading.setByteLimit(@intCast(limits.inflight_bytes))) return false;
-            }
-        }
         if (aliases) |items| {
             // Validate every active-screen image before changing any alias, so a
             // malformed sidecar cannot leave a partially restored mapping.

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -3555,6 +3555,16 @@ pub fn kittyGraphics(
     return kitty.graphics.execute(io_impl, alloc, self, cmd);
 }
 
+/// Execute Kitty graphics while retaining failures hidden by q=2.
+pub fn kittyGraphicsTracked(
+    self: *Terminal,
+    io_impl: std.Io,
+    alloc: Allocator,
+    cmd: *kitty.graphics.Command,
+) kitty.graphics.ExecuteResult {
+    return kitty.graphics.executeTracked(io_impl, alloc, self, cmd);
+}
+
 /// Execute a Glyph Protocol APC command against this terminal's per-session
 /// glossary. The returned response, if any, should be sent back to the pty as
 /// a complete APC sequence via `Response.formatWire`.

--- a/src/terminal/apc.zig
+++ b/src/terminal/apc.zig
@@ -197,6 +197,13 @@ pub const Handler = struct {
         defer self.kitty_error = false;
         return self.kitty_error;
     }
+
+    pub fn isInactive(self: *const Handler) bool {
+        return switch (self.state) {
+            .inactive => true,
+            else => false,
+        };
+    }
 };
 
 pub const State = union(enum) {

--- a/src/terminal/apc.zig
+++ b/src/terminal/apc.zig
@@ -12,6 +12,7 @@ const log = std.log.scoped(.terminal_apc);
 /// apcStart, apcPut, and apcEnd functions, respectively.
 pub const Handler = struct {
     state: State = .inactive,
+    kitty_error: bool = false,
 
     /// Maximum bytes each APC protocol can buffer. This is to prevent
     /// malicious input from causing us to allocate too much memory.
@@ -34,6 +35,7 @@ pub const Handler = struct {
     pub fn start(self: *Handler) void {
         self.state.deinit();
         self.state = .{ .identify = .{} };
+        self.kitty_error = false;
     }
 
     /// Enable or disable APC protocol recognition for future APC sequences.
@@ -100,6 +102,7 @@ pub const Handler = struct {
             .kitty => |*p| if (comptime build_options.kitty_graphics) {
                 p.feed(byte) catch |err| {
                     log.warn("kitty graphics protocol error: {}", .{err});
+                    self.kitty_error = true;
                     p.deinit();
                     self.state = .ignore;
                 };
@@ -136,6 +139,7 @@ pub const Handler = struct {
                 .kitty => |*p| if (comptime build_options.kitty_graphics) {
                     p.feedSlice(rem) catch |err| {
                         log.warn("kitty graphics protocol error: {}", .{err});
+                        self.kitty_error = true;
                         p.deinit();
                         self.state = .ignore;
                     };
@@ -170,6 +174,7 @@ pub const Handler = struct {
                 const alloc = p.arena.child_allocator;
                 const command = p.complete(alloc) catch |err| {
                     log.warn("kitty graphics protocol error: {}", .{err});
+                    self.kitty_error = true;
                     break :kitty null;
                 };
 
@@ -185,6 +190,12 @@ pub const Handler = struct {
                 break :glyph_cmd .{ .glyph = command };
             },
         };
+    }
+
+    /// Return and clear the parse failure for the most recent Kitty APC.
+    pub fn takeKittyError(self: *Handler) bool {
+        defer self.kitty_error = false;
+        return self.kitty_error;
     }
 };
 
@@ -508,6 +519,23 @@ test "feedSlice kitty max bytes exceeded" {
     try testing.expect(h.state != .ignore);
     h.feedSlice(alloc, "e");
     try testing.expect(h.state == .ignore);
+    try testing.expect(h.end() == null);
+    try testing.expect(h.takeKittyError());
+    try testing.expect(!h.takeKittyError());
+}
+
+test "unterminated Kitty parser error remains observable" {
+    if (comptime !build_options.kitty_graphics) return error.SkipZigTest;
+
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var h: Handler = .{ .max_bytes = .init(.{ .kitty = 4 }) };
+    defer h.deinit();
+    h.start();
+    h.feedSlice(alloc, "Ga=t;abcde");
+    try testing.expect(h.state == .ignore);
+    try testing.expect(h.takeKittyError());
 }
 
 test "disabled glyph command is ignored" {

--- a/src/terminal/kitty/graphics.zig
+++ b/src/terminal/kitty/graphics.zig
@@ -34,6 +34,8 @@ pub const Response = command.Response;
 pub const nextGeneration = storage.nextGeneration;
 
 pub const execute = exec.execute;
+pub const executeTracked = exec.executeTracked;
+pub const ExecuteResult = exec.ExecuteResult;
 
 test {
     @import("std").testing.refAllDecls(@This());

--- a/src/terminal/kitty/graphics_exec.zig
+++ b/src/terminal/kitty/graphics_exec.zig
@@ -112,7 +112,7 @@ pub fn executeTracked(
     // if this feature is not supported.
     if (!terminal.screens.active.kitty_images.enabled()) {
         log.debug("kitty graphics requested but disabled", .{});
-        return .{ .response = null, .succeeded = true };
+        return .{ .response = null, .succeeded = false };
     }
 
     log.debug("executing kitty graphics command: quiet={} control={}", .{

--- a/src/terminal/kitty/graphics_exec.zig
+++ b/src/terminal/kitty/graphics_exec.zig
@@ -543,6 +543,25 @@ test "kittygfx tracked execution retains a quiet failure" {
     try testing.expect(!result.succeeded);
 }
 
+test "kittygfx tracked execution rejects disabled storage" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const io = testing.io;
+
+    var t = try Terminal.init(io, alloc, .{
+        .rows = 5,
+        .cols = 5,
+        .kitty_image_storage_limit = 0,
+    });
+    defer t.deinit(alloc);
+
+    const cmd = try command.Parser.parseString(alloc, "a=p,i=99,q=2");
+    defer cmd.deinit(alloc);
+    const result = executeTracked(io, alloc, &t, &cmd);
+    try testing.expect(result.response == null);
+    try testing.expect(!result.succeeded);
+}
+
 test "kittygfx more chunks with q=0" {
     const testing = std.testing;
     const alloc = testing.allocator;

--- a/src/terminal/kitty/graphics_exec.zig
+++ b/src/terminal/kitty/graphics_exec.zig
@@ -91,12 +91,28 @@ pub fn execute(
     terminal: *Terminal,
     cmd: *const Command,
 ) ?Response {
+    return executeTracked(io, alloc, terminal, cmd).response;
+}
+
+pub const ExecuteResult = struct {
+    response: ?Response,
+    succeeded: bool,
+};
+
+/// Execute a command and retain its success state even when the Kitty quiet
+/// setting suppresses the protocol response.
+pub fn executeTracked(
+    io: std.Io,
+    alloc: Allocator,
+    terminal: *Terminal,
+    cmd: *const Command,
+) ExecuteResult {
     // If storage is disabled then we disable the full protocol. This means
     // we don't even respond to queries so the terminal completely acts as
     // if this feature is not supported.
     if (!terminal.screens.active.kitty_images.enabled()) {
         log.debug("kitty graphics requested but disabled", .{});
-        return null;
+        return .{ .response = null, .succeeded = true };
     }
 
     log.debug("executing kitty graphics command: quiet={} control={}", .{
@@ -146,14 +162,15 @@ pub fn execute(
             log.warn("erroneous kitty graphics response: {s}", .{resp.message});
         }
 
-        return switch (quiet) {
+        const response = switch (quiet) {
             .no => if (resp.empty()) null else resp,
             .ok => if (resp.ok()) null else resp,
             .failures => null,
         };
+        return .{ .response = response, .succeeded = resp.ok() };
     }
 
-    return null;
+    return .{ .response = null, .succeeded = true };
 }
 /// Execute a "query" command.
 ///
@@ -509,6 +526,21 @@ test "kittygfx more chunks with q=1" {
         const resp = execute(io, alloc, &t, &cmd);
         try testing.expect(resp == null);
     }
+}
+
+test "kittygfx tracked execution retains a quiet failure" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const io = testing.io;
+
+    var t = try Terminal.init(io, alloc, .{ .rows = 5, .cols = 5 });
+    defer t.deinit(alloc);
+
+    const cmd = try command.Parser.parseString(alloc, "a=p,i=99,q=2");
+    defer cmd.deinit(alloc);
+    const result = executeTracked(io, alloc, &t, &cmd);
+    try testing.expect(result.response == null);
+    try testing.expect(!result.succeeded);
 }
 
 test "kittygfx more chunks with q=0" {

--- a/src/termio/Termio.zig
+++ b/src/termio/Termio.zig
@@ -869,6 +869,12 @@ pub fn processKittyReplayOutputLocked(self: *Termio, buf: []const u8) void {
 
 /// Finish replay tracking and report all completed Kitty command failures.
 pub fn finishKittyReplayRestoreLocked(self: *Termio) bool {
+    if (self.terminal_stream.parser.state != .ground or
+        self.terminal_stream.utf8decoder.state != 0 or
+        !self.terminal_stream.handler.apc.isInactive())
+    {
+        self.terminal_stream.handler.failKittyReplayIfTracking();
+    }
     return self.terminal_stream.handler.finishKittyReplayTracking();
 }
 

--- a/src/termio/Termio.zig
+++ b/src/termio/Termio.zig
@@ -854,6 +854,28 @@ pub fn processOutput(self: *Termio, buf: []const u8) void {
     processOutputAndAdvanceLocked(self, buf);
 }
 
+/// Start a destructive replay on a surface that has not processed output.
+/// The caller must hold renderer_state.mutex until it finishes or cancels.
+pub fn beginKittyReplayRestoreLocked(self: *Termio) bool {
+    if (self.processed_output_bytes != 0) return false;
+    self.terminal_stream.handler.beginKittyReplayTracking();
+    return true;
+}
+
+/// Apply replay bytes while the caller holds renderer_state.mutex.
+pub fn processKittyReplayOutputLocked(self: *Termio, buf: []const u8) void {
+    processOutputAndAdvanceLocked(self, buf);
+}
+
+/// Finish replay tracking and report all completed Kitty command failures.
+pub fn finishKittyReplayRestoreLocked(self: *Termio) bool {
+    return self.terminal_stream.handler.finishKittyReplayTracking();
+}
+
+pub fn cancelKittyReplayRestoreLocked(self: *Termio) void {
+    self.terminal_stream.handler.cancelKittyReplayTracking();
+}
+
 /// Apply output and publish its byte position as one renderer-mutex critical
 /// section. Keeping the sequence update after the parser is the recovery
 /// contract: observers never see bytes as processed before terminal state does.
@@ -880,9 +902,12 @@ fn processOutputLocked(self: *Termio, buf: []const u8) void {
         }
 
         self.last_cursor_reset = now;
-        _ = self.renderer_mailbox.push(global.io(), .{
+        const queue_size = self.renderer_mailbox.push(global.io(), .{
             .reset_cursor_blink = {},
         }, .{ .instant = {} });
+        if (queue_size == 0) {
+            self.terminal_stream.handler.failKittyReplayIfTracking();
+        }
     }
 
     // If we have an inspector, we enter SLOW MODE because we need to

--- a/src/termio/mailbox.zig
+++ b/src/termio/mailbox.zig
@@ -95,6 +95,17 @@ pub const Mailbox = union(enum) {
         }
     }
 
+    /// Attempt to enqueue without releasing a caller-owned lock.
+    pub fn sendInstant(self: *Mailbox, msg: termio.Message) bool {
+        return switch (self.*) {
+            .spsc => |*mb| mb.queue.push(
+                global.io(),
+                msg,
+                .{ .instant = {} },
+            ) > 0,
+        };
+    }
+
     /// Notify that there are new messages. This may be a noop depending
     /// on the writer type.
     pub fn notify(self: *Mailbox) void {

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -298,6 +298,7 @@ pub const StreamHandler = struct {
         value: Stream.Action.Value(action),
     ) void {
         self.vtFallible(action, value) catch |err| {
+            self.failKittyReplayIfTracking();
             log.warn("error handling VT action action={} err={}", .{ action, err });
         };
     }

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -97,6 +97,14 @@ test "terminal response suppression drops every parser reply class" {
     ));
 }
 
+test "kitty replay suppresses protocol responses on normal surfaces" {
+    const testing = std.testing;
+    const reply: termio.Message = .{ .write_stable = "\x1b_Gi=1;OK\x1b\\" };
+
+    try testing.expect(suppressTerminalResponseForState(false, true, reply));
+    try testing.expect(!suppressTerminalResponseForState(false, false, reply));
+}
+
 /// This is used as the handler for the terminal.Stream type. This is
 /// stateful and is expected to live for the entire lifetime of the terminal.
 /// It is NOT VALID to stop a stream handler, create a new one, and use that

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -34,6 +34,22 @@ fn suppressTerminalResponse(enabled: bool, msg: termio.Message) bool {
     }
 }
 
+fn discardTermioMessage(msg: termio.Message) void {
+    switch (msg) {
+        .write_alloc => |req| req.alloc.free(req.data),
+        else => {},
+    }
+}
+
+fn discardSurfaceMessage(msg: apprt.surface.Message) void {
+    switch (msg) {
+        .clipboard_write => |value| value.req.deinit(),
+        .pwd_change => |value| value.pwd.deinit(),
+        .tmux_control => |value| value.data.deinit(),
+        else => {},
+    }
+}
+
 test "terminal response suppression drops every parser reply class" {
     const testing = std.testing;
 
@@ -146,6 +162,11 @@ pub const StreamHandler = struct {
     /// this to determine if we need to default the window title.
     seen_title: bool = false,
 
+    /// A surface replay needs Kitty command failures even when q=2 suppresses
+    /// their protocol responses.
+    kitty_replay_tracking: bool = false,
+    kitty_replay_failed: bool = false,
+
     pub const Stream = terminal.Stream(StreamHandler);
 
     /// True if we have tmux control mode built in.
@@ -188,6 +209,11 @@ pub const StreamHandler = struct {
         // See messageWriter which has similar logic and explains why
         // we may have to do this.
         if (self.surface_mailbox.push(msg, .{ .instant = {} }) == 0) {
+            if (self.kitty_replay_tracking) {
+                self.kitty_replay_failed = true;
+                discardSurfaceMessage(msg);
+                return;
+            }
             self.renderer_state.mutex.unlock(global.io());
             defer self.renderer_state.mutex.lockUncancelable(global.io());
             _ = self.surface_mailbox.push(msg, .{ .forever = {} });
@@ -197,6 +223,15 @@ pub const StreamHandler = struct {
     inline fn messageWriter(self: *StreamHandler, msg: termio.Message) void {
         if (suppressTerminalResponse(self.suppress_terminal_responses, msg))
             return;
+        if (self.kitty_replay_tracking) {
+            if (self.termio_mailbox.sendInstant(msg)) {
+                self.termio_messaged = true;
+            } else {
+                self.kitty_replay_failed = true;
+                discardTermioMessage(msg);
+            }
+            return;
+        }
         self.termio_mailbox.send(msg, self.renderer_state.mutex);
         self.termio_messaged = true;
     }
@@ -213,6 +248,12 @@ pub const StreamHandler = struct {
 
         // Try instant first. If it works then we can return.
         if (self.renderer_mailbox.push(msg, .{ .instant = {} }) > 0) {
+            return;
+        }
+        if (self.kitty_replay_tracking) {
+            self.kitty_replay_failed = true;
+            self.renderer_wakeup.notify() catch {};
+            msg.deinit();
             return;
         }
 
@@ -685,13 +726,27 @@ pub const StreamHandler = struct {
     }
 
     pub fn apcEnd(self: *StreamHandler) !void {
-        var cmd = self.apc.end() orelse return;
+        var cmd = self.apc.end() orelse {
+            if (self.kitty_replay_tracking and self.apc.takeKittyError()) {
+                self.kitty_replay_failed = true;
+            }
+            return;
+        };
+        _ = self.apc.takeKittyError();
         defer cmd.deinit(self.alloc);
 
         // log.warn("APC command: {}", .{cmd});
         switch (cmd) {
             .kitty => |*kitty_cmd| {
-                if (self.terminal.kittyGraphics(global.io(), self.alloc, kitty_cmd)) |resp| {
+                const result = self.terminal.kittyGraphicsTracked(
+                    global.io(),
+                    self.alloc,
+                    kitty_cmd,
+                );
+                if (self.kitty_replay_tracking and !result.succeeded) {
+                    self.kitty_replay_failed = true;
+                }
+                if (result.response) |resp| {
                     var buf: [1024]u8 = undefined;
                     var writer: std.Io.Writer = .fixed(&buf);
                     try resp.encode(&writer);
@@ -720,6 +775,29 @@ pub const StreamHandler = struct {
                 }
             },
         }
+    }
+
+    pub fn beginKittyReplayTracking(self: *StreamHandler) void {
+        assert(!self.kitty_replay_tracking);
+        self.kitty_replay_tracking = true;
+        self.kitty_replay_failed = false;
+    }
+
+    pub fn failKittyReplayIfTracking(self: *StreamHandler) void {
+        if (self.kitty_replay_tracking) self.kitty_replay_failed = true;
+    }
+
+    pub fn finishKittyReplayTracking(self: *StreamHandler) bool {
+        assert(self.kitty_replay_tracking);
+        if (self.apc.takeKittyError()) self.kitty_replay_failed = true;
+        self.kitty_replay_tracking = false;
+        defer self.kitty_replay_failed = false;
+        return !self.kitty_replay_failed;
+    }
+
+    pub fn cancelKittyReplayTracking(self: *StreamHandler) void {
+        self.kitty_replay_tracking = false;
+        self.kitty_replay_failed = false;
     }
 
     inline fn bell(self: *StreamHandler) void {

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -34,6 +34,14 @@ fn suppressTerminalResponse(enabled: bool, msg: termio.Message) bool {
     }
 }
 
+fn suppressTerminalResponseForState(
+    configured: bool,
+    kitty_replay_tracking: bool,
+    msg: termio.Message,
+) bool {
+    return suppressTerminalResponse(configured or kitty_replay_tracking, msg);
+}
+
 fn discardTermioMessage(msg: termio.Message) void {
     switch (msg) {
         .write_alloc => |req| req.alloc.free(req.data),
@@ -229,7 +237,11 @@ pub const StreamHandler = struct {
     }
 
     inline fn messageWriter(self: *StreamHandler, msg: termio.Message) void {
-        if (suppressTerminalResponse(self.suppress_terminal_responses, msg))
+        if (suppressTerminalResponseForState(
+            self.suppress_terminal_responses,
+            self.kitty_replay_tracking,
+            msg,
+        ))
             return;
         if (self.kitty_replay_tracking) {
             if (self.termio_mailbox.sendInstant(msg)) {


### PR DESCRIPTION
Adds the embedded Ghostty surface API used by cmux native renderer reset events. It restores Kitty replay state on a fresh surface under one terminal lock, validates all caller data, and reports parser, execution, and mailbox failures. On false, the caller must discard the surface.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/189"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788690553&installation_model_id=21920&pr_number=189&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F189&signature=8f4537a240edd0712dd099c7e2001f8c46f707444e217bef0f9e43e3f0d83237"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an atomic C API to restore Kitty graphics state for embedded surfaces during replays. Suppresses protocol replies while reliably tracking failures, and clarifies `inflight_bytes` as a producer-only bound.

- **New Features**
  - `ghostty_surface_restore_kitty_replay(...)`: Validates inputs; accepts empty replay (null pointer allowed when len=0); enforces non‑zero cursors; rejects duplicate/excessive aliases (≤65,536); creates the alternate screen if needed; applies image size/count/placement limits; treats `inflight_bytes` as a validated producer bound (not a decoded-image storage limit); validates alias targets; suppresses Kitty protocol replies during restore while still tracking failures (including `q=2`); streams bytes when Kitty support is compiled out; and returns false on any replay failure, including incomplete APC/UTF‑8 input.

- **Bug Fixes**
  - Keeps alias assignment order so duplicate image numbers are preserved.
  - Preserves Kitty image limit semantics (size, count, placement) during restore.
  - Fails the restore when Kitty image storage is disabled.

<sup>Written for commit 0ef5106634c60f56328e444ca7748a14ad3f2f13. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/189?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an API to restore Kitty graphics state when restoring a terminal session.
  * Supports graphics limits, image aliases, image ID counters, replay data, and primary or alternate screen state.
  * Invalid or unsupported restoration data is safely rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
