### PR TITLE
ios: report discarded tokened renders

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -568,6 +568,19 @@ typedef void (*ghostty_pty_tee_cb)(void* userdata,
 // main thread. Synchronous backends deliver on the rendering caller's thread.
 typedef void (*ghostty_render_presented_cb)(void*, uint64_t);
 
+// cmux fork: terminal outcome for an explicitly tokened render that did not
+// reach the host layer. The callback is paired with
+// ghostty_render_presented_cb and receives the same render token.
+typedef enum {
+  GHOSTTY_RENDER_PRESENTATION_PRESENTED = 0,
+  GHOSTTY_RENDER_PRESENTATION_DISCARDED = 1,
+  GHOSTTY_RENDER_PRESENTATION_BACKEND_FAILED = 2,
+} ghostty_render_presentation_status_e;
+typedef void (*ghostty_render_failed_cb)(
+    void*,
+    uint64_t,
+    ghostty_render_presentation_status_e);
+
 // cmux fork: semantic font binding actions emitted after the native mutation
 // succeeds. The callback runs synchronously on the surface's GUI thread.
 typedef enum {
@@ -1381,6 +1394,14 @@ GHOSTTY_API bool ghostty_surface_set_render_presented_callback(
     ghostty_surface_t,
     ghostty_render_presented_cb,
     void* userdata);
+// cmux fork: install the per-surface callback for explicitly tokened renders
+// that were discarded by the host layer or failed in the renderer. Call once
+// directly after construction. The callback userdata remains valid until
+// ghostty_surface_free returns.
+GHOSTTY_API bool ghostty_surface_set_render_failed_callback(
+    ghostty_surface_t,
+    ghostty_render_failed_cb,
+    void* userdata);
 // cmux fork: install a per-surface callback for successfully performed font
 // binding actions. Call once after construction. The callback is synchronous
 // on the GUI thread, must not destroy or otherwise reenter the surface, is not
@@ -1392,8 +1413,8 @@ GHOSTTY_API bool ghostty_surface_set_font_size_action_callback(
     void* userdata);
 // cmux fork: submit a forced render associated with `token`. When successful,
 // the installed callback fires after the backend presents the exact rendered
-// frame. On Metal this follows main-thread IOSurface assignment. A failed or
-// size-discarded render has no callback.
+// frame. On Metal this follows main-thread IOSurface assignment. Failed or
+// discarded renders invoke the optional render-failed callback instead.
 GHOSTTY_API void ghostty_surface_render_now_with_token(ghostty_surface_t,
                                                        uint64_t token);
 // cmux fork: queue a tokened forced render executed on the renderer thread.
@@ -1405,8 +1426,8 @@ GHOSTTY_API void ghostty_surface_render_now_with_token(ghostty_surface_t,
 // after the exact frame is presented to the platform layer (Metal: after the
 // main-thread IOSurface assignment). Returns false when no render-presented
 // callback is installed or another tokened draw is still pending; a
-// successfully queued render whose draw is skipped (renderer unrealized,
-// zero-sized surface, or a size-discarded layer assignment) has no callback.
+// successfully queued render whose draw is skipped (renderer unrealized or
+// zero-sized surface) invokes the optional render-failed callback.
 GHOSTTY_API bool ghostty_surface_request_render_with_token(ghostty_surface_t,
                                                            uint64_t token);
 GHOSTTY_API void ghostty_surface_set_content_scale(ghostty_surface_t, double, double);

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1625,6 +1625,9 @@ GHOSTTY_API void ghostty_surface_split_resize(ghostty_surface_t,
                                                  uint16_t);
 GHOSTTY_API void ghostty_surface_split_equalize(ghostty_surface_t);
 GHOSTTY_API bool ghostty_surface_binding_action(ghostty_surface_t, const char*, uintptr_t);
+// cmux fork: non-blocking prompt reveal for display-driven embedded clients.
+// A false result means the terminal-state mutex was busy; retry later.
+GHOSTTY_API bool ghostty_surface_try_scroll_to_bottom(ghostty_surface_t);
 GHOSTTY_API void ghostty_surface_complete_clipboard_request(ghostty_surface_t,
                                                                const char*,
                                                                void*,

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1418,9 +1418,11 @@ GHOSTTY_API bool ghostty_surface_set_font_size_action_callback(
 GHOSTTY_API void ghostty_surface_render_now_with_token(ghostty_surface_t,
                                                        uint64_t token);
 // cmux fork: queue a tokened forced render executed on the renderer thread.
-// Thread-safe while the renderer OS thread is live, unlike
+// Thread-safe while the renderer OS thread owns rendering, unlike
 // ghostty_surface_render_now_with_token which renders on the calling thread
-// and requires embedder-owned renderer state. Deliberately ignores the
+// and requires embedder-owned renderer state. Returns false on iOS and after
+// another platform activates external-drain rendering; those embedders must
+// submit through their external render driver instead. Deliberately ignores the
 // occlusion visibility gate so an occluded window still renders a fresh frame
 // (ground-truth capture). The installed render-presented callback fires only
 // after the exact frame is presented to the platform layer (Metal: after the

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -2185,6 +2185,14 @@ pub fn scrollToRowIfRevision(
     return snapshot;
 }
 
+/// Try to move the viewport to the bottom without waiting on terminal state.
+/// This is used by embedded display-driven clients when user input should
+/// reveal the prompt, but the render/output serial queue must never block on a
+/// busy PTY parser or renderer lock.
+pub fn tryScrollToBottom(self: *Surface) bool {
+    return self.io.tryScrollViewport(.{ .bottom = {} });
+}
+
 fn hashRowSpaceIdentity(
     surface_id: u64,
     screen_key: terminal.ScreenSet.Key,

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -5082,6 +5082,13 @@ pub const CAPI = struct {
         };
     }
 
+    /// Try to reveal the terminal prompt without waiting on the renderer-state
+    /// mutex. Embedded display-driven clients retry a false result on their
+    /// next frame instead of blocking the queue that also drains output.
+    export fn ghostty_surface_try_scroll_to_bottom(surface: *Surface) bool {
+        return surface.core_surface.tryScrollToBottom();
+    }
+
     /// Complete a clipboard read request started via the read callback.
     /// This can only be called once for a given request. Once it is called
     /// with a request the request pointer will be invalidated.

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -664,6 +664,11 @@ pub const IoWriteCallback = *const fn (?*anyopaque, [*]const u8, usize) callconv
 pub const PtyTeeCallback = *const fn (?*anyopaque, [*]const u8, usize) callconv(.c) void;
 pub const RendererEventCallback = renderer.InstrumentationCallback;
 pub const RenderPresentedCallback = *const fn (?*anyopaque, u64) callconv(.c) void;
+pub const RenderFailedCallback = *const fn (
+    ?*anyopaque,
+    u64,
+    renderer.RenderPresentationStatus,
+) callconv(.c) void;
 pub const FontSizeActionCallback = *const fn (
     ?*anyopaque,
     CoreSurface.FontSizeActionKind,
@@ -849,6 +854,8 @@ pub const Surface = struct {
     // the public by-value Options ABI.
     render_presented_cb: ?RenderPresentedCallback = null,
     render_presented_userdata: ?*anyopaque = null,
+    render_failed_cb: ?RenderFailedCallback = null,
+    render_failed_userdata: ?*anyopaque = null,
     // Binding callbacks run on the GUI thread. These fields belong to this
     // exact embedded surface and are never inherited by child surfaces.
     font_size_action_cb: ?FontSizeActionCallback = null,
@@ -1425,11 +1432,14 @@ pub const Surface = struct {
             self.renderNow();
             return;
         };
+        const failure_callback = self.render_failed_cb;
         self.core_surface.applyPendingResizeIfNeeded();
         self.core_surface.renderer_thread.renderNowWithPresentation(.{
             .callback = callback,
             .userdata = self.render_presented_userdata,
             .token = token,
+            .failure_callback = failure_callback,
+            .failure_userdata = self.render_failed_userdata,
         });
     }
 
@@ -1443,10 +1453,13 @@ pub const Surface = struct {
     /// another tokened draw is still pending.
     pub fn requestRenderWithToken(self: *Surface, token: u64) bool {
         const callback = self.render_presented_cb orelse return false;
+        const failure_callback = self.render_failed_cb;
         return self.core_surface.renderer_thread.requestDrawWithPresentation(.{
             .callback = callback,
             .userdata = self.render_presented_userdata,
             .token = token,
+            .failure_callback = failure_callback,
+            .failure_userdata = self.render_failed_userdata,
         });
     }
 
@@ -3177,6 +3190,23 @@ pub const CAPI = struct {
 
         surface.render_presented_cb = registered_callback;
         surface.render_presented_userdata = userdata;
+        return true;
+    }
+
+    /// Install the one-shot callback for an explicitly tokened render that did
+    /// not reach the host layer. The callback receives the exact token and a
+    /// terminal disposition, so an embedder never has to infer a dropped
+    /// frame from a watchdog timeout.
+    export fn ghostty_surface_set_render_failed_callback(
+        surface: *Surface,
+        callback: ?RenderFailedCallback,
+        userdata: ?*anyopaque,
+    ) bool {
+        const registered_callback = callback orelse return false;
+        if (surface.render_failed_cb != null) return false;
+
+        surface.render_failed_cb = registered_callback;
+        surface.render_failed_userdata = userdata;
         return true;
     }
 
@@ -5545,6 +5575,12 @@ test "render grid preserves terminal color semantics" {
 test "render presentation callback setter is per surface" {
     const Callbacks = struct {
         fn renderPresented(_: ?*anyopaque, _: u64) callconv(.c) void {}
+
+        fn renderFailed(
+            _: ?*anyopaque,
+            _: u64,
+            _: renderer.FramePresentation.Status,
+        ) callconv(.c) void {}
     };
 
     var parent_userdata: u8 = 0;
@@ -5552,9 +5588,13 @@ test "render presentation callback setter is per surface" {
     var parent: Surface = undefined;
     parent.render_presented_cb = null;
     parent.render_presented_userdata = null;
+    parent.render_failed_cb = null;
+    parent.render_failed_userdata = null;
     var child: Surface = undefined;
     child.render_presented_cb = null;
     child.render_presented_userdata = null;
+    child.render_failed_cb = null;
+    child.render_failed_userdata = null;
 
     try std.testing.expect(CAPI.ghostty_surface_set_render_presented_callback(
         &parent,
@@ -5597,6 +5637,23 @@ test "render presentation callback setter is per surface" {
         @as(?*anyopaque, &parent_userdata),
         parent.render_presented_userdata,
     );
+
+    try std.testing.expect(CAPI.ghostty_surface_set_render_failed_callback(
+        &parent,
+        Callbacks.renderFailed,
+        &parent_userdata,
+    ));
+    try std.testing.expectEqual(Callbacks.renderFailed, parent.render_failed_cb);
+    try std.testing.expectEqual(
+        @as(?*anyopaque, &parent_userdata),
+        parent.render_failed_userdata,
+    );
+    try std.testing.expect(!CAPI.ghostty_surface_set_render_failed_callback(
+        &parent,
+        Callbacks.renderFailed,
+        &child_userdata,
+    ));
+    try std.testing.expectEqual(null, child.render_failed_cb);
 }
 
 test "font size action callback preserves resolved action events" {

--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -74,7 +74,7 @@ pub const FramePresentation = struct {
     pub fn fail(self: FramePresentation, status: Status) void {
         if (self.delivery_gate) |gate| gate(self.delivery_gate_userdata);
         if (self.failure_callback) |callback| {
-            callback(self.failure_userdata orelse self.userdata, self.token, status);
+            callback(self.failure_userdata, self.token, status);
         }
     }
 };

--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -150,9 +150,37 @@ test "failed frame presentation reports after its delivery gate" {
         .delivery_gate = &TestState.gate,
         .delivery_gate_userdata = &state,
         .failure_callback = &TestState.callback,
+        .failure_userdata = &state,
     };
     presentation.fail(.discarded);
     try testing.expectEqualSlices(u8, &.{ 1, 2 }, state.events[0..state.len]);
+}
+
+test "failed frame presentation preserves null callback userdata" {
+    const testing = @import("std").testing;
+    const TestState = struct {
+        var saw_null_userdata = false;
+
+        fn callback(
+            userdata: ?*anyopaque,
+            _: u64,
+            _: FramePresentation.Status,
+        ) callconv(.c) void {
+            saw_null_userdata = userdata == null;
+        }
+    };
+
+    TestState.saw_null_userdata = false;
+    var unrelated_userdata: u8 = 0;
+    const presentation: FramePresentation = .{
+        .callback = undefined,
+        .userdata = &unrelated_userdata,
+        .token = 42,
+        .failure_callback = &TestState.callback,
+        .failure_userdata = null,
+    };
+    presentation.fail(.backend_failed);
+    try testing.expect(TestState.saw_null_userdata);
 }
 
 test "forced draw transfers synchronous presentation to its caller" {

--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -44,11 +44,22 @@ pub const lib = @import("lib/main.zig");
 /// support it invoke the callback only after the exact frame is presented to
 /// the platform layer.
 pub const FramePresentation = struct {
+    /// Final disposition of an explicitly tokened frame. A frame can fail
+    /// after the renderer has handed its IOSurface to the host, so the
+    /// embedder needs a terminal outcome for both success and discard paths.
+    pub const Status = enum(c_int) {
+        presented = 0,
+        discarded = 1,
+        backend_failed = 2,
+    };
+
     callback: *const fn (?*anyopaque, u64) callconv(.c) void,
     userdata: ?*anyopaque,
     token: u64,
     delivery_gate: ?*const fn (?*anyopaque) callconv(.c) void = null,
     delivery_gate_userdata: ?*anyopaque = null,
+    failure_callback: ?*const fn (?*anyopaque, u64, Status) callconv(.c) void = null,
+    failure_userdata: ?*anyopaque = null,
 
     /// Deliver only after the backend-specific gate confirms the renderer has
     /// left its draw critical section.
@@ -56,7 +67,20 @@ pub const FramePresentation = struct {
         if (self.delivery_gate) |gate| gate(self.delivery_gate_userdata);
         self.callback(self.userdata, self.token);
     }
+
+    /// Release the renderer gate and report a terminal non-presented outcome.
+    /// The gate runs first for the same reason as ``deliver``: foreign code
+    /// must never be called while the renderer draw critical section is held.
+    pub fn fail(self: FramePresentation, status: Status) void {
+        if (self.delivery_gate) |gate| gate(self.delivery_gate_userdata);
+        if (self.failure_callback) |callback| {
+            callback(self.failure_userdata orelse self.userdata, self.token, status);
+        }
+    }
 };
+
+/// C-facing name for the disposition carried by ``FramePresentation``.
+pub const RenderPresentationStatus = FramePresentation.Status;
 
 test "frame presentation waits for its delivery gate" {
     const testing = @import("std").testing;
@@ -89,6 +113,45 @@ test "frame presentation waits for its delivery gate" {
         .delivery_gate_userdata = &state,
     };
     presentation.deliver();
+    try testing.expectEqualSlices(u8, &.{ 1, 2 }, state.events[0..state.len]);
+}
+
+test "failed frame presentation reports after its delivery gate" {
+    const testing = @import("std").testing;
+    const TestState = struct {
+        events: [2]u8 = @splat(0),
+        len: usize = 0,
+
+        fn append(self: *@This(), event: u8) void {
+            self.events[self.len] = event;
+            self.len += 1;
+        }
+
+        fn gate(userdata: ?*anyopaque) callconv(.c) void {
+            const self: *@This() = @ptrCast(@alignCast(userdata.?));
+            self.append(1);
+        }
+
+        fn callback(
+            userdata: ?*anyopaque,
+            _: u64,
+            status: FramePresentation.Status,
+        ) callconv(.c) void {
+            const self: *@This() = @ptrCast(@alignCast(userdata.?));
+            self.append(if (status == .discarded) 2 else 3);
+        }
+    };
+
+    var state: TestState = .{};
+    const presentation: FramePresentation = .{
+        .callback = undefined,
+        .userdata = &state,
+        .token = 42,
+        .delivery_gate = &TestState.gate,
+        .delivery_gate_userdata = &state,
+        .failure_callback = &TestState.callback,
+    };
+    presentation.fail(.discarded);
     try testing.expectEqualSlices(u8, &.{ 1, 2 }, state.events[0..state.len]);
 }
 

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -1053,6 +1053,13 @@ fn takePendingDrawPresentation(self: *Thread) ?rendererpkg.FramePresentation {
     return presentation;
 }
 
+test "tokened draw queue admission rejects external drain mode" {
+    const testing = std.testing;
+    try testing.expect(tokenedDrawQueueAdmissionAllows(false, false));
+    try testing.expect(!tokenedDrawQueueAdmissionAllows(false, true));
+    try testing.expect(!tokenedDrawQueueAdmissionAllows(true, false));
+}
+
 /// Finish a forced draw before delivering a synchronous backend presentation.
 /// Delivery is the final operation because it may reentrantly destroy Thread.
 fn finishRenderNowWithPresentation(

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -1021,17 +1021,22 @@ pub fn renderNowWithPresentation(
 /// render cycle on the calling thread (safe only when the embedder owns
 /// renderer state, i.e. iOS external-drain mode), this is safe to call from
 /// any thread while the renderer OS thread is live: it only fills the pending
-/// slot and rings the existing `draw_now` async. Returns false when another
-/// tokened draw is still pending or the wakeup could not be delivered; the
-/// caller may retry.
+/// slot and rings the existing `draw_now` async. iOS always uses an external
+/// render driver, so this entrypoint rejects iOS before queueing. It also
+/// returns false after another platform enters external-drain mode, when
+/// another tokened draw is pending, or when the wakeup could not be delivered.
 pub fn requestDrawWithPresentation(
     self: *Thread,
     presentation: rendererpkg.FramePresentation,
 ) bool {
+    if (comptime builtin.os.tag == .ios) return false;
     {
         self.pending_draw_presentation_mutex.lockUncancelable(global.io());
         defer self.pending_draw_presentation_mutex.unlock(global.io());
-        if (self.pending_draw_presentation != null) return false;
+        if (!tokenedDrawQueueAdmissionAllows(
+            self.externalDrainActive(),
+            self.pending_draw_presentation != null,
+        )) return false;
         self.pending_draw_presentation = presentation;
     }
     self.draw_now.notify() catch |err| {
@@ -1051,6 +1056,13 @@ fn takePendingDrawPresentation(self: *Thread) ?rendererpkg.FramePresentation {
     const presentation = self.pending_draw_presentation;
     self.pending_draw_presentation = null;
     return presentation;
+}
+
+fn tokenedDrawQueueAdmissionAllows(
+    external_drain_active: bool,
+    has_pending_presentation: bool,
+) bool {
+    return !external_drain_active and !has_pending_presentation;
 }
 
 test "tokened draw queue admission rejects external drain mode" {
@@ -1847,15 +1859,23 @@ fn drawNowCallback(
     // Draw immediately. App-thread submission recovery has its own async, so
     // this remains a pure display-link draw and cannot consume stale retries.
     const t = self_.?;
-    if (t.externalDrainActive()) return .rearm;
+    if (t.externalDrainActive()) {
+        // Close the admission race with enterExternalDrainMode: a request
+        // accepted immediately before the transition still receives a
+        // terminal disposition instead of occupying the slot forever.
+        if (t.takePendingDrawPresentation()) |presentation| {
+            presentation.fail(.backend_failed);
+        }
+        return .rearm;
+    }
 
     // cmux fork: a queued tokened draw takes this wake. It rebuilds frame data
     // from current terminal state and skips the `flags.visible` gate on
     // purpose (drawFrame's early-return): the whole point of the tokened path
     // is ground-truth capture of a window the compositor considers occluded.
     // The renderer-realized gate still applies (drawing unrealized GPU state
-    // is invalid); an unconsumed presentation is dropped and its callback
-    // never fires, which the embedder surfaces as a timeout.
+    // is invalid); every consumed presentation receives a success or failure
+    // callback before this renderer accepts another token.
     if (t.takePendingDrawPresentation()) |presentation| {
         drawPendingTokenedFrame(t, presentation);
         return .rearm;

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -1005,6 +1005,7 @@ pub fn renderNowWithPresentation(
 
     self.updateFrame(self.effectiveCursorBlinkVisible()) catch |err| {
         log.warn("renderNowWithPresentation: error updating frame err={}", .{err});
+        presentation.fail(.backend_failed);
         return;
     };
 
@@ -1068,9 +1069,13 @@ fn finishRenderNowWithPresentation(
             error.Timeout => log.warn("renderNowWithPresentation: frame acquire timeout", .{}),
             else => log.warn("renderNowWithPresentation: error drawing err={}", .{err}),
         }
+        presentation.fail(.backend_failed);
         return;
     };
 
+    // Metal returns null here because its completion handler owns delivery;
+    // synchronous backends return the presentation value for this final
+    // handoff. A null result is therefore not itself a failure.
     const value = completed orelse return;
     value.deliver();
 }
@@ -1868,10 +1873,12 @@ fn drawPendingTokenedFrame(
 ) void {
     if (!t.renderer_realized) {
         log.warn("tokened draw skipped: renderer unrealized", .{});
+        presentation.fail(.backend_failed);
         return;
     }
     t.updateFrame(t.effectiveCursorBlinkVisible()) catch |err| {
         log.warn("tokened draw: error updating frame err={}", .{err});
+        presentation.fail(.backend_failed);
         return;
     };
     finishRenderNowWithPresentation(

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -1820,9 +1820,14 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             // Retrieve the most up-to-date surface size from the Graphics API
             const surface_size = try self.api.surfaceSize();
 
-            // If either of our surface dimensions is zero
-            // then drawing is absurd, so we just return.
-            if (surface_size.width == 0 or surface_size.height == 0) return null;
+            // If either of our surface dimensions is zero then drawing is
+            // absurd. A tokened embedder still needs a terminal disposition,
+            // otherwise its presentation gate would wait for a frame that
+            // was never submitted.
+            if (surface_size.width == 0 or surface_size.height == 0) {
+                if (presentation) |value| value.fail(.discarded);
+                return null;
+            }
 
             const size_changed =
                 self.size.screen.width != surface_size.width or
@@ -1841,6 +1846,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 // apprt may be swapping buffers and display an outdated frame
                 // if we don't draw something new.
                 try self.api.presentLastTarget();
+                if (presentation) |value| value.fail(.discarded);
                 return null;
             }
             var damage = DrawDamageCommit.begin(&self.cells_rebuilt);

--- a/src/renderer/metal/Frame.zig
+++ b/src/renderer/metal/Frame.zig
@@ -325,6 +325,7 @@ test "tokened completion freezes target before recycling slot" {
         dispatch,
         deinit,
         release_presentation_ownership,
+        delivery_gate,
     };
     const Event = struct {
         kind: EventKind,
@@ -414,14 +415,21 @@ test "tokened completion freezes target before recycling slot" {
     };
     const Callbacks = struct {
         fn presented(_: ?*anyopaque, _: u64) callconv(.c) void {}
+
+        fn deliveryGate(userdata: ?*anyopaque) callconv(.c) void {
+            const state: *State = @ptrCast(@alignCast(userdata.?));
+            state.append(.delivery_gate, 0);
+        }
     };
+    var state: State = .{};
     const presentation: FramePresentation = .{
         .callback = &Callbacks.presented,
-        .userdata = null,
+        .userdata = &state,
         .token = 42,
+        .delivery_gate = &Callbacks.deliveryGate,
+        .delivery_gate_userdata = &state,
     };
 
-    var state: State = .{};
     var renderer: MockRenderer = .{ .api = .{ .state = &state } };
     var target: MockTarget = .{ .id = 1, .state = &state };
     completeHealthyFrame(&renderer, &target, false, 1, 0, presentation);
@@ -441,6 +449,7 @@ test "tokened completion freezes target before recycling slot" {
     completeHealthyFrame(&renderer, &target, false, 2, 0, presentation);
     try testing.expectEqualSlices(Event, &.{
         .{ .kind = .complete, .target_id = 4 },
+        .{ .kind = .delivery_gate, .target_id = 0 },
     }, state.events[0..state.len]);
 
     // Ordinary frames retain the allocation-free presentation path.

--- a/src/renderer/metal/Frame.zig
+++ b/src/renderer/metal/Frame.zig
@@ -196,12 +196,12 @@ fn bufferCompleted(
         block.frame_token,
         false,
     );
-    if (block.presentation_failure_callback) |callback| {
+    if (block.presentation_callback) |callback| {
         (FramePresentation{
-            .callback = undefined,
+            .callback = callback,
             .userdata = block.presentation_userdata,
             .token = block.presentation_token,
-            .failure_callback = callback,
+            .failure_callback = block.presentation_failure_callback,
             .failure_userdata = block.presentation_failure_userdata,
             .delivery_gate = block.presentation_delivery_gate,
             .delivery_gate_userdata = block.presentation_delivery_gate_userdata,
@@ -224,7 +224,7 @@ fn completeHealthyFrame(
         var frozen = renderer.api.detachPresentationTarget(target) catch |err| {
             log.warn("Failed to detach tokened render target: err={}", .{err});
             renderer.frameCompleted(target, .healthy, frame_token, false);
-            if (value.failure_callback != null) value.fail(.backend_failed);
+            value.fail(.backend_failed);
             return;
         };
         defer frozen.releasePresentationOwnership();

--- a/src/renderer/metal/Frame.zig
+++ b/src/renderer/metal/Frame.zig
@@ -111,6 +111,8 @@ pub fn begin(
             .presentation_callback = if (presentation) |value| value.callback else null,
             .presentation_userdata = if (presentation) |value| value.userdata else null,
             .presentation_token = if (presentation) |value| value.token else 0,
+            .presentation_failure_callback = if (presentation) |value| value.failure_callback else null,
+            .presentation_failure_userdata = if (presentation) |value| value.failure_userdata else null,
             .presentation_delivery_gate = if (presentation) |value| value.delivery_gate else null,
             .presentation_delivery_gate_userdata = if (presentation) |value| value.delivery_gate_userdata else null,
         },
@@ -130,6 +132,12 @@ const CompletionBlock = objc.Block(struct {
     presentation_callback: ?*const fn (?*anyopaque, u64) callconv(.c) void,
     presentation_userdata: ?*anyopaque,
     presentation_token: u64,
+    presentation_failure_callback: ?*const fn (
+        ?*anyopaque,
+        u64,
+        FramePresentation.Status,
+    ) callconv(.c) void,
+    presentation_failure_userdata: ?*anyopaque,
     presentation_delivery_gate: ?*const fn (?*anyopaque) callconv(.c) void,
     presentation_delivery_gate_userdata: ?*anyopaque,
 }, .{
@@ -173,6 +181,8 @@ fn bufferCompleted(
                 .callback = callback,
                 .userdata = block.presentation_userdata,
                 .token = block.presentation_token,
+                .failure_callback = block.presentation_failure_callback,
+                .failure_userdata = block.presentation_failure_userdata,
                 .delivery_gate = block.presentation_delivery_gate,
                 .delivery_gate_userdata = block.presentation_delivery_gate_userdata,
             } else null,
@@ -186,6 +196,17 @@ fn bufferCompleted(
         block.frame_token,
         false,
     );
+    if (block.presentation_failure_callback) |callback| {
+        (FramePresentation{
+            .callback = undefined,
+            .userdata = block.presentation_userdata,
+            .token = block.presentation_token,
+            .failure_callback = callback,
+            .failure_userdata = block.presentation_failure_userdata,
+            .delivery_gate = block.presentation_delivery_gate,
+            .delivery_gate_userdata = block.presentation_delivery_gate_userdata,
+        }).fail(.backend_failed);
+    }
 }
 
 /// Present one healthy completed frame and recycle its exact swap-chain slot.
@@ -203,6 +224,7 @@ fn completeHealthyFrame(
         var frozen = renderer.api.detachPresentationTarget(target) catch |err| {
             log.warn("Failed to detach tokened render target: err={}", .{err});
             renderer.frameCompleted(target, .healthy, frame_token, false);
+            if (value.failure_callback != null) value.fail(.backend_failed);
             return;
         };
         defer frozen.releasePresentationOwnership();

--- a/src/renderer/metal/IOSurfaceLayer.zig
+++ b/src/renderer/metal/IOSurfaceLayer.zig
@@ -182,6 +182,8 @@ pub const PreparedSurfaceUpdate = struct {
             .presentation_callback = self.presentation.callback,
             .presentation_userdata = self.presentation.userdata,
             .presentation_token = self.presentation.token,
+            .presentation_failure_callback = self.presentation.failure_callback,
+            .presentation_failure_userdata = self.presentation.failure_userdata,
             .presentation_delivery_gate = self.presentation.delivery_gate,
             .presentation_delivery_gate_userdata = self.presentation.delivery_gate_userdata,
         }, &setSurfaceCallback);
@@ -235,6 +237,8 @@ fn setSurface_(
         .presentation_callback = if (presentation) |value| value.callback else null,
         .presentation_userdata = if (presentation) |value| value.userdata else null,
         .presentation_token = if (presentation) |value| value.token else 0,
+        .presentation_failure_callback = if (presentation) |value| value.failure_callback else null,
+        .presentation_failure_userdata = if (presentation) |value| value.failure_userdata else null,
         .presentation_delivery_gate = if (presentation) |value| value.delivery_gate else null,
         .presentation_delivery_gate_userdata = if (presentation) |value| value.delivery_gate_userdata else null,
     }, &setSurfaceCallback);
@@ -339,6 +343,12 @@ const SetSurfaceBlock = objc.Block(struct {
     presentation_callback: ?*const fn (?*anyopaque, u64) callconv(.c) void,
     presentation_userdata: ?*anyopaque,
     presentation_token: u64,
+    presentation_failure_callback: ?*const fn (
+        ?*anyopaque,
+        u64,
+        FramePresentation.Status,
+    ) callconv(.c) void,
+    presentation_failure_userdata: ?*anyopaque,
     presentation_delivery_gate: ?*const fn (?*anyopaque) callconv(.c) void,
     presentation_delivery_gate_userdata: ?*anyopaque,
 }, .{}, void);
@@ -388,9 +398,13 @@ fn setSurfaceCallback(
             "setSurfaceCallback(): surface is wrong size for layer, discarding. surface = {d}x{d}, layer = {d}x{d}",
             .{ surface.getWidth(), surface.getHeight(), width, height },
         );
+        notifyPresentationFailure(block, .discarded);
         return;
     }
-    if (!block.surface_generation.shouldCommit(block.generation)) return;
+    if (!block.surface_generation.shouldCommit(block.generation)) {
+        notifyPresentationFailure(block, .discarded);
+        return;
+    }
 
     layer.setProperty("contents", surface);
     block.surface_generation.commit(block.generation);
@@ -399,6 +413,25 @@ fn setSurfaceCallback(
             gate(block.presentation_delivery_gate_userdata);
         }
         callback(block.presentation_userdata, block.presentation_token);
+    }
+}
+
+fn notifyPresentationFailure(
+    block: *const SetSurfaceBlock.Context,
+    status: FramePresentation.Status,
+) void {
+    if (block.presentation_failure_callback) |callback| {
+        if (block.presentation_delivery_gate) |gate| {
+            gate(block.presentation_delivery_gate_userdata);
+        }
+        callback(
+            block.presentation_failure_userdata orelse block.presentation_userdata,
+            block.presentation_token,
+            status,
+        );
+    } else if (block.presentation_callback == null) {
+        // No callback owns this ordinary surface assignment.
+        return;
     }
 }
 
@@ -512,6 +545,7 @@ test "tokened surface updates defer delivery and teardown invalidates them" {
     const CallbackState = struct {
         gate_count: usize = 0,
         callback_count: usize = 0,
+        failure_count: usize = 0,
 
         fn gate(userdata: ?*anyopaque) callconv(.c) void {
             const self: *@This() = @ptrCast(@alignCast(userdata.?));
@@ -521,6 +555,15 @@ test "tokened surface updates defer delivery and teardown invalidates them" {
         fn callback(userdata: ?*anyopaque, _: u64) callconv(.c) void {
             const self: *@This() = @ptrCast(@alignCast(userdata.?));
             self.callback_count += 1;
+        }
+
+        fn failure(
+            userdata: ?*anyopaque,
+            _: u64,
+            _: FramePresentation.Status,
+        ) callconv(.c) void {
+            const self: *@This() = @ptrCast(@alignCast(userdata.?));
+            self.failure_count += 1;
         }
     };
 
@@ -557,6 +600,8 @@ test "tokened surface updates defer delivery and teardown invalidates them" {
         .presentation_callback = &CallbackState.callback,
         .presentation_userdata = &state,
         .presentation_token = 42,
+        .presentation_failure_callback = &CallbackState.failure,
+        .presentation_failure_userdata = &state,
         .presentation_delivery_gate = &CallbackState.gate,
         .presentation_delivery_gate_userdata = &state,
     }, &setSurfaceCallback);
@@ -564,6 +609,7 @@ test "tokened surface updates defer delivery and teardown invalidates them" {
 
     try testing.expectEqual(@as(usize, 0), state.gate_count);
     try testing.expectEqual(@as(usize, 0), state.callback_count);
+    try testing.expectEqual(@as(usize, 0), state.failure_count);
 }
 
 test "clear surface drops displayed IOSurface without disabling future updates" {

--- a/src/renderer/metal/IOSurfaceLayer.zig
+++ b/src/renderer/metal/IOSurfaceLayer.zig
@@ -420,19 +420,15 @@ fn notifyPresentationFailure(
     block: *const SetSurfaceBlock.Context,
     status: FramePresentation.Status,
 ) void {
-    if (block.presentation_failure_callback) |callback| {
-        if (block.presentation_delivery_gate) |gate| {
-            gate(block.presentation_delivery_gate_userdata);
-        }
-        callback(
-            block.presentation_failure_userdata orelse block.presentation_userdata,
-            block.presentation_token,
-            status,
-        );
-    } else if (block.presentation_callback == null) {
-        // No callback owns this ordinary surface assignment.
-        return;
+    const callback = block.presentation_failure_callback orelse return;
+    if (block.presentation_delivery_gate) |gate| {
+        gate(block.presentation_delivery_gate_userdata);
     }
+    callback(
+        block.presentation_failure_userdata orelse block.presentation_userdata,
+        block.presentation_token,
+        status,
+    );
 }
 
 fn detachFromHostCallback(

--- a/src/renderer/metal/IOSurfaceLayer.zig
+++ b/src/renderer/metal/IOSurfaceLayer.zig
@@ -608,6 +608,51 @@ test "tokened surface updates defer delivery and teardown invalidates them" {
     try testing.expectEqual(@as(usize, 0), state.failure_count);
 }
 
+test "discarded surface update releases a gate without a failure callback" {
+    const testing = std.testing;
+    const CallbackState = struct {
+        gate_count: usize = 0,
+
+        fn gate(userdata: ?*anyopaque) callconv(.c) void {
+            const self: *@This() = @ptrCast(@alignCast(userdata.?));
+            self.gate_count += 1;
+        }
+
+        fn callback(_: ?*anyopaque, _: u64) callconv(.c) void {}
+    };
+
+    var layer = try IOSurfaceLayer.init();
+    defer layer.release();
+    var surface = try IOSurface.init(.{
+        .width = 1,
+        .height = 1,
+        .pixel_format = .@"32BGRA",
+        .bytes_per_element = 4,
+        .colorspace = null,
+    });
+    defer surface.deinit();
+    surface.retain();
+    layer.surface_generation.retain();
+
+    var state: CallbackState = .{};
+    var block = SetSurfaceBlock.init(.{
+        .layer = layer.layer.value,
+        .surface = surface,
+        .surface_generation = layer.surface_generation,
+        .generation = layer.surface_generation.schedule(),
+        .presentation_callback = &CallbackState.callback,
+        .presentation_userdata = null,
+        .presentation_token = 42,
+        .presentation_failure_callback = null,
+        .presentation_failure_userdata = null,
+        .presentation_delivery_gate = &CallbackState.gate,
+        .presentation_delivery_gate_userdata = &state,
+    }, &setSurfaceCallback);
+    setSurfaceCallback(&block);
+
+    try testing.expectEqual(@as(usize, 1), state.gate_count);
+}
+
 test "clear surface drops displayed IOSurface without disabling future updates" {
     const testing = std.testing;
 

--- a/src/renderer/metal/IOSurfaceLayer.zig
+++ b/src/renderer/metal/IOSurfaceLayer.zig
@@ -420,15 +420,16 @@ fn notifyPresentationFailure(
     block: *const SetSurfaceBlock.Context,
     status: FramePresentation.Status,
 ) void {
-    const callback = block.presentation_failure_callback orelse return;
     if (block.presentation_delivery_gate) |gate| {
         gate(block.presentation_delivery_gate_userdata);
     }
-    callback(
-        block.presentation_failure_userdata orelse block.presentation_userdata,
-        block.presentation_token,
-        status,
-    );
+    if (block.presentation_failure_callback) |callback| {
+        callback(
+            block.presentation_failure_userdata,
+            block.presentation_token,
+            status,
+        );
+    }
 }
 
 fn detachFromHostCallback(

--- a/src/renderer/opengl/Frame.zig
+++ b/src/renderer/opengl/Frame.zig
@@ -81,6 +81,7 @@ fn completeFrame(
     renderer.api.present(target.*) catch |err| {
         log.warn("Failed to present render target: err={}", .{err});
         renderer.frameCompleted(target, .unhealthy, frame_token, false);
+        if (presentation) |value| value.fail(.backend_failed);
         return null;
     };
 
@@ -91,7 +92,9 @@ fn completeFrame(
     // generic renderer carries the returned value outward only after all of
     // its cleanup defers run; Thread delivers after its instrumentation ends.
     renderer.frameCompleted(target, health, frame_token, false);
-    return if (health == .healthy) presentation else null;
+    if (health == .healthy) return presentation;
+    if (presentation) |value| value.fail(.backend_failed);
+    return null;
 }
 
 test "OpenGL acknowledges only after successful present and GPU completion" {

--- a/src/termio/Termio.zig
+++ b/src/termio/Termio.zig
@@ -803,6 +803,22 @@ pub fn scrollViewport(
     self.terminal.scrollViewport(scroll);
 }
 
+/// Try to scroll the terminal viewport without waiting for the renderer-state
+/// mutex. Embedded display-driven surfaces run this from the same serial queue
+/// that feeds output and renders frames, so an unbounded lock wait here would
+/// strand every later output operation behind a transient PTY/render burst.
+/// The caller can retry after the next display tick when the lock is busy.
+pub fn tryScrollViewport(
+    self: *Termio,
+    scroll: terminalpkg.Terminal.ScrollViewport,
+) bool {
+    if (!self.renderer_state.mutex.tryLock()) return false;
+    self.terminal.scrollViewport(scroll);
+    self.renderer_state.mutex.unlock(global.io());
+    self.renderer_wakeup.notify() catch {};
+    return true;
+}
+
 /// Jump the viewport to the prompt.
 pub fn jumpToPrompt(self: *Termio, delta: isize) !void {
     {


### PR DESCRIPTION
Guarantees a terminal disposition for every accepted tokened iOS render.

Ghostty now reports presented, discarded, and backend-failed outcomes across Metal, OpenGL, generic, and renderer-thread paths. Tokened asynchronous requests reject synchronously when iOS or external-drain mode has no consumer. Explicit callback userdata stays independent, and the delivery gate releases even without a failure callback.

Also adds a non-blocking scroll-to-bottom entrypoint so display-driven embedders never block their output queue on the terminal-state lock.

Verification:
- focused frame-presentation, callback, and tokened-update tests pass
- GhosttyKit builds from source at 3da10da73ae848c0310e3e0f0cb29e509c2f6963
- published framework checksum 6a02a2ec3794de79a02af993083292a89517d2533eb20c746deca377f23456bd validates after download
- cmux isolated simulator passes 200 forced recovery cycles and recovers a deliberate discarded frame