### PR TITLE
terminal: clear_screen erases scrollback after the screen, not before

### DIFF
--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -3466,6 +3466,70 @@ pub fn eraseDisplay(
     }
 }
 
+/// Emulator-level screen clear used by the `clear_screen` binding (Cmd+K
+/// on macOS). Unlike `eraseDisplay`, this is not driven by the running
+/// program, so it must not disturb an application that owns the alternate
+/// screen: on the alternate screen this does nothing and returns false.
+///
+/// On the primary screen the behavior depends on whether the cursor is at
+/// a shell prompt (semantic prompt marks from shell integration):
+///
+///   - At a prompt, the whole active area is erased and true is returned so
+///     the caller can send a form feed (0x0C) for the shell to repaint its
+///     prompt. The prompt-aware `eraseDisplay(.complete)` scrolls the
+///     visible rows into scrollback before clearing them, so with `history`
+///     set the scrollback is erased AFTER that. Erasing it first left
+///     exactly one screen of text behind, the "Cmd+K must be pressed twice"
+///     defect (ghostty-org/ghostty discussions #10288, #11467, #13079).
+///   - Otherwise only the rows above the cursor are cleared so the running
+///     program's notion of the cursor row stays valid, and false is
+///     returned. With `history` set the scrollback is erased first and the
+///     rows above the cursor are physically removed (`eraseActive` requires
+///     an empty history); without it they are cleared in place.
+pub fn clearScreen(self: *Terminal, history: bool) bool {
+    if (self.screens.active_key == .alternate) return false;
+
+    // Clear our selection
+    self.screens.active.clearSelection();
+
+    if (self.cursorIsAtPrompt()) {
+        self.eraseDisplay(.complete, false);
+        if (history) self.eraseDisplay(.scrollback, false);
+        return true;
+    }
+
+    if (history) self.eraseDisplay(.scrollback, false);
+    if (self.screens.active.cursor.y > 0) {
+        const above: size.CellCountInt = self.screens.active.cursor.y - 1;
+        if (history) {
+            self.screens.active.eraseActive(above);
+        } else {
+            self.screens.active.clearRows(
+                .{ .active = .{} },
+                .{ .active = .{ .y = above } },
+                false,
+            );
+        }
+    }
+
+    if (comptime build_options.kitty_graphics) {
+        // Clear all Kitty graphics state for this screen. This copies
+        // Kitty's behavior when Cmd+K deletes all Kitty graphics. I
+        // didn't spend time researching whether it only deletes Kitty
+        // graphics that are placed above the cursor or if it deletes
+        // all of them. We delete all of them for now but if this behavior
+        // isn't fully correct we should fix this later.
+        self.screens.active.kitty_images.delete(
+            self.io(),
+            self.screens.active.alloc,
+            self,
+            .{ .all = true },
+        );
+    }
+
+    return false;
+}
+
 /// Resets all margins and fills the whole screen with the character 'E'
 ///
 /// Sets the cursor to the top left corner.
@@ -14591,6 +14655,165 @@ test "Terminal: semantic prompt continuations" {
         const row = list_cell.row;
         try testing.expectEqual(.prompt_continuation, row.semantic_prompt);
     }
