### PR TITLE
Fix VT formatter cursor restoration after margins

### DIFF
--- a/src/terminal/formatter.zig
+++ b/src/terminal/formatter.zig
@@ -295,34 +295,6 @@ pub const TerminalFormatter = struct {
                 ) catch return error.WriteFailed;
             }
 
-            // Scrolling regions and tabstop restoration move the cursor after
-            // ScreenFormatter emits it. Restore the cursor after all terminal
-            // state, with CUP coordinates relative to the origin margins.
-            if (self.extra.screen.cursor) {
-                const cursor = &self.terminal.screens.active.cursor;
-                const region = &self.terminal.scrolling_region;
-                const origin = self.terminal.modes.get(.origin);
-                const row = if (origin) cursor.y - region.top else cursor.y;
-                const col = if (origin) cursor.x - region.left else cursor.x;
-                try writer.print("\x1b[{d};{d}H", .{ row + 1, col + 1 });
-
-                if (self.pin_map) |*m| {
-                    var discarding: std.Io.Writer.Discarding = .init(&.{});
-                    try discarding.writer.print("\x1b[{d};{d}H", .{ row + 1, col + 1 });
-                    m.map.appendNTimes(
-                        m.alloc,
-                        if (m.map.items.len > 0) pin: {
-                            const last = m.map.items[m.map.items.len - 1];
-                            break :pin .{
-                                .node = last.node,
-                                .x = last.x,
-                                .y = last.y,
-                            };
-                        } else self.terminal.screens.active.pages.getTopLeft(.screen),
-                        std.math.cast(usize, discarding.count) orelse return error.WriteFailed,
-                    ) catch return error.WriteFailed;
-                }
-            }
         }
 
         // Emit terminal modes that differ from defaults. We probably have
@@ -446,6 +418,34 @@ pub const TerminalFormatter = struct {
                 ) catch return error.WriteFailed;
             }
 
+            // Scrolling regions and tabstop restoration move the cursor after
+            // ScreenFormatter emits it. Restore the cursor after all terminal
+            // state, with CUP coordinates relative to the origin margins.
+            if (self.extra.screen.cursor) {
+                const cursor = &self.terminal.screens.active.cursor;
+                const region = &self.terminal.scrolling_region;
+                const origin = self.terminal.modes.get(.origin);
+                const row = if (origin) cursor.y - region.top else cursor.y;
+                const col = if (origin) cursor.x - region.left else cursor.x;
+                try writer.print("\x1b[{d};{d}H", .{ row + 1, col + 1 });
+
+                if (self.pin_map) |*m| {
+                    var discarding: std.Io.Writer.Discarding = .init(&.{});
+                    try discarding.writer.print("\x1b[{d};{d}H", .{ row + 1, col + 1 });
+                    m.map.appendNTimes(
+                        m.alloc,
+                        if (m.map.items.len > 0) pin: {
+                            const last = m.map.items[m.map.items.len - 1];
+                            break :pin .{
+                                .node = last.node,
+                                .x = last.x,
+                                .y = last.y,
+                            };
+                        } else self.terminal.screens.active.pages.getTopLeft(.screen),
+                        std.math.cast(usize, discarding.count) orelse return error.WriteFailed,
+                    ) catch return error.WriteFailed;
+                }
+            }
         }
     }
 };

--- a/src/terminal/formatter.zig
+++ b/src/terminal/formatter.zig
@@ -416,6 +416,7 @@ pub const TerminalFormatter = struct {
                     std.math.cast(usize, discarding.count) orelse return error.WriteFailed,
                 ) catch return error.WriteFailed;
             }
+
         }
     }
 };
