### PR TITLE
fix: recover incomplete RenderState updates (#10037)

### DIFF
--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -1409,7 +1409,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             self: *Self,
             state: *renderer.State,
             cursor_blink_visible: bool,
-        ) Allocator.Error!void {
+        ) terminal.RenderState.UpdateError!void {
             // We fully deinit and reset the terminal state every so often
             // so that a particularly large terminal state doesn't cause
             // the renderer to hold on to retained memory.
@@ -1419,6 +1419,10 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             if (self.terminal_state_frame_count >= max_terminal_state_frame_count) {
                 self.terminal_state.deinit(self.alloc);
                 self.terminal_state = .empty;
+
+                // Reset the counter, otherwise every subsequent frame
+                // tears down and rebuilds the full terminal state.
+                self.terminal_state_frame_count = 0;
             }
             self.terminal_state_frame_count += 1;
 
@@ -2828,6 +2832,13 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 const cursor_vp = state.cursor.viewport orelse
                     break :preedit null;
 
+                // Defensive: see the cursor block below — an interrupted
+                // state update can leave row_data shorter than the cursor
+                // position, so never index it unchecked.
+                if (cursor_vp.y >= row_dirty.len or
+                    cursor_vp.x >= state.cols)
+                    break :preedit null;
+
                 // If our preedit row isn't dirty then we don't need the
                 // preedit range. This also avoids an issue later where we
                 // unconditionally add preedit cells when this is set.
@@ -2897,8 +2908,18 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 // need it for styling.
                 const cursor_vp = state.cursor.viewport orelse break :cursor;
                 const cursor_style: terminal.Style = cursor_style: {
+                    // Defensive: an interrupted state update (e.g. an
+                    // allocation failure or a short viewport iteration
+                    // in RenderState.beginUpdate) can leave a row with
+                    // an empty cell buffer while the cursor points at
+                    // it. Indexing it would be undefined behavior in
+                    // ReleaseFast, so skip the cursor for this frame;
+                    // the next complete update restores it.
                     const cells = state.row_data.items(.cells);
-                    const cell = cells[cursor_vp.y].get(cursor_vp.x);
+                    if (cursor_vp.y >= cells.len) break :cursor;
+                    const cursor_row_cells = &cells[cursor_vp.y];
+                    if (cursor_vp.x >= cursor_row_cells.len) break :cursor;
+                    const cell = cursor_row_cells.get(cursor_vp.x);
                     break :cursor_style if (cell.raw.hasStyling())
                         cell.style
                     else

--- a/src/terminal/render.zig
+++ b/src/terminal/render.zig
@@ -138,6 +138,24 @@ pub const RenderState = struct {
     /// beginUpdate.
     pending_styles: std.ArrayList(StyleRun) = .empty,
 
+    /// True while an update is in progress, and left set by an update
+    /// that never completed: an allocation failure mid-update, or a
+    /// viewport page iteration that came up short. Either can leave
+    /// rows whose cell buffers were never built while other state
+    /// (including the cursor viewport position) is already current.
+    /// When set at the start of the next update, a full rebuild is
+    /// forced so partially-built row data is never trusted.
+    incomplete: bool = false,
+
+    /// The error set returned by `beginUpdate` and `update`.
+    pub const UpdateError = Allocator.Error || error{
+        /// The viewport page iteration came up short, leaving rows
+        /// whose cell data was never built. The frame must be
+        /// discarded by the caller; `incomplete` stays set so the
+        /// next update performs a full rebuild.
+        IncompleteUpdate,
+    };
+
     /// Initial state.
     pub const empty: RenderState = .{
         .rows = 0,
@@ -341,7 +359,7 @@ pub const RenderState = struct {
         self: *RenderState,
         alloc: Allocator,
         t: *Terminal,
-    ) Allocator.Error!void {
+    ) UpdateError!void {
         try self.beginUpdate(alloc, t);
         self.endUpdate();
     }
@@ -371,7 +389,7 @@ pub const RenderState = struct {
         self: *RenderState,
         alloc: Allocator,
         t: *Terminal,
-    ) Allocator.Error!void {
+    ) UpdateError!void {
         const s: *Screen = t.screens.active;
         const viewport_pin = s.pages.getTopLeft(.viewport);
 
@@ -388,6 +406,10 @@ pub const RenderState = struct {
         };
 
         const redraw = redraw: {
+            // If our previous update never completed, our row data may
+            // be partially built and can't be trusted; rebuild it all.
+            if (self.incomplete) break :redraw true;
+
             // If our screen key changed, we need to do a full rebuild
             // because our render state is viewport-specific.
             if (t.screens.active_key != self.screen) break :redraw true;
@@ -426,6 +448,13 @@ pub const RenderState = struct {
 
             break :redraw false;
         };
+
+        // Mark this update as in progress. Any early exit — an
+        // allocation failure below, or a short page iteration — leaves
+        // this set so the next update forces a full rebuild rather
+        // than trusting partially-built row data. Cleared at the end
+        // once every viewport row has been accounted for.
+        self.incomplete = true;
 
         // Always set our cheap fields, its more expensive to compare
         self.rows = s.pages.rows;
@@ -666,8 +695,27 @@ pub const RenderState = struct {
             y += take;
         }
         // The overscan row was pre-verified to exist (viewport_pin.down),
-        // so the iterator always fills the full data length.
-        assert(y == data_rows);
+        // so the iterator should always fill the full data length.
+        if (y != data_rows) {
+            // The page iterator came up short: rows [y..data_rows) were
+            // never built, so their pins and cell buffers must not be
+            // read — not even by the rest of this frame. This is a bug,
+            // so crash loudly in safe builds. In release builds we
+            // recover by failing the update: the caller discards the
+            // frame, and `incomplete` stays set (with the terminal dirty
+            // flags unconsumed) so the next update performs a full
+            // rebuild.
+            //
+            // Note this must NOT be an `assert` above the branch: in
+            // ReleaseFast an assert lowers to `unreachable`, which lets
+            // the optimizer assume the condition and delete this
+            // recovery path entirely.
+            if (comptime std.debug.runtime_safety) @panic(
+                "beginUpdate viewport page iteration came up short",
+            );
+            return error.IncompleteUpdate;
+        }
+        self.incomplete = false;
 
         // If our screen has a selection, then mark the rows with the
         // selection. We do this outside of the loop above because its unlikely
@@ -1624,12 +1672,59 @@ test "interrupted render state rebuilds empty row on next update" {
     try testing.expectEqual(@as(usize, 10), cells[1].len);
     cells[1].deinit(alloc);
     cells[1] = .empty;
+    state.incomplete = true;
 
     try state.update(alloc, &t);
 
     // A subsequent update must notice the incomplete row and rebuild it even
     // though no terminal-side dirty flag remains to force a full redraw.
     try testing.expectEqual(@as(usize, 10), cells[1].len);
+}
+
+test "allocation failure mid-update recovers on the next update" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const io = testing.io;
+
+    var t = try Terminal.init(io, alloc, .{
+        .cols = 20,
+        .rows = 5,
+    });
+    defer t.deinit(alloc);
+    var s = t.vtStream();
+    defer s.deinit();
+
+    // Exercise row data, pending styles, and managed-memory allocations.
+    s.nextSlice("\x1b[1mBold\x1b[0m plain\r\n字👨‍👩‍👧\r\nrow2\r\nrow3");
+
+    // Start each fail-point injection with a fresh RenderState. Retained
+    // capacities from a prior attempt would otherwise hide allocation sites.
+    var fail_index: usize = 0;
+    const completed = while (fail_index < 1000) : (fail_index += 1) {
+        var state: RenderState = .empty;
+        defer state.deinit(alloc);
+
+        var failing = testing.FailingAllocator.init(alloc, .{
+            .fail_index = fail_index,
+        });
+        if (state.beginUpdate(failing.allocator(), &t)) |_| {
+            // No failure was injected: every allocation point was covered.
+            state.endUpdate();
+            break true;
+        } else |err| {
+            try testing.expectEqual(error.OutOfMemory, err);
+        }
+
+        // The failed update may have consumed source dirty flags. Recovery
+        // must still force a complete rebuild from the now-healthy allocator.
+        try state.update(alloc, &t);
+
+        var fresh: RenderState = .empty;
+        defer fresh.deinit(alloc);
+        try fresh.update(alloc, &t);
+        try testCompareStates(&state, &fresh);
+    } else false;
+    try testing.expect(completed);
 }
 
 test "begin and end update" {

--- a/src/terminal/render.zig
+++ b/src/terminal/render.zig
@@ -1597,6 +1597,41 @@ test "incremental updates match full rebuild" {
     }
 }
 
+test "interrupted render state rebuilds empty row on next update" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const io = testing.io;
+
+    var t = try Terminal.init(io, alloc, .{
+        .cols = 10,
+        .rows = 3,
+    });
+    defer t.deinit(alloc);
+
+    var s = t.vtStream();
+    defer s.deinit();
+    s.nextSlice("row0\r\nrow1\r\nrow2");
+
+    var state: RenderState = .empty;
+    defer state.deinit(alloc);
+    try state.update(alloc, &t);
+
+    // Model a partially completed update: one row's cell storage was never
+    // rebuilt, while the terminal and render state otherwise look clean.
+    state.dirty = .false;
+    @memset(state.row_data.items(.dirty), false);
+    const cells = state.row_data.items(.cells);
+    try testing.expectEqual(@as(usize, 10), cells[1].len);
+    cells[1].deinit(alloc);
+    cells[1] = .empty;
+
+    try state.update(alloc, &t);
+
+    // A subsequent update must notice the incomplete row and rebuild it even
+    // though no terminal-side dirty flag remains to force a full redraw.
+    try testing.expectEqual(@as(usize, 10), cells[1].len);
+}
+
 test "begin and end update" {
     const testing = std.testing;
     const alloc = testing.allocator;


### PR DESCRIPTION
This fork change hardens the renderer against partially built `RenderState` rows reported by manaflow-ai/cmux#10037.

Summary:
- track interrupted `RenderState.beginUpdate` calls and force a full rebuild on the next update;
- return `error.IncompleteUpdate` for short viewport iterations in ReleaseFast;
- bounds-check cursor/preedit row and cell accesses before rebuilding GPU cells;
- reset the periodic terminal-state teardown counter;
- add allocation-failure recovery coverage (including a fresh-state fail-point sweep).

The universal ReleaseFast GhosttyKit artifact is published at:
https://github.com/manaflow-ai/ghostty/releases/tag/xcframework-c1d6d8769e013fcb9d253b000889bc7d7a4196bf-crashsubdir-cmux-crash-sentry-off-v1

This is complementary to the open grapheme-rebuild work in #73: it covers the missing-row/incomplete-update and cursor-read paths behind the crash report.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/208"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790224210&installation_model_id=21920&pr_number=208&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F208&signature=d272f31ac197660776ef5d2d5fe5baa34f7923f9a4816c19967dc85726ab9f69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes crashes from partially built `RenderState` rows (manaflow-ai/cmux#10037). The renderer now detects interrupted updates, returns an explicit error, and forces a full rebuild on the next frame; it also fixes repeated terminal-state teardown.

- Adds an `incomplete` flag and `UpdateError` to `RenderState`; `beginUpdate`/`update` now return `UpdateError`.
- On a short viewport iteration, returns `error.IncompleteUpdate` (debug builds panic); clears `incomplete` only after all rows are built.
- Adds bounds checks for cursor and preedit cell access in the renderer to avoid out-of-bounds reads.
- Resets `terminal_state_frame_count` after teardown so teardown happens once, not every frame.
- Adds tests for interrupted rows and allocation-failure recovery, including fail-point sweeps that verify the next update fully rebuilds state.
- Required action: callers of `RenderState.update` (or renderer updates that forward it) must handle `error.IncompleteUpdate` by dropping the frame and retrying on the next tick.

<sup>Written for commit d01bf5f6f5cf6394dee0f03caa0f56f1964f5c7d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/208?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved terminal scrolling with configurable rendering space above and below the viewport.
  * Enhanced viewport handling for partial pixel scrolling and available scrollback content.

* **Bug Fixes**
  * Improved recovery from interrupted terminal updates and state resets.
  * Prevented invalid cursor and preedit positioning during rapid state changes.
  * Reduced stale or partially built screen data and reset frame tracking consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->