### PR TITLE
surface: tolerate embedded make_current failure during deinit

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -1081,11 +1081,24 @@ pub fn deinit(self: *Surface) void {
     if (self.search) |*s| s.deinit();
 
     // Stop rendering thread
+    var renderer_context_ok = true;
     {
         self.renderer_thr.join();
 
-        // We need to become the active rendering thread again
-        self.renderer.threadEnter(self.rt_surface) catch unreachable;
+        // We need to become the active rendering thread again. Embedded
+        // hosts can refuse make_current here (EGL rejects a context that is
+        // still current on another thread, and a tearing-down host may
+        // already have abandoned the context). The host owns the context and
+        // destroys it right after this surface is freed, so every GPU-side
+        // resource dies with it either way; skip the renderer's GPU teardown
+        // instead of crashing the whole process on `unreachable`.
+        self.renderer.threadEnter(self.rt_surface) catch |err| {
+            log.err(
+                "renderer threadEnter failed during deinit; skipping renderer teardown err={}",
+                .{err},
+            );
+            renderer_context_ok = false;
+        };
     }
 
     // Stop our IO thread
@@ -1096,7 +1109,7 @@ pub fn deinit(self: *Surface) void {
     // We need to deinit AFTER everything is stopped, since there are
     // shared values between the two threads.
     self.renderer_thread.deinit();
-    self.renderer.deinit();
+    if (renderer_context_ok) self.renderer.deinit();
     self.io_thread.deinit();
     self.mouse.selection_gesture.deinit(&self.io.terminal);
     _ = self.clearKeyboardCopyCursor();


### PR DESCRIPTION
Surface.deinit re-enters the render context after joining the renderer thread with `catch unreachable`. Embedded OpenGL hosts can legitimately refuse make_current at teardown (EGL returns BAD_ACCESS while the context is still current on another thread, and a tearing-down host may have abandoned the context), which turned every such failure into UB/SIGSEGV in ReleaseFast — this is the cmux-browser Linux crash when a replaced terminal surface is freed while another surface is live (cr2=0x117a in ghostty_surface_free).

The embedded host owns the GL context and destroys it right after the surface is freed, so GPU resources die with it regardless; log, skip the renderer's GPU teardown, and keep the process alive. No behavior change for apprt=gtk / Metal (their threadEnter cannot fail).

Reproduced and verified with cmux-browser's scripts/ghostty_free_repro2.c: 8 surface-replacement rounds including an injected teardown make_current failure, plus 3 kill/relaunch session-replay cycles in the browser with zero SEGV.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/203"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789820424&installation_model_id=21920&pr_number=203&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F203&signature=d5efe87d54bab1e2dba6e3d8b10de2cd6f4506ab1c98576b1e42351590af74e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tolerates failure to re-enter the render context during `Surface.deinit`, preventing teardown crashes on embedded OpenGL/EGL hosts. Previously we used `threadEnter(... ) catch unreachable` and always called `renderer.deinit()`, which could crash when the host rejected `make_current`; now we log the error and skip renderer GPU teardown while keeping the process alive.

**Reviewer notes**
- Adds a `renderer_context_ok` flag; only calls `renderer.deinit()` when `threadEnter` succeeds.
- Logs: "renderer threadEnter failed during deinit; skipping renderer teardown err={...}".
- Affects embedded GL hosts only; no behavior change for `gtk`/Metal backends.

<sup>Written for commit 4771807e0793addc8b8825421547ec29aa09fc2f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/203?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shutdown reliability when the renderer context cannot be reacquired.
  * Prevented crashes during surface cleanup and safely skipped GPU teardown when necessary.
  * Renderer deinitialization continues normally when context acquisition succeeds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->