@@ -5200,6 +5201,55 @@ test "Terminal vt with scrolling region" {
     try testing.expectEqual(t.scrolling_region.bottom, t2.scrolling_region.bottom);
     try testing.expectEqual(t.scrolling_region.left, t2.scrolling_region.left);
     try testing.expectEqual(t.scrolling_region.right, t2.scrolling_region.right);
+}
+
+test "Terminal vt restores cursor after scrolling margins" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const io = testing.io;
+
+    var builder: std.Io.Writer.Allocating = .init(alloc);
+    defer builder.deinit();
+
+    var t = try Terminal.init(io, alloc, .{
+        .cols = 5,
+        .rows = 5,
+    });
+    defer t.deinit(alloc);
+
+    var s = t.vtStream();
+    defer s.deinit();
+
+    // Use both margin axes and origin mode, then place the cursor at the
+    // second row and column inside those margins.
+    s.nextSlice("\x1b[?69h\x1b[2;4s\x1b[2;4r\x1b[?6h\x1b[2;2H");
+
+    var formatter: TerminalFormatter = .init(&t, .vt);
+    formatter.extra = .none;
+    formatter.extra.modes = true;
+    formatter.extra.scrolling_region = true;
+    formatter.extra.screen.cursor = true;
+
+    try formatter.format(&builder.writer);
+    const output = builder.writer.buffered();
+
+    var t2 = try Terminal.init(io, alloc, .{
+        .cols = 5,
+        .rows = 5,
+    });
+    defer t2.deinit(alloc);
+
+    var s2 = t2.vtStream();
+    defer s2.deinit();
+    s2.nextSlice(output);
+
+    try testing.expect(t2.modes.get(.origin));
+    try testing.expectEqual(t.scrolling_region.top, t2.scrolling_region.top);
+    try testing.expectEqual(t.scrolling_region.bottom, t2.scrolling_region.bottom);
+    try testing.expectEqual(t.scrolling_region.left, t2.scrolling_region.left);
+    try testing.expectEqual(t.scrolling_region.right, t2.scrolling_region.right);
+    try testing.expectEqual(t.screens.active.cursor.x, t2.screens.active.cursor.x);
+    try testing.expectEqual(t.screens.active.cursor.y, t2.screens.active.cursor.y);
 }
 
 test "Terminal vt with modes" {

--- a/src/terminal/formatter.zig
+++ b/src/terminal/formatter.zig
@@ -5380,6 +5380,46 @@ test "Terminal vt with tabstops" {
     try testing.expect(!t2.tabstops.get(8)); // Not a tab
 }
 
+test "Terminal vt restores cursor after tabstops without scrolling region" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const io = testing.io;
+
+    var builder: std.Io.Writer.Allocating = .init(alloc);
+    defer builder.deinit();
+
+    var t = try Terminal.init(io, alloc, .{
+        .cols = 8,
+        .rows = 5,
+    });
+    defer t.deinit(alloc);
+
+    var s = t.vtStream();
+    defer s.deinit();
+    s.nextSlice("\x1b[3g\x1b[2G\x1bH\x1b[6G\x1bH\x1b[3;3H");
+
+    var formatter: TerminalFormatter = .init(&t, .vt);
+    formatter.extra = .none;
+    formatter.extra.tabstops = true;
+    formatter.extra.screen.cursor = true;
+    try testing.expect(!formatter.extra.scrolling_region);
+
+    try formatter.format(&builder.writer);
+
+    var t2 = try Terminal.init(io, alloc, .{
+        .cols = 8,
+        .rows = 5,
+    });
+    defer t2.deinit(alloc);
+
+    var s2 = t2.vtStream();
+    defer s2.deinit();
+    s2.nextSlice(builder.writer.buffered());
+
+    try testing.expectEqual(t.screens.active.cursor.x, t2.screens.active.cursor.x);
+    try testing.expectEqual(t.screens.active.cursor.y, t2.screens.active.cursor.y);
+}
+
 test "Terminal vt with keyboard modes" {
     const testing = std.testing;
     const alloc = testing.allocator;

--- a/src/terminal/formatter.zig
+++ b/src/terminal/formatter.zig
@@ -5251,7 +5251,7 @@ test "Terminal vt restores cursor after scrolling margins" {
 
     // Use both margin axes and origin mode, then place the cursor at the
     // second row and column inside those margins.
-    s.nextSlice("\x1b[?69h\x1b[2;4s\x1b[2;4r\x1b[?6h\x1b[2;2H");
+    s.nextSlice("\x1b[2;4r\x1b[?6h\x1b[2;3H");
 
     var formatter: TerminalFormatter = .init(&t, .vt);
     formatter.extra = .none;
@@ -5318,7 +5318,6 @@ test "Terminal vt cursor is absolute when origin mode is omitted" {
 
     try testing.expect(!t2.modes.get(.origin));
     try testing.expectEqual(t.scrolling_region.top, t2.scrolling_region.top);
-    try testing.expectEqual(t.scrolling_region.left, t2.scrolling_region.left);
     try testing.expectEqual(t.screens.active.cursor.x, t2.screens.active.cursor.x);
     try testing.expectEqual(t.screens.active.cursor.y, t2.screens.active.cursor.y);
 }
@@ -5339,7 +5338,7 @@ test "Terminal vt cursor uses default margins when scrolling region is omitted" 
 
     var s = t.vtStream();
     defer s.deinit();
-    s.nextSlice("\x1b[?69h\x1b[2;4s\x1b[2;4r\x1b[?6h\x1b[2;2H");
+    s.nextSlice("\x1b[2;4r\x1b[?6h\x1b[2;3H");
 
     var formatter: TerminalFormatter = .init(&t, .vt);
     formatter.extra = .none;
@@ -5360,7 +5359,6 @@ test "Terminal vt cursor uses default margins when scrolling region is omitted" 
 
     try testing.expect(t2.modes.get(.origin));
     try testing.expectEqual(@as(usize, 0), t2.scrolling_region.top);
-    try testing.expectEqual(@as(usize, 0), t2.scrolling_region.left);
     try testing.expectEqual(t.screens.active.cursor.x, t2.screens.active.cursor.x);
     try testing.expectEqual(t.screens.active.cursor.y, t2.screens.active.cursor.y);
 }

--- a/src/terminal/formatter.zig
+++ b/src/terminal/formatter.zig
@@ -5281,6 +5281,90 @@ test "Terminal vt restores cursor after scrolling margins" {
     try testing.expectEqual(t.screens.active.cursor.y, t2.screens.active.cursor.y);
 }
 
+test "Terminal vt cursor is absolute when origin mode is omitted" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const io = testing.io;
+
+    var builder: std.Io.Writer.Allocating = .init(alloc);
+    defer builder.deinit();
+
+    var t = try Terminal.init(io, alloc, .{
+        .cols = 5,
+        .rows = 5,
+    });
+    defer t.deinit(alloc);
+
+    var s = t.vtStream();
+    defer s.deinit();
+    s.nextSlice("\x1b[?69h\x1b[2;4s\x1b[2;4r\x1b[?6h\x1b[2;2H");
+
+    var formatter: TerminalFormatter = .init(&t, .vt);
+    formatter.extra = .none;
+    formatter.extra.scrolling_region = true;
+    formatter.extra.screen.cursor = true;
+
+    try formatter.format(&builder.writer);
+
+    var t2 = try Terminal.init(io, alloc, .{
+        .cols = 5,
+        .rows = 5,
+    });
+    defer t2.deinit(alloc);
+
+    var s2 = t2.vtStream();
+    defer s2.deinit();
+    s2.nextSlice(builder.writer.buffered());
+
+    try testing.expect(!t2.modes.get(.origin));
+    try testing.expectEqual(t.scrolling_region.top, t2.scrolling_region.top);
+    try testing.expectEqual(t.scrolling_region.left, t2.scrolling_region.left);
+    try testing.expectEqual(t.screens.active.cursor.x, t2.screens.active.cursor.x);
+    try testing.expectEqual(t.screens.active.cursor.y, t2.screens.active.cursor.y);
+}
+
+test "Terminal vt cursor uses default margins when scrolling region is omitted" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const io = testing.io;
+
+    var builder: std.Io.Writer.Allocating = .init(alloc);
+    defer builder.deinit();
+
+    var t = try Terminal.init(io, alloc, .{
+        .cols = 5,
+        .rows = 5,
+    });
+    defer t.deinit(alloc);
+
+    var s = t.vtStream();
+    defer s.deinit();
+    s.nextSlice("\x1b[?69h\x1b[2;4s\x1b[2;4r\x1b[?6h\x1b[2;2H");
+
+    var formatter: TerminalFormatter = .init(&t, .vt);
+    formatter.extra = .none;
+    formatter.extra.modes = true;
+    formatter.extra.screen.cursor = true;
+
+    try formatter.format(&builder.writer);
+
+    var t2 = try Terminal.init(io, alloc, .{
+        .cols = 5,
+        .rows = 5,
+    });
+    defer t2.deinit(alloc);
+
+    var s2 = t2.vtStream();
+    defer s2.deinit();
+    s2.nextSlice(builder.writer.buffered());
+
+    try testing.expect(t2.modes.get(.origin));
+    try testing.expectEqual(@as(usize, 0), t2.scrolling_region.top);
+    try testing.expectEqual(@as(usize, 0), t2.scrolling_region.left);
+    try testing.expectEqual(t.screens.active.cursor.x, t2.screens.active.cursor.x);
+    try testing.expectEqual(t.screens.active.cursor.y, t2.screens.active.cursor.y);
+}
+
 test "Terminal vt with modes" {
     const testing = std.testing;
     const alloc = testing.allocator;

--- a/src/terminal/formatter.zig
+++ b/src/terminal/formatter.zig
@@ -455,40 +455,13 @@ pub const TerminalFormatter = struct {
             self.extra.modes and
             self.terminal.modes.get(.enable_left_and_right_margin);
         const emitted_top = if (self.extra.scrolling_region) region.top else 0;
-        const emitted_bottom = if (self.extra.scrolling_region)
-            region.bottom
-        else
-            self.terminal.rows - 1;
         const emitted_left = if (horizontal_margins) region.left else 0;
-        const emitted_right = if (horizontal_margins) region.right else self.terminal.cols - 1;
-        const outside_origin_region = origin and
-            (cursor.y < emitted_top or
-                cursor.y > emitted_bottom or
-                cursor.x < emitted_left or
-                cursor.x > emitted_right);
-
-        if (!outside_origin_region) {
-            const row = if (origin) cursor.y - emitted_top else cursor.y;
-            const col = if (origin) cursor.x - emitted_left else cursor.x;
-            try writer.print("\x1b[{d};{d}H", .{ row + 1, col + 1 });
-            return;
-        }
-
-        // CUP cannot address a cell outside active origin margins. Widen the
-        // margins, save the absolute cursor with origin mode still enabled,
-        // restore the emitted margins, then restore that saved cursor.
-        try writer.writeAll("\x1b[r");
-        if (horizontal_margins) try writer.writeAll("\x1b[s");
-        try writer.print("\x1b[{d};{d}H\x1b7", .{ cursor.y + 1, cursor.x + 1 });
-        if (region.top != 0 or region.bottom != self.terminal.rows - 1) {
-            try writer.print("\x1b[{d};{d}r", .{ region.top + 1, region.bottom + 1 });
-        }
-        if (horizontal_margins and
-            (region.left != 0 or region.right != self.terminal.cols - 1))
-        {
-            try writer.print("\x1b[{d};{d}s", .{ region.left + 1, region.right + 1 });
-        }
-        try writer.writeAll("\x1b8");
+        // CUP cannot address a cell outside active origin margins. Saturate
+        // its relative coordinates instead of using DECSC/DECRC as scratch
+        // storage, because that would overwrite the consumer's saved cursor.
+        const row = if (origin) cursor.y -| emitted_top else cursor.y;
+        const col = if (origin) cursor.x -| emitted_left else cursor.x;
+        try writer.print("\x1b[{d};{d}H", .{ row + 1, col + 1 });
     }
 };
 
