### PR TITLE
termio: drop instead of blocking on a full renderer mailbox (macOS) to fix sleep/wake UI hang

### DIFF
--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -170,25 +170,28 @@ pub const StreamHandler = struct {
                 .{err},
             );
         };
-        // cmux iOS fork: on iOS there is no draining renderer-thread vsync loop.
-        // `render_now` runs on the SAME serial dispatch queue that runs
-        // `process_output`, and it is the renderer mailbox's only drainer. So if
-        // a `process_output` burst (e.g. a render-grid resync storm) fills this
-        // mailbox, the `renderer_wakeup` above is a no-op and a `.forever` push
-        // blocks that queue forever — the `render_now` queued behind it can then
-        // never drain the mailbox, so the terminal freezes (renderInFlight
-        // latched, no frame, and no acquire-timeout because nextFrame is never
-        // reached). Invariant: nothing reachable from the iOS render serial queue
-        // may block unboundedly. Drop instead; `render_now` rebuilds from the
-        // current terminal state every frame, so a coalesced renderer message is
-        // re-derived on the next draw. Same class as the endFrame/frameCompleted
-        // `.forever`->`.instant` fork fixes. macOS keeps the proven wake+forever
-        // path (its renderer thread is a real draining loop).
-        if (comptime builtin.os.tag == .ios) {
-            _ = self.renderer_mailbox.push(msg, .{ .instant = {} });
-            return;
-        }
-        _ = self.renderer_mailbox.push(msg, .{ .forever = {} });
+        // cmux fork: never block the producer on a full renderer mailbox.
+        //
+        // On iOS there is no draining renderer-thread vsync loop: `render_now`
+        // runs on the SAME serial dispatch queue as `process_output` and is the
+        // mailbox's only drainer, so a `.forever` push deadlocks that queue.
+        //
+        // macOS originally kept the blocking `.forever` path because its renderer
+        // thread is a real draining loop, so the `renderer_wakeup` above normally
+        // frees a slot. But that assumption breaks across system sleep/wake: the
+        // renderer (or IO) `libxev` loop's cross-thread wakeup is an
+        // `xev.Async`-backed Darwin mach port with queue limit 1, and a single
+        // delivery edge lost during the power transition is unrecoverable (a full
+        // port makes every later `notify()` a coalesced no-op). The loop then
+        // never drains and `.forever` hangs the producer — which for cmux's
+        // manual-I/O remote-tmux mirror mode is the MAIN thread (`process_output`
+        // runs there), freezing the whole UI on wake while tmux replays `%output`.
+        //
+        // Drop instead on BOTH platforms: `render_now` / the next draw rebuilds
+        // from the current terminal state every frame, so a coalesced renderer
+        // message is re-derived on the next frame. Same class as the
+        // endFrame/frameCompleted `.forever`->`.instant` fork fixes.
+        _ = self.renderer_mailbox.push(msg, .{ .instant = {} });
     }
 
     pub fn vt(


### PR DESCRIPTION
## Problem

On macOS, `cmux` (a Ghostty-based terminal that mirrors remote `tmux -CC` sessions) **hangs with the UI frozen after the laptop sleeps and wakes**, while tmux replays a burst of `%output`.

Root cause: the renderer-mailbox producer in `StreamHandler.rendererMessageWriter` uses a blocking `.forever` push on macOS, on the assumption that the renderer thread's `libxev` loop always drains the mailbox (the `renderer_wakeup.notify()` above frees a slot). That assumption breaks across system sleep/wake: the cross-thread wakeup is an `xev.Async`-backed Darwin mach port with **queue limit 1**, and `notify()` treats a full port (`SEND_TIMED_OUT`) as success. If a single delivery edge is lost during the power transition, the port stays full → every later `notify()` is a coalesced no-op → the loop never drains and the `.forever` push **blocks the producer forever**.

For cmux's manual-I/O mirror surfaces, `process_output` runs on the **main thread**, so this freezes the whole UI on wake. (Diagnosed from a `sample`: main thread parked in a futex reached from `ghostty_surface_process_output`; every `io`/`renderer` worker parked in `kqueue.Loop.tick → kevent64`.)

## Fix

Drop instead of blocking on a full renderer mailbox on macOS too — exactly as iOS already does (the `.forever`→`.instant` handling this commit unifies). `render_now` / the next draw rebuilds from the current terminal state every frame, so a coalesced renderer message is re-derived on the next frame. This converts a permanent main-thread hang into, at worst, one dropped/coalesced frame that self-recovers.

## Testing

Built `GhosttyKit.xcframework` from this branch and ran cmux with remote tmux sessions across repeated standby→wake cycles; the post-wake UI hang no longer reproduces.

Note: this addresses the renderer mailbox (the one a `%output` flood fills). If the surface/termio mailboxes prove to hit the same lost-wakeup path, they can get the same bounded treatment; a `didWake` surface-loop kick on the app side is a complementary belt-and-suspenders.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/202"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789750478&installation_model_id=21920&pr_number=202&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F202&signature=6bbab8f6f9958d23852264c94e1928677303ecb42dc1244b2b2ca5bb456c70ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch macOS renderer mailbox pushes from blocking to drop, matching iOS, to prevent a post-sleep UI freeze when the wakeup port stays full. Old: `.forever` push could block the producer on a full mailbox; new: `.instant` drops when full. Side effect: at most one dropped/coalesced frame that self-recovers on the next draw.

- Unifies iOS/macOS to `_ = self.renderer_mailbox.push(msg, .{ .instant = {} });` in `src/termio/stream_handler.zig`.
- Fix rationale: the `libxev` `xev.Async` mach port (queue limit 1) can remain full across sleep/wake, making `notify()` a no-op; the renderer loop never drains and the producer blocks the main thread in cmux mirror mode while tmux replays `%output`.
- Only the renderer mailbox behavior changed; surface/termio mailboxes are unchanged.

<sup>Written for commit a144cc2d553d79305d4045e927063d36388d9aca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/202?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved renderer responsiveness by preventing message producers from blocking when the renderer mailbox is full.
  * Standardized nonblocking message handling across supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->