### PR TITLE
fix: preserve OSC 22 shapes across modifiers and mode changes

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -2103,7 +2103,7 @@ fn mouseRefreshLinks(
         _ = try self.rt_app.performAction(
             .{ .surface = self },
             .mouse_shape,
-            self.io.terminal.mouse_shape,
+            self.io.terminal.effectiveMouseShape(),
         );
         _ = try self.rt_app.performAction(
             .{ .surface = self },
@@ -4602,7 +4602,7 @@ pub fn keyCallback(
             _ = try self.rt_app.performAction(
                 .{ .surface = self },
                 .mouse_shape,
-                self.io.terminal.mouse_shape,
+                self.io.terminal.effectiveMouseShape(),
             );
             _ = try self.rt_app.performAction(
                 .{ .surface = self },
@@ -4618,7 +4618,7 @@ pub fn keyCallback(
     if ((SurfaceMouse{
         .physical_key = event.key,
         .mouse_event = self.io.terminal.flags.mouse_event,
-        .mouse_shape = self.io.terminal.mouse_shape,
+        .mouse_shape = self.io.terminal.effectiveMouseShape(),
         .mods = self.mouse.mods,
         .over_link = self.mouse.over_link,
         .hidden = self.mouse.hidden,
@@ -6640,7 +6640,7 @@ pub fn cursorPosCallback(
             _ = try self.rt_app.performAction(
                 .{ .surface = self },
                 .mouse_shape,
-                self.io.terminal.mouse_shape,
+                self.io.terminal.effectiveMouseShape(),
             );
             _ = try self.rt_app.performAction(
                 .{ .surface = self },

--- a/src/inspector/widgets/terminal.zig
+++ b/src/inspector/widgets/terminal.zig
@@ -461,7 +461,10 @@ fn mouseTable(t: *Terminal) void {
         }
         {
             _ = cimgui.c.ImGui_TableSetColumnIndex(1);
-            cimgui.c.ImGui_Text("%s", @tagName(t.mouse_shape).ptr);
+            cimgui.c.ImGui_Text(
+                "%s",
+                @tagName(t.effectiveMouseShape()).ptr,
+            );
         }
     }
 

--- a/src/surface_mouse.zig
+++ b/src/surface_mouse.zig
@@ -18,7 +18,8 @@ physical_key: input.Key,
 /// The mouse event tracking mode, if any.
 mouse_event: terminal.MouseEvent,
 
-/// The current terminal's mouse shape.
+/// The terminal's resolved base mouse shape, including its mode default when
+/// no OSC 22 shape has been set.
 mouse_shape: MouseShape,
 
 /// The last mods state when the last mouse button (whatever it was) was
@@ -88,7 +89,7 @@ pub fn keyToMouseShape(self: SurfaceMouse) ?MouseShape {
                 // Normal override state
                 return .text;
             } else {
-                return .default;
+                return self.mouse_shape;
             }
         },
 
@@ -97,7 +98,7 @@ pub fn keyToMouseShape(self: SurfaceMouse) ?MouseShape {
                 // Crosshair (rectangle select)
                 return .crosshair;
             } else {
-                return .text;
+                return self.mouse_shape;
             }
         },
 
@@ -127,6 +128,14 @@ pub fn isRectangleSelectState(mods: input.Mods) bool {
 
 test "keyToMouseShape" {
     const testing = std.testing;
+    const command_key: input.Key = if (comptime builtin.target.os.tag.isDarwin())
+        .meta_left
+    else
+        .control_left;
+    const command_mods: input.Mods = if (comptime builtin.target.os.tag.isDarwin())
+        .{ .super = true }
+    else
+        .{ .ctrl = true };
 
     {
         // No specific key pressed
@@ -223,11 +232,11 @@ test "keyToMouseShape" {
     }
 
     {
-        // crosshair -> text (mouse tracking)
+        // Base shape -> text override (mouse tracking)
         const m: SurfaceMouse = .{
             .physical_key = .alt_left,
             .mouse_event = .x10,
-            .mouse_shape = .crosshair,
+            .mouse_shape = .default,
             .mods = .{ .shift = true },
             .over_link = false,
             .hidden = false,
@@ -239,11 +248,11 @@ test "keyToMouseShape" {
     }
 
     {
-        // crosshair -> default (mouse tracking)
+        // Unspecified base -> default (mouse tracking)
         const m: SurfaceMouse = .{
             .physical_key = .alt_left,
             .mouse_event = .x10,
-            .mouse_shape = .crosshair,
+            .mouse_shape = .default,
             .mods = .{},
             .over_link = false,
             .hidden = false,
@@ -255,33 +264,17 @@ test "keyToMouseShape" {
     }
 
     {
-        // text -> crosshair (mouse tracking)
+        // Base shape -> crosshair override (mouse tracking)
         const m: SurfaceMouse = .{
             .physical_key = .alt_left,
             .mouse_event = .x10,
-            .mouse_shape = .text,
+            .mouse_shape = .default,
             .mods = .{ .ctrl = true, .super = true, .alt = true, .shift = true },
             .over_link = false,
             .hidden = false,
         };
 
         const want: MouseShape = .crosshair;
-        const got = m.keyToMouseShape();
-        try testing.expect(want == got);
-    }
-
-    {
-        // text -> default (mouse tracking)
-        const m: SurfaceMouse = .{
-            .physical_key = .shift_left,
-            .mouse_event = .x10,
-            .mouse_shape = .text,
-            .mods = .{},
-            .over_link = false,
-            .hidden = false,
-        };
-
-        const want: MouseShape = .default;
         const got = m.keyToMouseShape();
         try testing.expect(want == got);
     }
@@ -319,11 +312,11 @@ test "keyToMouseShape" {
     }
 
     {
-        // crosshair -> text (no mouse tracking)
+        // Unspecified base -> text (no mouse tracking)
         const m: SurfaceMouse = .{
             .physical_key = .alt_left,
             .mouse_event = .none,
-            .mouse_shape = .crosshair,
+            .mouse_shape = .text,
             .mods = .{},
             .over_link = false,
             .hidden = false,
@@ -339,17 +332,17 @@ test "keyToMouseShape" {
         // while the terminal is in its ordinary (non-mouse-reporting) mode.
         for ([_]MouseShape{ .pointer, .copy }) |shape| {
             const pressed: SurfaceMouse = .{
-                .physical_key = .meta_left,
+                .physical_key = command_key,
                 .mouse_event = .none,
                 .mouse_shape = shape,
-                .mods = .{ .super = true },
+                .mods = command_mods,
                 .over_link = false,
                 .hidden = false,
             };
             try testing.expect(shape == pressed.keyToMouseShape());
 
             const released: SurfaceMouse = .{
-                .physical_key = .meta_left,
+                .physical_key = command_key,
                 .mouse_event = .none,
                 .mouse_shape = shape,
                 .mods = .{},
@@ -367,7 +360,7 @@ test "keyToMouseShape" {
             .physical_key = .alt_left,
             .mouse_event = .none,
             .mouse_shape = .pointer,
-            .mods = .{ .alt = true },
+            .mods = .{ .ctrl = true, .super = true, .alt = true },
             .over_link = false,
             .hidden = false,
         };
@@ -388,17 +381,17 @@ test "keyToMouseShape" {
         // An explicit OSC 22 text shape remains text while mouse reporting is
         // active; a Cmd/Super modifier must not synthesize the default arrow.
         const pressed: SurfaceMouse = .{
-            .physical_key = .meta_left,
+            .physical_key = command_key,
             .mouse_event = .x10,
             .mouse_shape = .text,
-            .mods = .{ .super = true },
+            .mods = command_mods,
             .over_link = false,
             .hidden = false,
         };
         try testing.expect(.text == pressed.keyToMouseShape());
 
         const released: SurfaceMouse = .{
-            .physical_key = .meta_left,
+            .physical_key = command_key,
             .mouse_event = .x10,
             .mouse_shape = .text,
             .mods = .{},

--- a/src/surface_mouse.zig
+++ b/src/surface_mouse.zig
@@ -333,4 +333,78 @@ test "keyToMouseShape" {
         const got = m.keyToMouseShape();
         try testing.expect(want == got);
     }
+
+    {
+        // An explicit OSC 22 base shape survives Cmd/Super press and release
+        // while the terminal is in its ordinary (non-mouse-reporting) mode.
+        for ([_]MouseShape{ .pointer, .copy }) |shape| {
+            const pressed: SurfaceMouse = .{
+                .physical_key = .meta_left,
+                .mouse_event = .none,
+                .mouse_shape = shape,
+                .mods = .{ .super = true },
+                .over_link = false,
+                .hidden = false,
+            };
+            try testing.expect(shape == pressed.keyToMouseShape());
+
+            const released: SurfaceMouse = .{
+                .physical_key = .meta_left,
+                .mouse_event = .none,
+                .mouse_shape = shape,
+                .mods = .{},
+                .over_link = false,
+                .hidden = false,
+            };
+            try testing.expect(shape == released.keyToMouseShape());
+        }
+    }
+
+    {
+        // Rectangle selection temporarily overrides an explicit base shape,
+        // then restores that base when Option is released.
+        const pressed: SurfaceMouse = .{
+            .physical_key = .alt_left,
+            .mouse_event = .none,
+            .mouse_shape = .pointer,
+            .mods = .{ .alt = true },
+            .over_link = false,
+            .hidden = false,
+        };
+        try testing.expect(.crosshair == pressed.keyToMouseShape());
+
+        const released: SurfaceMouse = .{
+            .physical_key = .alt_left,
+            .mouse_event = .none,
+            .mouse_shape = .pointer,
+            .mods = .{},
+            .over_link = false,
+            .hidden = false,
+        };
+        try testing.expect(.pointer == released.keyToMouseShape());
+    }
+
+    {
+        // An explicit OSC 22 text shape remains text while mouse reporting is
+        // active; a Cmd/Super modifier must not synthesize the default arrow.
+        const pressed: SurfaceMouse = .{
+            .physical_key = .meta_left,
+            .mouse_event = .x10,
+            .mouse_shape = .text,
+            .mods = .{ .super = true },
+            .over_link = false,
+            .hidden = false,
+        };
+        try testing.expect(.text == pressed.keyToMouseShape());
+
+        const released: SurfaceMouse = .{
+            .physical_key = .meta_left,
+            .mouse_event = .x10,
+            .mouse_shape = .text,
+            .mods = .{},
+            .over_link = false,
+            .hidden = false,
+        };
+        try testing.expect(.text == released.keyToMouseShape());
+    }
 }

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -85,8 +85,9 @@ modes: modespkg.ModeState = .{},
 /// Terminal-level cursor state.
 cursor: Cursor = .{},
 
-/// The most recently set mouse shape for the terminal.
-mouse_shape: mouse.Shape = .text,
+/// The most recently set mouse shape for the terminal, or `null` until OSC 22
+/// supplies an explicit base shape.
+mouse_shape: ?mouse.Shape = null,
 
 /// Per-session Glyph Protocol registrations.
 glyph_glossary: glyph.Glossary = .empty,
@@ -155,6 +156,25 @@ pub const Colors = struct {
         .palette = .default,
     };
 };
+
+/// Resolves the base mouse shape when OSC 22 has not supplied one.
+pub fn effectiveMouseShape(self: *const Terminal) mouse.Shape {
+    return self.mouse_shape orelse if (self.flags.mouse_event == .none) .text else .default;
+}
+
+test "Terminal: effective mouse shape resolves explicit and mode defaults" {
+    const alloc = testing.allocator;
+    var t = try init(testing.io, alloc, .{ .cols = 10, .rows = 5 });
+    defer t.deinit(alloc);
+
+    try testing.expectEqual(mouse.Shape.text, t.effectiveMouseShape());
+    t.flags.mouse_event = .x10;
+    try testing.expectEqual(mouse.Shape.default, t.effectiveMouseShape());
+    t.mouse_shape = .text;
+    try testing.expectEqual(mouse.Shape.text, t.effectiveMouseShape());
+    t.mouse_shape = .pointer;
+    try testing.expectEqual(mouse.Shape.pointer, t.effectiveMouseShape());
+}
 
 /// Returns the current color for an xterm OSC color target.
 ///

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -4757,6 +4757,7 @@ pub fn fullReset(self: *Terminal) void {
     // Rest our basic state
     self.modes.reset();
     self.flags = .{};
+    self.mouse_shape = null;
     self.tabstops.reset(TABSTOP_INTERVAL);
     self.previous_char = null;
     self.pwd.clearRetainingCapacity();

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -115,7 +115,7 @@ test "kitty replay suppresses protocol responses on normal surfaces" {
 }
 
 test "OSC 22 base shape survives StreamHandler mode transitions" {
-    if (comptime !builtin.target.os.tag.isDarwin()) return;
+    if (comptime !builtin.target.os.tag.isDarwin()) return error.SkipZigTest;
 
     const testing = std.testing;
     const alloc = testing.allocator;
@@ -134,6 +134,7 @@ test "OSC 22 base shape survives StreamHandler mode transitions" {
     var rt_app: apprt.App = undefined;
     rt_app.core_app = &core_app;
     rt_app.opts = undefined;
+    rt_app.opts.userdata = null;
     rt_app.opts.wakeup = Callbacks.wakeup;
 
     var app_queue: CoreApp.Mailbox.Queue = .{};
@@ -143,12 +144,13 @@ test "OSC 22 base shape survives StreamHandler mode transitions" {
         .mailbox = &app_queue,
         .redraw_retry_requested = &redraw_retry_requested,
     };
+    var core_surface: @import("../Surface.zig") = undefined;
     const surface_mailbox: apprt.surface.Mailbox = .{
-        .surface = undefined,
+        .surface = &core_surface,
         .app = app_mailbox,
     };
 
-    var term = try terminal.init(testing.io, alloc, .{ .cols = 10, .rows = 5 });
+    var term = try terminal.Terminal.init(testing.io, alloc, .{ .cols = 10, .rows = 5 });
     defer term.deinit(alloc);
     var size: renderer.Size = undefined;
     var handler: StreamHandler = .{

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -175,39 +175,76 @@ test "OSC 22 base shape survives StreamHandler mode transitions" {
         .mouse_event_button,
         .mouse_event_any,
     };
+    const QueueAssertions = struct {
+        fn expectShape(
+            queue: *CoreApp.Mailbox.Queue,
+            expected: terminal.MouseShape,
+        ) !void {
+            const message = queue.pop(std.testing.io) orelse
+                return error.MissingSurfaceMessage;
+            switch (message) {
+                .surface_message => |surface_message| switch (surface_message.message) {
+                    .set_mouse_shape => |shape| try std.testing.expectEqual(expected, shape),
+                    else => return error.UnexpectedSurfaceMessage,
+                },
+                else => return error.UnexpectedSurfaceMessage,
+            }
+        }
+
+        fn expectEmpty(queue: *CoreApp.Mailbox.Queue) !void {
+            try std.testing.expect(queue.pop(std.testing.io) == null);
+        }
+    };
 
     // A terminal with no OSC 22 request keeps the mode-derived default
     // implicit while each real mode handler toggles reporting.
     for (reportingModes) |mode| {
         try handler.setMode(mode, true);
         try testing.expect(term.mouse_shape == null);
+        try testing.expectEqual(terminal.MouseShape.default, term.effectiveMouseShape());
+        try QueueAssertions.expectShape(&app_queue, .default);
         try handler.setMode(mode, false);
         try testing.expect(term.mouse_shape == null);
+        try testing.expectEqual(terminal.MouseShape.text, term.effectiveMouseShape());
+        try QueueAssertions.expectShape(&app_queue, .text);
     }
 
     // Drive the actual VT action path, then ensure mode handlers never replace
     // an explicit pointer or text request with their implicit default.
     handler.vt(.mouse_shape, .pointer);
+    try QueueAssertions.expectShape(&app_queue, .pointer);
     for (reportingModes) |mode| {
         try handler.setMode(mode, true);
         try testing.expectEqual(terminal.MouseShape.pointer, term.mouse_shape.?);
+        try QueueAssertions.expectEmpty(&app_queue);
         try handler.setMode(mode, false);
         try testing.expectEqual(terminal.MouseShape.pointer, term.mouse_shape.?);
+        try QueueAssertions.expectEmpty(&app_queue);
     }
 
     handler.vt(.mouse_shape, .text);
+    try QueueAssertions.expectShape(&app_queue, .text);
     for (reportingModes) |mode| {
         try handler.setMode(mode, true);
         try testing.expectEqual(terminal.MouseShape.text, term.mouse_shape.?);
+        try QueueAssertions.expectEmpty(&app_queue);
         try handler.setMode(mode, false);
         try testing.expectEqual(terminal.MouseShape.text, term.mouse_shape.?);
+        try QueueAssertions.expectEmpty(&app_queue);
     }
 
     // A full reset clears the explicit OSC 22 request, restoring mode-derived
     // defaults instead of manufacturing an explicit text request.
+    handler.vt(.mouse_shape, .pointer);
+    try QueueAssertions.expectShape(&app_queue, .pointer);
     try handler.fullReset();
     try testing.expect(term.mouse_shape == null);
     try testing.expectEqual(terminal.MouseShape.text, term.effectiveMouseShape());
+    try QueueAssertions.expectShape(&app_queue, .text);
+    while (app_queue.pop(std.testing.io)) |_| {}
+    try handler.setMode(.mouse_event_x10, true);
+    try testing.expectEqual(terminal.MouseShape.default, term.effectiveMouseShape());
+    try QueueAssertions.expectShape(&app_queue, .default);
 }
 
 /// This is used as the handler for the terminal.Stream type. This is
@@ -1114,40 +1151,16 @@ pub const StreamHandler = struct {
             }),
 
             .mouse_event_x10 => {
-                if (enabled) {
-                    self.terminal.flags.mouse_event = .x10;
-                    try self.setMouseShape(.default);
-                } else {
-                    self.terminal.flags.mouse_event = .none;
-                    try self.setMouseShape(.text);
-                }
+                self.updateMouseEventMode(if (enabled) .x10 else .none);
             },
             .mouse_event_normal => {
-                if (enabled) {
-                    self.terminal.flags.mouse_event = .normal;
-                    try self.setMouseShape(.default);
-                } else {
-                    self.terminal.flags.mouse_event = .none;
-                    try self.setMouseShape(.text);
-                }
+                self.updateMouseEventMode(if (enabled) .normal else .none);
             },
             .mouse_event_button => {
-                if (enabled) {
-                    self.terminal.flags.mouse_event = .button;
-                    try self.setMouseShape(.default);
-                } else {
-                    self.terminal.flags.mouse_event = .none;
-                    try self.setMouseShape(.text);
-                }
+                self.updateMouseEventMode(if (enabled) .button else .none);
             },
             .mouse_event_any => {
-                if (enabled) {
-                    self.terminal.flags.mouse_event = .any;
-                    try self.setMouseShape(.default);
-                } else {
-                    self.terminal.flags.mouse_event = .none;
-                    try self.setMouseShape(.text);
-                }
+                self.updateMouseEventMode(if (enabled) .any else .none);
             },
 
             .mouse_format_utf8 => self.terminal.flags.mouse_format = if (enabled) .utf8 else .x10,
@@ -1156,6 +1169,17 @@ pub const StreamHandler = struct {
             .mouse_format_sgr_pixels => self.terminal.flags.mouse_format = if (enabled) .sgr_pixels else .x10,
 
             else => {},
+        }
+    }
+
+    /// Updates mouse reporting without replacing an explicit OSC 22 base.
+    /// Notify the surface only when the resolved cursor actually changes.
+    fn updateMouseEventMode(self: *StreamHandler, event: terminal.MouseEvent) void {
+        const previous = self.terminal.effectiveMouseShape();
+        self.terminal.flags.mouse_event = event;
+        const next = self.terminal.effectiveMouseShape();
+        if (previous != next) {
+            self.surfaceMessageWriter(.{ .set_mouse_shape = next });
         }
     }
 
@@ -1256,8 +1280,12 @@ pub const StreamHandler = struct {
     pub fn fullReset(
         self: *StreamHandler,
     ) !void {
+        const previous = self.terminal.effectiveMouseShape();
         self.terminal.fullReset();
-        try self.setMouseShape(.text);
+        const next = self.terminal.effectiveMouseShape();
+        if (previous != next) {
+            self.surfaceMessageWriter(.{ .set_mouse_shape = next });
+        }
 
         // Reset resets our palette so we report it for mode 2031.
         self.messageWriter(.{ .color_scheme_report = .{ .force = false } });

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -7,6 +7,7 @@ const xev = global.xev;
 const apprt = @import("../apprt.zig");
 const build_config = @import("../build_config.zig");
 const configpkg = @import("../config.zig");
+const CoreApp = @import("../App.zig");
 const internal_os = @import("../os/main.zig");
 const renderer = @import("../renderer.zig");
 const termio = @import("../termio.zig");
@@ -111,6 +112,100 @@ test "kitty replay suppresses protocol responses on normal surfaces" {
 
     try testing.expect(suppressTerminalResponseForState(false, true, reply));
     try testing.expect(!suppressTerminalResponseForState(false, false, reply));
+}
+
+test "OSC 22 base shape survives StreamHandler mode transitions" {
+    if (comptime !builtin.target.os.tag.isDarwin()) return;
+
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    const Callbacks = struct {
+        fn wakeup(_: ?*anyopaque) callconv(.c) void {}
+    };
+
+    var core_app: CoreApp = undefined;
+    try core_app.init(alloc);
+    defer {
+        core_app.surfaces.deinit(alloc);
+        core_app.font_grid_set.deinit();
+    }
+
+    var rt_app: apprt.App = undefined;
+    rt_app.core_app = &core_app;
+    rt_app.opts = undefined;
+    rt_app.opts.wakeup = Callbacks.wakeup;
+
+    var app_queue: CoreApp.Mailbox.Queue = .{};
+    var redraw_retry_requested = std.atomic.Value(bool).init(false);
+    const app_mailbox: CoreApp.Mailbox = .{
+        .rt_app = &rt_app,
+        .mailbox = &app_queue,
+        .redraw_retry_requested = &redraw_retry_requested,
+    };
+    const surface_mailbox: apprt.surface.Mailbox = .{
+        .surface = undefined,
+        .app = app_mailbox,
+    };
+
+    var term = try terminal.init(testing.io, alloc, .{ .cols = 10, .rows = 5 });
+    defer term.deinit(alloc);
+    var size: renderer.Size = undefined;
+    var handler: StreamHandler = .{
+        .alloc = alloc,
+        .size = &size,
+        .terminal = &term,
+        .termio_mailbox = undefined,
+        .surface_mailbox = surface_mailbox,
+        .renderer_state = undefined,
+        .renderer_mailbox = undefined,
+        .renderer_wakeup = undefined,
+        .enquiry_response = "",
+        .osc_color_report_format = .none,
+        .clipboard_write = .allow,
+        .suppress_terminal_responses = true,
+    };
+    defer handler.deinit();
+
+    const reportingModes = [_]terminal.Mode{
+        .mouse_event_x10,
+        .mouse_event_normal,
+        .mouse_event_button,
+        .mouse_event_any,
+    };
+
+    // A terminal with no OSC 22 request keeps the mode-derived default
+    // implicit while each real mode handler toggles reporting.
+    for (reportingModes) |mode| {
+        try handler.setMode(mode, true);
+        try testing.expect(term.mouse_shape == null);
+        try handler.setMode(mode, false);
+        try testing.expect(term.mouse_shape == null);
+    }
+
+    // Drive the actual VT action path, then ensure mode handlers never replace
+    // an explicit pointer or text request with their implicit default.
+    handler.vt(.mouse_shape, .pointer);
+    for (reportingModes) |mode| {
+        try handler.setMode(mode, true);
+        try testing.expectEqual(terminal.MouseShape.pointer, term.mouse_shape.?);
+        try handler.setMode(mode, false);
+        try testing.expectEqual(terminal.MouseShape.pointer, term.mouse_shape.?);
+    }
+
+    handler.vt(.mouse_shape, .text);
+    for (reportingModes) |mode| {
+        try handler.setMode(mode, true);
+        try testing.expectEqual(terminal.MouseShape.text, term.mouse_shape.?);
+        try handler.setMode(mode, false);
+        try testing.expectEqual(terminal.MouseShape.text, term.mouse_shape.?);
+    }
+
+    // A full reset clears the explicit OSC 22 request, restoring mode-derived
+    // defaults instead of manufacturing an explicit text request.
+    try handler.fullReset();
+    try testing.expect(term.mouse_shape == null);
+    try testing.expectEqual(terminal.MouseShape.text, term.effectiveMouseShape());
 }
 
 /// This is used as the handler for the terminal.Stream type. This is


### PR DESCRIPTION
OSC 22 pointer requests were replaced by mode defaults on modifier keys and mouse-reporting transitions. In cmux #9362, `pointer → Cmd+D → focus original pane` returned I-beam. The linked micro-editor request also needs explicit text under mouse reporting.

The terminal now stores an optional explicit OSC 22 request and resolves an unspecified default from reporting mode. Modifier and link-exit paths use that resolved base, preserving rectangle/Shift selection overrides. Reporting-mode handlers update flags and emit effective cursor changes without overwriting the explicit request. Full reset clears the request and emits the resolved reset cursor separately. The internal Zig field type changes; the C action ABI is unchanged.

Validated at `f2c511a46f2a1ea7e6b34e6a0dff8a9d99941b26` on a leased M4 Pro with Zig 0.16.0:

- Modifier regression: test-only e4aa4ba16 fails the actual Cmd-pointer assertion (72 pass / 1 fail); fixed modifier run 73/73.
- Reporting-mode regression: test-only adb251c61 fails its actual state assertion (72 pass / 1 fail); fixed real StreamHandler/App-mailbox run 73/73. Tests check all four modes, explicit pointer/text, emitted default/text messages, absent mode-default messages for explicit requests, and full reset followed by reporting enable.
- Base-resolution run 73/73; inherited clearScreen run 77/77. Counts include dependency tests.
- Universal ReleaseFast GhosttyKit: 297/297 build steps; macOS arm64/x86_64, iOS arm64, iOS simulator arm64. Archive validation passes; SHA-256 `92f45e610406c0a16f57dbacdf86d191c5ebe45abd76cd4e43472f6a339e8991`.
- [Public red/green and build logs](https://gist.github.com/austinywang/be31954bb2eb00cde40d3ec4f5841d53). Fork GitHub test aggregation passes, but upstream-only matrix jobs are skipped; the concrete native runs above are the validation evidence.
- CodeRabbit's mode-transition finding is fixed, replied to in 3944371533, acknowledged in 3944372484, and resolved.

Trade-offs: optional state keeps explicit text distinct from a mode default without paired provenance flags. Existing tests that supplied transient displayed cursors now supply the actual terminal base. The branch includes fork-main's existing clearScreen correction, which was tested. No iOS app/device dogfood is claimed; the final native framework still needs the downstream app UI run after the dependency pin changes.

The final archive is retained in HQ artifacts and has not been published. A merge commit preserves this tested SHA and archive; a squash requires rebuilding/pinning its resulting SHA. This core is shared with iOS, so Austin must merge under the standing iOS exception. The parent policy requires the pinned commit to be reachable from fork main. After this dependency lands, cmux https://github.com/manaflow-ai/cmux/pull/9362 can publish/pin the framework, rerun native hover/divider/mouse-reporting UI verification, and build the tagged app.
