### PR TITLE
cmux: emit both sides for conditional theme selections

### DIFF
--- a/src/cli/list_themes.zig
+++ b/src/cli/list_themes.zig
@@ -422,18 +422,21 @@ fn encodeCmuxThemeValue(
             );
         }
 
+        // Ghostty's conditional theme parser requires both sides. A picker
+        // target can leave the opposite side unset on a fresh or stale cmux
+        // config, so duplicate the selected theme as the safe fallback.
         return try std.fmt.allocPrint(
             alloc,
-            "light:{s}",
-            .{light_theme},
+            "light:{s},dark:{s}",
+            .{ light_theme, light_theme },
         );
     }
 
     if (dark) |dark_theme| {
         return try std.fmt.allocPrint(
             alloc,
-            "dark:{s}",
-            .{dark_theme},
+            "light:{s},dark:{s}",
+            .{ dark_theme, dark_theme },
         );
     }
 

--- a/src/cli/list_themes.zig
+++ b/src/cli/list_themes.zig
@@ -440,6 +440,21 @@ fn encodeCmuxThemeValue(
     return null;
 }
 
+test "cmux theme encoding always emits both conditional sides" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    const light_only = (try encodeCmuxThemeValue(alloc, "Light Theme", null)).?;
+    try std.testing.expectEqualStrings("light:Light Theme,dark:Light Theme", light_only);
+
+    const dark_only = (try encodeCmuxThemeValue(alloc, null, "Dark Theme")).?;
+    try std.testing.expectEqualStrings("light:Dark Theme,dark:Dark Theme", dark_only);
+
+    const split = (try encodeCmuxThemeValue(alloc, "Light Theme", "Dark Theme")).?;
+    try std.testing.expectEqualStrings("light:Light Theme,dark:Dark Theme", split);
+}
+
 fn writeCmuxThemeOverride(
     alloc: std.mem.Allocator,
     cmux: *const CmuxThemePicker,


### PR DESCRIPTION
cmux writes the `theme` directive consumed by the bundled picker. Ghostty rejects single-sided conditional values (`light:<name>` / `dark:<name>`), so the picker must duplicate the selected side when the opposite side is unavailable.

This branch includes the focused regression test and the encoder fix used by cmux issue #10068. The parent cmux PR is https://github.com/manaflow-ai/cmux/pull/10358.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/201"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789678960&installation_model_id=21920&pr_number=201&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F201&signature=213f447f471d4c30417aa566b0e5326fd7c7e6732f387dc7588fc7531adad987"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emit both light and dark sides for conditional theme selections so Ghostty accepts the `theme` directive. Previously we wrote single-sided values (e.g., "light:<name>" or "dark:<name>") when only one side was chosen; now we duplicate the selected theme and write "light:<name>,dark:<name>", or pass through both when provided.

- Updates `encodeCmuxThemeValue` in src/cli/list_themes.zig to always output both sides.
- Adds a regression test for light-only, dark-only, and split selections.
- No migration required; the `cmux` picker will rewrite single-sided selections to two-sided on save.

<sup>Written for commit 987780a132a33fd69ab800b09e254b4584537d04. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/201?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Theme values now consistently include both light and dark variants.
  * Light-only and dark-only themes are automatically applied to the missing mode.
* **Tests**
  * Added coverage for light-only, dark-only, and split light/dark theme configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->