### PR TITLE
renderer: atomic fractional pixel scroll offset with one-row overscan

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1465,6 +1465,22 @@ GHOSTTY_API bool ghostty_surface_scroll_to_row_if_revision(
     uint64_t,
     uint64_t,
     ghostty_surface_scrollbar_s*);
+// cmux fork: pixel-precise variant of scroll_to_row_if_revision. Atomically
+// scrolls the viewport to the absolute row AND applies a fractional vertical
+// pixel offset in the same critical section; the renderer snapshots the pair
+// under one lock so every presented frame is composed from one consistent
+// scroll position. Positive offsets shift rendered content up, revealing the
+// top sliver of the next row (the renderer overscans one row). The offset is
+// a render-space translation only: terminal state and the PTY-visible grid
+// are unaffected, it is forced to zero on the alternate screen, and any other
+// viewport move resets it to zero. Arguments: row, pixel offset, expected
+// row-space revision, out scrollbar snapshot.
+GHOSTTY_API bool ghostty_surface_scroll_to_row_pixel_if_revision(
+    ghostty_surface_t,
+    uint64_t,
+    float,
+    uint64_t,
+    ghostty_surface_scrollbar_s*);
 GHOSTTY_API uint64_t ghostty_surface_foreground_pid(ghostty_surface_t);
 GHOSTTY_API ghostty_string_s ghostty_surface_tty_name(ghostty_surface_t);
 // cmux fork: export the Ghostty grid as a compact render-grid JSON frame for

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -568,6 +568,19 @@ typedef void (*ghostty_pty_tee_cb)(void* userdata,
 // main thread. Synchronous backends deliver on the rendering caller's thread.
 typedef void (*ghostty_render_presented_cb)(void*, uint64_t);
 
+// cmux fork: terminal outcome for an explicitly tokened render that did not
+// reach the host layer. The callback is paired with
+// ghostty_render_presented_cb and receives the same render token.
+typedef enum {
+  GHOSTTY_RENDER_PRESENTATION_PRESENTED = 0,
+  GHOSTTY_RENDER_PRESENTATION_DISCARDED = 1,
+  GHOSTTY_RENDER_PRESENTATION_BACKEND_FAILED = 2,
+} ghostty_render_presentation_status_e;
+typedef void (*ghostty_render_failed_cb)(
+    void*,
+    uint64_t,
+    ghostty_render_presentation_status_e);
+
 // cmux fork: semantic font binding actions emitted after the native mutation
 // succeeds. The callback runs synchronously on the surface's GUI thread.
 typedef enum {
@@ -1381,6 +1394,14 @@ GHOSTTY_API bool ghostty_surface_set_render_presented_callback(
     ghostty_surface_t,
     ghostty_render_presented_cb,
     void* userdata);
+// cmux fork: install the per-surface callback for explicitly tokened renders
+// that were discarded by the host layer or failed in the renderer. Call once
+// directly after construction. The callback userdata remains valid until
+// ghostty_surface_free returns.
+GHOSTTY_API bool ghostty_surface_set_render_failed_callback(
+    ghostty_surface_t,
+    ghostty_render_failed_cb,
+    void* userdata);
 // cmux fork: install a per-surface callback for successfully performed font
 // binding actions. Call once after construction. The callback is synchronous
 // on the GUI thread, must not destroy or otherwise reenter the surface, is not
@@ -1392,8 +1413,8 @@ GHOSTTY_API bool ghostty_surface_set_font_size_action_callback(
     void* userdata);
 // cmux fork: submit a forced render associated with `token`. When successful,
 // the installed callback fires after the backend presents the exact rendered
-// frame. On Metal this follows main-thread IOSurface assignment. A failed or
-// size-discarded render has no callback.
+// frame. On Metal this follows main-thread IOSurface assignment. Failed or
+// discarded renders invoke the optional render-failed callback instead.
 GHOSTTY_API void ghostty_surface_render_now_with_token(ghostty_surface_t,
                                                        uint64_t token);
 // cmux fork: queue a tokened forced render executed on the renderer thread.
@@ -1405,8 +1426,8 @@ GHOSTTY_API void ghostty_surface_render_now_with_token(ghostty_surface_t,
 // after the exact frame is presented to the platform layer (Metal: after the
 // main-thread IOSurface assignment). Returns false when no render-presented
 // callback is installed or another tokened draw is still pending; a
-// successfully queued render whose draw is skipped (renderer unrealized,
-// zero-sized surface, or a size-discarded layer assignment) has no callback.
+// successfully queued render whose draw is skipped (renderer unrealized or
+// zero-sized surface) invokes the optional render-failed callback.
 GHOSTTY_API bool ghostty_surface_request_render_with_token(ghostty_surface_t,
                                                            uint64_t token);
 GHOSTTY_API void ghostty_surface_set_content_scale(ghostty_surface_t, double, double);

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1625,6 +1625,9 @@ GHOSTTY_API void ghostty_surface_split_resize(ghostty_surface_t,
                                                  uint16_t);
 GHOSTTY_API void ghostty_surface_split_equalize(ghostty_surface_t);
 GHOSTTY_API bool ghostty_surface_binding_action(ghostty_surface_t, const char*, uintptr_t);
+// cmux fork: non-blocking prompt reveal for display-driven embedded clients.
+// A false result means the terminal-state mutex was busy; retry later.
+GHOSTTY_API bool ghostty_surface_try_scroll_to_bottom(ghostty_surface_t);
 GHOSTTY_API void ghostty_surface_complete_clipboard_request(ghostty_surface_t,
                                                                const char*,
                                                                void*,

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1418,9 +1418,11 @@ GHOSTTY_API bool ghostty_surface_set_font_size_action_callback(
 GHOSTTY_API void ghostty_surface_render_now_with_token(ghostty_surface_t,
                                                        uint64_t token);
 // cmux fork: queue a tokened forced render executed on the renderer thread.
-// Thread-safe while the renderer OS thread is live, unlike
+// Thread-safe while the renderer OS thread owns rendering, unlike
 // ghostty_surface_render_now_with_token which renders on the calling thread
-// and requires embedder-owned renderer state. Deliberately ignores the
+// and requires embedder-owned renderer state. Returns false on iOS and after
+// another platform activates external-drain rendering; those embedders must
+// submit through their external render driver instead. Deliberately ignores the
 // occlusion visibility gate so an occluded window still renders a fresh frame
 // (ground-truth capture). The installed render-presented callback fires only
 // after the exact frame is presented to the platform layer (Metal: after the

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -2146,6 +2146,80 @@ pub const AbsoluteScrollSnapshot = struct {
     row_space_revision: u64,
 };
 
+/// Bound for the fractional pixel scroll offset accepted from embedders.
+/// This is far larger than any cell height; it only guards against wildly
+/// wrong values (the offset is a render-space translation, so an absurd
+/// value would just translate content off screen).
+const max_viewport_pixel_offset: f32 = 4096.0;
+
+/// Pixel-precise variant of `scrollToRowIfRevision`: atomically scroll the
+/// viewport to `row` and apply a fractional vertical pixel offset in the
+/// same critical section. The renderer snapshots (viewport, offset) under
+/// the same lock, so a presented frame is always composed from one
+/// consistent scroll position. This is the primitive behind native touch
+/// scrolling on mobile.
+///
+/// `pixel_offset` is a render-space translation: positive values shift
+/// content up by that many pixels, revealing the top sliver of the row
+/// below the viewport bottom (the renderer overscans one row for this).
+/// Callers keep it in [0, cell_height) between rows; values at the row
+/// space edges render as background gap, which is what overscroll
+/// (rubber-band) looks like.
+///
+/// The offset only ever applies to the primary screen. On the alternate
+/// screen it is forced to zero: there is no scrollback and the application
+/// owns its content, so a fractional offset would shear against
+/// app-authored repaints.
+pub fn scrollToRowPixelIfRevision(
+    self: *Surface,
+    row: usize,
+    pixel_offset: f32,
+    expected_row_space_revision: u64,
+) !?AbsoluteScrollSnapshot {
+    if (!std.math.isFinite(pixel_offset)) return null;
+    const clamped = std.math.clamp(
+        pixel_offset,
+        -max_viewport_pixel_offset,
+        max_viewport_pixel_offset,
+    );
+
+    const snapshot: AbsoluteScrollSnapshot = snapshot: {
+        self.renderer_state.lockDemand(global.io());
+        defer self.renderer_state.unlockDemand(global.io());
+
+        const screens = &self.renderer_state.terminal.screens;
+        const screen_key = screens.active_key;
+        var scrollbar = screens.active.pages.scrollbar();
+        const revision = self.rowSpaceIdentity(
+            screen_key,
+            screens.generation(screen_key),
+            scrollbar.row_space_revision,
+        );
+        if (revision != expected_row_space_revision) return null;
+
+        // scroll() resets the pixel offset, so set it afterwards while
+        // still holding the lock.
+        screens.active.scroll(.{ .row = row });
+        if (screen_key == .primary) {
+            screens.active.pages.viewport_pixel_offset = clamped;
+        }
+
+        scrollbar = screens.active.pages.scrollbar();
+        break :snapshot .{
+            .total = @intCast(scrollbar.total),
+            .offset = @intCast(scrollbar.offset),
+            .len = @intCast(scrollbar.len),
+            .row_space_revision = self.rowSpaceIdentity(
+                screen_key,
+                screens.generation(screen_key),
+                scrollbar.row_space_revision,
+            ),
+        };
+    };
+    try self.queueRender();
+    return snapshot;
+}
+
 /// Scroll to an absolute row only while the caller's row-space identity is
 /// still current. Validation, mutation, and the returned geometry share the
 /// renderer-state lock so destructive output cannot race the operation.

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -2185,6 +2185,14 @@ pub fn scrollToRowIfRevision(
     return snapshot;
 }
 
+/// Try to move the viewport to the bottom without waiting on terminal state.
+/// This is used by embedded display-driven clients when user input should
+/// reveal the prompt, but the render/output serial queue must never block on a
+/// busy PTY parser or renderer lock.
+pub fn tryScrollToBottom(self: *Surface) bool {
+    return self.io.tryScrollViewport(.{ .bottom = {} });
+}
+
 fn hashRowSpaceIdentity(
     surface_id: u64,
     screen_key: terminal.ScreenSet.Key,

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -3375,6 +3375,38 @@ pub const CAPI = struct {
         return true;
     }
 
+    /// Pixel-precise variant of `ghostty_surface_scroll_to_row_if_revision`:
+    /// atomically scroll the viewport to `row` and apply a fractional
+    /// vertical pixel offset in the same critical section. Positive offsets
+    /// shift rendered content up, revealing the top sliver of the next row
+    /// (the renderer overscans one row). The offset is a render-space
+    /// translation only; terminal state and the PTY-visible grid are
+    /// unaffected, and it is forced to zero on the alternate screen. Any
+    /// other viewport move (mouse wheel, keyboard scroll, scroll-to-bottom
+    /// on output) resets the offset to zero.
+    export fn ghostty_surface_scroll_to_row_pixel_if_revision(
+        surface: *Surface,
+        row: u64,
+        pixel_offset: f32,
+        expected_row_space_revision: u64,
+        result: *SurfaceScrollbar,
+    ) bool {
+        const target_row = std.math.cast(usize, row) orelse return false;
+        const maybe_snapshot = surface.core_surface.scrollToRowPixelIfRevision(
+            target_row,
+            pixel_offset,
+            expected_row_space_revision,
+        ) catch return false;
+        const snapshot = maybe_snapshot orelse return false;
+        result.* = .{
+            .total = snapshot.total,
+            .offset = snapshot.offset,
+            .len = snapshot.len,
+            .row_space_revision = snapshot.row_space_revision,
+        };
+        return true;
+    }
+
     const RenderGridStyle = struct {
         id: u32,
         foreground: terminal.color.RGB,

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -5082,6 +5082,13 @@ pub const CAPI = struct {
         };
     }
 
+    /// Try to reveal the terminal prompt without waiting on the renderer-state
+    /// mutex. Embedded display-driven clients retry a false result on their
+    /// next frame instead of blocking the queue that also drains output.
+    export fn ghostty_surface_try_scroll_to_bottom(surface: *Surface) bool {
+        return surface.core_surface.tryScrollToBottom();
+    }
+
     /// Complete a clipboard read request started via the read callback.
     /// This can only be called once for a given request. Once it is called
     /// with a request the request pointer will be invalidated.

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -664,6 +664,11 @@ pub const IoWriteCallback = *const fn (?*anyopaque, [*]const u8, usize) callconv
 pub const PtyTeeCallback = *const fn (?*anyopaque, [*]const u8, usize) callconv(.c) void;
 pub const RendererEventCallback = renderer.InstrumentationCallback;
 pub const RenderPresentedCallback = *const fn (?*anyopaque, u64) callconv(.c) void;
+pub const RenderFailedCallback = *const fn (
+    ?*anyopaque,
+    u64,
+    renderer.RenderPresentationStatus,
+) callconv(.c) void;
 pub const FontSizeActionCallback = *const fn (
     ?*anyopaque,
     CoreSurface.FontSizeActionKind,
@@ -849,6 +854,8 @@ pub const Surface = struct {
     // the public by-value Options ABI.
     render_presented_cb: ?RenderPresentedCallback = null,
     render_presented_userdata: ?*anyopaque = null,
+    render_failed_cb: ?RenderFailedCallback = null,
+    render_failed_userdata: ?*anyopaque = null,
     // Binding callbacks run on the GUI thread. These fields belong to this
     // exact embedded surface and are never inherited by child surfaces.
     font_size_action_cb: ?FontSizeActionCallback = null,
@@ -1425,11 +1432,14 @@ pub const Surface = struct {
             self.renderNow();
             return;
         };
+        const failure_callback = self.render_failed_cb;
         self.core_surface.applyPendingResizeIfNeeded();
         self.core_surface.renderer_thread.renderNowWithPresentation(.{
             .callback = callback,
             .userdata = self.render_presented_userdata,
             .token = token,
+            .failure_callback = failure_callback,
+            .failure_userdata = self.render_failed_userdata,
         });
     }
 
@@ -1443,10 +1453,13 @@ pub const Surface = struct {
     /// another tokened draw is still pending.
     pub fn requestRenderWithToken(self: *Surface, token: u64) bool {
         const callback = self.render_presented_cb orelse return false;
+        const failure_callback = self.render_failed_cb;
         return self.core_surface.renderer_thread.requestDrawWithPresentation(.{
             .callback = callback,
             .userdata = self.render_presented_userdata,
             .token = token,
+            .failure_callback = failure_callback,
+            .failure_userdata = self.render_failed_userdata,
         });
     }
 
@@ -3177,6 +3190,23 @@ pub const CAPI = struct {
 
         surface.render_presented_cb = registered_callback;
         surface.render_presented_userdata = userdata;
+        return true;
+    }
+
+    /// Install the one-shot callback for an explicitly tokened render that did
+    /// not reach the host layer. The callback receives the exact token and a
+    /// terminal disposition, so an embedder never has to infer a dropped
+    /// frame from a watchdog timeout.
+    export fn ghostty_surface_set_render_failed_callback(
+        surface: *Surface,
+        callback: ?RenderFailedCallback,
+        userdata: ?*anyopaque,
+    ) bool {
+        const registered_callback = callback orelse return false;
+        if (surface.render_failed_cb != null) return false;
+
+        surface.render_failed_cb = registered_callback;
+        surface.render_failed_userdata = userdata;
         return true;
     }
 
@@ -5545,6 +5575,12 @@ test "render grid preserves terminal color semantics" {
 test "render presentation callback setter is per surface" {
     const Callbacks = struct {
         fn renderPresented(_: ?*anyopaque, _: u64) callconv(.c) void {}
+
+        fn renderFailed(
+            _: ?*anyopaque,
+            _: u64,
+            _: renderer.FramePresentation.Status,
+        ) callconv(.c) void {}
     };
 
     var parent_userdata: u8 = 0;
@@ -5552,9 +5588,13 @@ test "render presentation callback setter is per surface" {
     var parent: Surface = undefined;
     parent.render_presented_cb = null;
     parent.render_presented_userdata = null;
+    parent.render_failed_cb = null;
+    parent.render_failed_userdata = null;
     var child: Surface = undefined;
     child.render_presented_cb = null;
     child.render_presented_userdata = null;
+    child.render_failed_cb = null;
+    child.render_failed_userdata = null;
 
     try std.testing.expect(CAPI.ghostty_surface_set_render_presented_callback(
         &parent,
@@ -5597,6 +5637,23 @@ test "render presentation callback setter is per surface" {
         @as(?*anyopaque, &parent_userdata),
         parent.render_presented_userdata,
     );
+
+    try std.testing.expect(CAPI.ghostty_surface_set_render_failed_callback(
+        &parent,
+        Callbacks.renderFailed,
+        &parent_userdata,
+    ));
+    try std.testing.expectEqual(Callbacks.renderFailed, parent.render_failed_cb);
+    try std.testing.expectEqual(
+        @as(?*anyopaque, &parent_userdata),
+        parent.render_failed_userdata,
+    );
+    try std.testing.expect(!CAPI.ghostty_surface_set_render_failed_callback(
+        &parent,
+        Callbacks.renderFailed,
+        &child_userdata,
+    ));
+    try std.testing.expectEqual(null, child.render_failed_cb);
 }
 
 test "font size action callback preserves resolved action events" {

--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -74,7 +74,7 @@ pub const FramePresentation = struct {
     pub fn fail(self: FramePresentation, status: Status) void {
         if (self.delivery_gate) |gate| gate(self.delivery_gate_userdata);
         if (self.failure_callback) |callback| {
-            callback(self.failure_userdata orelse self.userdata, self.token, status);
+            callback(self.failure_userdata, self.token, status);
         }
     }
 };

--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -150,9 +150,37 @@ test "failed frame presentation reports after its delivery gate" {
         .delivery_gate = &TestState.gate,
         .delivery_gate_userdata = &state,
         .failure_callback = &TestState.callback,
+        .failure_userdata = &state,
     };
     presentation.fail(.discarded);
     try testing.expectEqualSlices(u8, &.{ 1, 2 }, state.events[0..state.len]);
+}
+
+test "failed frame presentation preserves null callback userdata" {
+    const testing = @import("std").testing;
+    const TestState = struct {
+        var saw_null_userdata = false;
+
+        fn callback(
+            userdata: ?*anyopaque,
+            _: u64,
+            _: FramePresentation.Status,
+        ) callconv(.c) void {
+            saw_null_userdata = userdata == null;
+        }
+    };
+
+    TestState.saw_null_userdata = false;
+    var unrelated_userdata: u8 = 0;
+    const presentation: FramePresentation = .{
+        .callback = undefined,
+        .userdata = &unrelated_userdata,
+        .token = 42,
+        .failure_callback = &TestState.callback,
+        .failure_userdata = null,
+    };
+    presentation.fail(.backend_failed);
+    try testing.expect(TestState.saw_null_userdata);
 }
 
 test "forced draw transfers synchronous presentation to its caller" {

--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -44,11 +44,22 @@ pub const lib = @import("lib/main.zig");
 /// support it invoke the callback only after the exact frame is presented to
 /// the platform layer.
 pub const FramePresentation = struct {
+    /// Final disposition of an explicitly tokened frame. A frame can fail
+    /// after the renderer has handed its IOSurface to the host, so the
+    /// embedder needs a terminal outcome for both success and discard paths.
+    pub const Status = enum(c_int) {
+        presented = 0,
+        discarded = 1,
+        backend_failed = 2,
+    };
+
     callback: *const fn (?*anyopaque, u64) callconv(.c) void,
     userdata: ?*anyopaque,
     token: u64,
     delivery_gate: ?*const fn (?*anyopaque) callconv(.c) void = null,
     delivery_gate_userdata: ?*anyopaque = null,
+    failure_callback: ?*const fn (?*anyopaque, u64, Status) callconv(.c) void = null,
+    failure_userdata: ?*anyopaque = null,
 
     /// Deliver only after the backend-specific gate confirms the renderer has
     /// left its draw critical section.
@@ -56,7 +67,20 @@ pub const FramePresentation = struct {
         if (self.delivery_gate) |gate| gate(self.delivery_gate_userdata);
         self.callback(self.userdata, self.token);
     }
+
+    /// Release the renderer gate and report a terminal non-presented outcome.
+    /// The gate runs first for the same reason as ``deliver``: foreign code
+    /// must never be called while the renderer draw critical section is held.
+    pub fn fail(self: FramePresentation, status: Status) void {
+        if (self.delivery_gate) |gate| gate(self.delivery_gate_userdata);
+        if (self.failure_callback) |callback| {
+            callback(self.failure_userdata orelse self.userdata, self.token, status);
+        }
+    }
 };
+
+/// C-facing name for the disposition carried by ``FramePresentation``.
+pub const RenderPresentationStatus = FramePresentation.Status;
 
 test "frame presentation waits for its delivery gate" {
     const testing = @import("std").testing;
@@ -89,6 +113,45 @@ test "frame presentation waits for its delivery gate" {
         .delivery_gate_userdata = &state,
     };
     presentation.deliver();
+    try testing.expectEqualSlices(u8, &.{ 1, 2 }, state.events[0..state.len]);
+}
+
+test "failed frame presentation reports after its delivery gate" {
+    const testing = @import("std").testing;
+    const TestState = struct {
+        events: [2]u8 = @splat(0),
+        len: usize = 0,
+
+        fn append(self: *@This(), event: u8) void {
+            self.events[self.len] = event;
+            self.len += 1;
+        }
+
+        fn gate(userdata: ?*anyopaque) callconv(.c) void {
+            const self: *@This() = @ptrCast(@alignCast(userdata.?));
+            self.append(1);
+        }
+
+        fn callback(
+            userdata: ?*anyopaque,
+            _: u64,
+            status: FramePresentation.Status,
+        ) callconv(.c) void {
+            const self: *@This() = @ptrCast(@alignCast(userdata.?));
+            self.append(if (status == .discarded) 2 else 3);
+        }
+    };
+
+    var state: TestState = .{};
+    const presentation: FramePresentation = .{
+        .callback = undefined,
+        .userdata = &state,
+        .token = 42,
+        .delivery_gate = &TestState.gate,
+        .delivery_gate_userdata = &state,
+        .failure_callback = &TestState.callback,
+    };
+    presentation.fail(.discarded);
     try testing.expectEqualSlices(u8, &.{ 1, 2 }, state.events[0..state.len]);
 }
 

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -1053,6 +1053,13 @@ fn takePendingDrawPresentation(self: *Thread) ?rendererpkg.FramePresentation {
     return presentation;
 }
 
+test "tokened draw queue admission rejects external drain mode" {
+    const testing = std.testing;
+    try testing.expect(tokenedDrawQueueAdmissionAllows(false, false));
+    try testing.expect(!tokenedDrawQueueAdmissionAllows(false, true));
+    try testing.expect(!tokenedDrawQueueAdmissionAllows(true, false));
+}
+
 /// Finish a forced draw before delivering a synchronous backend presentation.
 /// Delivery is the final operation because it may reentrantly destroy Thread.
 fn finishRenderNowWithPresentation(

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -1021,17 +1021,22 @@ pub fn renderNowWithPresentation(
 /// render cycle on the calling thread (safe only when the embedder owns
 /// renderer state, i.e. iOS external-drain mode), this is safe to call from
 /// any thread while the renderer OS thread is live: it only fills the pending
-/// slot and rings the existing `draw_now` async. Returns false when another
-/// tokened draw is still pending or the wakeup could not be delivered; the
-/// caller may retry.
+/// slot and rings the existing `draw_now` async. iOS always uses an external
+/// render driver, so this entrypoint rejects iOS before queueing. It also
+/// returns false after another platform enters external-drain mode, when
+/// another tokened draw is pending, or when the wakeup could not be delivered.
 pub fn requestDrawWithPresentation(
     self: *Thread,
     presentation: rendererpkg.FramePresentation,
 ) bool {
+    if (comptime builtin.os.tag == .ios) return false;
     {
         self.pending_draw_presentation_mutex.lockUncancelable(global.io());
         defer self.pending_draw_presentation_mutex.unlock(global.io());
-        if (self.pending_draw_presentation != null) return false;
+        if (!tokenedDrawQueueAdmissionAllows(
+            self.externalDrainActive(),
+            self.pending_draw_presentation != null,
+        )) return false;
         self.pending_draw_presentation = presentation;
     }
     self.draw_now.notify() catch |err| {
@@ -1051,6 +1056,13 @@ fn takePendingDrawPresentation(self: *Thread) ?rendererpkg.FramePresentation {
     const presentation = self.pending_draw_presentation;
     self.pending_draw_presentation = null;
     return presentation;
+}
+
+fn tokenedDrawQueueAdmissionAllows(
+    external_drain_active: bool,
+    has_pending_presentation: bool,
+) bool {
+    return !external_drain_active and !has_pending_presentation;
 }
 
 test "tokened draw queue admission rejects external drain mode" {
@@ -1847,15 +1859,23 @@ fn drawNowCallback(
     // Draw immediately. App-thread submission recovery has its own async, so
     // this remains a pure display-link draw and cannot consume stale retries.
     const t = self_.?;
-    if (t.externalDrainActive()) return .rearm;
+    if (t.externalDrainActive()) {
+        // Close the admission race with enterExternalDrainMode: a request
+        // accepted immediately before the transition still receives a
+        // terminal disposition instead of occupying the slot forever.
+        if (t.takePendingDrawPresentation()) |presentation| {
+            presentation.fail(.backend_failed);
+        }
+        return .rearm;
+    }
 
     // cmux fork: a queued tokened draw takes this wake. It rebuilds frame data
     // from current terminal state and skips the `flags.visible` gate on
     // purpose (drawFrame's early-return): the whole point of the tokened path
     // is ground-truth capture of a window the compositor considers occluded.
     // The renderer-realized gate still applies (drawing unrealized GPU state
-    // is invalid); an unconsumed presentation is dropped and its callback
-    // never fires, which the embedder surfaces as a timeout.
+    // is invalid); every consumed presentation receives a success or failure
+    // callback before this renderer accepts another token.
     if (t.takePendingDrawPresentation()) |presentation| {
         drawPendingTokenedFrame(t, presentation);
         return .rearm;

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -1005,6 +1005,7 @@ pub fn renderNowWithPresentation(
 
     self.updateFrame(self.effectiveCursorBlinkVisible()) catch |err| {
         log.warn("renderNowWithPresentation: error updating frame err={}", .{err});
+        presentation.fail(.backend_failed);
         return;
     };
 
@@ -1068,9 +1069,13 @@ fn finishRenderNowWithPresentation(
             error.Timeout => log.warn("renderNowWithPresentation: frame acquire timeout", .{}),
             else => log.warn("renderNowWithPresentation: error drawing err={}", .{err}),
         }
+        presentation.fail(.backend_failed);
         return;
     };
 
+    // Metal returns null here because its completion handler owns delivery;
+    // synchronous backends return the presentation value for this final
+    // handoff. A null result is therefore not itself a failure.
     const value = completed orelse return;
     value.deliver();
 }
@@ -1868,10 +1873,12 @@ fn drawPendingTokenedFrame(
 ) void {
     if (!t.renderer_realized) {
         log.warn("tokened draw skipped: renderer unrealized", .{});
+        presentation.fail(.backend_failed);
         return;
     }
     t.updateFrame(t.effectiveCursorBlinkVisible()) catch |err| {
         log.warn("tokened draw: error updating frame err={}", .{err});
+        presentation.fail(.backend_failed);
         return;
     };
     finishRenderNowWithPresentation(

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -974,6 +974,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                     .screen_size = undefined,
                     .padding_extend = .{},
                     .min_contrast = options.config.min_contrast,
+                    .scroll_offset = 0,
                     .cursor_pos = .{ std.math.maxInt(u16), std.math.maxInt(u16) },
                     .cursor_color = undefined,
                     .bg_color = .{
@@ -2750,13 +2751,18 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
         ) Allocator.Error!void {
             const state: *terminal.RenderState = &self.terminal_state;
 
+            // The GPU cell grid covers the viewport plus any overscan row
+            // needed by an active fractional pixel scroll offset.
+            const state_rows: terminal.size.CellCountInt =
+                state.rows + state.overscan_rows;
+
             const grid_size_diff =
-                self.cells.size.rows != state.rows or
+                self.cells.size.rows != state_rows or
                 self.cells.size.columns != state.cols;
 
             if (grid_size_diff) {
                 var new_size = self.cells.size;
-                new_size.rows = state.rows;
+                new_size.rows = state_rows;
                 new_size.columns = state.cols;
                 try self.cells.resize(self.alloc, new_size);
 
@@ -2764,6 +2770,11 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 // our background cells will be out of place.
                 self.uniforms.grid_size = .{ new_size.columns, new_size.rows };
             }
+
+            // The fractional pixel scroll offset is applied by the shaders
+            // as a vertical translation of every grid-positioned primitive,
+            // so a (content, offset) pair is always composed in one frame.
+            self.uniforms.scroll_offset = state.pixel_offset;
 
             const rebuild = state.dirty == .full or grid_size_diff;
             if (rebuild) {
@@ -2804,7 +2815,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             // the viewport is shorter than the cell contents buffer, we align
             // the top of the viewport with the top of the contents buffer.
             const row_len: usize = @min(
-                state.rows,
+                state_rows,
                 self.cells.size.rows,
             );
 

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -1820,9 +1820,14 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             // Retrieve the most up-to-date surface size from the Graphics API
             const surface_size = try self.api.surfaceSize();
 
-            // If either of our surface dimensions is zero
-            // then drawing is absurd, so we just return.
-            if (surface_size.width == 0 or surface_size.height == 0) return null;
+            // If either of our surface dimensions is zero then drawing is
+            // absurd. A tokened embedder still needs a terminal disposition,
+            // otherwise its presentation gate would wait for a frame that
+            // was never submitted.
+            if (surface_size.width == 0 or surface_size.height == 0) {
+                if (presentation) |value| value.fail(.discarded);
+                return null;
+            }
 
             const size_changed =
                 self.size.screen.width != surface_size.width or
@@ -1841,6 +1846,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 // apprt may be swapping buffers and display an outdated frame
                 // if we don't draw something new.
                 try self.api.presentLastTarget();
+                if (presentation) |value| value.fail(.discarded);
                 return null;
             }
             var damage = DrawDamageCommit.begin(&self.cells_rebuilt);

--- a/src/renderer/metal/Frame.zig
+++ b/src/renderer/metal/Frame.zig
@@ -325,6 +325,7 @@ test "tokened completion freezes target before recycling slot" {
         dispatch,
         deinit,
         release_presentation_ownership,
+        delivery_gate,
     };
     const Event = struct {
         kind: EventKind,
@@ -414,14 +415,21 @@ test "tokened completion freezes target before recycling slot" {
     };
     const Callbacks = struct {
         fn presented(_: ?*anyopaque, _: u64) callconv(.c) void {}
+
+        fn deliveryGate(userdata: ?*anyopaque) callconv(.c) void {
+            const state: *State = @ptrCast(@alignCast(userdata.?));
+            state.append(.delivery_gate, 0);
+        }
     };
+    var state: State = .{};
     const presentation: FramePresentation = .{
         .callback = &Callbacks.presented,
-        .userdata = null,
+        .userdata = &state,
         .token = 42,
+        .delivery_gate = &Callbacks.deliveryGate,
+        .delivery_gate_userdata = &state,
     };
 
-    var state: State = .{};
     var renderer: MockRenderer = .{ .api = .{ .state = &state } };
     var target: MockTarget = .{ .id = 1, .state = &state };
     completeHealthyFrame(&renderer, &target, false, 1, 0, presentation);
@@ -441,6 +449,7 @@ test "tokened completion freezes target before recycling slot" {
     completeHealthyFrame(&renderer, &target, false, 2, 0, presentation);
     try testing.expectEqualSlices(Event, &.{
         .{ .kind = .complete, .target_id = 4 },
+        .{ .kind = .delivery_gate, .target_id = 0 },
     }, state.events[0..state.len]);
 
     // Ordinary frames retain the allocation-free presentation path.

--- a/src/renderer/metal/Frame.zig
+++ b/src/renderer/metal/Frame.zig
@@ -196,12 +196,12 @@ fn bufferCompleted(
         block.frame_token,
         false,
     );
-    if (block.presentation_failure_callback) |callback| {
+    if (block.presentation_callback) |callback| {
         (FramePresentation{
-            .callback = undefined,
+            .callback = callback,
             .userdata = block.presentation_userdata,
             .token = block.presentation_token,
-            .failure_callback = callback,
+            .failure_callback = block.presentation_failure_callback,
             .failure_userdata = block.presentation_failure_userdata,
             .delivery_gate = block.presentation_delivery_gate,
             .delivery_gate_userdata = block.presentation_delivery_gate_userdata,
@@ -224,7 +224,7 @@ fn completeHealthyFrame(
         var frozen = renderer.api.detachPresentationTarget(target) catch |err| {
             log.warn("Failed to detach tokened render target: err={}", .{err});
             renderer.frameCompleted(target, .healthy, frame_token, false);
-            if (value.failure_callback != null) value.fail(.backend_failed);
+            value.fail(.backend_failed);
             return;
         };
         defer frozen.releasePresentationOwnership();

--- a/src/renderer/metal/Frame.zig
+++ b/src/renderer/metal/Frame.zig
@@ -111,6 +111,8 @@ pub fn begin(
             .presentation_callback = if (presentation) |value| value.callback else null,
             .presentation_userdata = if (presentation) |value| value.userdata else null,
             .presentation_token = if (presentation) |value| value.token else 0,
+            .presentation_failure_callback = if (presentation) |value| value.failure_callback else null,
+            .presentation_failure_userdata = if (presentation) |value| value.failure_userdata else null,
             .presentation_delivery_gate = if (presentation) |value| value.delivery_gate else null,
             .presentation_delivery_gate_userdata = if (presentation) |value| value.delivery_gate_userdata else null,
         },
@@ -130,6 +132,12 @@ const CompletionBlock = objc.Block(struct {
     presentation_callback: ?*const fn (?*anyopaque, u64) callconv(.c) void,
     presentation_userdata: ?*anyopaque,
     presentation_token: u64,
+    presentation_failure_callback: ?*const fn (
+        ?*anyopaque,
+        u64,
+        FramePresentation.Status,
+    ) callconv(.c) void,
+    presentation_failure_userdata: ?*anyopaque,
     presentation_delivery_gate: ?*const fn (?*anyopaque) callconv(.c) void,
     presentation_delivery_gate_userdata: ?*anyopaque,
 }, .{
@@ -173,6 +181,8 @@ fn bufferCompleted(
                 .callback = callback,
                 .userdata = block.presentation_userdata,
                 .token = block.presentation_token,
+                .failure_callback = block.presentation_failure_callback,
+                .failure_userdata = block.presentation_failure_userdata,
                 .delivery_gate = block.presentation_delivery_gate,
                 .delivery_gate_userdata = block.presentation_delivery_gate_userdata,
             } else null,
@@ -186,6 +196,17 @@ fn bufferCompleted(
         block.frame_token,
         false,
     );
+    if (block.presentation_failure_callback) |callback| {
+        (FramePresentation{
+            .callback = undefined,
+            .userdata = block.presentation_userdata,
+            .token = block.presentation_token,
+            .failure_callback = callback,
+            .failure_userdata = block.presentation_failure_userdata,
+            .delivery_gate = block.presentation_delivery_gate,
+            .delivery_gate_userdata = block.presentation_delivery_gate_userdata,
+        }).fail(.backend_failed);
+    }
 }
 
 /// Present one healthy completed frame and recycle its exact swap-chain slot.
@@ -203,6 +224,7 @@ fn completeHealthyFrame(
         var frozen = renderer.api.detachPresentationTarget(target) catch |err| {
             log.warn("Failed to detach tokened render target: err={}", .{err});
             renderer.frameCompleted(target, .healthy, frame_token, false);
+            if (value.failure_callback != null) value.fail(.backend_failed);
             return;
         };
         defer frozen.releasePresentationOwnership();

--- a/src/renderer/metal/IOSurfaceLayer.zig
+++ b/src/renderer/metal/IOSurfaceLayer.zig
@@ -182,6 +182,8 @@ pub const PreparedSurfaceUpdate = struct {
             .presentation_callback = self.presentation.callback,
             .presentation_userdata = self.presentation.userdata,
             .presentation_token = self.presentation.token,
+            .presentation_failure_callback = self.presentation.failure_callback,
+            .presentation_failure_userdata = self.presentation.failure_userdata,
             .presentation_delivery_gate = self.presentation.delivery_gate,
             .presentation_delivery_gate_userdata = self.presentation.delivery_gate_userdata,
         }, &setSurfaceCallback);
@@ -235,6 +237,8 @@ fn setSurface_(
         .presentation_callback = if (presentation) |value| value.callback else null,
         .presentation_userdata = if (presentation) |value| value.userdata else null,
         .presentation_token = if (presentation) |value| value.token else 0,
+        .presentation_failure_callback = if (presentation) |value| value.failure_callback else null,
+        .presentation_failure_userdata = if (presentation) |value| value.failure_userdata else null,
         .presentation_delivery_gate = if (presentation) |value| value.delivery_gate else null,
         .presentation_delivery_gate_userdata = if (presentation) |value| value.delivery_gate_userdata else null,
     }, &setSurfaceCallback);
@@ -339,6 +343,12 @@ const SetSurfaceBlock = objc.Block(struct {
     presentation_callback: ?*const fn (?*anyopaque, u64) callconv(.c) void,
     presentation_userdata: ?*anyopaque,
     presentation_token: u64,
+    presentation_failure_callback: ?*const fn (
+        ?*anyopaque,
+        u64,
+        FramePresentation.Status,
+    ) callconv(.c) void,
+    presentation_failure_userdata: ?*anyopaque,
     presentation_delivery_gate: ?*const fn (?*anyopaque) callconv(.c) void,
     presentation_delivery_gate_userdata: ?*anyopaque,
 }, .{}, void);
@@ -388,9 +398,13 @@ fn setSurfaceCallback(
             "setSurfaceCallback(): surface is wrong size for layer, discarding. surface = {d}x{d}, layer = {d}x{d}",
             .{ surface.getWidth(), surface.getHeight(), width, height },
         );
+        notifyPresentationFailure(block, .discarded);
         return;
     }
-    if (!block.surface_generation.shouldCommit(block.generation)) return;
+    if (!block.surface_generation.shouldCommit(block.generation)) {
+        notifyPresentationFailure(block, .discarded);
+        return;
+    }
 
     layer.setProperty("contents", surface);
     block.surface_generation.commit(block.generation);
@@ -399,6 +413,25 @@ fn setSurfaceCallback(
             gate(block.presentation_delivery_gate_userdata);
         }
         callback(block.presentation_userdata, block.presentation_token);
+    }
+}
+
+fn notifyPresentationFailure(
+    block: *const SetSurfaceBlock.Context,
+    status: FramePresentation.Status,
+) void {
+    if (block.presentation_failure_callback) |callback| {
+        if (block.presentation_delivery_gate) |gate| {
+            gate(block.presentation_delivery_gate_userdata);
+        }
+        callback(
+            block.presentation_failure_userdata orelse block.presentation_userdata,
+            block.presentation_token,
+            status,
+        );
+    } else if (block.presentation_callback == null) {
+        // No callback owns this ordinary surface assignment.
+        return;
     }
 }
 
@@ -512,6 +545,7 @@ test "tokened surface updates defer delivery and teardown invalidates them" {
     const CallbackState = struct {
         gate_count: usize = 0,
         callback_count: usize = 0,
+        failure_count: usize = 0,
 
         fn gate(userdata: ?*anyopaque) callconv(.c) void {
             const self: *@This() = @ptrCast(@alignCast(userdata.?));
@@ -521,6 +555,15 @@ test "tokened surface updates defer delivery and teardown invalidates them" {
         fn callback(userdata: ?*anyopaque, _: u64) callconv(.c) void {
             const self: *@This() = @ptrCast(@alignCast(userdata.?));
             self.callback_count += 1;
+        }
+
+        fn failure(
+            userdata: ?*anyopaque,
+            _: u64,
+            _: FramePresentation.Status,
+        ) callconv(.c) void {
+            const self: *@This() = @ptrCast(@alignCast(userdata.?));
+            self.failure_count += 1;
         }
     };
 
@@ -557,6 +600,8 @@ test "tokened surface updates defer delivery and teardown invalidates them" {
         .presentation_callback = &CallbackState.callback,
         .presentation_userdata = &state,
         .presentation_token = 42,
+        .presentation_failure_callback = &CallbackState.failure,
+        .presentation_failure_userdata = &state,
         .presentation_delivery_gate = &CallbackState.gate,
         .presentation_delivery_gate_userdata = &state,
     }, &setSurfaceCallback);
@@ -564,6 +609,7 @@ test "tokened surface updates defer delivery and teardown invalidates them" {
 
     try testing.expectEqual(@as(usize, 0), state.gate_count);
     try testing.expectEqual(@as(usize, 0), state.callback_count);
+    try testing.expectEqual(@as(usize, 0), state.failure_count);
 }
 
 test "clear surface drops displayed IOSurface without disabling future updates" {

--- a/src/renderer/metal/IOSurfaceLayer.zig
+++ b/src/renderer/metal/IOSurfaceLayer.zig
@@ -420,19 +420,15 @@ fn notifyPresentationFailure(
     block: *const SetSurfaceBlock.Context,
     status: FramePresentation.Status,
 ) void {
-    if (block.presentation_failure_callback) |callback| {
-        if (block.presentation_delivery_gate) |gate| {
-            gate(block.presentation_delivery_gate_userdata);
-        }
-        callback(
-            block.presentation_failure_userdata orelse block.presentation_userdata,
-            block.presentation_token,
-            status,
-        );
-    } else if (block.presentation_callback == null) {
-        // No callback owns this ordinary surface assignment.
-        return;
+    const callback = block.presentation_failure_callback orelse return;
+    if (block.presentation_delivery_gate) |gate| {
+        gate(block.presentation_delivery_gate_userdata);
     }
+    callback(
+        block.presentation_failure_userdata orelse block.presentation_userdata,
+        block.presentation_token,
+        status,
+    );
 }
 
 fn detachFromHostCallback(

--- a/src/renderer/metal/IOSurfaceLayer.zig
+++ b/src/renderer/metal/IOSurfaceLayer.zig
@@ -608,6 +608,51 @@ test "tokened surface updates defer delivery and teardown invalidates them" {
     try testing.expectEqual(@as(usize, 0), state.failure_count);
 }
 
+test "discarded surface update releases a gate without a failure callback" {
+    const testing = std.testing;
+    const CallbackState = struct {
+        gate_count: usize = 0,
+
+        fn gate(userdata: ?*anyopaque) callconv(.c) void {
+            const self: *@This() = @ptrCast(@alignCast(userdata.?));
+            self.gate_count += 1;
+        }
+
+        fn callback(_: ?*anyopaque, _: u64) callconv(.c) void {}
+    };
+
+    var layer = try IOSurfaceLayer.init();
+    defer layer.release();
+    var surface = try IOSurface.init(.{
+        .width = 1,
+        .height = 1,
+        .pixel_format = .@"32BGRA",
+        .bytes_per_element = 4,
+        .colorspace = null,
+    });
+    defer surface.deinit();
+    surface.retain();
+    layer.surface_generation.retain();
+
+    var state: CallbackState = .{};
+    var block = SetSurfaceBlock.init(.{
+        .layer = layer.layer.value,
+        .surface = surface,
+        .surface_generation = layer.surface_generation,
+        .generation = layer.surface_generation.schedule(),
+        .presentation_callback = &CallbackState.callback,
+        .presentation_userdata = null,
+        .presentation_token = 42,
+        .presentation_failure_callback = null,
+        .presentation_failure_userdata = null,
+        .presentation_delivery_gate = &CallbackState.gate,
+        .presentation_delivery_gate_userdata = &state,
+    }, &setSurfaceCallback);
+    setSurfaceCallback(&block);
+
+    try testing.expectEqual(@as(usize, 1), state.gate_count);
+}
+
 test "clear surface drops displayed IOSurface without disabling future updates" {
     const testing = std.testing;
 

--- a/src/renderer/metal/IOSurfaceLayer.zig
+++ b/src/renderer/metal/IOSurfaceLayer.zig
@@ -420,15 +420,16 @@ fn notifyPresentationFailure(
     block: *const SetSurfaceBlock.Context,
     status: FramePresentation.Status,
 ) void {
-    const callback = block.presentation_failure_callback orelse return;
     if (block.presentation_delivery_gate) |gate| {
         gate(block.presentation_delivery_gate_userdata);
     }
-    callback(
-        block.presentation_failure_userdata orelse block.presentation_userdata,
-        block.presentation_token,
-        status,
-    );
+    if (block.presentation_failure_callback) |callback| {
+        callback(
+            block.presentation_failure_userdata,
+            block.presentation_token,
+            status,
+        );
+    }
 }
 
 fn detachFromHostCallback(

--- a/src/renderer/metal/shaders.zig
+++ b/src/renderer/metal/shaders.zig
@@ -566,6 +566,12 @@ pub const Uniforms = extern struct {
     /// according to the WCAG 2.0 spec.
     min_contrast: f32 align(4),
 
+    /// Fractional vertical pixel scroll offset. Positive values shift all
+    /// grid-positioned primitives up by this many pixels, revealing the
+    /// overscan row at the bottom of the cell grid. Zero unless the
+    /// embedder drives pixel-precise scrolling.
+    scroll_offset: f32 align(4),
+
     /// The cursor position and color.
     cursor_pos: [2]u16 align(4),
     cursor_color: [4]u8 align(4),

--- a/src/renderer/opengl/Frame.zig
+++ b/src/renderer/opengl/Frame.zig
@@ -81,6 +81,7 @@ fn completeFrame(
     renderer.api.present(target.*) catch |err| {
         log.warn("Failed to present render target: err={}", .{err});
         renderer.frameCompleted(target, .unhealthy, frame_token, false);
+        if (presentation) |value| value.fail(.backend_failed);
         return null;
     };
 
@@ -91,7 +92,9 @@ fn completeFrame(
     // generic renderer carries the returned value outward only after all of
     // its cleanup defers run; Thread delivers after its instrumentation ends.
     renderer.frameCompleted(target, health, frame_token, false);
-    return if (health == .healthy) presentation else null;
+    if (health == .healthy) return presentation;
+    if (presentation) |value| value.fail(.backend_failed);
+    return null;
 }
 
 test "OpenGL acknowledges only after successful present and GPU completion" {

--- a/src/renderer/opengl/shaders.zig
+++ b/src/renderer/opengl/shaders.zig
@@ -181,6 +181,12 @@ pub const Uniforms = extern struct {
     /// according to the WCAG 2.0 spec.
     min_contrast: f32 align(4),
 
+    /// Fractional vertical pixel scroll offset. Positive values shift all
+    /// grid-positioned primitives up by this many pixels, revealing the
+    /// overscan row at the bottom of the cell grid. Zero unless the
+    /// embedder drives pixel-precise scrolling.
+    scroll_offset: f32 align(4),
+
     /// The cursor position and color.
     cursor_pos: [2]u16 align(4),
     cursor_color: [4]u8 align(4),

--- a/src/renderer/shaders/glsl/cell_bg.f.glsl
+++ b/src/renderer/shaders/glsl/cell_bg.f.glsl
@@ -12,7 +12,9 @@ layout(binding = 1, std430) readonly buffer bg_cells {
 
 vec4 cell_bg() {
     uvec2 grid_size = unpack2u16(grid_size_packed_2u16);
-    ivec2 grid_pos = ivec2(floor((gl_FragCoord.xy - grid_padding.wx) / cell_size));
+    // The fractional scroll offset shifts content up, so a fragment samples
+    // the cell `scroll_offset` pixels further down in grid space.
+    ivec2 grid_pos = ivec2(floor((gl_FragCoord.xy - grid_padding.wx + vec2(0.0, scroll_offset)) / cell_size));
     bool use_linear_blending = (bools & USE_LINEAR_BLENDING) != 0;
 
     vec4 bg = vec4(0.0);

--- a/src/renderer/shaders/glsl/cell_text.v.glsl
+++ b/src/renderer/shaders/glsl/cell_text.v.glsl
@@ -105,6 +105,11 @@ void main() {
     // Calculate the final position of the cell which uses our glyph size
     // and glyph offset to create the correct bounding box for the glyph.
     cell_pos = cell_pos + size * corner + offset;
+
+    // Apply the fractional scroll offset as a vertical translation so glyph
+    // motion matches the cell background lookup exactly.
+    cell_pos.y -= scroll_offset;
+
     gl_Position = projection_matrix * vec4(cell_pos.x, cell_pos.y, 0.0f, 1.0f);
 
     // Calculate the texture coordinate in pixels. This is NOT normalized

--- a/src/renderer/shaders/glsl/common.glsl
+++ b/src/renderer/shaders/glsl/common.glsl
@@ -19,6 +19,7 @@ layout(binding = 1, std140) uniform Globals {
     uniform vec4 grid_padding;
     uniform uint padding_extend;
     uniform float min_contrast;
+    uniform float scroll_offset;
     uniform uint cursor_pos_packed_2u16;
     uniform uint cursor_color_packed_4u8;
     uniform uint bg_color_packed_4u8;

--- a/src/renderer/shaders/glsl/image.v.glsl
+++ b/src/renderer/shaders/glsl/image.v.glsl
@@ -43,5 +43,9 @@ void main() {
     vec2 image_pos = (cell_size * grid_pos) + cell_offset;
     image_pos += dest_size * corner;
 
+    // Apply the fractional scroll offset as a vertical translation so images
+    // move with the cell grid.
+    image_pos.y -= scroll_offset;
+
     gl_Position = projection_matrix * vec4(image_pos.xy, 1.0, 1.0);
 }

--- a/src/renderer/shaders/shaders.metal
+++ b/src/renderer/shaders/shaders.metal
@@ -17,6 +17,7 @@ struct Uniforms {
   float4 grid_padding;
   uint8_t padding_extend;
   float min_contrast;
+  float scroll_offset;
   ushort2 cursor_pos;
   uchar4 cursor_color;
   uchar4 bg_color;
@@ -453,7 +454,9 @@ fragment float4 cell_bg_fragment(
   constant Uniforms& uniforms [[buffer(1)]],
   constant uchar4 *cells [[buffer(2)]]
 ) {
-  int2 grid_pos = int2(floor((in.position.xy - uniforms.grid_padding.wx) / uniforms.cell_size));
+  // The fractional scroll offset shifts content up, so a fragment samples
+  // the cell `scroll_offset` pixels further down in grid space.
+  int2 grid_pos = int2(floor((in.position.xy - uniforms.grid_padding.wx + float2(0.0, uniforms.scroll_offset)) / uniforms.cell_size));
 
   float4 bg = float4(0.0);
 
@@ -617,6 +620,11 @@ vertex CellTextVertexOut cell_text_vertex(
   // Calculate the final position of the cell which uses our glyph size
   // and glyph offset to create the correct bounding box for the glyph.
   cell_pos = cell_pos + size * corner + offset;
+
+  // Apply the fractional scroll offset as a vertical translation so glyph
+  // motion matches the cell background lookup exactly.
+  cell_pos.y -= uniforms.scroll_offset;
+
   out.position =
       uniforms.projection_matrix * float4(cell_pos.x, cell_pos.y, 0.0f, 1.0f);
 
@@ -822,6 +830,10 @@ vertex ImageVertexOut image_vertex(
   // adds the source rect width/height components.
   float2 image_pos = (uniforms.cell_size * in.grid_pos) + in.cell_offset;
   image_pos += in.dest_size * corner;
+
+  // Apply the fractional scroll offset as a vertical translation so images
+  // move with the cell grid.
+  image_pos.y -= uniforms.scroll_offset;
 
   out.position =
       uniforms.projection_matrix * float4(image_pos.x, image_pos.y, 0.0f, 1.0f);

--- a/src/terminal/PageList.zig
+++ b/src/terminal/PageList.zig
@@ -454,6 +454,19 @@ viewport_pin: *Pin,
 /// self-evident or quick to calculate.
 viewport_pin_row_offset: ?usize,
 
+/// A fractional vertical pixel offset applied to the viewport by the
+/// embedder for pixel-precise scrolling (e.g. touch scrolling on mobile).
+/// Positive values shift rendered content up by that many pixels, revealing
+/// the top of the row below the viewport bottom. The renderer samples this
+/// together with the viewport in one snapshot, so a (viewport, offset) pair
+/// is always presented atomically.
+///
+/// Any viewport move through `scroll` resets this to zero; embedders that
+/// support pixel scrolling re-apply it after scrolling (see
+/// `Surface.scrollToRowPixelIfRevision`). It is intentionally NOT part of
+/// terminal state semantics: the PTY-visible grid is unaffected.
+viewport_pixel_offset: f32 = 0,
+
 /// The current desired screen dimensions. I say "desired" because individual
 /// pages may still be a different size and not yet reflowed since we lazily
 /// reflow text.
@@ -1271,6 +1284,10 @@ pub fn resize(self: *PageList, opts: Resize) Allocator.Error!void {
     // places and try to update it in place, we just invalidate it because
     // its too easy to get the logic wrong in here.
     self.viewport_pin_row_offset = null;
+
+    // A reflow changes the row space entirely, so a fractional pixel
+    // offset from before the resize is meaningless.
+    self.viewport_pixel_offset = 0;
 
     if (!opts.reflow) return try self.resizeWithoutReflow(opts);
 
@@ -2838,6 +2855,11 @@ pub const Scroll = union(enum) {
 /// previously allocated pages.
 pub fn scroll(self: *PageList, behavior: Scroll) void {
     defer self.assertIntegrity();
+
+    // Any viewport move invalidates a fractional pixel offset previously
+    // applied by the embedder; callers that support pixel scrolling set a
+    // fresh offset after this call returns.
+    self.viewport_pixel_offset = 0;
 
     // Special case no-scrollback mode to never allow scrolling.
     if (self.explicit_max_size == 0) {

--- a/src/terminal/render.zig
+++ b/src/terminal/render.zig
@@ -431,6 +431,7 @@ pub const RenderState = struct {
         self.rows = s.pages.rows;
         self.cols = s.pages.cols;
         self.overscan_rows = overscan_rows;
+        const pixel_offset_changed = self.pixel_offset != pixel_offset;
         self.pixel_offset = pixel_offset;
         self.viewport_pin = viewport_pin;
         self.cursor.active = .{ .x = s.cursor.x, .y = s.cursor.y };
@@ -752,6 +753,12 @@ pub const RenderState = struct {
             // Note: we don't clear any row_data here because our rebuild
             // above did this.
         } else if (any_dirty and self.dirty == .false) {
+            self.dirty = .partial;
+        } else if (pixel_offset_changed and self.dirty == .false) {
+            // A fractional offset change moves every rendered primitive even
+            // when no row content changed (sub-row scrolling within one row).
+            // Mark the state dirty so dirty-gated consumers present a fresh
+            // frame instead of retaining the prior offset.
             self.dirty = .partial;
         }
 
@@ -2487,4 +2494,45 @@ test "overscan row transitions rebuild row data" {
     try state.update(alloc, &t);
     try testing.expectEqual(@as(usize, 3), state.row_data.len);
     try testing.expect(state.dirty == .full);
+}
+
+test "pixel scroll offset change alone marks dirty" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const io = testing.io;
+
+    var t = try Terminal.init(io, alloc, .{
+        .cols = 5,
+        .rows = 3,
+        .max_scrollback = 10_000,
+    });
+    defer t.deinit(alloc);
+
+    var s = t.vtStream();
+    defer s.deinit();
+    s.nextSlice("A\r\nB\r\nC\r\nD\r\nE");
+
+    const pages = &t.screens.active.pages;
+    pages.scroll(.top);
+    pages.viewport_pixel_offset = 2.0;
+
+    var state: RenderState = .empty;
+    defer state.deinit(alloc);
+    try state.update(alloc, &t);
+    try testing.expectEqual(@as(size.CellCountInt, 1), state.overscan_rows);
+
+    // A sub-row offset change with the same viewport pin and overscan count
+    // must still mark the state dirty, or a dirty-gated consumer would
+    // present the stale position.
+    state.dirty = .false;
+    pages.viewport_pixel_offset = 3.0;
+    try state.update(alloc, &t);
+    try testing.expectEqual(@as(size.CellCountInt, 1), state.overscan_rows);
+    try testing.expectEqual(@as(usize, 4), state.row_data.len);
+    try testing.expect(state.dirty == .partial);
+
+    // An unchanged offset stays clean.
+    state.dirty = .false;
+    try state.update(alloc, &t);
+    try testing.expect(state.dirty == .false);
 }

--- a/src/terminal/render.zig
+++ b/src/terminal/render.zig
@@ -82,6 +82,20 @@ pub const RenderState = struct {
     rows: size.CellCountInt,
     cols: size.CellCountInt,
 
+    /// Number of overscan rows included in `row_data` beyond `rows`.
+    /// This is nonzero (currently at most 1) only when a fractional pixel
+    /// scroll offset is active and a row exists below the viewport bottom:
+    /// the renderer needs that row to fill the sliver revealed by the
+    /// offset. Everything indexed by viewport y (cursor, selection) keeps
+    /// using `rows`; the overscan row is render-only.
+    overscan_rows: size.CellCountInt = 0,
+
+    /// Fractional vertical pixel offset snapshotted from the terminal's
+    /// PageList together with the viewport pin, under the same lock.
+    /// Positive values shift rendered content up. See
+    /// PageList.viewport_pixel_offset.
+    pixel_offset: f32 = 0,
+
     /// The color state for the terminal.
     colors: Colors,
 
@@ -360,6 +374,19 @@ pub const RenderState = struct {
     ) Allocator.Error!void {
         const s: *Screen = t.screens.active;
         const viewport_pin = s.pages.getTopLeft(.viewport);
+
+        // Snapshot the fractional pixel scroll offset with the viewport so
+        // the renderer always presents a consistent (viewport, offset) pair.
+        // An overscan row is needed only when the offset reveals a sliver
+        // below the viewport bottom AND such a row actually exists.
+        const pixel_offset: f32 = s.pages.viewport_pixel_offset;
+        const overscan_rows: size.CellCountInt = overscan: {
+            if (!(pixel_offset > 0)) break :overscan 0;
+            if (s.pages.viewport == .active) break :overscan 0;
+            if (viewport_pin.down(s.pages.rows) == null) break :overscan 0;
+            break :overscan 1;
+        };
+
         const redraw = redraw: {
             // If our screen key changed, we need to do a full rebuild
             // because our render state is viewport-specific.
@@ -393,12 +420,18 @@ pub const RenderState = struct {
                 if (!old.eql(viewport_pin)) break :redraw true;
             }
 
+            // If our overscan row count changed, row_data changes shape,
+            // so we do a full rebuild.
+            if (self.overscan_rows != overscan_rows) break :redraw true;
+
             break :redraw false;
         };
 
         // Always set our cheap fields, its more expensive to compare
         self.rows = s.pages.rows;
         self.cols = s.pages.cols;
+        self.overscan_rows = overscan_rows;
+        self.pixel_offset = pixel_offset;
         self.viewport_pin = viewport_pin;
         self.cursor.active = .{ .x = s.cursor.x, .y = s.cursor.y };
         self.cursor.cell = s.cursor.page_cell.*;
@@ -439,22 +472,25 @@ pub const RenderState = struct {
             }
         }
 
+        // The row data covers the viewport plus any overscan row.
+        const data_rows: usize = @as(usize, self.rows) + self.overscan_rows;
+
         // Ensure our row length is exactly our height, freeing or allocating
         // data as necessary. In most cases we'll have a perfectly matching
         // size.
-        if (self.row_data.len != self.rows) {
+        if (self.row_data.len != data_rows) {
             @branchHint(.unlikely);
 
-            if (self.row_data.len < self.rows) {
+            if (self.row_data.len < data_rows) {
                 // Resize our rows to the desired length, marking any added
                 // values undefined.
                 const old_len = self.row_data.len;
-                try self.row_data.resize(alloc, self.rows);
+                try self.row_data.resize(alloc, data_rows);
 
                 // Initialize all our values. Its faster to use slice() + set()
                 // because appendAssumeCapacity does this multiple times.
                 var row_data = self.row_data.slice();
-                for (old_len..self.rows) |y| {
+                for (old_len..data_rows) |y| {
                     row_data.set(y, .{
                         .arena = .{},
                         .pin = undefined,
@@ -469,14 +505,14 @@ pub const RenderState = struct {
             } else {
                 const row_data = self.row_data.slice();
                 for (
-                    row_data.items(.arena)[self.rows..],
-                    row_data.items(.cells)[self.rows..],
+                    row_data.items(.arena)[data_rows..],
+                    row_data.items(.cells)[data_rows..],
                 ) |state, *cell| {
                     var arena: ArenaAllocator = state.promote(alloc);
                     arena.deinit();
                     cell.deinit(alloc);
                 }
-                self.row_data.shrinkRetainingCapacity(self.rows);
+                self.row_data.shrinkRetainingCapacity(data_rows);
             }
         }
 
@@ -516,7 +552,7 @@ pub const RenderState = struct {
         var y: usize = 0;
         var any_dirty: bool = false;
         var page_it = viewport_pin.pageIterator(.right_down, null);
-        while (y < self.rows) {
+        while (y < data_rows) {
             const chunk = page_it.next() orelse break;
             const node = chunk.node;
             const node_serial = node.serial;
@@ -524,10 +560,10 @@ pub const RenderState = struct {
 
             // The number of rows we consume from this chunk. The chunk
             // may extend beyond the viewport (the viewport is always
-            // exactly `rows` tall) so we clamp.
+            // exactly `rows` tall, plus any overscan row) so we clamp.
             const take: usize = @min(
                 @as(usize, chunk.end - chunk.start),
-                self.rows - y,
+                data_rows - y,
             );
 
             // Find our cursor if we haven't found it yet. We do this even
@@ -628,7 +664,9 @@ pub const RenderState = struct {
 
             y += take;
         }
-        assert(y == self.rows);
+        // The overscan row was pre-verified to exist (viewport_pin.down),
+        // so the iterator always fills the full data length.
+        assert(y == data_rows);
 
         // If our screen has a selection, then mark the rows with the
         // selection. We do this outside of the loop above because its unlikely
@@ -2282,4 +2320,171 @@ test "dirty row resets highlights" {
         const row_highlights = row_data.items(.highlights);
         try testing.expectEqual(0, row_highlights[0].items.len);
     }
+}
+
+test "pixel scroll offset adds overscan row" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const io = testing.io;
+
+    var t = try Terminal.init(io, alloc, .{
+        .cols = 5,
+        .rows = 3,
+        .max_scrollback = 10_000,
+    });
+    defer t.deinit(alloc);
+
+    var s = t.vtStream();
+    defer s.deinit();
+    s.nextSlice("A\r\nB\r\nC\r\nD\r\nE");
+
+    // Scroll to the top and apply a fractional pixel offset, the way the
+    // pixel-scroll API does (scroll first, then set the offset).
+    const pages = &t.screens.active.pages;
+    pages.scroll(.top);
+    pages.viewport_pixel_offset = 5.5;
+
+    var state: RenderState = .empty;
+    defer state.deinit(alloc);
+    try state.update(alloc, &t);
+
+    try testing.expectEqual(@as(size.CellCountInt, 1), state.overscan_rows);
+    try testing.expectEqual(@as(f32, 5.5), state.pixel_offset);
+    try testing.expectEqual(@as(usize, 4), state.row_data.len);
+
+    // The overscan row is the row directly below the viewport bottom.
+    var w = std.Io.Writer.Allocating.init(alloc);
+    defer w.deinit();
+    try state.string(&w.writer, null);
+    const result = try w.toOwnedSlice();
+    defer alloc.free(result);
+    const expected =
+        "A\x00\x00\x00\x00\n" ++
+        "B\x00\x00\x00\x00\n" ++
+        "C\x00\x00\x00\x00\n" ++
+        "D\x00\x00\x00\x00\n";
+    try testing.expectEqualStrings(expected, result);
+}
+
+test "pixel scroll offset at active viewport has no overscan" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const io = testing.io;
+
+    var t = try Terminal.init(io, alloc, .{
+        .cols = 5,
+        .rows = 3,
+        .max_scrollback = 10_000,
+    });
+    defer t.deinit(alloc);
+
+    var s = t.vtStream();
+    defer s.deinit();
+    s.nextSlice("A\r\nB\r\nC\r\nD\r\nE");
+
+    // Docked at the tail: an offset here is bottom overshoot; there is no
+    // row below the viewport so no overscan row is added.
+    const pages = &t.screens.active.pages;
+    pages.viewport_pixel_offset = 5.5;
+
+    var state: RenderState = .empty;
+    defer state.deinit(alloc);
+    try state.update(alloc, &t);
+
+    try testing.expectEqual(@as(size.CellCountInt, 0), state.overscan_rows);
+    try testing.expectEqual(@as(f32, 5.5), state.pixel_offset);
+    try testing.expectEqual(@as(usize, 3), state.row_data.len);
+}
+
+test "pixel scroll offset without scrollback has no overscan" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const io = testing.io;
+
+    var t = try Terminal.init(io, alloc, .{
+        .cols = 5,
+        .rows = 3,
+    });
+    defer t.deinit(alloc);
+
+    var s = t.vtStream();
+    defer s.deinit();
+    s.nextSlice("A");
+
+    const pages = &t.screens.active.pages;
+    pages.scroll(.top);
+    pages.viewport_pixel_offset = 3.0;
+
+    var state: RenderState = .empty;
+    defer state.deinit(alloc);
+    try state.update(alloc, &t);
+
+    try testing.expectEqual(@as(size.CellCountInt, 0), state.overscan_rows);
+    try testing.expectEqual(@as(usize, 3), state.row_data.len);
+}
+
+test "pixel scroll offset resets on viewport scroll" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const io = testing.io;
+
+    var t = try Terminal.init(io, alloc, .{
+        .cols = 5,
+        .rows = 3,
+        .max_scrollback = 10_000,
+    });
+    defer t.deinit(alloc);
+
+    var s = t.vtStream();
+    defer s.deinit();
+    s.nextSlice("A\r\nB\r\nC\r\nD\r\nE");
+
+    const pages = &t.screens.active.pages;
+    pages.scroll(.top);
+    pages.viewport_pixel_offset = 5.5;
+
+    // Any viewport move through scroll() invalidates the offset.
+    pages.scroll(.{ .delta_row = 1 });
+    try testing.expectEqual(@as(f32, 0), pages.viewport_pixel_offset);
+
+    var state: RenderState = .empty;
+    defer state.deinit(alloc);
+    try state.update(alloc, &t);
+    try testing.expectEqual(@as(f32, 0), state.pixel_offset);
+    try testing.expectEqual(@as(size.CellCountInt, 0), state.overscan_rows);
+}
+
+test "overscan row transitions rebuild row data" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const io = testing.io;
+
+    var t = try Terminal.init(io, alloc, .{
+        .cols = 5,
+        .rows = 3,
+        .max_scrollback = 10_000,
+    });
+    defer t.deinit(alloc);
+
+    var s = t.vtStream();
+    defer s.deinit();
+    s.nextSlice("A\r\nB\r\nC\r\nD\r\nE");
+
+    var state: RenderState = .empty;
+    defer state.deinit(alloc);
+
+    // Frame 1: scrolled up with an offset -> overscan row present.
+    const pages = &t.screens.active.pages;
+    pages.scroll(.top);
+    pages.viewport_pixel_offset = 2.0;
+    try state.update(alloc, &t);
+    try testing.expectEqual(@as(usize, 4), state.row_data.len);
+
+    // Frame 2: offset settles to zero -> overscan row removed, full
+    // rebuild flagged so the renderer resizes its cell grid.
+    pages.viewport_pixel_offset = 0;
+    state.dirty = .false;
+    try state.update(alloc, &t);
+    try testing.expectEqual(@as(usize, 3), state.row_data.len);
+    try testing.expect(state.dirty == .full);
 }

--- a/src/termio/Termio.zig
+++ b/src/termio/Termio.zig
@@ -803,6 +803,22 @@ pub fn scrollViewport(
     self.terminal.scrollViewport(scroll);
 }
 
+/// Try to scroll the terminal viewport without waiting for the renderer-state
+/// mutex. Embedded display-driven surfaces run this from the same serial queue
+/// that feeds output and renders frames, so an unbounded lock wait here would
+/// strand every later output operation behind a transient PTY/render burst.
+/// The caller can retry after the next display tick when the lock is busy.
+pub fn tryScrollViewport(
+    self: *Termio,
+    scroll: terminalpkg.Terminal.ScrollViewport,
+) bool {
+    if (!self.renderer_state.mutex.tryLock()) return false;
+    self.terminal.scrollViewport(scroll);
+    self.renderer_state.mutex.unlock(global.io());
+    self.renderer_wakeup.notify() catch {};
+    return true;
+}
+
 /// Jump the viewport to the prompt.
 pub fn jumpToPrompt(self: *Termio, delta: isize) !void {
     {


### PR DESCRIPTION
Adds `ghostty_surface_scroll_to_row_pixel_if_revision`, a pixel-precise variant of `ghostty_surface_scroll_to_row_if_revision`. The viewport row and a fractional vertical pixel offset are set in one critical section, stored on `PageList` next to the viewport, and snapshotted by `RenderState` under the same renderer lock, so every presented frame is composed from one consistent (content, offset) pair. This is the primitive behind native touch scrolling in the cmux iOS mirror (cmux side: https://github.com/manaflow-ai/cmux/pull/TBD).

Mechanics: `RenderState` includes one overscan row below the viewport when the offset reveals a sliver (`viewport_pin.down(rows)` pre-verified, so the page iterator always fills). The Metal and GLSL shaders translate all grid-positioned primitives (bg lookup, glyphs, images) by a new `scroll_offset` uniform, keeping motion consistent within one frame by construction. Any other viewport move (`PageList.scroll`) or a reflow resets the offset; it is forced to zero on the alternate screen.

Desktop behavior is unchanged: the offset is zero unless an embedder drives pixel scrolling, and overscan only engages with a nonzero offset. Five new tests in `src/terminal/render.zig` cover overscan presence/absence, offset snapshotting, reset-on-scroll, and the rebuild on overscan transitions; `zig build test` with scroll/viewport/resize/render/selection/PageList filters passes 772/775 with the same 2 failures + 1 crash as the base commit (pre-existing, environmental).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/204"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789889098&installation_model_id=21920&pr_number=204&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F204&signature=0d22537c3a3f1547dfa6232dc2284c38c87affa345151c607710df4b0c0168e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds atomic fractional‑pixel scrolling with one-row overscan and guarantees a terminal outcome for tokened renders. Each frame now snapshots a consistent (viewport, pixel_offset) pair; offset-only changes mark the render state dirty to prevent stale presentation.

- New: ghostty_surface_scroll_to_row_pixel_if_revision(row, pixel_offset, expected_revision, out_scrollbar) atomically sets the viewport row and a fractional vertical offset. Positive offsets move content up; the renderer overscans one row when a row exists below the viewport. Any scroll or reflow resets the offset; the alternate screen forces it to zero.
- Rendering: shaders apply a new scroll_offset uniform; it is zero by default. Overscan engages only with a nonzero offset and an available row. Offset-only changes now dirty the render state.
- New: ghostty_surface_set_render_failed_callback(cb, userdata) and ghostty_render_presentation_status_e (PRESENTED, DISCARDED, BACKEND_FAILED). Tokened renders always end in presented or failed status. Failures fire on unrealized renderer, zero-sized surface, host-layer size discard, or backend errors; delivery gates release before callbacks.
- Changed: ghostty_surface_request_render_with_token(token) returns false on iOS and when a platform activates external‑drain mode. It invokes the failure callback when drawing is skipped or discarded.
- New: ghostty_surface_try_scroll_to_bottom() performs nonblocking prompt reveal for embedded clients.

<sup>Written for commit 5045df3f2072f0725394c87cebcc854b634e2131. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/204?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added precise pixel-based scrolling with revision checks.
  * Added a non-blocking “scroll to bottom” option for embedded displays.
  * Added callbacks reporting when tokened frames are presented, discarded, or fail.
* **Bug Fixes**
  * Improved fractional scrolling for text, images, and backgrounds.
  * Ensured failed or skipped renders are reported instead of remaining unresolved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->