### PR TITLE
feat(embedded): support GTK OpenGL hosts

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -69,6 +69,7 @@ typedef enum {
   GHOSTTY_PLATFORM_OPENGL = 3,
   GHOSTTY_PLATFORM_METAL_EXTERNAL = 4,
   GHOSTTY_PLATFORM_METAL_EXTERNAL_LEASED = 5,
+  GHOSTTY_PLATFORM_LINUX = 6,
 } ghostty_platform_e;
 
 typedef enum {
@@ -533,12 +534,17 @@ typedef struct {
   ghostty_opengl_swap_buffers_cb swap_buffers;
 } ghostty_platform_opengl_s;
 
+typedef struct {
+  void* reserved;
+} ghostty_platform_linux_s;
+
 typedef union {
   ghostty_platform_macos_s macos;
   ghostty_platform_ios_s ios;
   ghostty_platform_opengl_s opengl;
   ghostty_platform_metal_external_s metal_external;
   ghostty_platform_metal_external_leased_s metal_external_leased;
+  ghostty_platform_linux_s linux_platform;
 } ghostty_platform_u;
 
 typedef enum {
@@ -1368,6 +1374,12 @@ GHOSTTY_API float ghostty_surface_font_size(ghostty_surface_t);
 GHOSTTY_API bool ghostty_surface_font_size_adjusted(ghostty_surface_t);
 GHOSTTY_API void ghostty_surface_refresh(ghostty_surface_t);
 GHOSTTY_API void ghostty_surface_draw(ghostty_surface_t);
+// Notify an embedded Linux surface before its host GL context is destroyed.
+// The host must make the context current before calling this function.
+GHOSTTY_API void ghostty_surface_display_unrealized(ghostty_surface_t);
+// Notify an embedded Linux surface after its host GL context is recreated.
+// The host must make the new context current before calling this function.
+GHOSTTY_API void ghostty_surface_display_realized(ghostty_surface_t);
 // cmux fork: delete when upstream exposes a synchronous render tick for
 // embedders that drive rendering from a platform display callback.
 GHOSTTY_API void ghostty_surface_render_now(ghostty_surface_t);

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -42,6 +42,10 @@ pub const ExternalFrameColorSpace = renderer.external_frame.ColorSpace;
 pub const ExternalFrame = renderer.external_frame.Frame;
 
 pub const App = struct {
+    /// Linux OpenGL hosts such as GTK GLArea require all drawing on the
+    /// application thread that owns the current context.
+    pub const must_draw_from_app_thread = builtin.target.os.tag == .linux;
+
     /// Because we only expect the embedding API to be used in embedded
     /// environments, the options are extern so that we can expose it
     /// directly to a C callconv and not pay for any translation costs.
@@ -373,6 +377,7 @@ pub const Platform = union(PlatformTag) {
     opengl: OpenGL,
     metal_external: MetalExternal,
     metal_external_leased: MetalExternalLeased,
+    linux: Linux,
 
     // If our build target for libghostty is not darwin then we do
     // not include macos support at all.
@@ -385,6 +390,10 @@ pub const Platform = union(PlatformTag) {
         /// The view to render the surface on.
         uiview: objc.Object,
     } else void;
+
+    /// Linux platform. The embedder keeps its OpenGL context current before
+    /// creating, realizing, and drawing a surface.
+    pub const Linux = struct {};
 
     /// An embedder-owned presenter for Metal IOSurfaces. This platform never
     /// accesses an NSView, UIView, or CALayer. The callback runs on a Metal
@@ -436,6 +445,10 @@ pub const Platform = union(PlatformTag) {
             uiview: ?*anyopaque,
         },
 
+        linux_platform: extern struct {
+            reserved: ?*anyopaque,
+        },
+
         metal_external: extern struct {
             userdata: ?*anyopaque,
             present: ?*const fn (
@@ -480,6 +493,11 @@ pub const Platform = union(PlatformTag) {
                     break :ios error.UIViewMustBeSet);
                 break :ios .{ .ios = .{ .uiview = uiview } };
             } else error.UnsupportedPlatform,
+
+            .linux => if (builtin.target.os.tag == .linux)
+                .{ .linux = .{} }
+            else
+                error.UnsupportedPlatform,
 
             .metal_external => if (MetalExternal != void) metal_external: {
                 const config = c_platform.metal_external;
@@ -526,6 +544,7 @@ pub const PlatformTag = enum(c_int) {
     opengl = 3,
     metal_external = 4,
     metal_external_leased = 5,
+    linux = 6,
 };
 
 comptime {
@@ -1409,7 +1428,14 @@ pub const Surface = struct {
     }
 
     pub fn draw(self: *Surface) void {
-        self.core_surface.draw() catch |err| {
+        const result = switch (self.platform) {
+            // The synchronized path re-presents the previous frame during a
+            // resize. GTK GLArea needs the renderer to observe its new FBO
+            // size, so use the non-synchronized draw path on Linux.
+            .linux => self.core_surface.renderer.drawFrame(false),
+            else => self.core_surface.draw(),
+        };
+        result catch |err| {
             log.err("error in draw err={}", .{err});
             return;
         };
@@ -3150,6 +3176,18 @@ pub const CAPI = struct {
         surface.refresh();
     }
 
+    /// Notify a Linux surface before its host GL context is destroyed.
+    export fn ghostty_surface_display_unrealized(surface: *Surface) void {
+        surface.core_surface.renderer.displayUnrealized();
+    }
+
+    /// Notify a Linux surface after its host GL context is recreated.
+    export fn ghostty_surface_display_realized(surface: *Surface) void {
+        surface.core_surface.renderer.displayRealized() catch |err| {
+            log.err("error in displayRealized err={}", .{err});
+        };
+    }
+
     /// Tell the surface that it needs to schedule a render
     /// call as soon as possible (NOW if possible).
     export fn ghostty_surface_draw(surface: *Surface) void {
@@ -4380,21 +4418,11 @@ pub const CAPI = struct {
                 const face = try grid.resolver.collection.getFace(run.font_index);
 
                 var ps_buf: [256]u8 = undefined;
-                const ps_name: []const u8 = blk: {
-                    const s = face.font.copyPostScriptName();
-                    defer s.release();
-                    break :blk s.cstring(&ps_buf, .utf8) orelse "";
-                };
+                const ps_name = face.postscriptName(&ps_buf);
                 var family_buf: [256]u8 = undefined;
                 const family: []const u8 = face.name(&family_buf) catch "";
                 var url_buf: [1024]u8 = undefined;
-                const url_path: ?[]const u8 = blk: {
-                    const url = face.font.copyAttribute(.url) orelse break :blk null;
-                    defer url.release();
-                    const path = url.copyPath() orelse break :blk null;
-                    defer path.release();
-                    break :blk path.cstring(&url_buf, .utf8);
-                };
+                const url_path = face.urlPath(&url_buf);
                 if (shaped.len > 0) {
                     run_is_color = face.isColorGlyph(shaped[0].glyph_index);
                 }

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -42,9 +42,13 @@ pub const ExternalFrameColorSpace = renderer.external_frame.ColorSpace;
 pub const ExternalFrame = renderer.external_frame.Frame;
 
 pub const App = struct {
-    /// Linux OpenGL hosts such as GTK GLArea require all drawing on the
-    /// application thread that owns the current context.
-    pub const must_draw_from_app_thread = builtin.target.os.tag == .linux;
+    /// Linux GLArea surfaces must draw on the application thread that owns
+    /// the current context. Callback-backed OpenGL surfaces keep rendering on
+    /// Ghostty's renderer thread, where their callbacks make the context
+    /// current.
+    pub fn mustDrawFromAppThread(surface: *Surface) bool {
+        return std.meta.activeTag(surface.platform) == .linux;
+    }
 
     /// Because we only expect the embedding API to be used in embedded
     /// environments, the options are extern so that we can expose it

--- a/src/font/face/coretext.zig
+++ b/src/font/face/coretext.zig
@@ -211,6 +211,22 @@ pub const Face = struct {
         return family_name.cstring(buf, .utf8) orelse error.OutOfMemory;
     }
 
+    /// Return the PostScript name using caller-owned storage for conversion.
+    pub fn postscriptName(self: *const Face, buf: []u8) []const u8 {
+        const ps_name = self.font.copyPostScriptName();
+        defer ps_name.release();
+        return ps_name.cstring(buf, .utf8) orelse "";
+    }
+
+    /// Return the file URL path when CoreText associates one with this face.
+    pub fn urlPath(self: *const Face, buf: []u8) ?[]const u8 {
+        const url = self.font.copyAttribute(.url) orelse return null;
+        defer url.release();
+        const path = url.copyPath() orelse return null;
+        defer path.release();
+        return path.cstring(buf, .utf8);
+    }
+
     /// Resize the font in-place. If this succeeds, the caller is responsible
     /// for clearing any glyph caches, font atlas data, etc.
     pub fn setSize(self: *Face, opts: font.face.Options) !void {

--- a/src/font/face/freetype.zig
+++ b/src/font/face/freetype.zig
@@ -36,6 +36,9 @@ pub const Face = struct {
     /// Our font face.
     face: freetype.Face,
 
+    /// Owned path for file-backed faces. Memory-backed faces have no path.
+    source_path: ?[:0]u8 = null,
+
     /// This mutex MUST be held while doing anything with the
     /// glyph slot on the freetype face, because this struct
     /// may be shared across multiple surfaces.
@@ -69,11 +72,16 @@ pub const Face = struct {
         index: i32,
         opts: font.face.Options,
     ) !Face {
+        const source_path = try lib.alloc.dupeZ(u8, path);
+        errdefer lib.alloc.free(source_path);
+
         lib.mutex.lockUncancelable(global.io());
         defer lib.mutex.unlock(global.io());
         const face = try lib.lib.initFace(path, index);
         errdefer face.deinit();
-        return try initFace(lib, face, opts);
+        var result = try initFace(lib, face, opts);
+        result.source_path = source_path;
+        return result;
     }
 
     /// Initialize a new font face with the given source in-memory.
@@ -141,6 +149,7 @@ pub const Face = struct {
     }
 
     pub fn deinit(self: *Face) void {
+        if (self.source_path) |path| self.lib.alloc.free(path);
         self.lib.alloc.destroy(self.ft_mutex);
         {
             self.lib.mutex.lockUncancelable(global.io());
@@ -190,12 +199,12 @@ pub const Face = struct {
         return std.mem.sliceTo(ps_name, 0);
     }
 
-    /// FreeType faces do not retain the source URL. Embedded and Linux
-    /// fontconfig faces therefore report no path rather than fabricating one.
+    /// Return the retained source path for file-backed faces.
     pub fn urlPath(self: *const Face, buf: []u8) ?[]const u8 {
-        _ = self;
-        _ = buf;
-        return null;
+        const path = self.source_path orelse return null;
+        if (path.len > buf.len) return null;
+        @memcpy(buf[0..path.len], path);
+        return buf[0..path.len];
     }
 
     test "face name" {
@@ -225,6 +234,47 @@ pub const Face = struct {
         }
     }
 
+    test "file face source path survives synthetic copies" {
+        const embedded = @import("../embedded.zig");
+
+        var dir = testing.tmpDir(.{});
+        defer dir.cleanup();
+        try dir.dir.writeFile(testing.io, .{
+            .sub_path = "font.ttf",
+            .data = embedded.variable,
+        });
+
+        var path_buf: [std.fs.max_path_bytes + 1]u8 = undefined;
+        const path_len = try dir.dir.realPathFile(
+            testing.io,
+            "font.ttf",
+            path_buf[0..std.fs.max_path_bytes],
+        );
+        path_buf[path_len] = 0;
+        const path = path_buf[0..path_len :0];
+
+        var lib: Library = try .init(testing.allocator);
+        defer lib.deinit();
+        const opts: font.face.Options = .{ .size = .{ .points = 14 } };
+
+        var face = try Face.initFile(lib, path, 0, opts);
+        defer face.deinit();
+        var url_buf: [std.fs.max_path_bytes]u8 = undefined;
+        try testing.expectEqualStrings(path, face.urlPath(&url_buf).?);
+
+        var bold = try face.syntheticBold(opts);
+        defer bold.deinit();
+        try testing.expectEqualStrings(path, bold.urlPath(&url_buf).?);
+
+        var italic = try face.syntheticItalic(opts);
+        defer italic.deinit();
+        try testing.expectEqualStrings(path, italic.urlPath(&url_buf).?);
+
+        var memory_face = try Face.init(lib, embedded.variable, opts);
+        defer memory_face.deinit();
+        try testing.expect(memory_face.urlPath(&url_buf) == null);
+    }
+
     /// Return a new face that is the same as this but also has synthetic
     /// bold applied.
     pub fn syntheticBold(self: *const Face, opts: font.face.Options) !Face {
@@ -234,6 +284,9 @@ pub const Face = struct {
 
         var f = try initFace(self.lib, self.face, opts);
         errdefer f.deinit();
+        if (self.source_path) |path| {
+            f.source_path = try self.lib.alloc.dupeZ(u8, path);
+        }
         f.synthetic = self.synthetic;
         f.synthetic.bold = true;
 
@@ -249,6 +302,9 @@ pub const Face = struct {
 
         var f = try initFace(self.lib, self.face, opts);
         errdefer f.deinit();
+        if (self.source_path) |path| {
+            f.source_path = try self.lib.alloc.dupeZ(u8, path);
+        }
         f.synthetic = self.synthetic;
         f.synthetic.italic = true;
 

--- a/src/font/face/freetype.zig
+++ b/src/font/face/freetype.zig
@@ -181,6 +181,23 @@ pub const Face = struct {
         return "";
     }
 
+    /// Return the PostScript name when FreeType exposes one. The returned
+    /// string is owned by the FreeType face and remains valid until deinit.
+    /// `buf` is accepted for parity with the CoreText implementation.
+    pub fn postscriptName(self: *const Face, buf: []u8) []const u8 {
+        _ = buf;
+        const ps_name = freetype.c.FT_Get_Postscript_Name(self.face.handle) orelse return "";
+        return std.mem.sliceTo(ps_name, 0);
+    }
+
+    /// FreeType faces do not retain the source URL. Embedded and Linux
+    /// fontconfig faces therefore report no path rather than fabricating one.
+    pub fn urlPath(self: *const Face, buf: []u8) ?[]const u8 {
+        _ = self;
+        _ = buf;
+        return null;
+    }
+
     test "face name" {
         const embedded = @import("../embedded.zig");
 

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -205,9 +205,15 @@ pub fn surfaceInit(surface: *apprt.Surface) !void {
         => try prepareContext(null),
 
         apprt.embedded => {
-            try enterEmbedded(surface);
-            errdefer leaveEmbedded();
-            try prepareContext(&embeddedGetProcAddress);
+            switch (surface.platform) {
+                .linux => try prepareContext(null),
+                .opengl => {
+                    try enterEmbedded(surface);
+                    errdefer leaveEmbedded();
+                    try prepareContext(&embeddedGetProcAddress);
+                },
+                else => return error.OpenGLPlatformRequired,
+            }
         },
     }
 
@@ -244,9 +250,15 @@ pub fn threadEnter(self: *const OpenGL, surface: *apprt.Surface) !void {
         },
 
         apprt.embedded => {
-            try enterEmbedded(surface);
-            errdefer leaveEmbedded();
-            try prepareContext(&embeddedGetProcAddress);
+            switch (surface.platform) {
+                .linux => {},
+                .opengl => {
+                    try enterEmbedded(surface);
+                    errdefer leaveEmbedded();
+                    try prepareContext(&embeddedGetProcAddress);
+                },
+                else => return error.OpenGLPlatformRequired,
+            }
         },
     }
 }
@@ -275,11 +287,10 @@ pub fn displayRealized(self: *const OpenGL) !void {
     switch (apprt.runtime) {
         apprt.gtk => try prepareContext(null),
 
-        // Embedded contexts are prepared by surfaceInit and threadEnter. The
-        // embedder owns one context for the surface lifetime and never enters
-        // GTK's realize cycle, but the generic renderer still instantiates
-        // this method for every OpenGL runtime.
-        apprt.embedded => {},
+        // Generic OpenGL contexts are prepared by surfaceInit and threadEnter.
+        // Linux GTK embedders explicitly call this while their recreated
+        // GLArea context is current.
+        apprt.embedded => try prepareContext(null),
 
         else => @compileError("unsupported app runtime for OpenGL"),
     }
@@ -330,9 +341,13 @@ pub fn initShaders(
 pub fn surfaceSize(self: *const OpenGL) !struct { width: u32, height: u32 } {
     _ = self;
     if (comptime is_embedded) {
-        const state = embedded_state orelse return error.OpenGLContextNotCurrent;
-        const size = try state.surface.getSize();
-        return .{ .width = size.width, .height = size.height };
+        // Callback-backed embedders report their drawable size through the
+        // surface. Linux GTK embedders draw into the current GLArea FBO, so
+        // its viewport is authoritative instead.
+        if (embedded_state) |state| {
+            const size = try state.surface.getSize();
+            return .{ .width = size.width, .height = size.height };
+        }
     }
     var viewport: [4]gl.c.GLint = undefined;
     gl.glad.context.GetIntegerv.?(gl.c.GL_VIEWPORT, &viewport);
@@ -442,8 +457,11 @@ fn presentWithOps(
     self.last_target = target;
 
     if (comptime is_embedded) {
-        const state = embedded_state orelse return error.OpenGLContextNotCurrent;
-        state.platform.swap_buffers(state.platform.userdata);
+        // GTK presents its GLArea FBO after the render callback returns.
+        // Only callback-backed OpenGL platforms own a swap operation.
+        if (embedded_state) |state| {
+            state.platform.swap_buffers(state.platform.userdata);
+        }
     }
 }
 

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -698,15 +698,17 @@ const RendererRealizedRetryTimerHandoff = struct {
     }
 };
 
-/// Whether calls to `drawFrame` must be done from the app thread.
-///
-/// If this is `true` then we send a `redraw_surface` message to the apprt
-/// whenever we need to draw instead of calling `drawFrame` directly.
-const must_draw_from_app_thread =
-    if (@hasDecl(apprt.App, "must_draw_from_app_thread"))
+/// Return whether this surface must draw from the application thread. Such
+/// surfaces receive a `redraw_surface` message instead of a direct draw call.
+fn mustDrawFromAppThread(surface: *apprt.Surface) bool {
+    if (@hasDecl(apprt.App, "mustDrawFromAppThread")) {
+        return apprt.App.mustDrawFromAppThread(surface);
+    }
+    return if (@hasDecl(apprt.App, "must_draw_from_app_thread"))
         apprt.App.must_draw_from_app_thread
     else
         false;
+}
 
 /// The type used for sending messages to the IO thread. For now this is
 /// hardcoded with a capacity. We can make this a comptime parameter in
@@ -1719,7 +1721,7 @@ fn drawFrame(self: *Thread, now: bool) DrawFrameResult {
     // when we're forced to via `now`.
     if (!now and self.renderer.hasVsync()) return .deferred_to_vsync;
 
-    if (must_draw_from_app_thread) {
+    if (mustDrawFromAppThread(self.surface)) {
         const pushed = self.app_mailbox.push(
             .{ .redraw_surface = .{ .surface = self.surface } },
             .{ .instant = {} },


### PR DESCRIPTION
## Summary

- add a Linux embedded platform for main-thread GTK `GLArea` rendering
- expose display unrealize/realize hooks so hosts can rebuild OpenGL resources after widget reparenting
- preserve callback-backed OpenGL sizing and swap behavior
- make font query APIs compile and report names with FreeType as well as CoreText

This ports the minimal GTK embedding support originally implemented by FreeMeWat onto current `manaflow-ai/ghostty` without carrying the older fork. The commit retains original authorship credit through `Co-authored-by`.

## Why

GTK `GLArea` owns a main-thread framebuffer. Generic callback-backed OpenGL may render on Ghostty’s renderer thread, so it cannot safely replace this path. Linux also exposed a pre-existing build failure in the font query API because it directly accessed CoreText-only fields.

## Validation

- `zig build -Dapp-runtime=none -Doptimize=ReleaseFast -Dcpu=baseline`
- `zig build test -Dapp-runtime=none -Dtest-filter="OpenGL presentation preserves"`
- `zig build test -Dapp-runtime=none -Dtest-filter="face name"`
- C header translation through focused test builds

Full unfiltered Ghostty test process was killed with exit 137 on a memory-pressured workstation. Focused changed-path tests pass; downstream Limux full Rust and live GTK smoke gates run separately.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/196"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788920634&installation_model_id=21920&pr_number=196&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F196&signature=060bc0024f095a03b5aabb1962b8e20d08f873b71101d592e2ad8f6a99821886"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Linux GTK `GLArea` embedding for OpenGL with per-surface app-thread rendering and explicit display realize/unrealize hooks. Font queries are now portable across CoreText and FreeType, preserving file paths for file-backed faces on Linux.

- **New Features**
  - Added `GHOSTTY_PLATFORM_LINUX` and `linux_platform` in `ghostty.h`, plus `ghostty_surface_display_unrealized` and `ghostty_surface_display_realized`.
  - Linux `GLArea` draws on the app thread, uses the current FBO/viewport for size, and lets GTK swap after the render callback; callback-backed OpenGL retains enter/leave and `swap_buffers`.

- **Bug Fixes**
  - Choose app-thread drawing per surface so GTK `GLArea` uses its owning thread while callback-backed OpenGL stays on the renderer thread.
  - FreeType now returns a PostScript name and exposes `urlPath` for file-backed faces; the path is preserved across synthetic bold/italic. Memory-backed faces still have no URL.

<sup>Written for commit 1a89efa4d75e04702c375d32edf6bbdc5328fcd2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/196?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Linux as a supported embedded platform.
  * Added support for notifying surfaces when the host OpenGL display is created or destroyed.
  * Improved embedded OpenGL handling for Linux-based environments.
  * Added font metadata access for PostScript names and source paths where available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->