### PR TITLE
Avoid signaling recycled process groups

### DIFF
--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -2546,6 +2546,84 @@ test "subprocess stop kills descendants after the group leader was reaped" {
     try testing.expectEqual(posix.E.SRCH, group_probe_err);
 }
 
+test "subprocess stop ignores a cached process group after the child was reaped" {
+    if (comptime builtin.os.tag == .windows or builtin.os.tag == .ios) {
+        return error.SkipZigTest;
+    }
+
+    const testing = std.testing;
+    const c = Subprocess.c;
+    var pty = try Pty.open(.{});
+    defer pty.deinit();
+
+    const ready_pipe = try internal_os.pipe();
+    defer {
+        _ = posix.system.close(ready_pipe[0]);
+        _ = posix.system.close(ready_pipe[1]);
+    }
+
+    const unrelated_pid: posix.pid_t = unrelated: {
+        const rc = posix.system.fork();
+        switch (posix.errno(rc)) {
+            .SUCCESS => break :unrelated @intCast(rc),
+            .AGAIN, .NOMEM => return error.SystemResources,
+            else => |err| return posix.unexpectedErrno(err),
+        }
+    };
+    if (unrelated_pid == 0) {
+        _ = posix.system.close(ready_pipe[0]);
+        if (c.setsid() < 0) c._exit(1);
+
+        var action: posix.Sigaction = .{
+            .handler = .{ .handler = posix.SIG.IGN },
+            .mask = posix.sigemptyset(),
+            .flags = 0,
+        };
+        posix.sigaction(posix.SIG.HUP, &action, null);
+        if (posix.system.write(ready_pipe[1], "r", 1) != 1) c._exit(1);
+        while (true) _ = c.pause();
+    }
+
+    var unrelated_reaped = false;
+    defer if (!unrelated_reaped) {
+        _ = c.killpg(unrelated_pid, c.SIGKILL);
+        var status: c_int = 0;
+        _ = posix.system.waitpid(unrelated_pid, &status, 0);
+    };
+    _ = posix.system.close(ready_pipe[1]);
+    var ready: [1]u8 = undefined;
+    try testing.expectEqual(@as(usize, 1), try posix.read(ready_pipe[0], &ready));
+
+    var arena = ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var subprocess: Subprocess = .{
+        .arena = arena,
+        .cwd = null,
+        .env = null,
+        .args = &.{},
+        .grid_size = .{},
+        .screen_size = .{ .width = 1, .height = 1 },
+        .pty = pty,
+        .process = null,
+        .process_group_id = unrelated_pid,
+        .rt_pre_exec_info = undefined,
+        .rt_post_fork_info = undefined,
+    };
+    try testing.expectEqual(null, subprocess.foregroundProcessGroupId());
+
+    subprocess.stopWithTimeouts(.{
+        .sighup_grace = .fromMilliseconds(20),
+        .sigkill_grace = .fromMilliseconds(100),
+    });
+
+    var status: c_int = 0;
+    const wait_result: posix.pid_t = @intCast(
+        posix.system.waitpid(unrelated_pid, &status, std.c.W.NOHANG),
+    );
+    unrelated_reaped = wait_result == unrelated_pid;
+    try testing.expectEqual(@as(posix.pid_t, 0), wait_result);
+}
+
 test "subprocess stop kills a distinct foreground process group" {
     if (comptime builtin.os.tag == .windows or builtin.os.tag == .ios) {
         return error.SkipZigTest;

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -1163,16 +1163,13 @@ const Subprocess = struct {
                 },
             }
         } else if (comptime builtin.os.tag != .windows) {
-            // The process watcher may already have consumed the direct child's
-            // wait status. Its process group remains ours to terminate.
-            if (self.process_group_id) |pgid| {
-                killProcessGroupsWithTimeouts(
-                    pgid,
-                    foreground_process_group_id,
-                    null,
-                    timeouts,
-                ) catch |err|
-                    log.err("error stopping process group: {}", .{err});
+            // Once the watcher consumes the direct child's wait status, its
+            // cached numeric process-group id may be recycled. A foreground
+            // group freshly observed through this retained PTY is the only
+            // group identity that remains attributable to this subprocess.
+            if (foreground_process_group_id) |pgid| {
+                killProcessGroupWithTimeouts(pgid, null, timeouts) catch |err|
+                    log.err("error stopping foreground process group: {}", .{err});
             }
         }
 
@@ -2609,7 +2606,10 @@ test "subprocess stop ignores a cached process group after the child was reaped"
         .rt_pre_exec_info = undefined,
         .rt_post_fork_info = undefined,
     };