+}
+
+test "Terminal: clearScreen at prompt erases the screen and all history" {
+    const alloc = testing.allocator;
+    const io_impl = testing.io;
+    var t = try init(io_impl, alloc, .{
+        .cols = 10,
+        .rows = 3,
+        .max_scrollback = 1000,
+    });
+    defer t.deinit(alloc);
+
+    // Several screens of command output followed by a prompt on the
+    // bottom row, as a shell with OSC 133 integration produces.
+    for (0..10) |_| {
+        try t.printString("output");
+        t.carriageReturn();
+        try t.linefeed();
+    }
+    try t.semanticPrompt(.init(.fresh_line_new_prompt));
+    try t.printString("$ ");
+    try testing.expect(t.cursorIsAtPrompt());
+    try testing.expect(t.screens.active.pages.total_rows > t.rows);
+
+    // At a prompt the caller must send a form feed for the shell repaint.
+    try testing.expect(t.clearScreen(true));
+
+    // Nothing is left: no history (not even the screen that the
+    // prompt-aware erase scrolled into it) and an empty active area.
+    try testing.expectEqual(@as(usize, t.rows), t.screens.active.pages.total_rows);
+    {
+        const str = try t.plainString(alloc);
+        defer alloc.free(str);
+        try testing.expectEqualStrings("", str);
+    }
+}
+
+test "Terminal: clearScreen at prompt without history keeps scrollback" {
+    const alloc = testing.allocator;
+    const io_impl = testing.io;
+    var t = try init(io_impl, alloc, .{
+        .cols = 10,
+        .rows = 3,
+        .max_scrollback = 1000,
+    });
+    defer t.deinit(alloc);
+
+    for (0..10) |_| {
+        try t.printString("output");
+        t.carriageReturn();
+        try t.linefeed();
+    }
+    try t.semanticPrompt(.init(.fresh_line_new_prompt));
+    try t.printString("$ ");
+    const rows_before = t.screens.active.pages.total_rows;
+
+    try testing.expect(t.clearScreen(false));
+
+    // The visible rows were scrolled into history rather than destroyed.
+    try testing.expect(t.screens.active.pages.total_rows > rows_before);
+    {
+        const str = try t.plainString(alloc);
+        defer alloc.free(str);
+        try testing.expectEqualStrings("", str);
+    }
+}
+
+test "Terminal: clearScreen outside a prompt erases above the cursor only" {
+    const alloc = testing.allocator;
+    const io_impl = testing.io;
+    var t = try init(io_impl, alloc, .{
+        .cols = 10,
+        .rows = 3,
+        .max_scrollback = 1000,
+    });
+    defer t.deinit(alloc);
+
+    for (0..10) |_| {
+        try t.printString("output");
+        t.carriageReturn();
+        try t.linefeed();
+    }
+    try t.printString("live");
+    try testing.expect(!t.cursorIsAtPrompt());
+    try testing.expectEqual(@as(usize, 2), t.screens.active.cursor.y);
+
+    // No form feed: the running program owns the cursor row.
+    try testing.expect(!t.clearScreen(true));
+
+    try testing.expectEqual(@as(usize, t.rows), t.screens.active.pages.total_rows);
+    try testing.expectEqual(@as(usize, 0), t.screens.active.cursor.y);
+    try testing.expectEqual(@as(usize, 4), t.screens.active.cursor.x);
+    {
+        const str = try t.plainString(alloc);
+        defer alloc.free(str);
+        try testing.expectEqualStrings("live", str);
+    }
+}
+
+test "Terminal: clearScreen outside a prompt without history clears in place" {
+    const alloc = testing.allocator;
+    const io_impl = testing.io;
+    var t = try init(io_impl, alloc, .{
+        .cols = 10,
+        .rows = 3,
+        .max_scrollback = 1000,
+    });
+    defer t.deinit(alloc);
+
+    for (0..10) |_| {
+        try t.printString("output");
+        t.carriageReturn();
+        try t.linefeed();
+    }
+    try t.printString("live");
+    const rows_before = t.screens.active.pages.total_rows;
+
+    try testing.expect(!t.clearScreen(false));
+
+    // History is untouched and the cursor row does not move; only the rows
+    // above it are blank now.
+    try testing.expectEqual(rows_before, t.screens.active.pages.total_rows);
+    try testing.expectEqual(@as(usize, 2), t.screens.active.cursor.y);
+    try testing.expectEqual(@as(usize, 4), t.screens.active.cursor.x);
+    {
+        const str = try t.plainString(alloc);
+        defer alloc.free(str);
+        try testing.expectEqualStrings("\n\nlive", str);
+    }
+}
+
+test "Terminal: clearScreen is a no-op on the alternate screen" {
+    const alloc = testing.allocator;
+    const io_impl = testing.io;
+    var t = try init(io_impl, alloc, .{
+        .cols = 10,
+        .rows = 3,
+        .max_scrollback = 1000,
+    });
+    defer t.deinit(alloc);
+
+    for (0..10) |_| {
+        try t.printString("output");
+        t.carriageReturn();
+        try t.linefeed();
+    }
+    const rows_before = t.screens.active.pages.total_rows;
+    _ = try t.switchScreen(.alternate);
+    try t.printString("tui");
+
+    try testing.expect(!t.clearScreen(true));
+    {
+        const str = try t.plainString(alloc);
+        defer alloc.free(str);
+        try testing.expectEqualStrings("tui", str);
+    }
+
+    _ = try t.switchScreen(.primary);
+    try testing.expectEqual(rows_before, t.screens.active.pages.total_rows);
 }
 
 test "Terminal: index in prompt mode marks new row as prompt continuation" {

--- a/src/termio/Termio.zig
+++ b/src/termio/Termio.zig
@@ -739,58 +739,19 @@ pub fn resetSynchronizedOutput(self: *Termio) void {
 
 /// Clear the screen.
 pub fn clearScreen(self: *Termio, td: *ThreadData, history: bool) !void {
-    {
+    const at_prompt: bool = at_prompt: {
         self.renderer_state.mutex.lockUncancelable(global.io());
         defer self.renderer_state.mutex.unlock(global.io());
 
-        // If we're on the alternate screen, we do not clear. Since this is an
-        // emulator-level screen clear, this messes up the running programs
-        // knowledge of where the cursor is and causes rendering issues. So,
-        // for alt screen, we do nothing.
-        if (self.terminal.screens.active_key == .alternate) return;
+        // The terminal owns the whole clear (alternate screen no-op,
+        // prompt detection, erase ordering, history). It tells us whether
+        // the cursor was at a prompt, in which case the shell must repaint.
+        break :at_prompt self.terminal.clearScreen(history);
+    };
 
-        // Clear our selection
-        self.terminal.screens.active.clearSelection();
-
-        // Clear our scrollback
-        if (history) self.terminal.eraseDisplay(.scrollback, false);
-
-        // If we're not at a prompt, we just delete above the cursor.
-        if (!self.terminal.cursorIsAtPrompt()) {
-            if (self.terminal.screens.active.cursor.y > 0) {
-                self.terminal.screens.active.eraseActive(
-                    self.terminal.screens.active.cursor.y - 1,
-                );
-            }
-
-            // Clear all Kitty graphics state for this screen. This copies
-            // Kitty's behavior when Cmd+K deletes all Kitty graphics. I
-            // didn't spend time researching whether it only deletes Kitty
-            // graphics that are placed above the cursor or if it deletes
-            // all of them. We delete all of them for now but if this behavior
-            // isn't fully correct we should fix this later.
-            self.terminal.screens.active.kitty_images.delete(
-                self.terminal.io(),
-                self.terminal.screens.active.alloc,
-                &self.terminal,
-                .{ .all = true },
-            );
-
-            return;
-        }
-
-        // At a prompt, we want to first fully clear the screen, and then after
-        // send a FF (0x0C) to the shell so that it can repaint the screen.
-        // Mark the current row as a not a prompt so we can properly
-        // clear the full screen in the next eraseDisplay call.
-        // TODO: fix this
-        // self.terminal.markSemanticPrompt(.command);
-        // assert(!self.terminal.cursorIsAtPrompt());
-        self.terminal.eraseDisplay(.complete, false);
-    }
-
-    // If we reached here it means we're at a prompt, so we send a form-feed.
-    try self.queueWrite(td, &[_]u8{0x0C}, false);
+    // At a prompt the screen is now fully cleared, so send a form-feed
+    // (0x0C) to the shell so that it can repaint the prompt.
+    if (at_prompt) try self.queueWrite(td, &[_]u8{0x0C}, false);
 }
 
 /// Scroll the viewport


### PR DESCRIPTION
Cmd+K (the `clear_screen` binding) at a shell prompt left exactly one screen of text in scrollback and had to be pressed twice. `Termio.clearScreen` erased history first and then ran the prompt-aware `eraseDisplay(.complete)`, whose `scrollClear` pushes the visible rows into history before clearing them.

The whole clear now lives in `Terminal.clearScreen(history)` so the ordering is owned by the terminal model and unit-testable:

- alternate screen: no-op, returns false
- at a prompt: `eraseDisplay(.complete)`, then erase scrollback, returns true so Termio sends the form feed
- not at a prompt with history: erase scrollback first (required by `eraseActive`, which asserts an empty history above the active area), then physically erase the rows above the cursor
- not at a prompt without history: clear the rows above the cursor in place

Upstream tracks the same defect as ghostty-org/ghostty discussions #10288, #11467 and #13079 (the `TODO: fix this` in `Termio.clearScreen`).

Tests: five new `Terminal: clearScreen ...` tests. `zig build test -Dtest-filter='Terminal: '` passes 485/485 on a fleet Mac (Zig 0.16.0); `zig fmt --check` clean.

cmux: manaflow-ai/cmux#5680 area, pointer bump PR to follow.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/213"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790949247&installation_model_id=21920&pr_number=213&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F213&signature=24896efcd3fda49ab22164aa50734f8b4a215a54a0a25bf49cf71318d2be3ab1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Cmd+K clear_screen binding that left one screen of scrollback and required two presses.

- Moves the entire clear logic into `Terminal.clearScreen` so the terminal model owns erase ordering.
- At a prompt, scrollback is now erased after the screen; outside a prompt, only rows above the cursor are cleared.
- Alternate screen remains a no-op, and Termio only sends a form feed when at a prompt.
- Adds five unit tests covering prompt, non-prompt, and alternate screen cases.

<sup>Written for commit 431f5fea06418c60a73da44c30363fe565d50866. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/213?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved the terminal’s clear-screen command (Cmd+K) to behave appropriately at shell prompts and during active output.
  * Clearing at a prompt now fully removes the visible screen and can also clear scrollback.
  * Clearing during active output removes content above the cursor while preserving the current screen state.
  * Terminal graphics are cleared consistently when the screen is cleared. 


<!-- end of auto-generated comment: release notes by coderabbit.ai -->