### PR TITLE
Expose pure Ghostty config color parsing

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1306,6 +1306,9 @@ GHOSTTY_API const char* ghostty_translate(const char*);
 GHOSTTY_API void ghostty_string_free(ghostty_string_s);
 
 GHOSTTY_API ghostty_config_t ghostty_config_new();
+// Parses a color using Ghostty's config color syntax without requiring
+// ghostty_init or allocating a configuration object.
+GHOSTTY_API bool ghostty_config_color_parse(const char*, uintptr_t, ghostty_config_color_s*);
 GHOSTTY_API void ghostty_config_free(ghostty_config_t);
 GHOSTTY_API ghostty_config_t ghostty_config_clone(ghostty_config_t);
 // Serialize the effective configuration as valid Ghostty config-file syntax.

--- a/src/config/CApi.zig
+++ b/src/config/CApi.zig
@@ -28,6 +28,18 @@ export fn ghostty_config_new() ?*Config {
     return result;
 }
 
+/// Parse a color using Ghostty's config color syntax without requiring global
+/// Ghostty initialization or allocating a configuration object.
+export fn ghostty_config_color_parse(
+    value: [*]const u8,
+    value_len: usize,
+    out: *Config.Color.C,
+) bool {
+    const color = Config.Color.parseCLI(value[0..value_len]) catch return false;
+    out.* = color.cval();
+    return true;
+}
+
 export fn ghostty_config_free(ptr: ?*Config) void {
     if (ptr) |v| {
         v.deinit();


### PR DESCRIPTION
## Summary
- expose Ghostty's config color parser without constructing a global configuration
- allow embedders to resolve X11 and other Ghostty color syntax before `ghostty_init`

## Context
cmux loads user configuration while constructing its workspace model, before the terminal runtime initializes Ghostty. Calling `ghostty_config_new()` solely to parse a named color dereferences uninitialized global state. This API reuses `Config.Color.parseCLI` directly and has no global-state or allocation dependency.

## Validation
- Source-level review of `Config.Color.parseCLI` and the C API implementation.
- cmux will consume the API from its issue-1400 fix after this commit lands on `main`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/ghostty/pr/217"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791470748&installation_model_id=21920&pr_number=217&repository=manaflow-ai%2Fghostty&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fghostty%2Fpull%2F217&signature=13582958efbf78400367190329944f2e947df5b1ec7ea9d26080a8d3baf2432e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `ghostty_config_color_parse` to the C API so embedders can resolve Ghostty color syntax (e.g., X11 names) without constructing a config or initializing global state. Previously, calling `ghostty_config_new()` to parse a color dereferenced uninitialized globals before `ghostty_init`.

<sup>Written for commit 98c2407c5390287c9172c2078d4424683b8b1f7c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/ghostty/pull/217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a public API for parsing colors using Ghostty’s configuration color syntax.
  * Color parsing can be performed independently, without initializing Ghostty or creating a configuration object.
  * Parsing results are written to a caller-provided output, with a success status returned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->