### PR TITLE
feat(embedded): expose resize reflow policy

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1436,6 +1436,13 @@ GHOSTTY_API void ghostty_surface_set_content_scale(ghostty_surface_t, double, do
 GHOSTTY_API void ghostty_surface_set_focus(ghostty_surface_t, bool);
 GHOSTTY_API void ghostty_surface_set_occlusion(ghostty_surface_t, bool);
 GHOSTTY_API void ghostty_surface_set_size(ghostty_surface_t, uint32_t, uint32_t);
+// Update a surface size with an explicit primary-screen reflow policy. This
+// is for embedders that display a foreign rendered viewport and need to keep
+// its row boundaries stable while the local view changes size.
+GHOSTTY_API void ghostty_surface_set_size_with_reflow(ghostty_surface_t,
+                                                      uint32_t,
+                                                      uint32_t,
+                                                      bool reflow);
 GHOSTTY_API ghostty_surface_size_s ghostty_surface_size(ghostty_surface_t);
 GHOSTTY_API bool ghostty_surface_grid_metrics(
     ghostty_surface_t,
@@ -1448,6 +1455,14 @@ GHOSTTY_API bool ghostty_surface_set_grid_size(ghostty_surface_t,
                                                uint16_t columns,
                                                uint16_t rows,
                                                ghostty_surface_size_s* resolved);
+// Set an authoritative logical grid with an explicit primary-screen reflow
+// policy and optionally return the resolved pixel dimensions.
+GHOSTTY_API bool ghostty_surface_set_grid_size_with_reflow(
+    ghostty_surface_t,
+    uint16_t columns,
+    uint16_t rows,
+    bool reflow,
+    ghostty_surface_size_s* resolved);
 // Set an opaque value captured into subsequently submitted leased frames.
 GHOSTTY_API void ghostty_surface_set_external_frame_context(ghostty_surface_t,
                                                             uint64_t context);

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -138,6 +138,11 @@ inspector: ?*inspectorpkg.Inspector = null,
 /// All our sizing information.
 size: rendererpkg.Size,
 
+/// The reflow policy attached to the latest surface resize. Embedded manual
+/// viewers use this when the iOS display callback applies a pending resize
+/// synchronously before the IO mailbox can run.
+pending_resize_reflow: ?bool = null,
+
 /// The configuration derived from the main config. We "derive" it so that
 /// we don't have a shared pointer hanging around that we need to worry about
 /// the lifetime of. This makes updating config at runtime easier.
@@ -978,7 +983,7 @@ pub fn init(
     // init stuff we should get rid of this. But this is required because
     // sizeCallback does retina-aware stuff we don't do here and don't want
     // to duplicate.
-    try self.resize(self.size.screen);
+    try self.resize(self.size.screen, null);
 
     // Give the renderer one more opportunity to finalize any surface
     // setup on the main thread prior to spinning up the rendering thread.
@@ -4102,6 +4107,7 @@ fn setCellSize(self: *Surface, size: rendererpkg.CellSize) !void {
     self.balancePaddingIfNeeded();
 
     // Notify the terminal
+    self.pending_resize_reflow = null;
     self.queueIo(.{ .resize = self.size }, .unlocked);
 
     // Update our terminal default size if necessary.
@@ -4216,6 +4222,18 @@ fn queueRender(self: *Surface) !void {
 }
 
 pub fn sizeCallback(self: *Surface, size: apprt.SurfaceSize) !void {
+    try self.sizeCallbackWithReflow(size, null);
+}
+
+/// Apply an embedder resize with an explicit primary-screen reflow policy.
+/// A null policy follows the terminal's normal DECAWM behavior. Manual
+/// rendered mirrors pass false so a viewport resize cannot reinterpret already
+/// rendered rows as a newly wrapped local transcript.
+pub fn sizeCallbackWithReflow(
+    self: *Surface,
+    size: apprt.SurfaceSize,
+    reflow: ?bool,
+) !void {
     // Crash metadata in case we crash in here
     crash.sentry.thread_state = self.crashThreadState();
     defer crash.sentry.thread_state = null;
@@ -4230,10 +4248,10 @@ pub fn sizeCallback(self: *Surface, size: apprt.SurfaceSize) !void {
     // changed, so we just return.
     if (self.size.screen.equals(new_screen_size)) return;
 
-    try self.resize(new_screen_size);
+    try self.resize(new_screen_size, reflow);
 }
 
-fn resize(self: *Surface, size: rendererpkg.ScreenSize) !void {
+fn resize(self: *Surface, size: rendererpkg.ScreenSize, reflow: ?bool) !void {
     // Save our screen size
     self.size.screen = size;
     self.balancePaddingIfNeeded();
@@ -4252,8 +4270,18 @@ fn resize(self: *Surface, size: rendererpkg.ScreenSize) !void {
             "set. Is your padding reasonable?", .{});
     }
 
-    // Mail the IO thread
-    self.queueIo(.{ .resize = self.size }, .unlocked);
+    // Keep the policy available to the synchronous embedded render path, and
+    // carry it through the normal IO ordering for every backend.
+    self.pending_resize_reflow = reflow;
+    if (reflow) |value| {
+        if (value) {
+            self.queueIo(.{ .resize = self.size }, .unlocked);
+        } else {
+            self.queueIo(.{ .resize_no_reflow = self.size }, .unlocked);
+        }
+    } else {
+        self.queueIo(.{ .resize = self.size }, .unlocked);
+    }
 }
 
 /// Apply pending terminal resize directly from the calling thread.
@@ -4279,6 +4307,7 @@ pub fn applyPendingResizeIfNeeded(self: *Surface) void {
                 .width = self.size.cell.width,
                 .height = self.size.cell.height,
             },
+            .reflow = self.pending_resize_reflow,
         },
     ) catch |err| {
         log.warn("applyPendingResizeIfNeeded: resize error={}", .{err});
@@ -5463,7 +5492,7 @@ pub fn contentScaleCallback(self: *Surface, content_scale: apprt.ContentScale) !
 
     // Force a resize event because the change in padding will affect
     // pixel-level changes to the renderer and viewport.
-    try self.resize(self.size.screen);
+    try self.resize(self.size.screen, null);
 }
 
 /// Returns true if mouse reporting is enabled both in the config and

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1482,6 +1482,18 @@ pub const Surface = struct {
     }
 
     pub fn updateSize(self: *Surface, width: u32, height: u32) void {
+        self.updateSizeWithReflow(width, height, null);
+    }
+
+    /// Update the surface size while carrying an explicit primary-screen
+    /// reflow policy through the core resize path. A null policy follows the
+    /// terminal's normal DECAWM behavior.
+    pub fn updateSizeWithReflow(
+        self: *Surface,
+        width: u32,
+        height: u32,
+        reflow: ?bool,
+    ) void {
         // Runtimes sometimes generate superfluous resize events even
         // if the size did not actually change (SwiftUI). We check
         // that the size actually changed from what we last recorded
@@ -1494,7 +1506,7 @@ pub const Surface = struct {
         };
 
         // Call the primary callback.
-        self.core_surface.sizeCallback(self.size) catch |err| {
+        self.core_surface.sizeCallbackWithReflow(self.size, reflow) catch |err| {
             log.err("error in size callback err={}", .{err});
             return;
         };
@@ -1504,20 +1516,31 @@ pub const Surface = struct {
     /// from the live cell metrics and padding. The renderer and PTY still flow
     /// through the normal resize path, so all existing ordering is preserved.
     pub fn updateGridSize(self: *Surface, columns: u16, rows: u16) bool {
+        return self.updateGridSizeWithReflow(columns, rows, null);
+    }
+
+    /// Set an authoritative logical grid and carry an explicit primary-screen
+    /// reflow policy through the resize transaction.
+    pub fn updateGridSizeWithReflow(
+        self: *Surface,
+        columns: u16,
+        rows: u16,
+        reflow: ?bool,
+    ) bool {
         const requested: renderer.GridSize = .{
             .columns = columns,
             .rows = rows,
         };
         const screen = self.core_surface.size.screenForGrid(requested) orelse
             return false;
-        self.updateSize(screen.width, screen.height);
+        self.updateSizeWithReflow(screen.width, screen.height, reflow);
 
         // Padding balancing may be recomputed by the core resize. Re-resolve
         // once with that authoritative padding if necessary.
         if (!self.core_surface.size.grid().equals(requested)) {
             const adjusted = self.core_surface.size.screenForGrid(requested) orelse
                 return false;
-            self.updateSize(adjusted.width, adjusted.height);
+            self.updateSizeWithReflow(adjusted.width, adjusted.height, reflow);
         }
 
         return self.core_surface.size.grid().equals(requested);
@@ -3247,6 +3270,18 @@ pub const CAPI = struct {
         surface.updateSize(w, h);
     }
 
+    /// Update the surface size with an explicit primary-screen reflow policy.
+    /// This is used by embedders that display a foreign rendered viewport and
+    /// must not change its row boundaries while the local view is resized.
+    export fn ghostty_surface_set_size_with_reflow(
+        surface: *Surface,
+        w: u32,
+        h: u32,
+        reflow: bool,
+    ) void {
+        surface.updateSizeWithReflow(w, h, reflow);
+    }
+
     fn surfaceSize(surface: *Surface) SurfaceSize {
         const grid_size = surface.core_surface.size.grid();
         return .{
@@ -3292,6 +3327,20 @@ pub const CAPI = struct {
         resolved: ?*SurfaceSize,
     ) bool {
         if (!surface.updateGridSize(columns, rows)) return false;
+        if (resolved) |result| result.* = surfaceSize(surface);
+        return true;
+    }
+
+    /// Set an authoritative logical grid with an explicit primary-screen
+    /// reflow policy and return the resolved pixel size.
+    export fn ghostty_surface_set_grid_size_with_reflow(
+        surface: *Surface,
+        columns: u16,
+        rows: u16,
+        reflow: bool,
+        resolved: ?*SurfaceSize,
+    ) bool {
+        if (!surface.updateGridSizeWithReflow(columns, rows, reflow)) return false;
         if (resolved) |result| result.* = surfaceSize(surface);
         return true;
     }

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -3876,6 +3876,12 @@ pub const Resize = struct {
         width: u32,
         height: u32,
     } = null,
+
+    /// Override the primary-screen reflow decision for this resize. A null
+    /// value preserves the terminal's normal DECAWM-derived behavior. An
+    /// explicit false is used by embedders that render an already-rendered
+    /// foreign viewport and therefore must preserve row boundaries.
+    reflow: ?bool = null,
 };
 
 pub const ResizeError = error{
@@ -3975,7 +3981,7 @@ pub fn resize(
     try primary.resize(.{
         .cols = opts.cols,
         .rows = opts.rows,
-        .reflow = self.modes.get(.wraparound),
+        .reflow = opts.reflow orelse self.modes.get(.wraparound),
         .prompt_redraw = self.flags.shell_redraws_prompt,
     });
 
@@ -15245,6 +15251,27 @@ test "Terminal: resize with wraparound on" {
     const str = try t.plainString(testing.allocator);
     defer testing.allocator.free(str);
     try testing.expectEqualStrings("01\n23", str);
+}
+
+test "Terminal: explicit resize reflow policy overrides wraparound" {
+    const alloc = testing.allocator;
+    const io_impl = testing.io;
+    var t = try init(io_impl, alloc, .{ .cols = 2, .rows = 3 });
+    defer t.deinit(alloc);
+
+    // DECAWM is enabled, but the embedder explicitly asks to preserve the
+    // already-rendered row boundaries.
+    t.modes.set(.wraparound, true);
+    try t.printString("1A2B");
+    try t.resize(alloc, .{
+        .cols = 5,
+        .rows = 3,
+        .reflow = false,
+    });
+
+    const str = try t.plainString(testing.allocator);
+    defer testing.allocator.free(str);
+    try testing.expectEqualStrings("1A\n2B", str);
 }
 
 test "Terminal: resize with high unique style per cell" {

--- a/src/termio/Termio.zig
+++ b/src/termio/Termio.zig
@@ -501,8 +501,11 @@ fn queueMessageManual(self: *Termio, msg: termio.Message) void {
             };
         },
         .inspector => {},
-        .resize => |v| self.resize(&td, v) catch |err| {
+        .resize => |v| self.resize(&td, v, null) catch |err| {
             log.warn("manual inline resize failed err={}", .{err});
+        },
+        .resize_no_reflow => |v| self.resize(&td, v, false) catch |err| {
+            log.warn("manual inline no-reflow resize failed err={}", .{err});
         },
         .size_report => |v| self.sizeReport(&td, v) catch |err| {
             log.warn("manual inline size_report failed err={}", .{err});
@@ -637,6 +640,7 @@ pub fn resize(
     self: *Termio,
     td: *ThreadData,
     size: renderer.Size,
+    reflow: ?bool,
 ) !void {
     self.size = size;
     const grid_size = size.grid();
@@ -659,6 +663,7 @@ pub fn resize(
                     .width = self.size.cell.width,
                     .height = self.size.cell.height,
                 },
+                .reflow = reflow,
             },
         );
 

--- a/src/termio/Thread.zig
+++ b/src/termio/Thread.zig
@@ -30,7 +30,15 @@ const Coalesce = struct {
     /// Not all message types are coalesced.
     const min_ms = 25;
 
-    resize: ?renderer.Size = null,
+    resize: ?ResizeRequest = null,
+};
+
+/// A resize plus the optional primary-screen reflow policy. Keeping this
+/// outside `renderer.Size` means renderer messages and the common resize path
+/// retain their existing ABI and queue footprint.
+const ResizeRequest = struct {
+    size: renderer.Size,
+    reflow: ?bool,
 };
 
 /// The number of milliseconds before we reset the synchronized output flag
@@ -326,7 +334,8 @@ fn drainMailbox(
                 try io.changeConfig(data, config.ptr);
             },
             .inspector => |v| self.flags.has_inspector = v,
-            .resize => |v| self.handleResize(cb, v),
+            .resize => |v| self.handleResize(cb, v, null),
+            .resize_no_reflow => |v| self.handleResize(cb, v, false),
             .size_report => |v| try io.sizeReport(data, v),
             .clear_screen => |v| try io.clearScreen(data, v.history),
             .scroll_viewport => |v| io.scrollViewport(v),
@@ -381,8 +390,13 @@ fn startSynchronizedOutput(self: *Thread, cb: *CallbackData) void {
     );
 }
 
-fn handleResize(self: *Thread, cb: *CallbackData, resize: renderer.Size) void {
-    self.coalesce_data.resize = resize;
+fn handleResize(
+    self: *Thread,
+    cb: *CallbackData,
+    resize: renderer.Size,
+    reflow: ?bool,
+) void {
+    self.coalesce_data.resize = .{ .size = resize, .reflow = reflow };
 
     // If the timer is already active we just return. In the future we want
     // to reset the timer up to a maximum wait time but for now this ensures
@@ -437,7 +451,7 @@ fn coalesceCallback(
 
     if (cb.self.coalesce_data.resize) |v| {
         cb.self.coalesce_data.resize = null;
-        cb.io.resize(&cb.data, v) catch |err| {
+        cb.io.resize(&cb.data, v.size, v.reflow) catch |err| {
             log.warn("error during resize err={}", .{err});
         };
     }

--- a/src/termio/message.zig
+++ b/src/termio/message.zig
@@ -39,6 +39,11 @@ pub const Message = union(enum) {
     /// Resize the window.
     resize: renderer.Size,
 
+    /// Resize the window while preserving the primary-screen row boundaries.
+    /// This is a separate message variant so the common resize message keeps
+    /// its compact payload and callers cannot accidentally omit the policy.
+    resize_no_reflow: renderer.Size,
+
     /// Request a size report is sent to the pty ([in-band
     /// size report, mode 2048](https://gist.github.com/rockorager/e695fb2924d36b2bcf1fff4a3704bd83) and
     /// [XTWINOPS](https://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h4-Functions-using-CSI-_-ordered-by-the-final-character-lparen-s-rparen:CSI-Ps;Ps;Ps-t.1EB0)).


### PR DESCRIPTION
## Summary
- add an embedded resize API with an explicit primary-screen reflow policy
- carry the policy through Surface, termio, and Terminal resize ordering
- keep the existing API behavior unchanged and preserve compact common resize messages

## Verification
- `zig build test -Dtest-filter="explicit resize reflow policy" -Demit-macos-app=false -Demit-xcframework=false`
- `zig build -Demit-xcframework=false -Demit-macos-app=false`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/214"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790959733&installation_model_id=21920&pr_number=214&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F214&signature=8220bd7ea7b7530cc5c4785e5ff0ff1614e8f5fe919ada3a5de584dae0a8eec0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an explicit primary-screen reflow policy to embedded surface resizes. Embedders with a foreign rendered viewport can now preserve row boundaries when the local view changes size; existing resize APIs keep the terminal's normal DECAWM behavior.

- Exposes `ghostty_surface_set_size_with_reflow` and `ghostty_surface_set_grid_size_with_reflow`.
- Carries the policy through `Surface`, `Termio`, and `Terminal` resize paths.
- Adds a separate no-reflow resize message so common resize messages stay compact and callers can't accidentally omit the policy.

<sup>Written for commit ec77c1a8432e14b9f1e3f332fc7b16a2232816f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/214?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added resize APIs that let embedded applications explicitly control whether terminal content reflows.
  * Added grid-resize support with optional resolved pixel dimensions.
  * Window resizing can now preserve existing primary-screen row boundaries when reflow is disabled.

* **Bug Fixes**
  * Prevented unintended content reflow during explicitly non-reflowing resize operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->