### PR TITLE
Merge Fish SSH fix with current cmux APIs

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1337,6 +1337,11 @@ GHOSTTY_API bool ghostty_app_key(ghostty_app_t, ghostty_input_key_s);
 GHOSTTY_API void ghostty_app_keyboard_changed(ghostty_app_t);
 GHOSTTY_API void ghostty_app_open_config(ghostty_app_t);
 GHOSTTY_API void ghostty_app_update_config(ghostty_app_t, ghostty_config_t);
+// Updates app-scoped configuration without synchronously propagating it to
+// surfaces. The embedder must update every live surface separately.
+GHOSTTY_API void ghostty_app_update_config_without_surface_propagation(
+    ghostty_app_t,
+    ghostty_config_t);
 GHOSTTY_API bool ghostty_app_needs_confirm_quit(ghostty_app_t);
 GHOSTTY_API bool ghostty_app_has_global_keybinds(ghostty_app_t);
 GHOSTTY_API void ghostty_app_set_color_scheme(ghostty_app_t, ghostty_color_scheme_e);

--- a/src/App.zig
+++ b/src/App.zig
@@ -248,7 +248,21 @@ pub fn tick(self: *App, rt_app: *apprt.App) !void {
 /// called from the main thread. The caller owns the config memory. The
 /// memory can be freed immediately when this returns.
 pub fn updateConfig(self: *App, rt_app: *apprt.App, config: *const Config) !void {
-    // Go through and update all of the surface configurations.
+    try self.updateSurfaceConfigs(config);
+    try self.updateAppConfig(rt_app, config);
+}
+
+/// Update only application-scoped configuration state. Embedders that own
+/// incremental surface scheduling use this to avoid one synchronous fan-out.
+pub fn updateConfigWithoutSurfacePropagation(
+    self: *App,
+    rt_app: *apprt.App,
+    config: *const Config,
+) !void {
+    try self.updateAppConfig(rt_app, config);
+}
+
+fn updateSurfaceConfigs(self: *App, config: *const Config) !void {
     {
         self.lockSurfaceRegistry();
         defer self.unlockSurfaceRegistry();
@@ -257,7 +271,9 @@ pub fn updateConfig(self: *App, rt_app: *apprt.App, config: *const Config) !void
             try surface.core().handleMessage(.{ .change_config = config });
         }
     }
+}
 
+fn updateAppConfig(self: *App, rt_app: *apprt.App, config: *const Config) !void {
     // Apply our conditional state. If we fail to apply the conditional state
     // then we log and attempt to move forward with the old config.
     // We only apply this to the app-level config because the surface

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -2475,6 +2475,18 @@ pub const CAPI = struct {
         };
     }
 
+    /// Update app-scoped configuration state without synchronously walking
+    /// surfaces. The embedder must propagate `config` to every live surface.
+    export fn ghostty_app_update_config_without_surface_propagation(
+        v: *App,
+        config: *const Config,
+    ) void {
+        v.core_app.updateConfigWithoutSurfacePropagation(v, config) catch |err| {
+            log.err("error updating app config err={}", .{err});
+            return;
+        };
+    }
+
     /// Returns true if the app needs to confirm quitting.
     export fn ghostty_app_needs_confirm_quit(v: *App) bool {
         return v.core_app.needsConfirmQuit();

--- a/src/shell-integration/fish/vendor_conf.d/ghostty-shell-integration.fish
+++ b/src/shell-integration/fish/vendor_conf.d/ghostty-shell-integration.fish
@@ -124,13 +124,15 @@ function __ghostty_setup --on-event fish_prompt -d "Setup ghostty integration"
     # Wrap `ssh` with `ghostty +ssh` and translate the shell-integration
     # feature flags into command options.
     set -l features (string split ',' -- "$GHOSTTY_SHELL_FEATURES")
-    if test -n "$GHOSTTY_BIN"; and contains ssh-env $features; or test -n "$GHOSTTY_BIN"; and contains ssh-terminfo $features
-        function ssh --wraps=ssh --description "SSH wrapper with Ghostty integration"
-            set -l features (string split ',' -- "$GHOSTTY_SHELL_FEATURES")
-            set -l flags
-            contains ssh-env $features; or set -a flags --forward-env=false
-            contains ssh-terminfo $features; or set -a flags --terminfo=false
-            "$GHOSTTY_BIN" +ssh $flags -- $argv
+    if test -n "$GHOSTTY_BIN"
+        if contains ssh-env $features; or contains ssh-terminfo $features
+            function ssh --wraps=ssh --description "SSH wrapper with Ghostty integration"
+                set -l features (string split ',' -- "$GHOSTTY_SHELL_FEATURES")
+                set -l flags
+                contains ssh-env $features; or set -a flags --forward-env=false
+                contains ssh-terminfo $features; or set -a flags --terminfo=false
+                "$GHOSTTY_BIN" +ssh $flags -- $argv
+            end
         end
     end
 


### PR DESCRIPTION
Carry the Fish SSH feature-condition fix on top of the current cmux Ghostty fork APIs (render-disposition and nonblocking prompt reveal).

This commit already has the published GhosttyKit artifact and checksum used by cmux CI; merging it into fork main makes the exact parent pin reachable from the tracked mainline.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/206"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790208859&installation_model_id=21920&pr_number=206&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F206&signature=b8d5c18358c051fa45b30325867934c28a17e153f24e97c37bdb0f69384a5541"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an app-only config update API and fixes Fish SSH wrapper gating to avoid accidental overrides. Previously updates always fanned out to all surfaces and Fish could wrap ssh under loose conditions; now embedders can defer surface updates and Fish only wraps when `ssh-env` or `ssh-terminfo` are enabled.

- New C API `ghostty_app_update_config_without_surface_propagation(...)`: updates app-scoped config without walking surfaces. Embedders must propagate the config to each live surface separately. Existing `ghostty_app_update_config(...)` retains synchronous fan-out.
- Fish shell integration: defines the `ssh` wrapper only when `GHOSTTY_BIN` is set and at least one of `ssh-env` or `ssh-terminfo` is present, preventing overrides when both features are disabled.

<sup>Written for commit fd13a3fc20f8aab4136437b5693e2e447b86eafc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an API option to update application-wide settings without immediately propagating changes to open surfaces.
  - This enables controlled, incremental updates when surface configuration is managed separately.

- **Bug Fixes**
  - Improved shell integration so the SSH wrapper is only enabled when the required executable and features are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->