-    try testing.expectEqual(null, subprocess.foregroundProcessGroupId());
+    try testing.expectEqual(
+        @as(?c.pid_t, null),
+        subprocess.foregroundProcessGroupId(),
+    );
 
     subprocess.stopWithTimeouts(.{
         .sighup_grace = .fromMilliseconds(20),
@@ -2682,7 +2682,7 @@ test "subprocess stop kills a distinct foreground process group" {
         if (posix.system.read(job_ready_pipe[0], &job_ready, 1) != 1) c._exit(1);
         if (c.tcsetpgrp(pty.slave, @intCast(job_pid)) < 0) c._exit(1);
         if (posix.system.write(ready_pipe[1], "r", 1) != 1) c._exit(1);
-        while (true) _ = c.pause();
+        c._exit(0);
     }
 
     var leader_reaped = false;
@@ -2700,6 +2700,13 @@ test "subprocess stop kills a distinct foreground process group" {
     var ready: [1]u8 = undefined;
     try testing.expectEqual(@as(usize, 1), try posix.read(ready_pipe[0], &ready));
     _ = posix.system.close(pty.slave);
+
+    var leader_status: c_int = 0;
+    try testing.expectEqual(
+        leader_pid,
+        @as(posix.pid_t, @intCast(posix.system.waitpid(leader_pid, &leader_status, 0))),
+    );
+    leader_reaped = true;
 
     foreground_pgid = @intCast(
         pty.getProcessInfo(.foreground_pid) orelse
@@ -2722,33 +2729,11 @@ test "subprocess stop kills a distinct foreground process group" {
         .rt_pre_exec_info = undefined,
         .rt_post_fork_info = undefined,
     };
-    var leader_status: c_int = 0;
-    var wait_result: posix.pid_t = 0;
-    const leader_reaper = try std.Thread.spawn(.{}, struct {
-        fn run(
-            pid: posix.pid_t,
-            status: *c_int,
-            result: *posix.pid_t,
-        ) void {
-            result.* = @intCast(posix.system.waitpid(pid, status, 0));
-        }
-    }.run, .{ leader_pid, &leader_status, &wait_result });
-    var leader_reaper_joined = false;
-    defer if (!leader_reaper_joined) {
-        _ = c.killpg(leader_pid, c.SIGKILL);
-        leader_reaper.join();
-        leader_reaped = true;
-    };
 
     subprocess.stopWithTimeouts(.{
         .sighup_grace = .fromMilliseconds(20),
         .sigkill_grace = .fromSeconds(1),
     });
-
-    leader_reaper.join();
-    leader_reaper_joined = true;
-    leader_reaped = wait_result == leader_pid;
-    try testing.expectEqual(leader_pid, wait_result);
 
     const foreground_probe = c.killpg(foreground_pgid.?, 0);
     const foreground_probe_err = posix.errno(foreground_probe);


### PR DESCRIPTION
After the direct child has been reaped, stop trusting its cached numeric process-group id because the kernel may reuse it. Teardown now signals only a foreground group freshly observed through the retained PTY. Includes regression coverage for an unrelated cached group and for reaping a distinct foreground job after the leader has genuinely exited.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/193"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788831601&installation_model_id=21920&pr_number=193&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F193&signature=c0b8f77a3243c2ffaad010632f63054c5ce7a1a535b23422162e46699b7cacb7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents teardown from signaling a recycled process group after the child is reaped. Now we only stop the foreground group read from the retained PTY, avoiding signals to unrelated jobs.

- **Bug Fixes**
  - Stop trusting cached `process_group_id` once the child is reaped; use fresh `foreground_process_group_id` from the PTY.
  - Switch to `killProcessGroupWithTimeouts` to target only the active foreground group.
  - Add regression tests for ignoring stale groups and for killing a distinct foreground job after the leader exits.

<sup>Written for commit bc7e9f7466f409a8f10ea52baf017c16302ee492. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/193?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved subprocess cleanup after a process exits.
  - Prevented teardown from targeting stale process information, reducing the risk of terminating unrelated foreground processes.
  - Ensured remaining subprocesses are consistently cleaned up when their leader exits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->