### PR TITLE
renderer: render insets with scrollback overscan bands

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1441,15 +1441,18 @@ GHOSTTY_API void ghostty_surface_set_content_scale(ghostty_surface_t, double, do
 GHOSTTY_API void ghostty_surface_set_focus(ghostty_surface_t, bool);
 GHOSTTY_API void ghostty_surface_set_occlusion(ghostty_surface_t, bool);
 GHOSTTY_API void ghostty_surface_set_size(ghostty_surface_t, uint32_t, uint32_t);
-// cmux fork: reserve extra drawable pixels above the padded grid for
-// render-only scrollback overscan (the iOS scroll-edge-effect band). The
-// app-facing size round-trip (ghostty_surface_set_size/ghostty_surface_size)
-// and the mouse coordinate space are unchanged; the drawable grows upward by
-// this many pixels and the renderer fills the band with the rows directly
-// above the viewport, translated in the same critical section as the pixel
-// scroll offset. The terminal grid and PTY size never change from this call.
-GHOSTTY_API void ghostty_surface_set_render_top_inset(ghostty_surface_t,
-                                                      uint32_t);
+// cmux fork: reserve extra drawable pixels above and below the padded grid
+// for render-only scrollback overscan (the iOS scroll-edge-effect bands
+// under the navigation bar and the bottom chrome). The app-facing size
+// round-trip (ghostty_surface_set_size/ghostty_surface_size) and the mouse
+// coordinate space are unchanged; the drawable grows by the insets and the
+// renderer fills the bands with the rows directly above and below the
+// viewport, translated in the same critical section as the pixel scroll
+// offset. The terminal grid and PTY size never change from this call.
+// Arguments: top inset px, bottom inset px.
+GHOSTTY_API void ghostty_surface_set_render_insets(ghostty_surface_t,
+                                                   uint32_t,
+                                                   uint32_t);
 GHOSTTY_API ghostty_surface_size_s ghostty_surface_size(ghostty_surface_t);
 GHOSTTY_API bool ghostty_surface_grid_metrics(
     ghostty_surface_t,

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1441,6 +1441,15 @@ GHOSTTY_API void ghostty_surface_set_content_scale(ghostty_surface_t, double, do
 GHOSTTY_API void ghostty_surface_set_focus(ghostty_surface_t, bool);
 GHOSTTY_API void ghostty_surface_set_occlusion(ghostty_surface_t, bool);
 GHOSTTY_API void ghostty_surface_set_size(ghostty_surface_t, uint32_t, uint32_t);
+// cmux fork: reserve extra drawable pixels above the padded grid for
+// render-only scrollback overscan (the iOS scroll-edge-effect band). The
+// app-facing size round-trip (ghostty_surface_set_size/ghostty_surface_size)
+// and the mouse coordinate space are unchanged; the drawable grows upward by
+// this many pixels and the renderer fills the band with the rows directly
+// above the viewport, translated in the same critical section as the pixel
+// scroll offset. The terminal grid and PTY size never change from this call.
+GHOSTTY_API void ghostty_surface_set_render_top_inset(ghostty_surface_t,
+                                                      uint32_t);
 GHOSTTY_API ghostty_surface_size_s ghostty_surface_size(ghostty_surface_t);
 GHOSTTY_API bool ghostty_surface_grid_metrics(
     ghostty_surface_t,

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -4233,9 +4233,13 @@ pub fn sizeCallback(self: *Surface, size: apprt.SurfaceSize) !void {
     crash.sentry.thread_state = self.crashThreadState();
     defer crash.sentry.thread_state = null;
 
+    // cmux fork: the apprt speaks the app-facing size; the drawable grows
+    // by the render top inset internally (see Size.top_inset). This is the
+    // single point where the inset is added, so re-feeding the stored
+    // screen through resize() stays idempotent.
     const new_screen_size: rendererpkg.ScreenSize = .{
         .width = size.width,
-        .height = size.height,
+        .height = size.height +| self.size.top_inset,
     };
 
     // Update our screen size, but only if it actually changed. And if
@@ -4244,6 +4248,23 @@ pub fn sizeCallback(self: *Surface, size: apprt.SurfaceSize) !void {
     if (self.size.screen.equals(new_screen_size)) return;
 
     try self.resize(new_screen_size);
+}
+
+/// cmux fork: reserve `px` drawable pixels at the top of the surface, above
+/// the padded grid, for render-only scrollback overscan (the iOS
+/// scroll-edge-effect band). The app-facing size contract is unchanged:
+/// sizeCallback keeps speaking the un-inset size and the drawable grows by
+/// `px` internally, so the terminal grid (and therefore the PTY size) never
+/// changes when the inset does. The renderer fills the band with the rows
+/// directly above the viewport (see terminal.RenderState top overscan).
+pub fn setRenderTopInset(self: *Surface, px: u32) !void {
+    if (self.size.top_inset == px) return;
+    const app_height = self.size.screen.height -| self.size.top_inset;
+    self.size.top_inset = px;
+    try self.resize(.{
+        .width = self.size.screen.width,
+        .height = app_height +| px,
+    });
 }
 
 fn resize(self: *Surface, size: rendererpkg.ScreenSize) !void {

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -4234,12 +4234,12 @@ pub fn sizeCallback(self: *Surface, size: apprt.SurfaceSize) !void {
     defer crash.sentry.thread_state = null;
 
     // cmux fork: the apprt speaks the app-facing size; the drawable grows
-    // by the render top inset internally (see Size.top_inset). This is the
-    // single point where the inset is added, so re-feeding the stored
-    // screen through resize() stays idempotent.
+    // by the render insets internally (see Size.top_inset/bottom_inset).
+    // This is the single point where the insets are added, so re-feeding
+    // the stored screen through resize() stays idempotent.
     const new_screen_size: rendererpkg.ScreenSize = .{
         .width = size.width,
-        .height = size.height +| self.size.top_inset,
+        .height = size.height +| self.size.top_inset +| self.size.bottom_inset,
     };
 
     // Update our screen size, but only if it actually changed. And if
@@ -4250,20 +4250,26 @@ pub fn sizeCallback(self: *Surface, size: apprt.SurfaceSize) !void {
     try self.resize(new_screen_size);
 }
 
-/// cmux fork: reserve `px` drawable pixels at the top of the surface, above
-/// the padded grid, for render-only scrollback overscan (the iOS
-/// scroll-edge-effect band). The app-facing size contract is unchanged:
-/// sizeCallback keeps speaking the un-inset size and the drawable grows by
-/// `px` internally, so the terminal grid (and therefore the PTY size) never
-/// changes when the inset does. The renderer fills the band with the rows
-/// directly above the viewport (see terminal.RenderState top overscan).
-pub fn setRenderTopInset(self: *Surface, px: u32) !void {
-    if (self.size.top_inset == px) return;
-    const app_height = self.size.screen.height -| self.size.top_inset;
-    self.size.top_inset = px;
+/// cmux fork: reserve drawable pixels above and below the padded grid for
+/// render-only scrollback overscan (the iOS scroll-edge-effect bands under
+/// the navigation bar and the bottom chrome). The app-facing size contract
+/// is unchanged: sizeCallback keeps speaking the un-inset size and the
+/// drawable grows by the insets internally, so the terminal grid (and
+/// therefore the PTY size) never changes when the insets do. The renderer
+/// fills the bands with the rows directly above and below the viewport
+/// (see terminal.RenderState overscan).
+pub fn setRenderInsets(self: *Surface, top_px: u32, bottom_px: u32) !void {
+    const top: u16 = std.math.cast(u16, top_px) orelse std.math.maxInt(u16);
+    const bottom: u16 = std.math.cast(u16, bottom_px) orelse std.math.maxInt(u16);
+    if (self.size.top_inset == top and
+        self.size.bottom_inset == bottom) return;
+    const app_height = self.size.screen.height -|
+        (@as(u32, self.size.top_inset) + self.size.bottom_inset);
+    self.size.top_inset = top;
+    self.size.bottom_inset = bottom;
     try self.resize(.{
         .width = self.size.screen.width,
-        .height = app_height +| px,
+        .height = app_height +| top +| bottom,
     });
 }
 

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -3259,13 +3259,30 @@ pub const CAPI = struct {
         surface.updateSize(w, h);
     }
 
+    /// cmux fork: reserve extra drawable pixels above the padded grid for
+    /// render-only scrollback overscan (the iOS scroll-edge-effect band).
+    /// The app-facing size round-trip (ghostty_surface_set_size /
+    /// ghostty_surface_size) and the mouse coordinate space are unchanged;
+    /// the drawable simply grows upward by `px` and the renderer fills the
+    /// band with the rows directly above the viewport, translated in the
+    /// same critical section as the pixel scroll offset. The terminal grid
+    /// and PTY size never change from this call.
+    export fn ghostty_surface_set_render_top_inset(surface: *Surface, px: u32) void {
+        surface.core_surface.setRenderTopInset(px) catch |err| {
+            log.err("error setting render top inset err={}", .{err});
+        };
+    }
+
     fn surfaceSize(surface: *Surface) SurfaceSize {
         const grid_size = surface.core_surface.size.grid();
         return .{
             .columns = grid_size.columns,
             .rows = grid_size.rows,
             .width_px = surface.core_surface.size.screen.width,
-            .height_px = surface.core_surface.size.screen.height,
+            // cmux fork: report the app-facing height so set_size/size
+            // round-trips; the render top inset is drawable-internal.
+            .height_px = surface.core_surface.size.screen.height -|
+                surface.core_surface.size.top_inset,
             .cell_width_px = surface.core_surface.size.cell.width,
             .cell_height_px = surface.core_surface.size.cell.height,
         };

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -3259,17 +3259,22 @@ pub const CAPI = struct {
         surface.updateSize(w, h);
     }
 
-    /// cmux fork: reserve extra drawable pixels above the padded grid for
-    /// render-only scrollback overscan (the iOS scroll-edge-effect band).
-    /// The app-facing size round-trip (ghostty_surface_set_size /
+    /// cmux fork: reserve extra drawable pixels above and below the padded
+    /// grid for render-only scrollback overscan (the iOS scroll-edge-effect
+    /// bands under the navigation bar and the bottom chrome). The
+    /// app-facing size round-trip (ghostty_surface_set_size /
     /// ghostty_surface_size) and the mouse coordinate space are unchanged;
-    /// the drawable simply grows upward by `px` and the renderer fills the
-    /// band with the rows directly above the viewport, translated in the
-    /// same critical section as the pixel scroll offset. The terminal grid
-    /// and PTY size never change from this call.
-    export fn ghostty_surface_set_render_top_inset(surface: *Surface, px: u32) void {
-        surface.core_surface.setRenderTopInset(px) catch |err| {
-            log.err("error setting render top inset err={}", .{err});
+    /// the drawable simply grows by the insets and the renderer fills the
+    /// bands with the rows directly above and below the viewport,
+    /// translated in the same critical section as the pixel scroll offset.
+    /// The terminal grid and PTY size never change from this call.
+    export fn ghostty_surface_set_render_insets(
+        surface: *Surface,
+        top_px: u32,
+        bottom_px: u32,
+    ) void {
+        surface.core_surface.setRenderInsets(top_px, bottom_px) catch |err| {
+            log.err("error setting render insets err={}", .{err});
         };
     }
 
@@ -3280,9 +3285,10 @@ pub const CAPI = struct {
             .rows = grid_size.rows,
             .width_px = surface.core_surface.size.screen.width,
             // cmux fork: report the app-facing height so set_size/size
-            // round-trips; the render top inset is drawable-internal.
+            // round-trips; the render insets are drawable-internal.
             .height_px = surface.core_surface.size.screen.height -|
-                surface.core_surface.size.top_inset,
+                (@as(u32, surface.core_surface.size.top_inset) +
+                    surface.core_surface.size.bottom_inset),
             .cell_width_px = surface.core_surface.size.cell.width,
             .cell_height_px = surface.core_surface.size.cell.height,
         };

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -1479,6 +1479,13 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                     state.terminal.scrollViewport(.bottom);
                 }
 
+                // cmux fork: request enough rows above the viewport to
+                // fill the render top inset band, plus one for the sliver
+                // revealed by a fractional pixel scroll offset. Zero inset
+                // keeps the band (and all its costs) off entirely.
+                self.terminal_state.requested_top_overscan_rows =
+                    self.topOverscanRowsRequested();
+
                 // Begin the update of our terminal state. Work that
                 // doesn't require terminal access (e.g. style
                 // denormalization) is deferred to the endUpdate call
@@ -2365,6 +2372,22 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
         }
 
         /// Resize the screen.
+        /// cmux fork: rows of scrollback requested above the viewport to
+        /// fill the render top inset band. One extra row covers the sliver
+        /// revealed by a fractional pixel scroll offset, mirroring the
+        /// bottom overscan row.
+        fn topOverscanRowsRequested(self: *Self) terminal.size.CellCountInt {
+            const inset = self.size.top_inset;
+            if (inset == 0) return 0;
+            const cell_height = self.grid_metrics.cell_height;
+            if (cell_height == 0) return 0;
+            const rows = std.math.divCeil(u32, inset, cell_height) catch return 0;
+            return std.math.cast(
+                terminal.size.CellCountInt,
+                rows + 1,
+            ) orelse std.math.maxInt(terminal.size.CellCountInt);
+        }
+
         pub fn setScreenSize(
             self: *Self,
             size: renderer.Size,
@@ -2372,9 +2395,10 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             self.draw_mutex.lockUncancelable(global.io());
             defer self.draw_mutex.unlock(global.io());
 
-            // We only actually need the padding from this,
-            // everything else is derived elsewhere.
+            // We only actually need the padding (and the cmux render top
+            // inset) from this, everything else is derived elsewhere.
             self.size.padding = size.padding;
+            self.size.top_inset = size.top_inset;
 
             self.updateScreenSizeUniforms();
 
@@ -2400,15 +2424,19 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 },
             ).add(self.size.padding);
 
-            // Setup our uniforms
+            // Setup our uniforms. The cmux render top inset behaves like
+            // extra top padding for positioning: the grid origin moves down
+            // by the inset so the band above it can hold the top overscan
+            // rows (drawn at negative terminal-space y via the scroll
+            // offset translation).
             self.uniforms.projection_matrix = math.ortho2d(
                 -1 * @as(f32, @floatFromInt(self.size.padding.left)),
                 @floatFromInt(terminal_size.width + self.size.padding.right),
                 @floatFromInt(terminal_size.height + self.size.padding.bottom),
-                -1 * @as(f32, @floatFromInt(self.size.padding.top)),
+                -1 * @as(f32, @floatFromInt(self.size.padding.top + self.size.top_inset)),
             );
             self.uniforms.grid_padding = .{
-                @floatFromInt(blank.top),
+                @floatFromInt(blank.top + self.size.top_inset),
                 @floatFromInt(blank.right),
                 @floatFromInt(blank.bottom),
                 @floatFromInt(blank.left),
@@ -2751,10 +2779,19 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
         ) Allocator.Error!void {
             const state: *terminal.RenderState = &self.terminal_state;
 
-            // The GPU cell grid covers the viewport plus any overscan row
+            // The GPU cell grid covers the top overscan band (the render
+            // top inset rows), the viewport, plus any bottom overscan row
             // needed by an active fractional pixel scroll offset.
             const state_rows: terminal.size.CellCountInt =
-                state.rows + state.overscan_rows;
+                state.top_overscan_rows + state.rows + state.overscan_rows;
+
+            // cmux fork: GPU rows are row_data indices, so the band shifts
+            // every grid-positioned primitive down by this many pixels; the
+            // scroll offset translation (below) shifts them back up so the
+            // viewport keeps its position and the band lands in the inset.
+            const top_overscan_px: f32 = @floatFromInt(
+                @as(u32, state.top_overscan_rows) * self.grid_metrics.cell_height,
+            );
 
             const grid_size_diff =
                 self.cells.size.rows != state_rows or
@@ -2774,7 +2811,16 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             // The fractional pixel scroll offset is applied by the shaders
             // as a vertical translation of every grid-positioned primitive,
             // so a (content, offset) pair is always composed in one frame.
-            self.uniforms.scroll_offset = state.pixel_offset;
+            // The top overscan shift folds into the same translation, so
+            // every primitive that already composes correctly with pixel
+            // scroll (text, backgrounds, cursor, selection, images) also
+            // composes correctly with the band.
+            self.uniforms.scroll_offset = state.pixel_offset + top_overscan_px;
+
+            // Image placements are viewport-relative and share the same
+            // scroll-offset translation, so they carry the compensating
+            // band shift (see renderer image.zig).
+            self.images.top_overscan_rows = state.top_overscan_rows;
 
             const rebuild = state.dirty == .full or grid_size_diff;
             if (rebuild) {
@@ -2828,17 +2874,22 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 const cursor_vp = state.cursor.viewport orelse
                     break :preedit null;
 
+                // The preedit range is consumed against row_data indices,
+                // which are shifted by the top overscan band.
+                const cursor_data_y: usize =
+                    @as(usize, cursor_vp.y) + state.top_overscan_rows;
+
                 // If our preedit row isn't dirty then we don't need the
                 // preedit range. This also avoids an issue later where we
                 // unconditionally add preedit cells when this is set.
-                if (!rebuild and !row_dirty[cursor_vp.y]) break :preedit null;
+                if (!rebuild and !row_dirty[cursor_data_y]) break :preedit null;
 
                 const range = preedit_v.range(
                     cursor_vp.x,
                     state.cols - 1,
                 );
                 break :preedit .{
-                    .y = @intCast(cursor_vp.y),
+                    .y = @intCast(cursor_data_y),
                     .x = .{ range.start, range.end },
                     .cp_offset = range.cp_offset,
                 };
@@ -2897,8 +2948,11 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 // need it for styling.
                 const cursor_vp = state.cursor.viewport orelse break :cursor;
                 const cursor_style: terminal.Style = cursor_style: {
+                    // row_data indices are shifted by the top overscan band.
                     const cells = state.row_data.items(.cells);
-                    const cell = cells[cursor_vp.y].get(cursor_vp.x);
+                    const cell = cells[
+                        @as(usize, cursor_vp.y) + state.top_overscan_rows
+                    ].get(cursor_vp.x);
                     break :cursor_style if (cell.raw.hasStyling())
                         cell.style
                     else
@@ -2969,7 +3023,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                             .narrow, .spacer_head, .wide => cursor_vp.x,
                             .spacer_tail => cursor_vp.x -| 1,
                         },
-                        @intCast(cursor_vp.y),
+                        @intCast(cursor_vp.y + state.top_overscan_rows),
                     };
 
                     self.uniforms.bools.cursor_wide = switch (wide) {
@@ -3103,10 +3157,12 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 .selection = if (selection) |s| s else null,
 
                 // We want to do font shaping as long as the cursor is
-                // visible on this viewport.
+                // visible on this viewport. `y` is a row_data index, so the
+                // viewport-relative cursor row shifts by the top overscan
+                // band before comparing.
                 .cursor_x = cursor_x: {
                     const vp = state.cursor.viewport orelse break :cursor_x null;
-                    if (vp.y != y) break :cursor_x null;
+                    if (vp.y + state.top_overscan_rows != y) break :cursor_x null;
                     break :cursor_x vp.x;
                 },
             };
@@ -3372,11 +3428,14 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
 
                 // Give links a single underline, unless they already have
                 // an underline, in which case use a double underline to
-                // distinguish them.
+                // distinguish them. The link set is keyed by viewport
+                // coordinates while `y` is a row_data index; rows in the
+                // top overscan band (above the viewport) can never hold a
+                // hovered link.
                 const underline: terminal.Attribute.Underline = underline: {
-                    if (links.contains(.{
+                    if (y >= state.top_overscan_rows and links.contains(.{
                         .x = @intCast(x),
-                        .y = @intCast(y),
+                        .y = @intCast(y - state.top_overscan_rows),
                     })) {
                         break :underline if (style.flags.underline == .single)
                             .double
@@ -3742,7 +3801,12 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             self.cells.setCursor(.{
                 .atlas = .grayscale,
                 .bools = .{ .is_cursor_glyph = true },
-                .grid_pos = .{ x, cursor_vp.y },
+                // GPU rows are row_data indices, shifted by the top
+                // overscan band; cursor.viewport stays viewport-relative.
+                .grid_pos = .{
+                    x,
+                    cursor_vp.y + self.terminal_state.top_overscan_rows,
+                },
                 .color = .{ cursor_color.r, cursor_color.g, cursor_color.b, alpha },
                 .glyph_pos = .{ render.glyph.atlas_x, render.glyph.atlas_y },
                 .glyph_size = .{ render.glyph.width, render.glyph.height },

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -1479,12 +1479,14 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                     state.terminal.scrollViewport(.bottom);
                 }
 
-                // cmux fork: request enough rows above the viewport to
-                // fill the render top inset band, plus one for the sliver
-                // revealed by a fractional pixel scroll offset. Zero inset
-                // keeps the band (and all its costs) off entirely.
+                // cmux fork: request enough rows above and below the
+                // viewport to fill the render inset bands, plus one for the
+                // sliver revealed by a fractional pixel scroll offset. Zero
+                // insets keep the bands (and all their costs) off entirely.
                 self.terminal_state.requested_top_overscan_rows =
                     self.topOverscanRowsRequested();
+                self.terminal_state.requested_bottom_overscan_rows =
+                    self.bottomOverscanRowsRequested();
 
                 // Begin the update of our terminal state. Work that
                 // doesn't require terminal access (e.g. style
@@ -2377,9 +2379,26 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
         /// revealed by a fractional pixel scroll offset, mirroring the
         /// bottom overscan row.
         fn topOverscanRowsRequested(self: *Self) terminal.size.CellCountInt {
-            const inset = self.size.top_inset;
+            return overscanRowsForInset(
+                self.size.top_inset,
+                self.grid_metrics.cell_height,
+            );
+        }
+
+        /// cmux fork: the bottom sibling — rows requested below the
+        /// viewport to fill the render bottom inset band.
+        fn bottomOverscanRowsRequested(self: *Self) terminal.size.CellCountInt {
+            return overscanRowsForInset(
+                self.size.bottom_inset,
+                self.grid_metrics.cell_height,
+            );
+        }
+
+        fn overscanRowsForInset(
+            inset: u32,
+            cell_height: u32,
+        ) terminal.size.CellCountInt {
             if (inset == 0) return 0;
-            const cell_height = self.grid_metrics.cell_height;
             if (cell_height == 0) return 0;
             const rows = std.math.divCeil(u32, inset, cell_height) catch return 0;
             return std.math.cast(
@@ -2395,10 +2414,11 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             self.draw_mutex.lockUncancelable(global.io());
             defer self.draw_mutex.unlock(global.io());
 
-            // We only actually need the padding (and the cmux render top
-            // inset) from this, everything else is derived elsewhere.
+            // We only actually need the padding (and the cmux render
+            // insets) from this, everything else is derived elsewhere.
             self.size.padding = size.padding;
             self.size.top_inset = size.top_inset;
+            self.size.bottom_inset = size.bottom_inset;
 
             self.updateScreenSizeUniforms();
 
@@ -2424,21 +2444,23 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 },
             ).add(self.size.padding);
 
-            // Setup our uniforms. The cmux render top inset behaves like
-            // extra top padding for positioning: the grid origin moves down
-            // by the inset so the band above it can hold the top overscan
-            // rows (drawn at negative terminal-space y via the scroll
-            // offset translation).
+            // Setup our uniforms. The cmux render insets behave like extra
+            // padding for positioning: the grid origin moves down by the
+            // top inset so the band above it can hold the top overscan rows
+            // (drawn at negative terminal-space y via the scroll offset
+            // translation), and the projection extends past the grid bottom
+            // by the bottom inset so the bottom overscan rows draw into
+            // that band.
             self.uniforms.projection_matrix = math.ortho2d(
                 -1 * @as(f32, @floatFromInt(self.size.padding.left)),
                 @floatFromInt(terminal_size.width + self.size.padding.right),
-                @floatFromInt(terminal_size.height + self.size.padding.bottom),
+                @floatFromInt(terminal_size.height + self.size.padding.bottom + self.size.bottom_inset),
                 -1 * @as(f32, @floatFromInt(self.size.padding.top + self.size.top_inset)),
             );
             self.uniforms.grid_padding = .{
                 @floatFromInt(blank.top + self.size.top_inset),
                 @floatFromInt(blank.right),
-                @floatFromInt(blank.bottom),
+                @floatFromInt(blank.bottom + self.size.bottom_inset),
                 @floatFromInt(blank.left),
             };
             self.uniforms.screen_size = .{

--- a/src/renderer/image.zig
+++ b/src/renderer/image.zig
@@ -37,6 +37,13 @@ pub const State = struct {
     /// Overlays
     overlay_placements: std.ArrayListUnmanaged(Placement),
 
+    /// cmux fork: rows of scrollback rendered above the viewport (the top
+    /// overscan band). Placement rows are viewport-relative while the image
+    /// shader's scroll-offset translation is shared with the (band-shifted)
+    /// cell grid, so placements shift down by this many rows to compensate.
+    /// Set by the renderer alongside the scroll-offset uniform.
+    top_overscan_rows: i32,
+
     pub const empty: State = .{
         .images = .empty,
         .kitty_placements = .empty,
@@ -44,6 +51,7 @@ pub const State = struct {
         .kitty_text_end = 0,
         .kitty_virtual = false,
         .overlay_placements = .empty,
+        .top_overscan_rows = 0,
     };
 
     pub fn deinit(self: *State, alloc: Allocator) void {
@@ -141,7 +149,7 @@ pub const State = struct {
                 &.{.{
                     .grid_pos = .{
                         @as(f32, @floatFromInt(p.x)),
-                        @as(f32, @floatFromInt(p.y)),
+                        @as(f32, @floatFromInt(p.y + self.top_overscan_rows)),
                     },
 
                     .cell_offset = .{

--- a/src/renderer/size.zig
+++ b/src/renderer/size.zig
@@ -30,22 +30,37 @@ pub const Size = struct {
     cell: CellSize,
     padding: Padding,
 
+    /// cmux fork: extra drawable pixels at the top of the screen, above the
+    /// padded terminal grid, reserved for render-only scrollback overscan
+    /// (the iOS scroll-edge-effect band). Unlike padding, this band is
+    /// invisible to the surface coordinate contract: mouse/surface
+    /// coordinates keep their origin at the top of the padding, and the
+    /// embedded app-facing size round-trip (set_size/size) excludes it.
+    /// Only the drawable (`screen`) and the renderer know it exists.
+    top_inset: u32 = 0,
+
     /// Return the grid size for this size. The grid size is calculated by
     /// taking the screen size, removing padding, and dividing by the cell
     /// dimensions.
     pub fn grid(self: Size) GridSize {
-        return .init(self.screen.subPadding(self.padding), self.cell);
+        return .init(self.terminal(), self.cell);
     }
 
     /// The size of the terminal. This is the same as the screen without
-    /// padding.
+    /// padding (and without the cmux render top inset).
     pub fn terminal(self: Size) ScreenSize {
-        return self.screen.subPadding(self.padding);
+        var s = self.screen.subPadding(self.padding);
+        s.height -|= self.top_inset;
+        return s;
     }
 
     /// Resolve the exact surface pixel dimensions for an authoritative grid
     /// using the current cell metrics and padding. Invalid or overflowing
     /// dimensions return null without truncation.
+    ///
+    /// The returned size is in the app-facing coordinate space: it excludes
+    /// the cmux render top inset, matching what `Surface.sizeCallback`
+    /// expects as input (the inset is added back internally).
     pub fn screenForGrid(self: Size, requested: GridSize) ?ScreenSize {
         if (requested.columns == 0 or requested.rows == 0 or
             self.cell.width == 0 or self.cell.height == 0) return null;
@@ -54,7 +69,8 @@ pub const Size = struct {
             self.padding.left + self.padding.right;
         const height = @as(u64, requested.rows) * self.cell.height +
             self.padding.top + self.padding.bottom;
-        if (width > std.math.maxInt(u32) or height > std.math.maxInt(u32))
+        if (width > std.math.maxInt(u32) or
+            height + self.top_inset > std.math.maxInt(u32))
             return null;
 
         const screen: ScreenSize = .{
@@ -62,7 +78,10 @@ pub const Size = struct {
             .height = @intCast(height),
         };
         var resolved = self;
-        resolved.screen = screen;
+        resolved.screen = .{
+            .width = screen.width,
+            .height = @intCast(height + self.top_inset),
+        };
         if (!resolved.grid().equals(requested)) return null;
         return screen;
     }
@@ -448,6 +467,53 @@ test "Size.screenForGrid resolves exact logical dimensions" {
     resolved.screen = screen;
     try std.testing.expectEqual(
         GridSize{ .columns = 120, .rows = 40 },
+        resolved.grid(),
+    );
+}
+
+test "Size top_inset excludes the band from the grid" {
+    const testing = std.testing;
+
+    // screen=100x220 with a 20px top inset: the terminal area is
+    // 100x200, so a 10x20 cell yields a 10x10 grid regardless of the
+    // inset band above it.
+    const size: Size = .{
+        .screen = .{ .width = 100, .height = 220 },
+        .cell = .{ .width = 10, .height = 20 },
+        .padding = .{},
+        .top_inset = 20,
+    };
+    try testing.expectEqual(
+        ScreenSize{ .width = 100, .height = 200 },
+        size.terminal(),
+    );
+    try testing.expectEqual(
+        GridSize{ .columns = 10, .rows = 10 },
+        size.grid(),
+    );
+}
+
+test "Size.screenForGrid round-trips app-facing size with top_inset" {
+    const testing = std.testing;
+
+    const size: Size = .{
+        .screen = .{ .width = 1, .height = 1 },
+        .cell = .{ .width = 10, .height = 20 },
+        .padding = .{},
+        .top_inset = 44,
+    };
+
+    // The resolved size is the app-facing (un-inset) size...
+    const screen = size.screenForGrid(.{ .columns = 10, .rows = 10 }).?;
+    try testing.expectEqual(@as(u32, 100), screen.width);
+    try testing.expectEqual(@as(u32, 200), screen.height);
+
+    // ...which yields the requested grid once the inset is added back
+    // (the sizeCallback contract).
+    var resolved = size;
+    resolved.screen = .{ .width = screen.width, .height = screen.height + 44 };
+    try testing.expectEqual(
+        GridSize{ .columns = 10, .rows = 10 },
         resolved.grid(),
     );
 }

--- a/src/renderer/size.zig
+++ b/src/renderer/size.zig
@@ -37,7 +37,16 @@ pub const Size = struct {
     /// coordinates keep their origin at the top of the padding, and the
     /// embedded app-facing size round-trip (set_size/size) excludes it.
     /// Only the drawable (`screen`) and the renderer know it exists.
-    top_inset: u32 = 0,
+    /// u16: insets are fractions of a screen height; keeping them small
+    /// keeps `Size` (and the IO message that carries it) at its old size.
+    top_inset: u16 = 0,
+
+    /// cmux fork: the bottom sibling of `top_inset` — extra drawable pixels
+    /// below the padded grid holding the rows below the viewport (visible
+    /// only when scrolled into scrollback), for the band under bottom
+    /// chrome. Same contract: render-only, excluded from the app-facing
+    /// size round-trip and the coordinate spaces.
+    bottom_inset: u16 = 0,
 
     /// Return the grid size for this size. The grid size is calculated by
     /// taking the screen size, removing padding, and dividing by the cell
@@ -47,10 +56,10 @@ pub const Size = struct {
     }
 
     /// The size of the terminal. This is the same as the screen without
-    /// padding (and without the cmux render top inset).
+    /// padding (and without the cmux render insets).
     pub fn terminal(self: Size) ScreenSize {
         var s = self.screen.subPadding(self.padding);
-        s.height -|= self.top_inset;
+        s.height -|= @as(u32, self.top_inset) + self.bottom_inset;
         return s;
     }
 
@@ -69,8 +78,9 @@ pub const Size = struct {
             self.padding.left + self.padding.right;
         const height = @as(u64, requested.rows) * self.cell.height +
             self.padding.top + self.padding.bottom;
+        const insets = @as(u64, self.top_inset) + self.bottom_inset;
         if (width > std.math.maxInt(u32) or
-            height + self.top_inset > std.math.maxInt(u32))
+            height + insets > std.math.maxInt(u32))
             return null;
 
         const screen: ScreenSize = .{
@@ -80,7 +90,7 @@ pub const Size = struct {
         var resolved = self;
         resolved.screen = .{
             .width = screen.width,
-            .height = @intCast(height + self.top_inset),
+            .height = @intCast(height + insets),
         };
         if (!resolved.grid().equals(requested)) return null;
         return screen;

--- a/src/terminal/render.zig
+++ b/src/terminal/render.zig
@@ -82,12 +82,13 @@ pub const RenderState = struct {
     rows: size.CellCountInt,
     cols: size.CellCountInt,
 
-    /// Number of overscan rows included in `row_data` beyond `rows`.
-    /// This is nonzero (currently at most 1) only when a fractional pixel
-    /// scroll offset is active and a row exists below the viewport bottom:
-    /// the renderer needs that row to fill the sliver revealed by the
-    /// offset. Everything indexed by viewport y (cursor, selection) keeps
-    /// using `rows`; the overscan row is render-only.
+    /// Number of overscan rows included in `row_data` beyond `rows`, BELOW
+    /// the viewport: the rows filling a render bottom inset band (visible
+    /// only when scrolled into scrollback) plus the sliver revealed below
+    /// the viewport bottom by a fractional pixel scroll offset. Clamped to
+    /// the rows that actually exist below the viewport (zero at the live
+    /// tail). Everything indexed by viewport y (cursor, selection) keeps
+    /// using `rows`; overscan rows are render-only.
     overscan_rows: size.CellCountInt = 0,
 
     /// cmux fork: requested rows of scrollback rendered ABOVE the viewport
@@ -97,6 +98,15 @@ pub const RenderState = struct {
     /// clamped to the history available above the viewport and stored in
     /// `top_overscan_rows`.
     requested_top_overscan_rows: size.CellCountInt = 0,
+
+    /// cmux fork: requested rows rendered BELOW the viewport (the bottom
+    /// overscan band that fills a render bottom inset, e.g. the band under
+    /// the iOS composer/toolbar chrome). Set by the renderer before
+    /// `beginUpdate`; the count actually included is clamped to the rows
+    /// existing below the viewport and stored in `overscan_rows` (shared
+    /// with the pixel-scroll sliver row, which is subsumed by any nonzero
+    /// request).
+    requested_bottom_overscan_rows: size.CellCountInt = 0,
 
     /// cmux fork: rows of scrollback actually included above the viewport
     /// in `row_data`. Indices [0, top_overscan_rows) are the band (oldest
@@ -395,14 +405,23 @@ pub const RenderState = struct {
 
         // Snapshot the fractional pixel scroll offset with the viewport so
         // the renderer always presents a consistent (viewport, offset) pair.
-        // An overscan row is needed only when the offset reveals a sliver
-        // below the viewport bottom AND such a row actually exists.
+        // The bottom overscan covers the render bottom inset band plus the
+        // sliver revealed below the viewport bottom by the offset, clamped
+        // to the rows that actually exist below (zero at the live tail).
         const pixel_offset: f32 = s.pages.viewport_pixel_offset;
         const overscan_rows: size.CellCountInt = overscan: {
-            if (!(pixel_offset > 0)) break :overscan 0;
-            if (s.pages.viewport == .active) break :overscan 0;
-            if (viewport_pin.down(s.pages.rows) == null) break :overscan 0;
-            break :overscan 1;
+            var needed: usize = self.requested_bottom_overscan_rows;
+            if (needed == 0 and pixel_offset > 0) needed = 1;
+            if (needed == 0) break :overscan 0;
+            switch (viewport_pin.downOverflow(
+                @as(usize, s.pages.rows) - 1 + needed,
+            )) {
+                .offset => break :overscan @intCast(needed),
+                .overflow => |v| {
+                    if (v.remaining >= needed) break :overscan 0;
+                    break :overscan @intCast(needed - v.remaining);
+                },
+            }
         };
 
         // cmux fork: walk up from the viewport for the requested top
@@ -2718,6 +2737,103 @@ test "top overscan count transitions rebuild row data" {
     try state.update(alloc, &t);
     try testing.expectEqual(@as(usize, 5), state.row_data.len);
     try testing.expect(state.dirty == .full);
+}
+
+test "bottom overscan renders rows below the viewport" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const io = testing.io;
+
+    var t = try Terminal.init(io, alloc, .{
+        .cols = 5,
+        .rows = 3,
+        .max_scrollback = 10_000,
+    });
+    defer t.deinit(alloc);
+
+    var s = t.vtStream();
+    defer s.deinit();
+    s.nextSlice("A\r\nB\r\nC\r\nD\r\nE");
+
+    // Scrolled to the top: viewport is A,B,C with D,E below it.
+    const pages = &t.screens.active.pages;
+    pages.scroll(.top);
+
+    var state: RenderState = .empty;
+    defer state.deinit(alloc);
+    state.requested_bottom_overscan_rows = 2;
+    try state.update(alloc, &t);
+
+    try testing.expectEqual(@as(size.CellCountInt, 2), state.overscan_rows);
+    try testing.expectEqual(@as(usize, 5), state.row_data.len);
+
+    var w = std.Io.Writer.Allocating.init(alloc);
+    defer w.deinit();
+    try state.string(&w.writer, null);
+    const result = try w.toOwnedSlice();
+    defer alloc.free(result);
+    const expected =
+        "A\x00\x00\x00\x00\n" ++
+        "B\x00\x00\x00\x00\n" ++
+        "C\x00\x00\x00\x00\n" ++
+        "D\x00\x00\x00\x00\n" ++
+        "E\x00\x00\x00\x00\n";
+    try testing.expectEqualStrings(expected, result);
+}
+
+test "bottom overscan clamps at the live tail" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const io = testing.io;
+
+    var t = try Terminal.init(io, alloc, .{
+        .cols = 5,
+        .rows = 3,
+        .max_scrollback = 10_000,
+    });
+    defer t.deinit(alloc);
+
+    var s = t.vtStream();
+    defer s.deinit();
+    s.nextSlice("A\r\nB\r\nC\r\nD\r\nE");
+
+    // Docked at the tail: no rows exist below the viewport.
+    var state: RenderState = .empty;
+    defer state.deinit(alloc);
+    state.requested_bottom_overscan_rows = 3;
+    try state.update(alloc, &t);
+
+    try testing.expectEqual(@as(size.CellCountInt, 0), state.overscan_rows);
+    try testing.expectEqual(@as(usize, 3), state.row_data.len);
+}
+
+test "bottom overscan partially clamps near the tail" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const io = testing.io;
+
+    var t = try Terminal.init(io, alloc, .{
+        .cols = 5,
+        .rows = 3,
+        .max_scrollback = 10_000,
+    });
+    defer t.deinit(alloc);
+
+    var s = t.vtStream();
+    defer s.deinit();
+    s.nextSlice("A\r\nB\r\nC\r\nD\r\nE");
+
+    // One row up from the tail: only E exists below the viewport.
+    const pages = &t.screens.active.pages;
+    pages.scroll(.{ .delta_row = -1 });
+
+    var state: RenderState = .empty;
+    defer state.deinit(alloc);
+    state.requested_bottom_overscan_rows = 3;
+    try state.update(alloc, &t);
+
+    try testing.expectEqual(@as(size.CellCountInt, 1), state.overscan_rows);
+    try testing.expectEqual(@as(usize, 4), state.row_data.len);
 }
 
 test "top overscan combines with pixel scroll bottom overscan" {

--- a/src/terminal/render.zig
+++ b/src/terminal/render.zig
@@ -90,6 +90,24 @@ pub const RenderState = struct {
     /// using `rows`; the overscan row is render-only.
     overscan_rows: size.CellCountInt = 0,
 
+    /// cmux fork: requested rows of scrollback rendered ABOVE the viewport
+    /// (the top overscan band that fills a render top inset, e.g. the iOS
+    /// scroll-edge-effect band under a translucent navigation bar). Set by
+    /// the renderer before `beginUpdate`; the count actually included is
+    /// clamped to the history available above the viewport and stored in
+    /// `top_overscan_rows`.
+    requested_top_overscan_rows: size.CellCountInt = 0,
+
+    /// cmux fork: rows of scrollback actually included above the viewport
+    /// in `row_data`. Indices [0, top_overscan_rows) are the band (oldest
+    /// first) and the viewport starts at index `top_overscan_rows`. Like the
+    /// bottom overscan row, these rows are render-only: `cursor.viewport`
+    /// and selection coordinates remain viewport-relative, so renderers must
+    /// add `top_overscan_rows` when mapping them into `row_data` (or GPU
+    /// grid) indices. On the alternate screen or at scrollback top this is
+    /// naturally less than requested (down to zero).
+    top_overscan_rows: size.CellCountInt = 0,
+
     /// Fractional vertical pixel offset snapshotted from the terminal's
     /// PageList together with the viewport pin, under the same lock.
     /// Positive values shift rendered content up. See
@@ -387,6 +405,26 @@ pub const RenderState = struct {
             break :overscan 1;
         };
 
+        // cmux fork: walk up from the viewport for the requested top
+        // overscan band, clamped to the history that actually exists above
+        // it. On the alternate screen (no scrollback above the active area)
+        // and at scrollback top this yields fewer rows, down to zero.
+        var top_pin = viewport_pin;
+        var top_overscan_rows: size.CellCountInt = 0;
+        if (self.requested_top_overscan_rows > 0) {
+            const requested: usize = self.requested_top_overscan_rows;
+            switch (viewport_pin.upOverflow(requested)) {
+                .offset => |p| {
+                    top_pin = p;
+                    top_overscan_rows = @intCast(requested);
+                },
+                .overflow => |v| {
+                    top_pin = v.end;
+                    top_overscan_rows = @intCast(requested - v.remaining);
+                },
+            }
+        }
+
         const redraw = redraw: {
             // If our screen key changed, we need to do a full rebuild
             // because our render state is viewport-specific.
@@ -424,6 +462,10 @@ pub const RenderState = struct {
             // so we do a full rebuild.
             if (self.overscan_rows != overscan_rows) break :redraw true;
 
+            // cmux fork: same for the top overscan band; a count change
+            // shifts every row_data index.
+            if (self.top_overscan_rows != top_overscan_rows) break :redraw true;
+
             break :redraw false;
         };
 
@@ -431,6 +473,7 @@ pub const RenderState = struct {
         self.rows = s.pages.rows;
         self.cols = s.pages.cols;
         self.overscan_rows = overscan_rows;
+        self.top_overscan_rows = top_overscan_rows;
         const pixel_offset_changed = self.pixel_offset != pixel_offset;
         self.pixel_offset = pixel_offset;
         self.viewport_pin = viewport_pin;
@@ -473,8 +516,10 @@ pub const RenderState = struct {
             }
         }
 
-        // The row data covers the viewport plus any overscan row.
-        const data_rows: usize = @as(usize, self.rows) + self.overscan_rows;
+        // The row data covers the top overscan band, the viewport, and any
+        // bottom overscan row.
+        const data_rows: usize = @as(usize, self.top_overscan_rows) +
+            @as(usize, self.rows) + self.overscan_rows;
 
         // Ensure our row length is exactly our height, freeing or allocating
         // data as necessary. In most cases we'll have a perfectly matching
@@ -552,7 +597,9 @@ pub const RenderState = struct {
         };
         var y: usize = 0;
         var any_dirty: bool = false;
-        var page_it = viewport_pin.pageIterator(.right_down, null);
+        // cmux fork: iteration starts at the top of the overscan band; the
+        // viewport rows begin at row_data index `top_overscan_rows`.
+        var page_it = top_pin.pageIterator(.right_down, null);
         while (y < data_rows) {
             const chunk = page_it.next() orelse break;
             const node = chunk.node;
@@ -575,8 +622,14 @@ pub const RenderState = struct {
             cursor: {
                 const cy = s.cursor.page_pin.y;
                 if (cy < chunk.start or cy >= chunk.start + take) break :cursor;
+                // cmux fork: cursor.viewport stays viewport-relative; the
+                // top overscan band holds scrollback rows, which can never
+                // contain the cursor, so the data index is always at or
+                // below the band (guarded anyway for safety).
+                const data_index = y + (cy - chunk.start);
+                if (data_index < self.top_overscan_rows) break :cursor;
                 self.cursor.viewport = .{
-                    .y = @intCast(y + (cy - chunk.start)),
+                    .y = @intCast(data_index - self.top_overscan_rows),
                     .x = s.cursor.x,
 
                     // Future: we should use our own state here to look this
@@ -2535,4 +2588,179 @@ test "pixel scroll offset change alone marks dirty" {
     state.dirty = .false;
     try state.update(alloc, &t);
     try testing.expect(state.dirty == .false);
+}
+
+test "top overscan renders scrollback rows above the viewport" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const io = testing.io;
+
+    var t = try Terminal.init(io, alloc, .{
+        .cols = 5,
+        .rows = 3,
+        .max_scrollback = 10_000,
+    });
+    defer t.deinit(alloc);
+
+    var s = t.vtStream();
+    defer s.deinit();
+    s.nextSlice("A\r\nB\r\nC\r\nD\r\nE");
+
+    // Docked at the tail: the viewport is C,D,E with A,B in scrollback.
+    var state: RenderState = .empty;
+    defer state.deinit(alloc);
+    state.requested_top_overscan_rows = 2;
+    try state.update(alloc, &t);
+
+    try testing.expectEqual(@as(size.CellCountInt, 2), state.top_overscan_rows);
+    try testing.expectEqual(@as(usize, 5), state.row_data.len);
+
+    // The band holds the two scrollback rows, oldest first, and the
+    // viewport starts at index top_overscan_rows.
+    var w = std.Io.Writer.Allocating.init(alloc);
+    defer w.deinit();
+    try state.string(&w.writer, null);
+    const result = try w.toOwnedSlice();
+    defer alloc.free(result);
+    const expected =
+        "A\x00\x00\x00\x00\n" ++
+        "B\x00\x00\x00\x00\n" ++
+        "C\x00\x00\x00\x00\n" ++
+        "D\x00\x00\x00\x00\n" ++
+        "E\x00\x00\x00\x00\n";
+    try testing.expectEqualStrings(expected, result);
+
+    // The cursor sits on the viewport row with E (viewport y=2), NOT
+    // shifted by the band: cursor.viewport stays viewport-relative.
+    try testing.expectEqual(
+        @as(size.CellCountInt, 2),
+        state.cursor.viewport.?.y,
+    );
+}
+
+test "top overscan clamps to available history" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const io = testing.io;
+
+    var t = try Terminal.init(io, alloc, .{
+        .cols = 5,
+        .rows = 3,
+        .max_scrollback = 10_000,
+    });
+    defer t.deinit(alloc);
+
+    var s = t.vtStream();
+    defer s.deinit();
+    s.nextSlice("A\r\nB\r\nC\r\nD\r\nE");
+
+    var state: RenderState = .empty;
+    defer state.deinit(alloc);
+    state.requested_top_overscan_rows = 10;
+    try state.update(alloc, &t);
+
+    // Only two scrollback rows exist above the tail viewport.
+    try testing.expectEqual(@as(size.CellCountInt, 2), state.top_overscan_rows);
+    try testing.expectEqual(@as(usize, 5), state.row_data.len);
+}
+
+test "top overscan is empty without history" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const io = testing.io;
+
+    var t = try Terminal.init(io, alloc, .{
+        .cols = 5,
+        .rows = 3,
+        .max_scrollback = 10_000,
+    });
+    defer t.deinit(alloc);
+
+    var s = t.vtStream();
+    defer s.deinit();
+    s.nextSlice("A");
+
+    var state: RenderState = .empty;
+    defer state.deinit(alloc);
+    state.requested_top_overscan_rows = 4;
+    try state.update(alloc, &t);
+
+    try testing.expectEqual(@as(size.CellCountInt, 0), state.top_overscan_rows);
+    try testing.expectEqual(@as(usize, 3), state.row_data.len);
+}
+
+test "top overscan count transitions rebuild row data" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const io = testing.io;
+
+    var t = try Terminal.init(io, alloc, .{
+        .cols = 5,
+        .rows = 3,
+        .max_scrollback = 10_000,
+    });
+    defer t.deinit(alloc);
+
+    var s = t.vtStream();
+    defer s.deinit();
+    s.nextSlice("A\r\nB\r\nC\r\nD\r\nE");
+
+    var state: RenderState = .empty;
+    defer state.deinit(alloc);
+    state.requested_top_overscan_rows = 1;
+    try state.update(alloc, &t);
+    try testing.expectEqual(@as(usize, 4), state.row_data.len);
+
+    // A band size change reshapes row_data, so it must flag a full
+    // rebuild for the renderer's cell grid resize.
+    state.requested_top_overscan_rows = 2;
+    state.dirty = .false;
+    try state.update(alloc, &t);
+    try testing.expectEqual(@as(usize, 5), state.row_data.len);
+    try testing.expect(state.dirty == .full);
+}
+
+test "top overscan combines with pixel scroll bottom overscan" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const io = testing.io;
+
+    var t = try Terminal.init(io, alloc, .{
+        .cols = 5,
+        .rows = 3,
+        .max_scrollback = 10_000,
+    });
+    defer t.deinit(alloc);
+
+    var s = t.vtStream();
+    defer s.deinit();
+    s.nextSlice("A\r\nB\r\nC\r\nD\r\nE");
+
+    // Scroll up one row with a fractional offset: viewport is B,C,D, one
+    // row (A) above, one bottom overscan row (E) below.
+    const pages = &t.screens.active.pages;
+    pages.scroll(.{ .delta_row = -1 });
+    pages.viewport_pixel_offset = 5.5;
+
+    var state: RenderState = .empty;
+    defer state.deinit(alloc);
+    state.requested_top_overscan_rows = 2;
+    try state.update(alloc, &t);
+
+    try testing.expectEqual(@as(size.CellCountInt, 1), state.top_overscan_rows);
+    try testing.expectEqual(@as(size.CellCountInt, 1), state.overscan_rows);
+    try testing.expectEqual(@as(usize, 5), state.row_data.len);
+
+    var w = std.Io.Writer.Allocating.init(alloc);
+    defer w.deinit();
+    try state.string(&w.writer, null);
+    const result = try w.toOwnedSlice();
+    defer alloc.free(result);
+    const expected =
+        "A\x00\x00\x00\x00\n" ++
+        "B\x00\x00\x00\x00\n" ++
+        "C\x00\x00\x00\x00\n" ++
+        "D\x00\x00\x00\x00\n" ++
+        "E\x00\x00\x00\x00\n";
+    try testing.expectEqualStrings(expected, result);
 }


### PR DESCRIPTION
Adds `ghostty_surface_set_render_insets(surface, top_px, bottom_px)`: the drawable grows upward and downward while the app-facing size round-trip (`ghostty_surface_set_size`/`ghostty_surface_size`), the mouse coordinate space, the grid, and the PTY size are all unchanged. The renderer fills the top band with the rows directly above the viewport and the bottom band with the rows below it (which exist exactly when scrolled into scrollback), so an embedder can extend the terminal under translucent top and bottom chrome and fade real content there — the iOS scroll-edge treatment.

Mechanism: `Size.top_inset`/`Size.bottom_inset` join the size model as u16s (grid/terminal subtract them; `screenForGrid` verifies with them and returns app-area sizes; `renderer.Size` — and the IO message that carries it — keeps its old size). `RenderState.requested_top_overscan_rows` and `requested_bottom_overscan_rows` are set by the renderer (`ceil(inset/cell)+1`, one extra row for the fractional pixel-scroll sliver); `beginUpdate` walks `viewport_pin.upOverflow`/`downOverflow` so both bands clamp to what actually exists — the top band is naturally empty on the alternate screen, the bottom band at the live tail. The bottom band subsumes the old single pixel-scroll overscan row. The top shift folds into the existing `scroll_offset` uniform (`pixel_offset + top_rows*cell_h`) and the projection/`grid_padding` extend past the grid by the insets, so every primitive that already composes with pixel scroll — text, backgrounds, cursor, selection, images — composes with the bands with zero shader changes. `cursor.viewport` stays viewport-relative (external contracts: `ghostty_surface_keyboard_copy_cursor_viewport`, `terminal/c/render.zig`); renderer consumers add `top_overscan_rows` when mapping into row_data/GPU indices, and kitty image placements carry the compensating shift.

The PTY continues to receive `size.terminal()` (bands excluded), so TIOCSWINSZ never changes when the insets do. With zero insets every path is bit-identical to before.

Tests: `top overscan` and `bottom overscan` cases in `src/terminal/render.zig` (band contents, clamping at scrollback top / live tail / partial, alt-screen empty, shape-change rebuild, combined bands + sliver), `Size` inset tests, and the existing `pixel scroll` suite and `termio.message` size guard pass unchanged (`zig build test-lib-vt`, `zig build test -Dtest-filter=...`).

Consumed by cmux PR: https://github.com/manaflow-ai/cmux/pull/11282 (iOS terminal scroll edge effect).

🤖 Generated with [Claude Code](https://claude.com/claude-code)