### PR TITLE
Merge Fish SSH wrapper feature gating

### DIFF
--- a/src/shell-integration/fish/vendor_conf.d/ghostty-shell-integration.fish
+++ b/src/shell-integration/fish/vendor_conf.d/ghostty-shell-integration.fish
@@ -124,13 +124,15 @@ function __ghostty_setup --on-event fish_prompt -d "Setup ghostty integration"
     # Wrap `ssh` with `ghostty +ssh` and translate the shell-integration
     # feature flags into command options.
     set -l features (string split ',' -- "$GHOSTTY_SHELL_FEATURES")
-    if test -n "$GHOSTTY_BIN"; and contains ssh-env $features; or test -n "$GHOSTTY_BIN"; and contains ssh-terminfo $features
-        function ssh --wraps=ssh --description "SSH wrapper with Ghostty integration"
-            set -l features (string split ',' -- "$GHOSTTY_SHELL_FEATURES")
-            set -l flags
-            contains ssh-env $features; or set -a flags --forward-env=false
-            contains ssh-terminfo $features; or set -a flags --terminfo=false
-            "$GHOSTTY_BIN" +ssh $flags -- $argv
+    if test -n "$GHOSTTY_BIN"
+        if contains ssh-env $features; or contains ssh-terminfo $features
+            function ssh --wraps=ssh --description "SSH wrapper with Ghostty integration"
+                set -l features (string split ',' -- "$GHOSTTY_SHELL_FEATURES")
+                set -l flags
+                contains ssh-env $features; or set -a flags --forward-env=false
+                contains ssh-terminfo $features; or set -a flags --terminfo=false
+                "$GHOSTTY_BIN" +ssh $flags -- $argv
+            end
         end
     end
 


### PR DESCRIPTION
Make the Fish SSH wrapper available when either `ssh-env` or `ssh-terminfo` is enabled.

This is the existing cmux integration fix from `a63a978`; merging it into fork `main` makes the parent cmux submodule pin fetchable from the tracked mainline.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/205"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790205068&installation_model_id=21920&pr_number=205&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F205&signature=0f8389fc96ddafa3b60861ac932e5d9ef31af3b37bd36165f13f725d1eb4d664"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Fish SSH wrapper gating so the wrapper is defined when either SSH feature (`ssh-env` or `ssh-terminfo`) is enabled and `GHOSTTY_BIN` is set. This prevents missing wrapper setup when only one feature is active and avoids wrapping when no SSH features are enabled. Also syncs the existing `cmux` integration fix into the fork so the parent `cmux` submodule pin is fetchable.

- Touches only `src/shell-integration/fish/vendor_conf.d/ghostty-shell-integration.fish`; refactors the condition with nested checks.
- Behavior: wrapper installs if at least one SSH feature is enabled; flag defaults (`--forward-env=false`, `--terminfo=false` when features are absent) are unchanged.
- No migration required; effective on new Fish sessions.

<sup>Written for commit cb6f34a4034810cdd6f341dea822b822bebec5ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/205?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Fish shell SSH integration so the SSH wrapper is consistently available when Ghostty is configured.
  * SSH environment forwarding and terminal information behavior continue to follow their respective feature settings.
  * Prevents SSH integration from being unavailable when optional SSH features are disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->