### PR TITLE
Fix clear_screen binding on alternate screen

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -7320,6 +7320,7 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
                 break :active_screen self.io.terminal.screens.active_key;
             };
             if (active_screen == .alternate) {
+                if (self.readonly) return false;
                 self.queueIo(.{ .write_stable = "\x0c" }, .unlocked);
                 return true;
             }

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -7309,14 +7309,19 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
 
         .clear_screen => {
             // This is a duplicate of some of the logic in termio.clearScreen
-            // but we need to do this here so we can know the answer before
-            // we send the message. If the currently active screen is on the
-            // alternate screen then clear screen does nothing so we want to
-            // return false so the keybind can be unconsumed.
-            {
+            // but we need to decide here whether the key event was performed.
+            // An alternate-screen application owns its contents, so deliver
+            // the redraw request through its PTY instead of mutating the
+            // emulator's private buffer. This keeps the binding consumed and
+            // gives socket/action callers the same behavior as a key press.
+            const active_screen = active_screen: {
                 self.renderer_state.mutex.lockUncancelable(global.io());
                 defer self.renderer_state.mutex.unlock(global.io());
-                if (self.io.terminal.screens.active_key == .alternate) return false;
+                break :active_screen self.io.terminal.screens.active_key;
+            };
+            if (active_screen == .alternate) {
+                self.queueIo(.{ .write_stable = "\x0c" }, .unlocked);
+                return true;
             }
 
             self.queueIo(.{


### PR DESCRIPTION
When a clear_screen binding runs while an alternate-screen application is active, send Ctrl-L through the PTY and report the action as performed. This lets the application redraw its own buffer and keeps physical key and explicit surface action callers on one path. Primary-screen clear behavior is unchanged.

The cmux parent adds a tagged socket regression covering a real DEC alternate-screen sequence and both surface.clear_history and Cmd+K.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `clear_screen` binding on alternate screens so it sends Ctrl-L through the PTY and reports the action as performed, letting the app redraw its own buffer. Readonly surfaces still report the binding as unconsumed since they can't write to the PTY; primary-screen behavior is unchanged.

**Bug Fixes**
- Adds a tagged socket regression test covering a real DEC alternate-screen sequence and both `surface.clear_history` and Cmd+K.

<sup>Written for commit 533c766744da2debeb1f39250ecec92ce760bbc4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/215?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the clear-screen keyboard action in alternate-screen applications to trigger a redraw correctly.
  * Prevented the key event from passing through after the action is handled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->