### PR TITLE
Keep bracketed paste framing atomic

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -7935,29 +7935,13 @@ fn completeClipboardPaste(
         break :encode_opts opts;
     };
 
-    // Encode the data. In most cases this doesn't require any
-    // copies, so we optimize for that case.
-    var data_duped: ?[]u8 = null;
-    const vecs = input.paste.encode(data, encode_opts) catch |err| switch (err) {
-        error.MutableRequired => vecs: {
-            const buf: []u8 = try self.alloc.dupe(u8, data);
-            errdefer self.alloc.free(buf);
-            data_duped = buf;
-            break :vecs input.paste.encode(buf, encode_opts);
-        },
-    };
-    defer if (data_duped) |v| {
-        // This code path means the data did require a copy and mutation.
-        // We must free it.
-        self.alloc.free(v);
-    };
-
-    for (vecs) |vec| if (vec.len > 0) {
-        self.queueIo(try termio.Message.writeReq(
-            self.alloc,
-            vec,
-        ), .unlocked);
-    };
+    // The opening fence, payload, and closing fence must cross the IO mailbox
+    // as one message. Terminal replies share this mailbox and must never land
+    // inside a bracketed paste while these bytes are being enqueued.
+    self.queueIo(.{ .write_alloc = .{
+        .alloc = self.alloc,
+        .data = try input.paste.encodeAlloc(self.alloc, data, encode_opts),
+    } }, .unlocked);
 }
 
 fn completeTextInput(

--- a/src/input/paste.zig
+++ b/src/input/paste.zig
@@ -152,6 +152,21 @@ test "encode bracketed" {
     try testing.expectEqualStrings("\x1b[201~", result[2]);
 }
 
+test "encodeAlloc returns one contiguous bracketed paste" {
+    const testing = std.testing;
+    const result = try encodeAlloc(
+        testing.allocator,
+        "hello",
+        .{ .bracketed = true },
+    );
+    defer testing.allocator.free(result);
+
+    try testing.expectEqualStrings(
+        "\x1b[200~hello\x1b[201~",
+        result,
+    );
+}
+
 test "encode unbracketed no newlines" {
     const testing = std.testing;
     const result = try encode(

--- a/src/input/paste.zig
+++ b/src/input/paste.zig
@@ -1,6 +1,9 @@
 const std = @import("std");
 const Terminal = @import("../terminal/Terminal.zig");
 
+const bracketed_start = "\x1b[200~";
+const bracketed_end = "\x1b[201~";
+
 pub const Options = struct {
     /// True if bracketed paste mode is on.
     bracketed: bool,
@@ -93,8 +96,8 @@ pub fn encode(
     // Bracketed paste mode (mode 2004) wraps pasted data in
     // fenceposts so that the terminal can ignore things like newlines.
     if (opts.bracketed) {
-        result[0] = "\x1b[200~";
-        result[2] = "\x1b[201~";
+        result[0] = bracketed_start;
+        result[2] = bracketed_end;
         return result;
     }
 
@@ -105,6 +108,37 @@ pub fn encode(
         std.mem.replaceScalar(u8, data, '\n', '\r');
     } else if (std.mem.indexOfScalar(u8, data, '\n') != null) {
         return Error.MutableRequired;
+    }
+
+    return result;
+}
+
+/// Encode a paste into one owned buffer. Callers that cross an asynchronous
+/// transport boundary can submit this as one write so terminal replies cannot
+/// be inserted between the bracketed-paste fenceposts and payload.
+pub fn encodeAlloc(
+    alloc: std.mem.Allocator,
+    data: []const u8,
+    opts: Options,
+) std.mem.Allocator.Error![]u8 {
+    const framing_len = if (opts.bracketed)
+        bracketed_start.len + bracketed_end.len
+    else
+        0;
+    const result_len = std.math.add(usize, data.len, framing_len) catch
+        return error.OutOfMemory;
+    const result = try alloc.alloc(u8, result_len);
+
+    const payload_offset = if (opts.bracketed) bracketed_start.len else 0;
+    const payload = result[payload_offset..][0..data.len];
+    @memcpy(payload, data);
+
+    // Reuse the canonical sanitizer and newline normalization in `encode`.
+    _ = encode(payload, opts);
+
+    if (opts.bracketed) {
+        @memcpy(result[0..bracketed_start.len], bracketed_start);
+        @memcpy(result[result.len - bracketed_end.len ..], bracketed_end);
     }
 
     return result;


### PR DESCRIPTION
Fixes the Ghostty-side ordering race behind manaflow-ai/cmux#9544.

A bracketed paste now crosses the termio mailbox as one contiguous write, preventing parser-generated terminal replies from landing between the opening fence, payload, and closing fence. Includes a regression test in the commit immediately before the fix.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/194"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788904742&installation_model_id=21920&pr_number=194&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F194&signature=ac11f1317f276ca3d698e77fc236030105a6dbd1e664df6f5735e6a311f8e633"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bracketed paste now crosses the `termio` mailbox as one atomic write, preventing terminal replies from interleaving with the opening fence, payload, and closing fence. This removes the race that caused paste desync in bracketed paste mode.

- **Bug Fixes**
  - Send bracketed paste as a single `write_alloc` message with an owned buffer.
  - Add `input.paste.encodeAlloc` to build one contiguous, sanitized payload.
  - Add a regression test for contiguous framing: ESC[200~payloadESC[201~.

<sup>Written for commit 9829bec6bf67c6bf9e4bd562a2f7000189181d1e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/194?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bracketed paste handling so the complete pasted content and its control markers are delivered together.
  * Prevented partial or fragmented bracketed paste sequences during clipboard insertion.

* **Tests**
  * Added coverage confirming bracketed paste output is produced as one contiguous sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->