@@ -5293,7 +5266,7 @@ test "Terminal vt restores cursor after scrolling margins" {
 
     // Use both margin axes and origin mode, then place the cursor at the
     // second row and column inside those margins.
-    s.nextSlice("\x1b[2;4r\x1b[?6h\x1b[2;3H");
+    s.nextSlice("\x1b[?69h\x1b[2;4s\x1b[2;4r\x1b[?6h\x1b[2;2H");
 
     var formatter: TerminalFormatter = .init(&t, .vt);
     formatter.extra = .none;
@@ -5323,7 +5296,7 @@ test "Terminal vt restores cursor after scrolling margins" {
     try testing.expectEqual(t.screens.active.cursor.y, t2.screens.active.cursor.y);
 }
 
-test "Terminal vt restores origin cursor outside new margins" {
+test "Terminal vt clamps an outside origin cursor without overwriting saved cursor" {
     const testing = std.testing;
     const alloc = testing.allocator;
     const io = testing.io;
@@ -5339,10 +5312,11 @@ test "Terminal vt restores origin cursor outside new margins" {
 
     var s = t.vtStream();
     defer s.deinit();
-    // Save an origin-mode cursor before narrowing the margins, then restore
-    // it above the new top margin.
-    s.nextSlice("\x1b[?6h\x1b[1;3H\x1b7\x1b[2;4r\x1b8");
+    // Save an origin-mode cursor before narrowing both margin axes, then
+    // restore it above and to the left of the new margins.
+    s.nextSlice("\x1b[?6h\x1b[1;1H\x1b7\x1b[?69h\x1b[2;4s\x1b[2;4r\x1b8");
     try testing.expect(t.screens.active.cursor.y < t.scrolling_region.top);
+    try testing.expect(t.screens.active.cursor.x < t.scrolling_region.left);
 
     var formatter: TerminalFormatter = .init(&t, .vt);
     formatter.extra = .none;
@@ -5360,13 +5334,21 @@ test "Terminal vt restores origin cursor outside new margins" {
 
     var s2 = t2.vtStream();
     defer s2.deinit();
+    s2.nextSlice("\x1b[5;5H\x1b7");
     s2.nextSlice(builder.writer.buffered());
 
     try testing.expect(t2.modes.get(.origin));
     try testing.expectEqual(t.scrolling_region.top, t2.scrolling_region.top);
     try testing.expectEqual(t.scrolling_region.bottom, t2.scrolling_region.bottom);
-    try testing.expectEqual(t.screens.active.cursor.x, t2.screens.active.cursor.x);
-    try testing.expectEqual(t.screens.active.cursor.y, t2.screens.active.cursor.y);
+    try testing.expectEqual(t.scrolling_region.left, t2.scrolling_region.left);
+    try testing.expectEqual(t.scrolling_region.right, t2.scrolling_region.right);
+    try testing.expectEqual(t2.scrolling_region.left, t2.screens.active.cursor.x);
+    try testing.expectEqual(t2.scrolling_region.top, t2.screens.active.cursor.y);
+
+    s2.nextSlice("\x1b8");
+    try testing.expect(!t2.modes.get(.origin));
+    try testing.expectEqual(@as(size.CellCountInt, 4), t2.screens.active.cursor.x);
+    try testing.expectEqual(@as(size.CellCountInt, 4), t2.screens.active.cursor.y);
 }
 
 test "Terminal vt cursor is absolute when origin mode is omitted" {

--- a/src/terminal/formatter.zig
+++ b/src/terminal/formatter.zig
@@ -424,9 +424,11 @@ pub const TerminalFormatter = struct {
             if (self.extra.screen.cursor) {
                 const cursor = &self.terminal.screens.active.cursor;
                 const region = &self.terminal.scrolling_region;
-                const origin = self.terminal.modes.get(.origin);
-                const row = if (origin) cursor.y - region.top else cursor.y;
-                const col = if (origin) cursor.x - region.left else cursor.x;
+                const origin = self.extra.modes and self.terminal.modes.get(.origin);
+                const emitted_top = if (self.extra.scrolling_region) region.top else 0;
+                const emitted_left = if (self.extra.scrolling_region) region.left else 0;
+                const row = if (origin) cursor.y - emitted_top else cursor.y;
+                const col = if (origin) cursor.x - emitted_left else cursor.x;
                 try writer.print("\x1b[{d};{d}H", .{ row + 1, col + 1 });
 
                 if (self.pin_map) |*m| {

--- a/src/terminal/formatter.zig
+++ b/src/terminal/formatter.zig
@@ -5283,6 +5283,52 @@ test "Terminal vt restores cursor after scrolling margins" {
     try testing.expectEqual(t.screens.active.cursor.y, t2.screens.active.cursor.y);
 }
 
+test "Terminal vt restores origin cursor outside new margins" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const io = testing.io;
+
+    var builder: std.Io.Writer.Allocating = .init(alloc);
+    defer builder.deinit();
+
+    var t = try Terminal.init(io, alloc, .{
+        .cols = 5,
+        .rows = 5,
+    });
+    defer t.deinit(alloc);
+
+    var s = t.vtStream();
+    defer s.deinit();
+    // Save an origin-mode cursor before narrowing the margins, then restore
+    // it above the new top margin.
+    s.nextSlice("\x1b[?6h\x1b[1;3H\x1b7\x1b[2;4r\x1b8");
+    try testing.expect(t.screens.active.cursor.y < t.scrolling_region.top);
+
+    var formatter: TerminalFormatter = .init(&t, .vt);
+    formatter.extra = .none;
+    formatter.extra.modes = true;
+    formatter.extra.scrolling_region = true;
+    formatter.extra.screen.cursor = true;
+
+    try formatter.format(&builder.writer);
+
+    var t2 = try Terminal.init(io, alloc, .{
+        .cols = 5,
+        .rows = 5,
+    });
+    defer t2.deinit(alloc);
+
+    var s2 = t2.vtStream();
+    defer s2.deinit();
+    s2.nextSlice(builder.writer.buffered());
+
+    try testing.expect(t2.modes.get(.origin));
+    try testing.expectEqual(t.scrolling_region.top, t2.scrolling_region.top);
+    try testing.expectEqual(t.scrolling_region.bottom, t2.scrolling_region.bottom);
+    try testing.expectEqual(t.screens.active.cursor.x, t2.screens.active.cursor.x);
+    try testing.expectEqual(t.screens.active.cursor.y, t2.screens.active.cursor.y);
+}
+
 test "Terminal vt cursor is absolute when origin mode is omitted" {
     const testing = std.testing;
     const alloc = testing.allocator;

--- a/src/terminal/formatter.zig
+++ b/src/terminal/formatter.zig
@@ -422,18 +422,11 @@ pub const TerminalFormatter = struct {
             // ScreenFormatter emits it. Restore the cursor after all terminal
             // state, with CUP coordinates relative to the origin margins.
             if (self.extra.screen.cursor) {
-                const cursor = &self.terminal.screens.active.cursor;
-                const region = &self.terminal.scrolling_region;
-                const origin = self.extra.modes and self.terminal.modes.get(.origin);
-                const emitted_top = if (self.extra.scrolling_region) region.top else 0;
-                const emitted_left = if (self.extra.scrolling_region) region.left else 0;
-                const row = if (origin) cursor.y - emitted_top else cursor.y;
-                const col = if (origin) cursor.x - emitted_left else cursor.x;
-                try writer.print("\x1b[{d};{d}H", .{ row + 1, col + 1 });
+                try self.formatCursorRestore(writer);
 
                 if (self.pin_map) |*m| {
                     var discarding: std.Io.Writer.Discarding = .init(&.{});
-                    try discarding.writer.print("\x1b[{d};{d}H", .{ row + 1, col + 1 });
+                    try self.formatCursorRestore(&discarding.writer);
                     m.map.appendNTimes(
                         m.alloc,
                         if (m.map.items.len > 0) pin: {
@@ -449,6 +442,53 @@ pub const TerminalFormatter = struct {
                 }
             }
         }
+    }
+
+    fn formatCursorRestore(
+        self: TerminalFormatter,
+        writer: *std.Io.Writer,
+    ) std.Io.Writer.Error!void {
+        const cursor = &self.terminal.screens.active.cursor;
+        const region = &self.terminal.scrolling_region;
+        const origin = self.extra.modes and self.terminal.modes.get(.origin);
+        const horizontal_margins = self.extra.scrolling_region and
+            self.extra.modes and
+            self.terminal.modes.get(.enable_left_and_right_margin);
+        const emitted_top = if (self.extra.scrolling_region) region.top else 0;
+        const emitted_bottom = if (self.extra.scrolling_region)
+            region.bottom
+        else
+            self.terminal.rows - 1;
+        const emitted_left = if (horizontal_margins) region.left else 0;
+        const emitted_right = if (horizontal_margins) region.right else self.terminal.cols - 1;
+        const outside_origin_region = origin and
+            (cursor.y < emitted_top or
+                cursor.y > emitted_bottom or
+                cursor.x < emitted_left or
+                cursor.x > emitted_right);
+
+        if (!outside_origin_region) {
+            const row = if (origin) cursor.y - emitted_top else cursor.y;
+            const col = if (origin) cursor.x - emitted_left else cursor.x;
+            try writer.print("\x1b[{d};{d}H", .{ row + 1, col + 1 });
+            return;
+        }
+
+        // CUP cannot address a cell outside active origin margins. Widen the
+        // margins, save the absolute cursor with origin mode still enabled,
+        // restore the emitted margins, then restore that saved cursor.
+        try writer.writeAll("\x1b[r");
+        if (horizontal_margins) try writer.writeAll("\x1b[s");
+        try writer.print("\x1b[{d};{d}H\x1b7", .{ cursor.y + 1, cursor.x + 1 });
+        if (region.top != 0 or region.bottom != self.terminal.rows - 1) {
+            try writer.print("\x1b[{d};{d}r", .{ region.top + 1, region.bottom + 1 });
+        }
+        if (horizontal_margins and
+            (region.left != 0 or region.right != self.terminal.cols - 1))
+        {
+            try writer.print("\x1b[{d};{d}s", .{ region.left + 1, region.right + 1 });
+        }
+        try writer.writeAll("\x1b8");
     }
 };
 

--- a/src/terminal/formatter.zig
+++ b/src/terminal/formatter.zig
@@ -294,6 +294,35 @@ pub const TerminalFormatter = struct {
                     std.math.cast(usize, discarding.count) orelse return error.WriteFailed,
                 ) catch return error.WriteFailed;
             }
+
+            // Scrolling regions and tabstop restoration move the cursor after
+            // ScreenFormatter emits it. Restore the cursor after all terminal
+            // state, with CUP coordinates relative to the origin margins.
+            if (self.extra.screen.cursor) {
+                const cursor = &self.terminal.screens.active.cursor;
+                const region = &self.terminal.scrolling_region;
+                const origin = self.terminal.modes.get(.origin);
+                const row = if (origin) cursor.y - region.top else cursor.y;
+                const col = if (origin) cursor.x - region.left else cursor.x;
+                try writer.print("\x1b[{d};{d}H", .{ row + 1, col + 1 });
+
+                if (self.pin_map) |*m| {
+                    var discarding: std.Io.Writer.Discarding = .init(&.{});
+                    try discarding.writer.print("\x1b[{d};{d}H", .{ row + 1, col + 1 });
+                    m.map.appendNTimes(
+                        m.alloc,
+                        if (m.map.items.len > 0) pin: {
+                            const last = m.map.items[m.map.items.len - 1];
+                            break :pin .{
+                                .node = last.node,
+                                .x = last.x,
+                                .y = last.y,
+                            };
+                        } else self.terminal.screens.active.pages.getTopLeft(.screen),
+                        std.math.cast(usize, discarding.count) orelse return error.WriteFailed,
+                    ) catch return error.WriteFailed;
+                }
+            }
         }
 
         // Emit terminal modes that differ from defaults. We probably have


### PR DESCRIPTION
Fix VT formatter cursor restoration after scrolling-region and tabstop state.

The first commit adds a regression test. The second commit restores the cursor after terminal-wide state and converts CUP coordinates for origin mode.

Verification will run through the cmux exact-head hosted workflow on Blacksmith macOS and Linux, plus hosted Windows. No local Zig or Rust command was run.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/191"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788757150&installation_model_id=21920&pr_number=191&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F191&signature=3e0df7743793497d53b33fca7d10b7418d6dbcdabba8549f20fc2bcd41210847"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore the cursor after emitting scrolling margins, origin mode, and tabstop state in the VT formatter. Prevents cursor jumps, preserves pending-wrap, and keeps saved cursors intact during replay, including when origin/scrolling region are omitted and when the cursor is outside origin margins.

- **Bug Fixes**
  - Restore the cursor after terminal-wide state; use CUP with coordinates derived from emitted origin/margins and update `pin_map`.
  - Clamp outside-origin CUP coordinates to the margin’s top-left instead of using DECSC/DECRC, preserving user-saved cursors. Add regression tests for margins+origin, outside-origin clamping, tabstop-only, omitted origin, and omitted scrolling region.

<sup>Written for commit 533c27ae1c87c02671e36d44baf5973f1d6b7113. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/191?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal screen formatting to preserve cursor position during replay.
  * Correctly maintains cursor placement when scrolling margins and origin mode are active.
  * Preserves cursor placement after tab-related terminal output, including when scrolling regions are not configured.
  * Fixed cursor restoration for positions outside the active scrolling region.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->